### PR TITLE
Add external boolean to Partners table

### DIFF
--- a/db/migrate/20210607030039_add_external_to_partners.rb
+++ b/db/migrate/20210607030039_add_external_to_partners.rb
@@ -1,0 +1,5 @@
+class AddExternalToPartners < ActiveRecord::Migration[6.0]
+  def change
+    add_column :partners, :external, :boolean, null: false, default: true
+  end
+end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe Partner, type: :model do
   it "is valid" do
     expect(partner).to be_valid
   end
+
+  it "defaults to external" do
+    expect(partner).to be_external
+  end
 end


### PR DESCRIPTION
closes #1676

run after merging
```ruby
p = Partner.where(slug: 'bank').first
p.external = false
p.save!
```