### PR TITLE
Configure Event deliver webhook retry

### DIFF
--- a/app/jobs/event_job/deliver_webhook.rb
+++ b/app/jobs/event_job/deliver_webhook.rb
@@ -2,8 +2,19 @@
 
 module EventJob
   class DeliverWebhook < ApplicationJob
+    WebhookFailed = Class.new(StandardError)
+
+    retry_on WebhookFailed, wait: :exponentially_longer, attempts: 18
+    # exponentially_longer uses this algorithm to determine the wait between retries: (attempts ^ 4) + 2
+    # 16 attempts will take roughly 3 days to complete (following Stripe: https://stripe.com/docs/webhooks/best-practices#retry-logic)
+    # ∑((n^4)+2) from n=1 to n=16 equals 243880 seconds which is 2.8 days
+
     def perform(event_id)
-      ::EventService::DeliverWebhook.new(event_id: event_id).run
+      begin
+        ::EventService::DeliverWebhook.new(event_id: event_id).run # raises ArgumentError on failure
+      rescue
+        raise WebhookFailed
+      end
     end
   end
 end


### PR DESCRIPTION
A total of 16 attempts over a span of 3 days with an exponential back off

#1675