### PR TITLE
Default has_fiscal_sponsorship_document to false on event creation

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -339,7 +339,7 @@ class Event < ApplicationRecord
   end
 
   def default_values
-    self.has_fiscal_sponsorship_document ||= true
+    self.has_fiscal_sponsorship_document ||= false
   end
 
   def point_of_contact_is_admin


### PR DESCRIPTION
I believe by default, an event shouldn't have a fiscal sponsorship document. `has_fiscal_sponsorship_document` should only be true when they have signed the contract and are moved off the spend-only plan.

Can anyone confirm?