### PR TITLE
Removed fluff and shows only active applications

### DIFF
--- a/app/controllers/g_suites_controller.rb
+++ b/app/controllers/g_suites_controller.rb
@@ -3,7 +3,7 @@ class GSuitesController < ApplicationController
 
   # GET /g_suites
   def index
-    @g_suites = GSuite.all.includes(:event).order(created_at: :desc)
+    @g_suites = GSuite.all.includes(:event).where('deleted_at is null and aasm_state in (?)', ['creating', 'verifying'])
     authorize @g_suites
   end
 


### PR DESCRIPTION
Closes #1165 

All of the other daily tasks work by showing only actionable data. For example if you click pending disbursements it will remain blank until a new disburement requests pops up. GSuite should be no different if you need to make changes in reality you should be going to the information setting http://bank.hackclub.com/g_suite_accounts

The daily tasks was never meant to be a source of information but a source of what needs to be done for the day. Once those tasks are completed they shouldn't even show up. If you need to access them at a later date you go to http://bank.hackclub.com/g_suite_accounts