### PR TITLE
[781] Plaid Connection Issues: Step 1. Raw Import.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,4 +142,5 @@ gem 'airbrake'
 gem 'blazer'
 gem 'money-rails' # back cent fields as money objects 
 gem 'paper_trail'
+gem 'sidekiq-cron', '~> 1.1' # run sidekiq scheduled tasks
 gem 'strong_migrations'

--- a/Gemfile
+++ b/Gemfile
@@ -140,5 +140,6 @@ gem 'heroku-deflater', group: :production
 
 gem 'airbrake'
 gem 'blazer'
+gem 'money-rails' # back cent fields as money objects 
 gem 'paper_trail'
 gem 'strong_migrations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,15 @@ GEM
     mini_racer (0.2.15)
       libv8 (> 7.3)
     minitest (5.14.1)
+    monetize (1.9.4)
+      money (~> 6.12)
+    money (6.13.8)
+      i18n (>= 0.6.4, <= 2)
+    money-rails (1.13.3)
+      activesupport (>= 3.0)
+      monetize (~> 1.9.0)
+      money (~> 6.13.2)
+      railties (>= 3.0)
     msgpack (1.3.3)
     multi_json (1.14.1)
     multi_xml (0.6.0)
@@ -420,6 +429,7 @@ DEPENDENCIES
   maildown
   mini_magick
   mini_racer
+  money-rails
   paper_trail
   pg (>= 0.18, < 2.0)
   phonelib

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     errbase (0.2.0)
     erubi (1.9.0)
+    et-orbi (1.2.4)
+      tzinfo
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -127,6 +129,9 @@ GEM
     ffi (1.13.1)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    fugit (1.3.8)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-api-client (0.41.1)
