### PR TITLE
Fix codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="3.3-bookworm"
+ARG VARIANT="3.4-bookworm"
 FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 # Install Rails
 RUN su vscode -c "gem install rails webdrivers"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	"build": {
 		"args": {
 			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9
-			"VARIANT": "3.3-bookworm",
+			"VARIANT": "3.4-bookworm",
 			"NODE_VERSION": "22"  // Node version installed by nvm (https://github.com/devcontainers/images/tree/main/src/ruby#installing-nodejs)
 		}
 	},


### PR DESCRIPTION
Cause the ruby version was changed to 3.4.2, the codespace no longer works.
Fixed this by changing variant to `3.4-bookworm` in Dockerfile and devcontainer.json