### PR TITLE
Load environment variables at the highest level

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require_relative "../app/lib/credentials"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv.load
+Dotenv.load if Rails.env.development?
 
 module Bank
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,8 @@ require_relative "../app/lib/credentials"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv.load
+
 module Bank
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
I moved my Doppler token from `.env` to `.env.development` and this worked.

<img width="214" alt="Screenshot 2025-03-22 at 2 39 56 AM" src="https://github.com/user-attachments/assets/70136d3e-f102-4a8d-9a53-6cfe1edd0e81" />

Closes https://github.com/hackclub/hcb/issues/9934