### PR TITLE
Makes phone number input return E.164 standard

### DIFF
--- a/app/assets/javascripts/phone_input.js
+++ b/app/assets/javascripts/phone_input.js
@@ -1,0 +1,11 @@
+const phoneInputField = document.querySelector("#phone_raw");
+const phoneInput = window.intlTelInput(phoneInputField, {
+    initialCountry: 'us',
+    utilsScript:
+        "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js",
+});
+
+function onSubmit() {
+    document.getElementById('phone_number').value = phoneInput.getNumber();
+    return true;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true, presence: true
   validates :phone_number, phone: { allow_blank: true }
+
   validate :profile_picture_format
 
   # admin? takes into account an admin user's preference

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -20,7 +20,7 @@
   <p>Complete your profile to get started.</p>
 <% end %>
 
-<%= form_with(model: @user, local: true) do |form| %>
+<%= form_with(model: @user, local: true, html:{ onsubmit: 'onSubmit()'}) do |form| %>
   <%= form_errors @user, 'user information' %>
 
   <div class="field">
@@ -30,7 +30,8 @@
 
   <div class="field">
     <%= form.label :phone_number, 'Mobile phone number (so we can contact you on short notice)' %>
-    <%= form.text_field :phone_number, required: true, placeholder: '555-555-5555' %>
+    <%= form.hidden_field :phone_number, required: true, placeholder: '555-555-5555', id: 'phone_number' %>
+    <input type="tel" id="phone_raw" value="<%= @user.phone_number || nil %>">
   </div>
 
   <div class="field">
@@ -89,4 +90,18 @@
     <%= form.submit @user.full_name.present? ? 'Save profile' : 'Start using Bank' %>
   </div>
 <% end %>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.13/js/intlTelInput.min.js" integrity="sha512-QMUqEPmhXq1f3DnAVdXvu40C8nbTgxvBGvNruP6RFacy3zWKbNTmx7rdQVVM2gkd2auCWhlPYtcW2tHwzso4SA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.13/css/intlTelInput.css" integrity="sha512-gxWow8Mo6q6pLa1XH/CcH8JyiSDEtiwJV78E+D+QP0EVasFs8wKXq16G8CLD4CJ2SnonHr4Lm/yY2fSI2+cbmw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script>
+      const phoneInputField = document.querySelector("#phone_raw");
+      const phoneInput = window.intlTelInput(phoneInputField, {
+          initialCountry: 'us',
+          utilsScript:
+              "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js",
+      });
+      function onSubmit() {
+          document.getElementById('phone_number').value = phoneInput.getNumber();
+          return true;
+      }
+  </script>
 </section>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -92,16 +92,5 @@
 <% end %>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.13/js/intlTelInput.min.js" integrity="sha512-QMUqEPmhXq1f3DnAVdXvu40C8nbTgxvBGvNruP6RFacy3zWKbNTmx7rdQVVM2gkd2auCWhlPYtcW2tHwzso4SA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.13/css/intlTelInput.css" integrity="sha512-gxWow8Mo6q6pLa1XH/CcH8JyiSDEtiwJV78E+D+QP0EVasFs8wKXq16G8CLD4CJ2SnonHr4Lm/yY2fSI2+cbmw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <script>
-      const phoneInputField = document.querySelector("#phone_raw");
-      const phoneInput = window.intlTelInput(phoneInputField, {
-          initialCountry: 'us',
-          utilsScript:
-              "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js",
-      });
-      function onSubmit() {
-          document.getElementById('phone_number').value = phoneInput.getNumber();
-          return true;
-      }
-  </script>
+  <%= javascript_include_tag "phone_input.js" %>
 </section>


### PR DESCRIPTION
As a pre-requisite of the phone SMS login codes, I'm cleaning up the settings page with a better phone input. 

This will allow us to record full E.164 numbers, e.g.  + (206)-123-4678 instead of just free form phone numbers. This is the format that Twilio requires.

I tested that onboarding and re-editing the page works
