### PR TITLE
Adds Network IDs to the Card Charge Transaction v4 API

### DIFF
--- a/app/views/api/v4/transactions/_card_charge.json.jbuilder
+++ b/app/views/api/v4/transactions/_card_charge.json.jbuilder
@@ -9,6 +9,7 @@ json.merchant do
   json.name merchant_data["name"]
   json.smart_name humanized_merchant_name(merchant_data) rescue nil
   json.country merchant_data["country"]
+  json.network_id merchant_data["network_id"]
 end
 
 json.charge_method stripe_authorization&.dig("authorization_method")


### PR DESCRIPTION
Adds Network IDs to the Card Charge Transaction v4 API

## Summary of the problem
I can't access network IDs from card charges via the v4 API



## Describe your changes
Added another field under merchants called "network_id" to return this



