### PR TITLE
Remove No Card Support Message

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -91,8 +91,7 @@
   <button
     type="button"
     <%= organizer_signed_in? ? 'data-behavior=menu_toggle aria-expanded=false tabindex=0' : 'disabled=disabled' %>
-    class="btn bg-info menu__toggle overflow-visible tooltipped tooltipped--n"
-    aria-label="Export currently only processes bank transactions—let the Bank team know if you want card transactions.">
+    class="btn bg-info menu__toggle overflow-visible tooltipped tooltipped--n">
       <%= inline_icon 'download', size: 16 %>
       Export
       <% if organizer_signed_in? %>


### PR DESCRIPTION
I'm fairly sure that it now exports card transactions, at least when I tried it out it did :)

best, 

sam