### PR TITLE
762 auto migrate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,3 +139,4 @@ end
 gem 'heroku-deflater', group: :production
 
 gem 'blazer'
+gem 'strong_migrations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stripe (5.22.0)
+    strong_migrations (0.7.1)
+      activerecord (>= 5)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -421,6 +423,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   stripe
+  strong_migrations
   turbolinks (~> 5.2.0)
   uglifier (>= 1.3.0)
   validates_email_format_of

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rails server -p $PORT -e production
 worker: bundle exec sidekiq
+release: bin/release-tasks

--- a/bin/release-tasks
+++ b/bin/release-tasks
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$DISABLE_RAILS_DB_MIGRATIONS" = "true" ]; then
+  echo "SKIPPING DATABASE MIGRATIONS"
+else
+  bundle exec rake db:migrate
+fi

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,22 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20200812000005
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end


### PR DESCRIPTION
This will automatically run migrations on deploy - for prod only. The review apps will still require migrations to be run by hand by design.

https://github.com/hackclub/bank/issues/762