### PR TITLE
[920] Add emburse.memo method

### DIFF
--- a/app/models/emburse_transaction.rb
+++ b/app/models/emburse_transaction.rb
@@ -29,13 +29,15 @@ class EmburseTransaction < ApplicationRecord
   end
 
   def memo
-    return 'Transfer from bank account' if amount > 0
+    @memo ||= begin
+      return 'Transfer from bank account' if amount > 0
 
-    merchant_name || 'Transfer back to bank account'
+      merchant_name || 'Transfer back to bank account'
+    end
   end
 
   def transfer?
-    amount > 0 || merchant_name.nil?
+    @transfer ||= amount > 0 || merchant_name.nil?
   end
 
   def under_review?

--- a/app/models/emburse_transaction.rb
+++ b/app/models/emburse_transaction.rb
@@ -28,6 +28,12 @@ class EmburseTransaction < ApplicationRecord
     self.where(["emburse_transactions.transaction_time >= ? and emburse_transactions.transaction_time <= ?", start_time, end_time])
   end
 
+  def memo
+    return 'Transfer from bank account' if amount > 0
+
+    merchant_name || 'Transfer back to bank account'
+  end
+
   def under_review?
     self.event_id.nil? && undeclined?
   end

--- a/app/models/emburse_transaction.rb
+++ b/app/models/emburse_transaction.rb
@@ -34,6 +34,10 @@ class EmburseTransaction < ApplicationRecord
     merchant_name || 'Transfer back to bank account'
   end
 
+  def transfer?
+    amount > 0 || merchant_name.nil?
+  end
+
   def under_review?
     self.event_id.nil? && undeclined?
   end

--- a/app/views/emburse_transactions/_emburse_transaction.html.erb
+++ b/app/views/emburse_transactions/_emburse_transaction.html.erb
@@ -13,7 +13,7 @@
     </td>
   <% else %>
     <td class="transaction__icon tooltipped tooltipped--e" aria-label="Emburse card transaction">
-      <%= inline_icon et.amount > 0 || et.merchant_name.nil? ? 'payment-transfer' : 'card' %>
+      <%= inline_icon et.transfer? ? 'payment-transfer' : 'card' %>
     </td>
   <% end %>
   <td>
@@ -21,9 +21,9 @@
   </td>
   <td class="flex justify-between">
     <% if et.completed? %>
-      <%= et.merchant_name %>
+      <%= et.memo %>
     <% else %>
-      <i><%= et.merchant_name %></i>
+      <i><%= et.memo %></i>
     <% end %>
   </td>
   <td>

--- a/app/views/emburse_transactions/_transaction.html.erb
+++ b/app/views/emburse_transactions/_transaction.html.erb
@@ -5,26 +5,25 @@
       <span class="tooltipped tooltipped--w mr1" aria-label="<%= et.state.capitalize %>">
         <%= status_badge et.status_badge_type %>
       </span>
-      <% if et.amount > 0 %>
-        <strong>Transfer from bank account</strong>
-      <% elsif et.merchant_name.nil? %>
-        <strong>Transfer back to bank account</strong>
+      <% if et.transfer? %>
+        <strong><%= et.memo %></strong>
       <% else %>
-        <%= et.merchant_name %>
+        <%= et.memo %>
       <% end %>
+
       <% if et.receipt_url.present? %>
-      <% if organizer_signed_in? %>
-        <span class="tooltipped tooltipped--e" aria-label="<%= et.category_name.present? ? et.category_name : 'Not categorized' %>">
-          <%= link_to et.receipt_url, target: '_blank', class: 'text-decoration-none' do %>
-            <%= inline_icon 'receipt', size: 16, class: 'ml1' %>
-          <% end %>
-        </span>
+        <% if organizer_signed_in? %>
+          <span class="tooltipped tooltipped--e" aria-label="<%= et.category_name.present? ? et.category_name : 'Not categorized' %>">
+            <%= link_to et.receipt_url, target: '_blank', class: 'text-decoration-none' do %>
+              <%= inline_icon 'receipt', size: 16, class: 'ml1' %>
+            <% end %>
+          </span>
         <% else %>
