### PR TITLE
Remove team invite form in transparency mode

### DIFF
--- a/app/views/events/team.html.erb
+++ b/app/views/events/team.html.erb
@@ -36,7 +36,11 @@
 <% end %>
 
 <h2 class="mt3">Invite a team member</h2>
-<%= render 'form_invite', invite: OrganizerPositionInvite.new %>
+<% if organizer_signed_in? %>
+  <%= render 'form_invite', invite: OrganizerPositionInvite.new %>
+<% else %>
+  <p>Disabled in transparency mode</p>
+<% end %>
 
 <% if @pending.any? %>
   <h2 class="flex items-center mt3 mb0">


### PR DESCRIPTION

<img width="528" alt="Screen Shot 2021-03-24 at 18 23 57" src="https://user-images.githubusercontent.com/5891442/112391326-1ba6cd00-8cce-11eb-8a4f-db3c40843f43.png">
This confused a user https://hackclub.slack.com/archives/CN523HLKW/p1616624020107800