### PR TITLE
Fixes circular dependency on syntax sugar

### DIFF
--- a/app/services/transaction_engine/syntax_sugar_service/linked_object.rb
+++ b/app/services/transaction_engine/syntax_sugar_service/linked_object.rb
@@ -7,7 +7,6 @@ module TransactionEngine
 
       def initialize(canonical_transaction:)
         @canonical_transaction = canonical_transaction
-        @hcb_code = HcbCodeService::FindOrCreate.new(hcb_code: @canonical_transaction.hcb_code).run
       end
 
       def run
@@ -88,7 +87,6 @@ module TransactionEngine
       end
 
       def likely_donation
-        return @hcb_code.donation if @hcb_code.donation?
         return nil unless event
 
         potential_donation_payouts = event.donation_payouts.where("donation_payouts.statement_descriptor ilike 'DONATE #{likely_donation_short_name}%' and donation_payouts.amount = #{amount_cents}")

--- a/app/services/transaction_engine/syntax_sugar_service/shared.rb
+++ b/app/services/transaction_engine/syntax_sugar_service/shared.rb
@@ -81,7 +81,7 @@ module TransactionEngine
       end
 
       def donation?
-        memo_upcase.include?(DONATION_MEMO_PART1) || memo_upcase.include?(DONATION_MEMO_PART2) || (@hcb_code.donation if @hcb_code.present?)
+        memo_upcase.include?(DONATION_MEMO_PART1) || memo_upcase.include?(DONATION_MEMO_PART2)
       end
 
       def likely_donation_short_name


### PR DESCRIPTION
Fixes this error: 
https://heroku-app97991095.airbrake.io/projects/288439/groups/3142086725441650381?tab=overview

I tested it by running:
`::TransactionGroupingEngine::Nightly.new(start_date: '2021-10-01').run` before and after my change locally to make sure that it does the exception is gone.