### PR TITLE
Remove donation payout datetime

### DIFF
--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -72,7 +72,6 @@
       <strong>Paid at</strong>
       <%= donation_paid_at %>
     </p>
-    <%= donation_payout_datetime %>
   </section>
   <% if @donation.payout %>
     <section class="pt2 pb2 details">


### PR DESCRIPTION
Removing to remove confusion to the user. pending transactions replace this.