### PR TITLE
[Impersonate] Add power user ability to impersonate a user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,14 @@ class UsersController < ApplicationController
   skip_after_action :verify_authorized, except: [:edit, :update]
   before_action :hide_footer
 
+  def impersonate
+    authorize current_user
+
+    sign_in(User.find(params[:user_id]))
+
+    redirect_to root_path
+  end
+
   # view to log in
   def auth
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,9 @@ class UsersController < ApplicationController
   def impersonate
     authorize current_user
 
-    sign_in(User.find(params[:user_id]))
+    impersonate_user(User.find(params[:user_id]))
 
-    redirect_to root_path
+    redirect_to root_path, status: 302
   end
 
   # view to log in

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,8 @@
 class UserPolicy < ApplicationPolicy
+  def impersonate?
+    user.admin?
+  end
+
   def edit?
     user.admin? || record == user
   end

--- a/app/views/static_pages/search.html.erb
+++ b/app/views/static_pages/search.html.erb
@@ -38,6 +38,10 @@
           <% end %>
         </p>
       <% end %>
+      <hr/>
+      <p>
+        <%= link_to "Impersonate this user", impersonate_users_path(user_id: r.id) %>
+      </p>
     </div>
   <% end %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,18 +18,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
+  config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.cache_store = :memory_store
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{2.days.to_i}"
+  }
 
   config.action_mailer.show_previews = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:edit, :update] do
     collection do
+      get 'impersonate', to: 'users#impersonate'
       get 'auth', to: 'users#auth'
       post 'login_code', to: 'users#login_code'
       post 'exchange_login_code', to: 'users#exchange_login_code'


### PR DESCRIPTION
Useful for debugging issues around gsuite and for other uses.

How to use:

While signed in as an admin only, you can type in the following url:

```
http://bankurl/users/impersonate?user_id=1234
```

You will then be logged in as that user. The feature is a little janky in that then you will have to log back out to log back in as an admin. That can be solved later but requires much more complexity via multiple cookies typically.

Here's a gif demonstrating its usage and verifying it is only permitted as an admin.
