### PR TITLE
@Luke-Oldenburg Standardize transaction title bar

### DIFF
--- a/app/views/hcb_codes/_ach_transfer.html.erb
+++ b/app/views/hcb_codes/_ach_transfer.html.erb
@@ -18,11 +18,16 @@
               data-action="dblclick->navigation#navigate"
               data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
               data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
-
           <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @hcb_code.ach_transfer.amount %></span>
         </span>
+
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
       <% end %>
     </span>
     <span class="badge h4 md-right ml0 bg-<%= @hcb_code.ach_transfer.state %> nowrap">

--- a/app/views/hcb_codes/_ach_transfer.html.erb
+++ b/app/views/hcb_codes/_ach_transfer.html.erb
@@ -7,9 +7,23 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 1ch">
     <span style="flex-grow: 1">
-      <span class="regular muted"><%= @hcb_code.ach_transfer.deposited? ? "Transferred " : "Transferring " %> </span>
-      <%= @hcb_code.ach_transfer.recipient_name %>
-      <span class="regular"><%= render_money @hcb_code.ach_transfer.amount %></span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @hcb_code.ach_transfer.amount %></span>
+        </span>
+      <% end %>
     </span>
     <span class="badge h4 md-right ml0 bg-<%= @hcb_code.ach_transfer.state %> nowrap">
       <%= @hcb_code.ach_transfer.status_text %>

--- a/app/views/hcb_codes/_check.html.erb
+++ b/app/views/hcb_codes/_check.html.erb
@@ -12,10 +12,27 @@
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 8px">
     <div class="flex items-start" style="flex-grow: 1">
       <span class="flex-auto mr1">
-        <span class="regular muted"><%= @hcb_code.check.deposited? ? "Sent" : "Sending" %> </span>
-        <%= @hcb_code.check.lob_address.name %>
-        <span class="regular muted"> a&nbsp;check for </span>
-        <span class="regular"><%= render_money @hcb_code.check.amount %></span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @hcb_code.check.amount %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
       </span>
       <span class="badge h4 ml2 nowrap bg-<%= @hcb_code.check.state %>">
         <%= @hcb_code.check.status_text %>

--- a/app/views/hcb_codes/_check.html.erb
+++ b/app/views/hcb_codes/_check.html.erb
@@ -17,16 +17,17 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
               data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
               data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
-
           <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @hcb_code.check.amount %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 
         <span style="flex-grow: 1;"></span>

--- a/app/views/hcb_codes/_check_deposit.html.erb
+++ b/app/views/hcb_codes/_check_deposit.html.erb
@@ -28,11 +28,26 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between gap-4">
     <span class="grow">
-      Check deposit
-      <span class="regular muted">
-        of
-      </span>
-      <span class="regular"><%= render_money @hcb_code.check_deposit.amount_cents %></span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @hcb_code.check_deposit.amount_cents %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
     </span>
     <%= render "check_deposits/status", check_deposit: @hcb_code.check_deposit %>
     <%= render partial: "hcb_codes/meatballs", locals: { hcb_code: @hcb_code } %>

--- a/app/views/hcb_codes/_check_deposit.html.erb
+++ b/app/views/hcb_codes/_check_deposit.html.erb
@@ -33,6 +33,7 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
@@ -42,6 +43,7 @@
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @hcb_code.check_deposit.amount_cents %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 
         <span style="flex-grow: 1;"></span>

--- a/app/views/hcb_codes/_disbursement.html.erb
+++ b/app/views/hcb_codes/_disbursement.html.erb
@@ -7,19 +7,26 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 8px">
     <span style="flex-grow: 1">
-      <%= @source.name %>
-      <span class="regular muted">
-        <% if @hcb_code.disbursement.fulfilled? || (@destination.can_front_balance? && (@hcb_code.disbursement.processed? || @hcb_code.disbursement.pending?)) %>
-          transferred
-        <% elsif @hcb_code.disbursement.processed? || @hcb_code.disbursement.pending? %>
-          transferring
-        <% else %>
-          transfer of
-        <% end %>
-      </span>
-      <span class="regular"><%= render_money @hcb_code.disbursement.amount %></span>
-      <span class="regular muted">to</span>
-      <%= @destination.name %>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @hcb_code.disbursement.amount %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
     </span>
     <span class="badge h4 md-right ml0 bg-<%= @hcb_code.disbursement.state %>">
       <%= @hcb_code.disbursement.state_text.humanize %>

--- a/app/views/hcb_codes/_disbursement.html.erb
+++ b/app/views/hcb_codes/_disbursement.html.erb
@@ -12,6 +12,7 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
@@ -21,6 +22,7 @@
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @hcb_code.disbursement.amount %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 
         <span style="flex-grow: 1;"></span>

--- a/app/views/hcb_codes/_donation.html.erb
+++ b/app/views/hcb_codes/_donation.html.erb
@@ -36,17 +36,25 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 8px">
     <span style="flex-grow: 1">