@@ -248,6 +253,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
+    raabro (1.3.1)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -345,6 +351,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-cron (1.2.0)
+      fugit (~> 1.1)
+      sidekiq (>= 4.2.1)
     signet (0.14.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -447,6 +456,7 @@ DEPENDENCIES
   rubyzip (>= 1.2.1)
   sassc-rails
   sidekiq
+  sidekiq-cron (~> 1.1)
   skylight
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/jobs/plaid_transaction_job/imports.rb
+++ b/app/jobs/plaid_transaction_job/imports.rb
@@ -2,10 +2,10 @@
 
 module PlaidTransactionJob
   class Imports < ApplicationJob
-		def perform
-			BankAccount.syncing.pluck(:id).each do |bank_account_id|
-				::PlaidTransactionService::Plaid::Import.new(bank_account_id: bank_account_id).run
-			end
-		end
-	end
+    def perform
+      BankAccount.syncing.pluck(:id).each do |bank_account_id|
+        ::PlaidTransactionService::Plaid::Import.new(bank_account_id: bank_account_id).run
+      end
+    end
+  end
 end

--- a/app/jobs/plaid_transaction_job/imports.rb
+++ b/app/jobs/plaid_transaction_job/imports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PlaidTransactionJob
+  class Imports < ApplicationJob
+		def perform
+			BankAccount.syncing.pluck(:id).each do |bank_account_id|
+				::PlaidTransactionService::Plaid::Import.new(bank_account_id: bank_account_id).run
+			end
+		end
+	end
+end

--- a/app/jobs/sync_transactions_job.rb
+++ b/app/jobs/sync_transactions_job.rb
@@ -103,5 +103,9 @@ class SyncTransactionsJob < ApplicationJob
     end
 
     transactions
+  rescue ::Plaid::ItemError, ::Plaid::InvalidInputError => error
+    Airbrake.notify("plaid_client.transactions.get failed for bank_account #{account.id} with access token #{account.plaid_access_token}. #{error.message}")
+
+    raise error
   end
 end

--- a/app/models/plaid_transaction.rb
+++ b/app/models/plaid_transaction.rb
@@ -1,0 +1,3 @@
+class PlaidTransaction < ApplicationRecord
+  monetize :amount_cents
+end

--- a/app/services/partners/plaid/auth/get.rb
+++ b/app/services/partners/plaid/auth/get.rb
@@ -1,0 +1,18 @@
+module Partners
+  module Plaid
+    module Auth
+      class Get
+        include ::Partners::Plaid::Shared::Client
+
+        def initialize(access_token:)
+          @access_token = access_token
+        end
+
+        def run
+          plaid_client.auth.get(@access_token)
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/partners/plaid/shared/client.rb
+++ b/app/services/partners/plaid/shared/client.rb
@@ -1,0 +1,41 @@
+module Partners
+  module Plaid
+    module Shared
+      module Client
+        private
+
+        def plaid_client
+          ::Plaid::Client.new(env: plaid_env,
+                              client_id: plaid_client_id,
+                              secret: plaid_secret,
+                              public_key: plaid_public_key)
+        end
+
+        def plaid_client_id
+          Rails.application.credentials.plaid[:client_id]
+        end
+
+        def plaid_secret
+          case plaid_env
+          when "development"
+            Rails.application.credentials.plaid[:development_secret]
+          when "sandbox"
+            Rails.application.credentials.plaid[:sandbox_secret]
+          end
+        end
+
+        def plaid_public_key
+          Rails.application.credentials.plaid[:public_key]
+        end
+
+        def plaid_env
+          # Since we're only using one account & Plaid's development plan supports up
+          # to 100 accounts, we're just going to stick with the development key in
+          # production for now. Plaid is essentially read-only, so this also works in development.
+          "development"
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/partners/plaid/transactions/get.rb
+++ b/app/services/partners/plaid/transactions/get.rb
@@ -1,0 +1,73 @@
+module Partners
+  module Plaid
+    module Transactions
+      class Get
+        include ::Partners::Plaid::Shared::Client
+
+				def initialize(bank_account_id:)
+					@bank_account_id = bank_account_id
+				end
+
+        def run
+          plaid_transactions
+        end
+
+        private
+
+        def plaid_transactions
+          @plaid_transactions ||= fetch_transactions['transactions']
+        end
+
+        def fetch_transactions
+          begin
+            results = plaid_client.transactions.get(access_token, start_date, end_date, account_ids: account_ids)
+
+            # mark_plaid_item_success! # TODO
+
+            results
+          rescue ::Plaid::ItemError, ::Plaid::InvalidInputError => error
+            Airbrake.notify("plaid_client.transactions.get failed for bank_account #{bank_account.id} with access token #{access_token}. #{error.message}")
+
+            # mark_plaid_item_failed! # TODO
+
+            { 'accounts' => [], 'transactions' => [] }
+          end
+        end
+
+        def access_token
+          @access_token ||= bank_account.plaid_access_token
+        end
+
+        def start_date
+          (Time.now.utc - 15.days).strftime(strftime_format)
+        end
+
+        def end_date
+          (Time.now.utc + 2.days).strftime(strftime_format)
+        end
+
+        def strftime_format
+          '%Y-%m-%d'
+        end
+
+        def mark_plaid_item_failed!
+          bank_account.touch(:failed_at) # mark plaid item failed
+          BankAccount.increment_counter(:failure_count, bank_account.id)
+        end
+
+        def mark_plaid_item_success!
+          bank_account.update_attribute(:failed_at, nil)
+        end
+
+				def account_ids
+					[bank_account.plaid_account_id]
+				end
+
+				def bank_account
+					@bank_account ||= BankAccount.find(@bank_account_id)
+				end
+      end
+    end
+  end
+end
+

--- a/app/services/partners/plaid/transactions/get.rb
+++ b/app/services/partners/plaid/transactions/get.rb
@@ -15,7 +15,7 @@ module Partners
         private
 
         def plaid_transactions
-          @plaid_transactions ||= fetch_transactions['transactions']
+          @plaid_transactions ||= fetch_transactions["transactions"]
         end
 
         def fetch_transactions
@@ -30,7 +30,7 @@ module Partners
 
             # mark_plaid_item_failed! # TODO
 
-            { 'accounts' => [], 'transactions' => [] }
+            { "accounts" => [], "transactions" => [] }
           end
         end
 
@@ -47,7 +47,7 @@ module Partners
         end
 
         def strftime_format
-          '%Y-%m-%d'
+          "%Y-%m-%d"
         end
 
         def mark_plaid_item_failed!

--- a/app/services/plaid_transaction_service/plaid/import.rb
+++ b/app/services/plaid_transaction_service/plaid/import.rb
@@ -22,7 +22,11 @@ module PlaidTransactionService
       private
 
       def plaid_transactions
-        @plaid_transactions ||= ::Partners::Plaid::Transactions::Get.new(bank_account_id: @bank_account_id).run
+        @plaid_transactions ||= ::Partners::Plaid::Transactions::Get.new(bank_account_id: @bank_account_id, start_date: start_date).run
+      end
+
+      def start_date
+        (Time.now.utc - 5.years).strftime(::Partners::Plaid::Transactions::Get::DATE_FORMAT)
       end
     end
   end

--- a/app/views/bank_accounts/reauthenticate.html.erb
+++ b/app/views/bank_accounts/reauthenticate.html.erb
@@ -25,3 +25,10 @@ document.getElementById('linkButton').onclick = function() {
   linkHandler.open();
 };
 </script>
+
+<ul>
+  <li>env: <%= @link_env %></li>
+  <li>clientName: <%= @client_name %></li>
+  <li>product: <%= @product %></li>
+  <li>token: <%= @public_token %></li>
+</ul>

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,115 @@
+# encoding : utf-8
+
+MoneyRails.configure do |config|
+
+  # To set the default currency
+  #
+  config.default_currency = :usd
+
+  # Set default bank object
+  #
+  # Example:
+  # config.default_bank = EuCentralBank.new
+
+  # Add exchange rates to current money bank object.
+  # (The conversion rate refers to one direction only)
+  #
+  # Example:
+  # config.add_rate "USD", "CAD", 1.24515
+  # config.add_rate "CAD", "USD", 0.803115
+
+  # To handle the inclusion of validations for monetized fields
+  # The default value is true
+  #
+  # config.include_validations = true
+
+  # Default ActiveRecord migration configuration values for columns:
+  #
+  # config.amount_column = { prefix: '',           # column name prefix
+  #                          postfix: '_cents',    # column name  postfix
+  #                          column_name: nil,     # full column name (overrides prefix, postfix and accessor name)
+  #                          type: :integer,       # column type
+  #                          present: true,        # column will be created
+  #                          null: false,          # other options will be treated as column options
+  #                          default: 0
+  #                        }
+  #
+  # config.currency_column = { prefix: '',
+  #                            postfix: '_currency',
+  #                            column_name: nil,
+  #                            type: :string,
+  #                            present: true,
+  #                            null: false,
+  #                            default: 'USD'
+  #                          }
+
+  # Register a custom currency
+  #
+  # Example:
+  # config.register_currency = {
+  #   priority:            1,
+  #   iso_code:            "EU4",
+  #   name:                "Euro with subunit of 4 digits",
+  #   symbol:              "€",
+  #   symbol_first:        true,
+  #   subunit:             "Subcent",
+  #   subunit_to_unit:     10000,
+  #   thousands_separator: ".",
+  #   decimal_mark:        ","
+  # }
+
+  # Specify a rounding mode
+  # Any one of:
+  #
+  # BigDecimal::ROUND_UP,
+  # BigDecimal::ROUND_DOWN,
+  # BigDecimal::ROUND_HALF_UP,
+  # BigDecimal::ROUND_HALF_DOWN,
+  # BigDecimal::ROUND_HALF_EVEN,
+  # BigDecimal::ROUND_CEILING,
+  # BigDecimal::ROUND_FLOOR
+  #
+  # set to BigDecimal::ROUND_HALF_EVEN by default
+  #
+  config.rounding_mode = BigDecimal::ROUND_HALF_UP
+
+  # Set default money format globally.
+  # Default value is nil meaning "ignore this option".
+  # Example:
+  #
+  # config.default_format = {
+  #   no_cents_if_whole: nil,
+  #   symbol: nil,
+  #   sign_before_symbol: nil
+  # }
+
+  # If you would like to use I18n localization (formatting depends on the
+  # locale):
+  config.locale_backend = :i18n
+  #
+  # Example (using default localization from rails-i18n):
+  #
+  # I18n.locale = :en
+  # Money.new(10_000_00, 'USD').format # => $10,000.00
+  # I18n.locale = :es
+  # Money.new(10_000_00, 'USD').format # => $10.000,00
+  #
+  # For the legacy behaviour of "per currency" localization (formatting depends
+  # only on currency):
+  # config.locale_backend = :currency
+  #
+  # Example:
+  # Money.new(10_000_00, 'USD').format # => $10,000.00
+  # Money.new(10_000_00, 'EUR').format # => €10.000,00
+  #
+  # In case you don't need localization and would like to use default values
+  # (can be redefined using config.default_format):
+  # config.locale_backend = nil
+
+  # Set default raise_error_on_money_parsing option
+  # It will be raise error if assigned different currency
+  # The default value is false
+  #
+  # Example:
+  # config.raise_error_on_money_parsing = false
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+schedule_file = "config/schedule.yml"
+
+if File.exists?(schedule_file) && Sidekiq.server?
+  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/web'
+require 'sidekiq/cron/web'
 require 'admin_constraint'
 
 Rails.application.routes.draw do

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,4 @@
+plaid_transaction_imports_job:
+  cron: "*/5 * * * *" # run every 5 minutes
+  class: "PlaidTransactionJob::Imports"
+  queue: "default"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,4 +1,4 @@
 plaid_transaction_imports_job:
-  cron: "*/5 * * * *" # run every 5 minutes
+  cron: "0 * * * *" # run every 1 hour
   class: "PlaidTransactionJob::Imports"
   queue: "default"

--- a/db/migrate/20200904235817_create_plaid_transactions.rb
+++ b/db/migrate/20200904235817_create_plaid_transactions.rb
@@ -1,0 +1,14 @@
+class CreatePlaidTransactions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :plaid_transactions do |t|
+      t.text :plaid_account_id
+      t.text :plaid_item_id
+      t.text :plaid_transaction_id
+      t.jsonb :plaid_transaction
+      t.integer :amount_cents
+      t.date :date_posted
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2020_08_20_050245) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_050245) do
+ActiveRecord::Schema.define(version: 2020_09_04_235817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -625,6 +625,17 @@ ActiveRecord::Schema.define(version: 2020_08_20_050245) do
     t.datetime "deleted_at"
     t.index ["event_id"], name: "index_organizer_positions_on_event_id"
     t.index ["user_id"], name: "index_organizer_positions_on_user_id"
+  end
+
+  create_table "plaid_transactions", force: :cascade do |t|
+    t.text "plaid_account_id"
+    t.text "plaid_item_id"
+    t.text "plaid_transaction_id"
+    t.jsonb "plaid_transaction"
+    t.integer "amount_cents"
+    t.date "date_posted"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "receipts", force: :cascade do |t|

--- a/spec/fixtures/plaid_transactions.yml
+++ b/spec/fixtures/plaid_transactions.yml
@@ -1,0 +1,7 @@
+plaid_transaction1:
+  plaid_account_id: "plaid_account_id1"
+  plaid_item_id: "plaid_item_id1"
+  plaid_transaction_id: "plaid_transaction_id1"
+  amount_cents: 100
+  date_posted: "2020-09-02"
+  created_at: <%= Time.now %>

--- a/spec/models/plaid_transaction_spec.rb
+++ b/spec/models/plaid_transaction_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlaidTransaction, type: :model do
+  fixtures "plaid_transactions"
+
+  let(:plaid_transaction) { plaid_transactions(:plaid_transaction1) }
+
+  it "is valid" do
+    expect(plaid_transaction).to be_valid
+  end
+
+  describe "#amount" do
+    it "uses money gem to display amount" do
+      expect(plaid_transaction.amount).to eql(Money.new(100))
+      expect(plaid_transaction.amount_cents).to eql(100)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an hourly job to import all enabled raw plaid transactions.

This data table is not in relation to any other table. It will run in parallel and provide a constant to check against all the other currently mapped transactions.

For example, the first thing that stands out is that FS Main shows 3,526 transactions in Bank right now, but when importing from Plaid, I only receive 2,813. This kind of raw data will let me safely and slowly work toward a solution to transactions that is solid and also ideally not tied to Plaid transaction ids.

Here's this PR in action:

![raw-plaid-transactions-import](https://user-images.githubusercontent.com/3848/92310189-b0c7bb80-ef60-11ea-9966-980d5dd3ca12.gif)
