### PR TITLE
Add partner name to event show + remove v1 tx link

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,14 +11,10 @@
       #<%= @event.id %>
       </span>
     <% end %>
-    
+
     <% admin_tools('p0 badge', 'span') do %>
       <span class="m0 badge bg-muted">
-        <% if params[:v1] %>
-          <%= link_to "view v2", url_for(only_path: false, v2: true), class: "white" %>
-        <% else %>
-          <%= link_to "view v1", url_for(only_path: false, v1: true), class: "white" %>
-        <% end %>
+        <%= @event.partner.slug.capitalize %>
       </span>
     <% end %>
   <% end %>


### PR DESCRIPTION
I left the controller logic for showing v1 engine transactions in case anyone still happens to need it later