### PR TITLE
Un-hardcode some SMTP/Email stuff

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -29,3 +29,13 @@ TWILIO__SMS_VERIFY__ACCOUNT_SID="..."
 TWILIO__SMS_VERIFY__AUTH_TOKEN="..."
 
 HELPSCOUT__BEACON_ID="..."
+
+# Will disable letter_opener and enable SMTP
+SMTP__ENABLED=false
+SMTP__USERNAME=hcb
+SMTP__PASSWORD=password123
+# SMTP Server
+SMTP__ADDRESS=smtp.example.com
+# Domain email come from, like hcb.example.com will send email from ...@hcb.example.com
+SMTP__DOMAIN=hcb.example.com 
+SMTP__PORT=2525

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,8 +3,10 @@
 class ApplicationMailer < ActionMailer::Base
   OPERATIONS_EMAIL = "hcb@hackclub.com"
 
-  DOMAIN = Rails.env.production? ? "hackclub.com" : "staging.hcb.hackclub.com"
-  default from: "HCB <hcb@#{DOMAIN}>"
+  DOMAIN = Credentials.fetch(:SMTP, :DOMAIN) || (Rails.env.production? ? "hackclub.com" : "staging.hcb.hackclub.com")
+  USERNAME = Credentials.fetch(:SMTP, :USERNAME) || "hcb"
+
+  default from: "HCB <#{USERNAME}@#{DOMAIN}>"
   layout "mailer/default"
 
   # allow usage of application helper
@@ -20,7 +22,7 @@ class ApplicationMailer < ActionMailer::Base
       name = "HCB"
     end
 
-    email_address_with_name("hcb@hackclub.com", name)
+    email_address_with_name("#{USERNAME}@#{DOMAIN}", name)
   end
 
 end

--- a/config/credentials/development.yml.enc
+++ b/config/credentials/development.yml.enc
@@ -1,1 +1,0 @@
-GxZcLC0/przYcpYa9wTLGIOSSmmrHczJ4jRWZhF0e/Gm6gUpTt8YrCrrtM7A8qPI2Z1WLDxsqXcE+U2Ekw==--2j640khvlDEpHtcy--+s4x3Zm9OTDPkD/38ccf6A==

--- a/config/credentials/development.yml.enc
+++ b/config/credentials/development.yml.enc
@@ -1,0 +1,1 @@
+GxZcLC0/przYcpYa9wTLGIOSSmmrHczJ4jRWZhF0e/Gm6gUpTt8YrCrrtM7A8qPI2Z1WLDxsqXcE+U2Ekw==--2j640khvlDEpHtcy--+s4x3Zm9OTDPkD/38ccf6A==

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
   Rails.application.routes.default_url_options[:host] = Credentials.fetch(:TEST_URL_HOST)
 
   # SMTP config
-  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.delivery_method = Credentials.fetch(:SMTP, :ENABLED) == "true" ? :smtp : :letter_opener_web
 
   # Bullet for finding N+1s
   config.after_initialize do


### PR DESCRIPTION
This PR unhardcodes the selection between letter opener or SMTP on dev, by making some env vars.
- If SMTP__ENABLED is false or not set, it will use letter opener

It also un-harcodes the emails in app/mailers/application_mailer.rb!
- if SMTP__DOMAIN is not set, it falls back to hcb.hackclub.com for prod, and staging.hcb.hackclub.com for dev
- if SMTP__USERNAME is not set, it falls back to "hcb"