### PR TITLE
Remove extra "the" in legal relationship statement

### DIFF
--- a/app/views/static_pages/branding.html.erb
+++ b/app/views/static_pages/branding.html.erb
@@ -36,7 +36,7 @@
   </h2>
 
   <p>
-  <%= @event_name %> is fiscally sponsored by Hack Club Bank, a project by the The Hack
+  <%= @event_name %> is fiscally sponsored by Hack Club Bank, a project by The Hack
   Foundation (d.b.a Hack Club), a 501(c)(3) nonprofit (EIN: 81-2908499).
   </p>
 </div>


### PR DESCRIPTION
I removed the extra "the" in the sentence. **Is there a legal reason for including that extra "the"?**

> <%= @event_name %> is fiscally sponsored by Hack Club Bank, a project by `the` The Hack Foundation (d.b.a Hack Club), a 501(c)(3) nonprofit (EIN: 81-2908499).

TO

> <%= @event_name %> is fiscally sponsored by Hack Club Bank, a project by The Hack Foundation (d.b.a Hack Club), a 501(c)(3) nonprofit (EIN: 81-2908499).`

---
https://bank.hackclub.com/branding