### PR TITLE
Upgrade codespaces Ruby version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT="3.3-bookworm"
+ARG VARIANT="3.4-bookworm"
 FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 # Install Rails
 RUN su vscode -c "gem install rails webdrivers"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	"build": {
 		"args": {
 			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9
-			"VARIANT": "3.3-bookworm",
+			"VARIANT": "3.4.2-bookworm",
 			"NODE_VERSION": "22"  // Node version installed by nvm (https://github.com/devcontainers/images/tree/main/src/ruby#installing-nodejs)
 		}
 	},


### PR DESCRIPTION
This pull request includes updates to the Ruby version used in the development container configuration. The changes involve updating the base image and build arguments to use a newer version of Ruby.

Updates to Ruby version:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R1): Updated the `VARIANT` argument from "3.3-bookworm" to "3.4-bookworm" to use a newer Ruby version.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L22-R22): Updated the `VARIANT` argument from "3.3-bookworm" to "3.4.2-bookworm" to specify the exact newer Ruby version.