### PR TITLE
Removed versions from docker files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build:

--- a/docker-compose.dbonly.yml
+++ b/docker-compose.dbonly.yml
@@ -1,6 +1,5 @@
 # To use this DB-only ("dockerless") setup, pass a `-f docker-compose.dbonly.yml` to docker compose.
 # e.g. `docker compose -f docker-compose.dbonly.yml up`
-version: '3'
 services:
   db:
     image: "postgres:11.16"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: ghcr.io/hackclub/hcb

--- a/docker-compose.solargraph.yml
+++ b/docker-compose.solargraph.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   solargraph:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: "postgres:11.16"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
This is because version has been deprecated from Docker and it automatically takes the latest Docker compose file schema. 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Just removed the 'Versions' - it works the exact same. It just removes the warning when you docker compose.