### PR TITLE
Add buildpacks that are used in heroku prod

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,6 +43,21 @@
   "addons": ["heroku-postgresql", "heroku-redis"],
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-google-chrome"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-chromedriver"
+    },
+    {
+      "url": "https://github.com/dscout/wkhtmltopdf-buildpack.git"
+    },
+    {
+      "url": "https://github.com/evantahler/heroku-buildpack-notify-slack-deploy.git"
+    },
+    {
       "url": "heroku/nodejs"
     },
     {


### PR DESCRIPTION
They will be used in review dynos (such as for generating pdfs with `wkhtmltopdf`)