### PR TITLE
@Luke-Oldenburg [Policy] Let grant cardholders see all card charge info

### DIFF
--- a/app/policies/canonical_pending_transaction_policy.rb
+++ b/app/policies/canonical_pending_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalPendingTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember || record.user == user
+    admin_or_teammember || record.stripe_cardholder.user_id == user.id
   end
 
   def edit?

--- a/app/policies/canonical_pending_transaction_policy.rb
+++ b/app/policies/canonical_pending_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalPendingTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember || record.stripe_cardholder.user_id == user.id
+    admin_or_teammember || record.stripe_cardholder&.user_id == user.id
   end
 
   def edit?

--- a/app/policies/canonical_pending_transaction_policy.rb
+++ b/app/policies/canonical_pending_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalPendingTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember
+    admin_or_teammember || record.user == user
   end
 
   def edit?

--- a/app/policies/canonical_transaction_policy.rb
+++ b/app/policies/canonical_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember || record.user == user
+    admin_or_teammember || record.stripe_cardholder.user_id == user.id
   end
 
   def edit?

--- a/app/policies/canonical_transaction_policy.rb
+++ b/app/policies/canonical_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember || record.stripe_cardholder.user_id == user.id
+    admin_or_teammember || record.stripe_cardholder&.user_id == user.id
   end
 
   def edit?

--- a/app/policies/canonical_transaction_policy.rb
+++ b/app/policies/canonical_transaction_policy.rb
@@ -2,7 +2,7 @@
 
 class CanonicalTransactionPolicy < ApplicationPolicy
   def show?
-    admin_or_teammember
+    admin_or_teammember || record.user == user
   end
 
   def edit?

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -13,7 +13,7 @@ class TransactionPolicy < ApplicationPolicy
   def show?
     # removing is_public check due to https://github.com/hackclub/hcb/issues/675
     # is_public || admin_or_teammember
-    admin_or_teammember || record.user == user
+    admin_or_teammember
   end
 
   def edit?

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -13,7 +13,7 @@ class TransactionPolicy < ApplicationPolicy
   def show?
     # removing is_public check due to https://github.com/hackclub/hcb/issues/675
     # is_public || admin_or_teammember
-    admin_or_teammember
+    admin_or_teammember || record.user == user
   end
 
   def edit?


### PR DESCRIPTION
Supersedes https://github.com/hackclub/hcb/pull/9076 due to git rewrite. Original PR by @Luke-Oldenburg

---

## Summary of the problem
Grant cardholders were unable to see info on charges they made. This was discovered while trying to view receipts on HCB Mobile. The only allowed for admins and organizers but grant card users are just a cardholder and not a member of the organization.



## Describe your changes
I added a check to see if the user from the transaction record was the user being checked for policy.

