### PR TITLE
Fixes donation amount

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -203,8 +203,10 @@ class EventsController < ApplicationController
     relation = @event.donations.not_pending
 
     @stats = {
-      deposited: relation.deposited.sum(:amount),
-      in_transit: relation.in_transit.sum(:amount),
+      # Amount we already deposited + partial amount that was deposit for in transit transactions
+      deposited: relation.deposited.sum(:amount) + relation.in_transit.sum(&:amount_settled),
+      # Amount in transit minus the amount that is already settled
+      in_transit: relation.in_transit.sum(:amount) - relation.in_transit.sum(&:amount_settled),
       refunded: relation.refunded.sum(:amount)
     }
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -178,9 +178,9 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def fee_reimbursement
-    return linked_object.fee_reimbursement if linked_object.is_a?(Donation)
+    return linked_object.fee_reimbursement if linked_object.is_a?(Donation) || linked_object.is_a?(Invoice)
 
-    nil # TODO
+    nil
   end
 
   def check

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -178,6 +178,8 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def fee_reimbursement
+    return linked_object.fee_reimbursement if linked_object.is_a?(Donation)
+
     nil # TODO
   end
 

--- a/app/models/canonical_transaction_grouped.rb
+++ b/app/models/canonical_transaction_grouped.rb
@@ -40,7 +40,7 @@ class CanonicalTransactionGrouped
     ct.fee_reimbursement
   end
 
-  def fee_reimbursement_completed?
+  def fee_reimbursed?
     ct.fee_reimbursement.completed?
   end
 
@@ -86,16 +86,16 @@ class CanonicalTransactionGrouped
 
   private
 
-  def donation
-    Donation.find(hcb_i2)
-  end
-
   def invoice
     Invoice.find(hcb_i2)
   end
 
   def invoice_memo
     smartish_custom_memo || "INVOICE TO #{invoice.smart_memo}"
+  end
+
+  def donation
+    Donation.find(hcb_i2)
   end
 
   def donation_memo

--- a/app/models/canonical_transaction_grouped.rb
+++ b/app/models/canonical_transaction_grouped.rb
@@ -36,6 +36,14 @@ class CanonicalTransactionGrouped
     ct.fee_payment?
   end
 
+  def fee_reimbursement?
+    ct.fee_reimbursement
+  end
+
+  def fee_reimbursement_completed?
+    ct.fee_reimbursement.completed?
+  end
+
   def raw_stripe_transaction
     ct.raw_stripe_transaction
   end
@@ -76,11 +84,11 @@ class CanonicalTransactionGrouped
     @local_hcb_code ||= HcbCode.find_or_create_by(hcb_code: hcb_code)
   end
 
+  private
+
   def donation
     Donation.find(hcb_i2)
   end
-
-  private
 
   def invoice
     Invoice.find(hcb_i2)
@@ -89,7 +97,6 @@ class CanonicalTransactionGrouped
   def invoice_memo
     smartish_custom_memo || "INVOICE TO #{invoice.smart_memo}"
   end
-
 
   def donation_memo
     smartish_custom_memo || "DONATION FROM #{donation.smart_memo}"

--- a/app/models/canonical_transaction_grouped.rb
+++ b/app/models/canonical_transaction_grouped.rb
@@ -76,6 +76,10 @@ class CanonicalTransactionGrouped
     @local_hcb_code ||= HcbCode.find_or_create_by(hcb_code: hcb_code)
   end
 
+  def donation
+    Donation.find(hcb_i2)
+  end
+
   private
 
   def invoice
@@ -86,9 +90,6 @@ class CanonicalTransactionGrouped
     smartish_custom_memo || "INVOICE TO #{invoice.smart_memo}"
   end
 
-  def donation
-    Donation.find(hcb_i2)
-  end
 
   def donation_memo
     smartish_custom_memo || "DONATION FROM #{donation.smart_memo}"

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -194,7 +194,7 @@ class Donation < ApplicationRecord
   end
 
   def fee_reimbursed?
