### PR TITLE
Create `Event#pending_reimbursements_balance` and use it in `balance_available_v2_cents`

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -505,13 +505,17 @@ class Event < ApplicationRecord
     cpt.sum(:amount_cents)
   end
 
+  def pending_reimbursements_balance
+    Reimbursement::Expense.where(report: reimbursement_reports.reimbursement_requested).approved.sum(:amount_cents)
+  end
+
   def balance_available_v2_cents
     @balance_available_v2_cents ||= begin
       fee_balance = can_front_balance? ? fronted_fee_balance_v2_cents : fee_balance_v2_cents
       if fee_balance.positive?
-        balance_v2_cents - fee_balance
+        balance_v2_cents - fee_balance - pending_reimbursements_balance
       else # `fee_balance` is negative, indicating a fee credit
-        balance_v2_cents
+        balance_v2_cents - pending_reimbursements_balance
       end
     end
   end

--- a/app/views/events/_pending_reimbursements_transaction.html.erb
+++ b/app/views/events/_pending_reimbursements_transaction.html.erb
@@ -1,0 +1,17 @@
+<tr class="transaction <%= "transaction--negative" unless current_user && Flipper.enabled?(:transactions_background_2024_06_05, current_user) %> muted">
+  <td class="transaction__icon transaction__fee_icon tooltipped tooltipped--e" aria-label="Fiscal sponsorship fee">
+    <%= inline_icon "attachment" %>
+  </td>
+  <td><%= format_date Time.now %></td>
+  <td class="transaction__memo">
+    <span class="badge bg-transparent border border-dashed border-muted m0 mr1 bg-muted">Pending</span>
+    <%= link_to "Reimbursements", event_reimbursements_path(@event), class: "no-underline hover:underline", data: { turbo_frame: "_top" } %>
+  </td>
+  <td class="nowrap text-right">
+    <%= render_transaction_amount(-1 * @event.pending_reimbursements_balance) %>
+  </td>
+  <% if @show_running_balance %>
+    <td></td>
+  <% end %>
+  <td><%# user avatar %></td>
+</tr>

--- a/app/views/events/ledger.html.erb
+++ b/app/views/events/ledger.html.erb
@@ -18,6 +18,7 @@
         </thead>
         <tbody data-behavior="transactions">
         <%= render "pending_fee_transaction" if @event.fronted_fee_balance_v2_cents > 0 %>
+        <%= render "pending_reimbursements_transaction" if @event.pending_reimbursements_balance > 0 %>
 
         <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0, show_author_column: true } %>
 


### PR DESCRIPTION
<img width="1088" alt="Screenshot 2025-02-26 at 7 04 59 PM" src="https://github.com/user-attachments/assets/83ad9e76-4f5b-4cae-aa06-7cc211476a0f" />
