### PR TITLE
Added Merchant Info to V3 Card Charge endpoint

### DIFF
--- a/app/api/api/entities/card_charge.rb
+++ b/app/api/api/entities/card_charge.rb
@@ -11,6 +11,23 @@ module Api
           expose :date
         end
 
+        expose :merchant, using: Merchant do |hcb_code|
+          stripe_transaction = hcb_code.ct&.raw_stripe_transaction&.stripe_transaction
+          stripe_authorization = hcb_code.pt&.raw_pending_stripe_transaction&.stripe_transaction
+          merchant_data = (stripe_transaction || stripe_authorization)&.dig("merchant_data")
+
+          {
+            name: merchant_data&.dig("name"),
+            smart_name: begin
+              humanized_merchant_name(merchant_data)
+            rescue StandardError
+              nil
+            end,
+            country: merchant_data&.dig("country"),
+            network_id: merchant_data&.dig("network_id")
+          }
+        end
+
         expose_associated Card, hide: [Card, Organization, User] do |hcb_code, options|
           hcb_code.stripe_card
         end

--- a/app/api/api/entities/merchant.rb
+++ b/app/api/api/entities/merchant.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module Entities
+    class Merchant < Grape::Entity
+      expose :name
+      expose :smart_name
+      expose :country
+      expose :network_id
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

I wasn't able to fetch the info of card charges via the v3 api.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

I added merchant info: name, smart name, country, and network id and made sure the docs reflected it elegantly
