### PR TITLE
Prevent invite being created without an event first existing

### DIFF
--- a/app/mailers/organizer_position_invites_mailer.rb
+++ b/app/mailers/organizer_position_invites_mailer.rb
@@ -2,7 +2,6 @@ class OrganizerPositionInvitesMailer < ApplicationMailer
   def notify
     @invite = params[:invite]
 
-    mail to: @invite.email,
-      subject: "You've been invited to join #{@invite.event.name} on Hack Club Bank 🚀"
+    mail to: @invite.email, subject: "You've been invited to join #{@invite.event.name} on Hack Club Bank 🚀"
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -155,8 +155,9 @@ class Event < ApplicationRecord
     ActiveRecord::Base.transaction do
       # most common POC will be the POC for this event
       point_of_contact_id = Event.all.pluck(:point_of_contact_id).max_by {|i| Event.all.count(i) }
+      sender = User.find_by_id(point_of_contact_id)
 
-      event = Event.create(
+      event = Event.create!(
         name: event_name,
         start: Date.current,
         end: Date.current,
@@ -168,11 +169,9 @@ class Event < ApplicationRecord
         is_spend_only: true,
       )
 
-      sender = User.find_by_id point_of_contact_id
-
       user_emails ||= []
       user_emails.each do |email|
-        OrganizerPositionInvite.create(
+        OrganizerPositionInvite.create!(
           sender: sender,
           event: event,
           email: email


### PR DESCRIPTION
There are 8 organizer invitations missing the event id. This should be impossible given the model. Not yet sure how they made it into this state. This PR is a start toward solving that.