-      <%= @donation.name(show_anonymous: organizer_signed_in?) %>
-      <% if @donation.anonymous? %>
-        <div class="line-height-0 mx-1 tooltipped tooltipped--s inline align-bottom" style="margin: 0 2px;" aria-label="Anonymous donor"><%= inline_icon "private-fill", size: 24, class: "muted" %></div>
-      <% end %>
-      <% if @donation.in_person? %>
-        <div class="line-height-0 mx-1 tooltipped tooltipped--s inline align-bottom" style="margin: 0 2px;" aria-label="In-person donor"><%= inline_icon "card", size: 24, class: "muted" %></div>
-      <% end %>
-      <span class="regular muted"> donated </span>
-      <span class="regular"><%= render_money @donation.amount_received %></span>
-      <% if @donation.refunded? %>
-        <span class="regular muted">and was later refunded</span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @donation.amount_received %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
       <% end %>
     </span>
 

--- a/app/views/hcb_codes/_donation.html.erb
+++ b/app/views/hcb_codes/_donation.html.erb
@@ -41,6 +41,7 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
@@ -50,6 +51,7 @@
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @donation.amount_received %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 
         <span style="flex-grow: 1;"></span>

--- a/app/views/hcb_codes/_increase_check.html.erb
+++ b/app/views/hcb_codes/_increase_check.html.erb
@@ -22,10 +22,28 @@
   <h2 class="h2 mt0 border-none">
     <div class="flex items-center justify-between" style="gap: 8px">
       <span class="flex-auto mr1">
-        <span class="regular muted"><%= @hcb_code.increase_check.sent? ? "Sent" : "Sending" %></span>
-        <%= @hcb_code.increase_check.recipient_name %>
-        <span class="regular muted"> a&nbsp;check for </span>
-        <span class="regular"><%= render_money @hcb_code.increase_check.amount %></span>
+        <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+          <%= pop_icon_to "edit",
+              edit_hcb_code_path(@hcb_code),
+              class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+              data: { turbo: true } %>
+          <span class="align-middle"
+                data-controller="navigation"
+                data-action="dblclick->navigation#navigate"
+                data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+                data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+
+            <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.increase_check.memo %></span>
+            <span class="regular muted"> for </span>
+            <%= render_money @hcb_code.increase_check.amount %>
+          </span>
+
+          <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+          <span style="flex-grow: 1;"></span>
+
+          <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+        <% end %>
       </span>
       <span class="badge h4 ml2 nowrap bg-<%= @hcb_code.increase_check.state %>">
         <%= @hcb_code.increase_check.state_text %>

--- a/app/views/hcb_codes/_increase_check.html.erb
+++ b/app/views/hcb_codes/_increase_check.html.erb
@@ -27,15 +27,15 @@
               edit_hcb_code_path(@hcb_code),
               class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
               data: { turbo: true } %>
+
           <span class="align-middle"
                 data-controller="navigation"
                 data-action="dblclick->navigation#navigate"
                 data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
                 data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
-
-            <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.increase_check.memo %></span>
+            <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
             <span class="regular muted"> for </span>
-            <%= render_money @hcb_code.increase_check.amount %>
+            <span class="regular"><%= render_money @hcb_code.increase_check.amount %></span>
           </span>
 
           <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>

--- a/app/views/hcb_codes/_invoice.html.erb
+++ b/app/views/hcb_codes/_invoice.html.erb
@@ -47,9 +47,24 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 mx0 border-none flex items-center justify-between" style="gap: 8px">
     <span style="flex-grow: 1">
-      <%= @sponsor.name %>
-      <span class="regular muted"> invoiced for </span>
-      <span class="regular"><%= render_money @invoice.item_amount %></span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= render_money @invoice.item_amount %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+        <span style="flex-grow: 1;"></span>
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
     </span>
 
     <span class="md-right">

--- a/app/views/hcb_codes/_invoice.html.erb
+++ b/app/views/hcb_codes/_invoice.html.erb
@@ -52,6 +52,7 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
@@ -61,8 +62,11 @@
           <span class="regular muted"> for </span>
           <span class="regular"><%= render_money @invoice.item_amount %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
         <span style="flex-grow: 1;"></span>
+
         <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
       <% end %>
     </span>

--- a/app/views/hcb_codes/_paypal_transfer.html.erb
+++ b/app/views/hcb_codes/_paypal_transfer.html.erb
@@ -1,10 +1,28 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 1ch">
     <span style="flex-grow: 1">
-      <span class="regular muted"><%= @hcb_code.paypal_transfer.deposited? ? "Transferred " : "Transferring " %> </span>
-      <%= @hcb_code.paypal_transfer.recipient_name %>
-      <span class="regular"><%= render_money @hcb_code.amount.abs %></span>
-      <span class="regular muted">via PayPal</span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.paypal_transfer.memo %></span>
+          <span class="regular muted"> for </span>
+          <%= render_money @hcb_code.amount.abs %>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
     </span>
     <span class="badge h4 md-right ml0 bg-<%= @hcb_code.paypal_transfer.state %> nowrap">
       <%= @hcb_code.paypal_transfer.state_text %>