-    amount_settled == amount
+    fee_reimbursement.canonical_transaction.present?
   end
 
   private

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -189,6 +189,14 @@ class Donation < ApplicationRecord
     remote_donation[:charges][:data][0][:refunded]
   end
 
+  def amount_settled
+    canonical_transactions.sum(:amount_cents)
+  end
+
+  def fee_reimbursed?
+    amount_settled == amount
+  end
+
   private
 
   def raw_pending_donation_transaction

--- a/app/models/fee_reimbursement.rb
+++ b/app/models/fee_reimbursement.rb
@@ -26,7 +26,7 @@ class FeeReimbursement < ApplicationRecord
   end
 
   def completed?
-    !t_transaction.nil?
+    canonical_transaction.present?
   end
 
   def status

--- a/app/services/donation_service/nightly.rb
+++ b/app/services/donation_service/nightly.rb
@@ -8,6 +8,7 @@ module DonationService
 
         next unless cpt
         next unless cpt.settled?
+        next unless donation.fee_reimbursed?
 
         raise ArgumentError, "anomaly detected when attempting to mark deposited donation #{donation.id}" if anomaly_detected?(donation: donation)
 

--- a/app/services/transaction_engine/syntax_sugar_service/linked_object.rb
+++ b/app/services/transaction_engine/syntax_sugar_service/linked_object.rb
@@ -28,8 +28,13 @@ module TransactionEngine
 
           return likely_bank_fee if outgoing_bank_fee?
 
-          nil
         end
+        hcb_code = HcbCodeService::FindOrCreate.new(hcb_code: @canonical_transaction.hcb_code).run
+        if hcb_code.donation?
+          return hcb_code.donation
+        end
+
+        nil
       end
 
       private

--- a/app/services/transaction_engine/syntax_sugar_service/shared.rb
+++ b/app/services/transaction_engine/syntax_sugar_service/shared.rb
@@ -81,7 +81,7 @@ module TransactionEngine
       end
 
       def donation?
-        memo_upcase.include?(DONATION_MEMO_PART1) || memo_upcase.include?(DONATION_MEMO_PART2)
+        memo_upcase.include?(DONATION_MEMO_PART1) || memo_upcase.include?(DONATION_MEMO_PART2) || (@hcb_code.donation if @hcb_code.present?)
       end
 
       def likely_donation_short_name

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -55,7 +55,11 @@
     <% end %>
   </td>
   <td class="nowrap">
-    <span><%= number_to_currency ct.amount %></span>
+    <%
+      # if it's a donation, we'll look at the donation amount
+      amount = ct.donation? ? ct.donation.amount / 100 : ct.amount
+    %>
+    <span><%= number_to_currency amount %></span>
   </td>
   <td>
     <%= link_to "Details", ct.url if organizer_signed_in? || defined?(force_display_details) %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -55,11 +55,7 @@
     <% end %>
   </td>
   <td class="nowrap">
-    <%
-      # if it's a donation, we'll look at the donation amount
-      amount = ct.donation? ? ct.donation.amount / 100 : ct.amount
-    %>
-    <span><%= number_to_currency amount %></span>
+    <span><%= number_to_currency ct.amount %></span>
   </td>
   <td>
     <%= link_to "Details", ct.url if organizer_signed_in? || defined?(force_display_details) %>


### PR DESCRIPTION
New donations now don't transition to `Deposited` until the fees are reimbursed. This should solve some confusion about the donation page not matching up with the balance.

To test, I went and two transaction states for John and Josh locally to `:in_transit`  then ran 
```
irb(main):044:0> DonationService::Nightly.new.run
```
in irb to make sure that we don't update it to deposited until everything's settled.

I also added some convenience functions in canonical_transaction_grouped and the made the `linked_object` work with Donations created on the TransactionEngineV2
 
![image](https://user-images.githubusercontent.com/8843960/141215838-cd86611d-3227-416f-8f7a-d66cdf753f70.png)
