### PR TITLE
Filter state on events list

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -110,18 +110,27 @@ class AdminController < ApplicationController
     @page = params[:page] || 1
     @per = params[:per] || 100
     @q = params[:q].present? ? params[:q] : nil
-    @pending = params[:pending] == "1" ? true : nil
+    @pending = params[:pending] == "0" ? nil : true # checked by default
+    @unapproved = params[:unapproved] == "0" ? nil : true # checked by default
+    @approved = params[:approved] == "0" ? nil : true # checked by default
     @transparent = params[:transparent] == "1" ? true : nil
     @omitted = params[:omitted] == "1" ? true : nil
-    @hidden = params[:hidden] == "1" ? true : nil
+    @hidden = params[:hidden].present? ? params[:hidden] : nil
 
     relation = Event
 
     relation = relation.search_name(@q) if @q
-    relation = relation.pending if @pending
     relation = relation.transparent if @transparent
     relation = relation.omitted if @omitted
-    relation = relation.hidden if @hidden
+    relation = relation.hidden if @hidden == 'hidden'
+    relation = relation.not_hidden if @hidden == 'not_hidden'
+
+    states = [];
+    states << 'pending' if @pending
+    states << 'unapproved' if @unapproved
+    states << 'approved' if @approved
+    relation = relation.where('aasm_state in (?)', states)
+
 
     @count = relation.count
 

--- a/app/views/admin/events.html.erb
+++ b/app/views/admin/events.html.erb
@@ -6,10 +6,23 @@
 
 <%= form_with local: true, url: events_admin_index_path, method: :get do |form| %>
   <%= form.text_field :q, value: params[:q] %>
-  <%= form.label :pending do %>
-    <%= form.check_box :pending, checked: @pending %>
-    Pending
-  <% end %>
+  <div style='display: inline; border: 1px lightgray solid; border-radius: 0.2rem; padding: 0.2rem; margin-right: 0.5rem;'>
+    State: |
+    <%= form.label :pending do %>
+      <%= form.check_box :pending, checked: @pending %>
+      Pending
+    <% end %>
+    |
+    <%= form.label :unapproved do %>
+      <%= form.check_box :unapproved, checked: @unapproved %>
+      Unapproved
+    <% end %>
+    |
+    <%= form.label :approved do %>
+      <%= form.check_box :approved, checked: @approved %>
+      Approved
+    <% end %>
+  </div>
   |
   <%= form.label :transparent do %>
     <%= form.check_box :transparent, checked: @transparent %>
@@ -22,8 +35,8 @@
   <% end %>
   |
   <%= form.label :hidden do %>
-    <%= form.check_box :hidden, checked: @hidden %>
     Hidden
+    <%= form.select :hidden, [["Not Hidden", 'not_hidden'], ['Hidden', 'hidden'], ['Both', 'both']], :selected => @hidden %>
   <% end %>
   |
 


### PR DESCRIPTION
#1538

![image]()

The yellow row background that indicates needing ops action is messed up because it runs on `has_fiscal_sponsorship_document`. fixed in https://github.com/hackclub/bank/commit/1a62c723aa574432111f3d76bfd78c6e8ee9ab8a.