--- a/app/views/hcb_codes/_paypal_transfer.html.erb
+++ b/app/views/hcb_codes/_paypal_transfer.html.erb
@@ -12,10 +12,9 @@
               data-action="dblclick->navigation#navigate"
               data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
               data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
-
-          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.paypal_transfer.memo %></span>
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
           <span class="regular muted"> for </span>
-          <%= render_money @hcb_code.amount.abs %>
+          <span class="regular"><%= render_money @hcb_code.amount.abs %></span>
         </span>
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 

--- a/app/views/hcb_codes/_stripe_card.html.erb
+++ b/app/views/hcb_codes/_stripe_card.html.erb
@@ -34,7 +34,7 @@
               data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
           <% if @hcb_code.stripe_cash_withdrawal? && @hcb_code.custom_memo.nil? %>
             <span>
-              <%= render_money(renderable_amount_cents) %>
+              <span class="regular"><%= render_money(renderable_amount_cents) %></span>
             </span>
             <span class="regular muted">
               withdrawal from
@@ -43,7 +43,7 @@
           <% else %>
             <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
             <span class="regular muted"> <%= @hcb_code.stripe_refund? ? "refunded" : "for" %> </span>
-            <%= render_money(renderable_amount_cents) %>
+            <span class="regular"><%= render_money(renderable_amount_cents) %></span>
           <% end %>
         </span>
 

--- a/app/views/hcb_codes/_wire.html.erb
+++ b/app/views/hcb_codes/_wire.html.erb
@@ -7,10 +7,26 @@
 <article class="card pb0 mt3 mb1">
   <h2 class="h2 mt0 border-none flex items-center justify-between" style="gap: 1ch">
     <span style="flex-grow: 1">
-      <span class="regular muted"><%= @hcb_code.wire.deposited? ? "Transferred " : "Transferring " %> </span>
-      <%= @hcb_code.wire.recipient_name %>
-      <span class="regular"><%= Money.from_cents(@hcb_code.wire.amount_cents, @hcb_code.wire.currency).format %></span>
-      <span class="regular muted">via a wire</span>
+      <%= turbo_frame_tag @hcb_code, class: "flex items-center" do %>
+        <%= pop_icon_to "edit",
+            edit_hcb_code_path(@hcb_code),
+            class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
+            data: { turbo: true } %>
+        <span class="align-middle"
+              data-controller="navigation"
+              data-action="dblclick->navigation#navigate"
+              data-navigation-location-param="<%= edit_hcb_code_path(@hcb_code) %>"
+              data-navigation-frame-param="<%= dom_id(@hcb_code) %>">
+          <span data-memo-for="<%= dom_id(@hcb_code) %>"><%= @hcb_code.memo %></span>
+          <span class="regular muted"> for </span>
+          <span class="regular"><%= Money.from_cents(@hcb_code.wire.amount_cents, @hcb_code.wire.currency).format %></span>
+        </span>
+        <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
+
+        <span style="flex-grow: 1;"></span>
+
+        <%= render partial: "hcb_codes/ai_memo", locals: { hcb_code: @hcb_code } %>
+      <% end %>
     </span>
     <span class="badge h4 md-right ml0 bg-<%= @hcb_code.wire.state %> nowrap">
       <%= @hcb_code.wire.state_text %>

--- a/app/views/hcb_codes/_wire.html.erb
+++ b/app/views/hcb_codes/_wire.html.erb
@@ -12,6 +12,7 @@
             edit_hcb_code_path(@hcb_code),
             class: "mr2 align-middle tooltipped tooltipped--e", "aria-label": "Rename transaction",
             data: { turbo: true } %>
+
         <span class="align-middle"
               data-controller="navigation"
               data-action="dblclick->navigation#navigate"
@@ -21,6 +22,7 @@
           <span class="regular muted"> for </span>
           <span class="regular"><%= Money.from_cents(@hcb_code.wire.amount_cents, @hcb_code.wire.currency).format %></span>
         </span>
+
         <%= render "hcb_codes/memo_stream", hcb_code: @hcb_code %>
 
         <span style="flex-grow: 1;"></span>


### PR DESCRIPTION
Supersedes https://github.com/hackclub/hcb/pull/9007 due to git rewrite. Original PR owned by @Luke-Oldenburg 

---

## Summary of the problem
Not all transaction types had an edit button and memo in the title bar.



## Describe your changes
I updated the title bar for all other title bars to have an edit button and transaction type. This PR is moreso just a demo of what it looks like. I'm honestly not sure that I like the changes after looking at it. Another idea would be to move the rename button for all charges into the meatball menu and make card charges look like the rest (e.g. "USER made a card charge at MERCHANT for $X.XX" instead of being special and having the edit button and memo as the title unlike the others.

