### PR TITLE
Make `WKHTMLTOPDF_PATH` configurable

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -16,6 +16,7 @@ WickedPdf.configure do |c|
   # c.exe_path = '/usr/local/bin/wkhtmltopdf',
   #   or
   # exe_path = Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf'),
+  c.exe_path = ENV["WKHTMLTOPDF_PATH"] if ENV["WKHTMLTOPDF_PATH"].present?
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

wickedpdf is having a hard time finding the right install of wkhtmltopdf. This is because `wkhtmltopdf-binary` was installed within bundler's gemset, but not used in Gmefile.

I ran `bundle clean` (which removed `wkhtmltopdf-binary`) and restarted the rails server which fixed the issue.
https://github.com/mileszs/wicked_pdf/blob/9b5931faf8067730c08fdf9d68658c197491731f/lib/wicked_pdf/binary.rb#L57

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

To make sure this doesn't happen again, I'm make the path configurable.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

