### PR TITLE
Removed Emburse language and added Stripe

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -106,7 +106,7 @@
 
   <% admin_tools do %>
     <div class="field">
-      <%= form.label :name, 'Name (if changed, also change across G Suite & Emburse)' %>
+      <%= form.label :name, 'Name (if changed, also change in G Suite)' %>
       <%= form.text_field :name %>
     </div>
 

--- a/app/views/organizer_position_deletion_requests/_form.html.erb
+++ b/app/views/organizer_position_deletion_requests/_form.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <p>
-    Does <%= user_mention @target %> have transactions without receipts on Emburse?
+    Does <%= user_mention @target %> have transactions without receipts on Stripe?
   </p>
   <div class="field field--radiobox">
     <%= form.radio_button :subject_has_outstanding_transactions_emburse, false, value: false %>

--- a/app/views/organizer_position_deletion_requests/_form.html.erb
+++ b/app/views/organizer_position_deletion_requests/_form.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <p>
-    Does <%= user_mention @target %> have transactions without receipts on Stripe?
+    Does <%= user_mention @target %> have transactions without receipts on their cards?
   </p>
   <div class="field field--radiobox">
     <%= form.radio_button :subject_has_outstanding_transactions_emburse, false, value: false %>

--- a/app/views/organizer_position_deletion_requests/show.html.erb
+++ b/app/views/organizer_position_deletion_requests/show.html.erb
@@ -34,7 +34,7 @@
 
   <p>
     <%= @opdr.subject_has_outstanding_transactions_emburse ? '✅' : '❌' %>
-    <strong>Outstanding Emburse transactions?</strong>
+    <strong>Outstanding Stripe transactions?</strong>
   </p>
 
   <p>


### PR DESCRIPTION
With Emburse no longer being our provider we don’t need this language here anymore and it can be substituted.