### PR TITLE
Reorganize links in footer and support button

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -20,9 +20,9 @@
         Build info
       </span>
       •
-      <%= link_to "Security", security_path %>
-      •
-      <%= link_to "API docs", docs_api_index_path %>
     <% end %>
+    <%= link_to "Security", security_path %>
+    •
+    <%= link_to "API docs", docs_api_index_path %>
   </p>
 </footer>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,19 +1,28 @@
-<footer class="[&_*]:transition-colors [&_*]:text-muted/50 [&:hover_*]:text-muted/80 [&_a:hover]:text-muted">
-  <p class="center mt-12">
+<footer class="[&_*]:transition-colors [&_*]:text-muted/50 [&:hover_*]:text-muted/80 [&_a:hover]:text-muted [&_.footer-extras]:transition-opacity [&_.footer-extras]:invisible [&:hover_.footer-extras]:visible py-2 mt-10">
+  <p class="text-center">
     <%= help_message if current_user && local_assigns[:help_message] != false %>
   </p>
 
-  <p class="text-center text-xs">
+  <% unless Rails.env.production? %>
+    <% @sql_count = QueryCount::Counter.counter %>
+    <% @sql_cached_count = QueryCount::Counter.counter_cache %>
+    <p class="text-center text-xs">
+      Loaded using <%= @sql_count %> unique
+      SQL <%= "query".pluralize @sql_count %> (+ <%= @sql_cached_count %>
+      cached). Running on Rails <%= Rails::VERSION::STRING %> with
+      Ruby <%= RUBY_VERSION %>.
+    </p>
+  <% end %>
+
+  <p class="footer-extras text-xs flex justify-center gap-1">
     <% if Build.commit_hash.present? %>
-      Build <em><%= Build.commit_name %></em>
-      <% if Build.age.present? %>
-        from <%= Build.age %> ago.
-      <% end %>
-    <% end %>
-    <% unless Rails.env.production? %>
-      <% @sql_count = QueryCount::Counter.counter %>
-      <% @sql_cached_count = QueryCount::Counter.counter_cache %>
-      Loaded using <%= @sql_count %> unique SQL <%= "query".pluralize @sql_count %> (+ <%= @sql_cached_count %> cached). Running on Rails <%= Rails::VERSION::STRING %> with Ruby <%= RUBY_VERSION %>.
+      <span class="tooltipped tooltipped--n tooltipped--xl underline" aria-label="Build <%= Build.commit_name %><%= " from #{Build.age} ago" if Build.age.present? %>">
+        Build info
+      </span>
+      •
+      <%= link_to "Security", security_path %>
+      •
+      <%= link_to "API docs", docs_api_index_path %>
     <% end %>
   </p>
 </footer>

--- a/app/views/application/_support_button.html.erb
+++ b/app/views/application/_support_button.html.erb
@@ -30,11 +30,5 @@
     <a class="support-menu__item" href="<%= branding_path %>" target="_blank">
       <%= inline_icon "bank-account", size: 24 %> Brand guidelines
     </a>
-    <a class="support-menu__item" href="<%= security_path %>" target="_blank">
-      <%= inline_icon "private-outline", size: 24 %> Security
-    </a>
-    <a class="support-menu__item" href="<%= docs_api_index_path %>" target="_blank">
-      <%= inline_icon "code", size: 24 %> API docs
-    </a>
   </div>
 </div>


### PR DESCRIPTION
## Changes

- Create a "show on hover" section of the footer. This section contains developer/technical-esque information:
	- Build information (commit hash & time since deploy)
	- Link to Security page
	- Link to API docs
- Since the Security and API docs are now linked in the footer, I've removed them from the Support button.

**not hovered**
![image](https://github.com/user-attachments/assets/47e9f51d-a4a8-4a75-b81c-ece2f870261d)

**on hover**
![image](https://github.com/user-attachments/assets/bd9a4f9f-917c-4ebe-913d-ca38b9580b58)
![image](https://github.com/user-attachments/assets/d26a2ed2-12c9-4485-b1e2-52cafb6f0b2e)

**support button**

![image](https://github.com/user-attachments/assets/3bac9ac1-4e53-47af-8f0e-e6a3575d40e4)
