### PR TITLE
[ActiveStorage] Disallow S3 access unless in production

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,9 +6,11 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+<% if Rails.env.production? %>
 amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
   region: <%= Rails.application.credentials.dig(:aws, :region) %>
   bucket: <%= Rails.application.credentials.dig(:aws, :bucket) %>
+<% end %>


### PR DESCRIPTION
Previously, when running HCB in Rails development but using production credentials, there was a possibility of interacting with production's S3 bucket (e.g. deleting images).

Rails [recommends using `Rails.env` in the bucket name](https://guides.rubyonrails.org/active_storage_overview.html#replacing-vs-adding-attachments:~:text=It%20is%20recommended%20to%20use%20Rails.env%20in%20the%20bucket%20names%20to%20further%20reduce%20the%20risk%20of%20accidentally%20destroying%20production%20data.), however, it's too late for us to do that.

_still needs to be tested_