### PR TITLE
[v4 API][Organization] Support filtering transaction by type

### DIFF
--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -23,6 +23,10 @@ module Api
         @pending_transactions = PendingTransactionEngine::PendingTransaction::All.new(event_id: @event.id).run
         PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions: @pending_transactions, event: @event).run!
 
+        type_results = ::EventsController.filter_transaction_type(params[:type], settled_transactions: @settled_transactions, pending_transactions: @pending_transactions)
+        @settled_transactions = type_results[:settled_transactions]
+        @pending_transactions = type_results[:pending_transactions]
+
         @total_count = @pending_transactions.count + @settled_transactions.count
         @transactions = paginate_transactions(@pending_transactions + @settled_transactions)
       end

--- a/app/views/api/v4/transactions/_donation.json.jbuilder
+++ b/app/views/api/v4/transactions/_donation.json.jbuilder
@@ -14,5 +14,6 @@ json.attribution do
   json.utm_term donation.utm_term
   json.utm_content donation.utm_content
 end
+json.message donation.message
 json.donated_at donation.donated_at
 json.refunded donation.refunded?


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

@zachlatta needs an API for listing an organization's donations with:
- donor's email
- donation amount
- and donation message

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Allow filtering transactions by type. It supports the same `type` filter as the dashboard.

![image](https://github.com/user-attachments/assets/a9ac7fb0-7b8e-49fa-8dbe-cf71c05a6f5d)


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