-        <span class="tooltipped tooltipped--e" aria-label="Sign in to view receipts">
-          <%= link_to root_path, target: '_blank', class: 'text-decoration-none' do %>
-            <%= inline_icon 'receipt', size: 16, class: 'ml1' %>
-          <% end %>
-        </span>
+          <span class="tooltipped tooltipped--e" aria-label="Sign in to view receipts">
+            <%= link_to root_path, target: '_blank', class: 'text-decoration-none' do %>
+              <%= inline_icon 'receipt', size: 16, class: 'ml1' %>
+            <% end %>
+          </span>
         <% end %>
       <% end %>
     </div>

--- a/spec/fixtures/emburse_transactions.yml
+++ b/spec/fixtures/emburse_transactions.yml
@@ -1,0 +1,5 @@
+emburse_transaction1:
+  emburse_id: "9321acfd-14a6-49cc-9b98-d888ac7bf4f2"
+  amount: -100
+  state: "completed"
+  created_at: <%= Time.now %>

--- a/spec/models/emburse_transaction_spec.rb
+++ b/spec/models/emburse_transaction_spec.rb
@@ -49,4 +49,44 @@ RSpec.describe EmburseTransaction, type: :model do
       end
     end
   end
+
+  describe '#transfer?' do
+    context 'amount is negative and merchant name is null' do
+      it 'is a transfer' do
+        expect(emburse_transaction).to be_transfer
+      end
+    end
+
+    context 'amount is postitive and merchant name is null' do
+      before do
+        allow(emburse_transaction).to receive(:amount).and_return(100)
+      end
+
+      it 'is a transfer from bank account' do
+        expect(emburse_transaction).to be_transfer
+      end
+    end
+
+    context 'amount is positive and merchant name is somehow present' do
+      before do
+        allow(emburse_transaction).to receive(:merchant_name).and_return('Some merchant name')
+        allow(emburse_transaction).to receive(:amount).and_return(100)
+      end
+
+      it 'is still a transfer from bank account' do
+        expect(emburse_transaction).to be_transfer
+      end
+    end
+
+    context 'amount is negative and merchant name is present' do
+      before do
+        allow(emburse_transaction).to receive(:merchant_name).and_return('Some merchant name')
+      end
+
+      it 'is not a transfer' do
+        expect(emburse_transaction).to_not be_transfer
+      end
+    end
+  end
+
 end

--- a/spec/models/emburse_transaction_spec.rb
+++ b/spec/models/emburse_transaction_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmburseTransaction, type: :model do
+  fixtures 'emburse_transactions'
+
+  let(:emburse_transaction) { emburse_transactions(:emburse_transaction1) }
+
+  it 'is valid' do
+    expect(emburse_transaction).to be_valid
+  end
+
+  describe '#memo' do
+    context 'amount is negative and merchant name is null' do
+      it 'is a transfer back to bank account' do
+        expect(emburse_transaction.memo).to eql('Transfer back to bank account')
+      end
+    end
+
+    context 'amount is postitive and merchant name is null' do
+      before do
+        allow(emburse_transaction).to receive(:amount).and_return(100)
+      end
+
+      it 'is a transfer from bank account' do
+        expect(emburse_transaction.memo).to eql('Transfer from bank account')
+      end
+    end
+
+    context 'amount is positive and merchant name is somehow present' do
+      before do
+        allow(emburse_transaction).to receive(:merchant_name).and_return('Some merchant name')
+        allow(emburse_transaction).to receive(:amount).and_return(100)
+      end
+
+      it 'is still a transfer from bank account' do
+        expect(emburse_transaction.memo).to eql('Transfer from bank account')
+      end
+    end
+
+    context 'amount is negative and merchant name is present' do
+      before do
+        allow(emburse_transaction).to receive(:merchant_name).and_return('Some merchant name')
+      end
+
+      it 'uses merchant name as memo' do
+        expect(emburse_transaction.memo).to eql('Some merchant name')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/hackclub/bank/issues/920 by adding a #memo method on emburse_transaction and calling that in the views.

Slowly over time we ideally remove string logic from the views and move those into the model. (i.e. if/else statements that are largely about returning a string/value)

Then we can provide various simple methods to front-end (eventually via API endpoints if it makes sense) for display view logic.