### PR TITLE
Add required `yarn install` to setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Run bundler
 bundle install
 ```
 
+Install yarn dependencies
+
+```bash
+yarn install
+```
+
 Create and migrate database
 
 ```bash


### PR DESCRIPTION
I had to do this when setting up the app locally on my machine.