### PR TITLE
 Un-hardcode some SMTP/Email settings

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -29,3 +29,13 @@ TWILIO__SMS_VERIFY__ACCOUNT_SID="..."
 TWILIO__SMS_VERIFY__AUTH_TOKEN="..."
 
 HELPSCOUT__BEACON_ID="..."
+
+# Will disable letter_opener and enable SMTP
+SMTP__ENABLED=false
+SMTP__USERNAME=hcb
+SMTP__PASSWORD=password123
+# SMTP Server
+SMTP__ADDRESS=smtp.example.com
+# Domain email come from, like hcb.example.com will send email from ...@hcb.example.com
+SMTP__DOMAIN=hcb.example.com 
+SMTP__PORT=2525

--- a/.env.development.example
+++ b/.env.development.example
@@ -30,7 +30,7 @@ TWILIO__SMS_VERIFY__AUTH_TOKEN="..."
 
 HELPSCOUT__BEACON_ID="..."
 
-# Will disable letter_opener and enable SMTP
+# Setting to true will disable letter_opener and enable SMTP
 SMTP__ENABLED=false
 SMTP__USERNAME=hcb
 SMTP__PASSWORD=password123

--- a/.env.development.example
+++ b/.env.development.example
@@ -30,12 +30,14 @@ TWILIO__SMS_VERIFY__AUTH_TOKEN="..."
 
 HELPSCOUT__BEACON_ID="..."
 
-# Setting to true will disable letter_opener and enable SMTP
+# Alongside enabling SMTP, toggling SMTP__ENABLED disables Letter Opener
 SMTP__ENABLED=false
 SMTP__USERNAME=hcb
 SMTP__PASSWORD=password123
+
 # SMTP Server
 SMTP__ADDRESS=smtp.example.com
+
 # Domain email come from, like hcb.example.com will send email from ...@hcb.example.com
 SMTP__DOMAIN=hcb.example.com 
 SMTP__PORT=2525

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -21,7 +21,6 @@ class ApplicationMailer < ActionMailer::Base
     else
       name = "HCB"
     end
-    
     email_address_with_name("#{USERNAME}@#{DOMAIN}", name)
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,8 +3,10 @@
 class ApplicationMailer < ActionMailer::Base
   OPERATIONS_EMAIL = "hcb@hackclub.com"
 
-  DOMAIN = Rails.env.production? ? "hackclub.com" : "staging.hcb.hackclub.com"
-  default from: "HCB <hcb@#{DOMAIN}>"
+  DOMAIN = Credentials.fetch(:SMTP, :DOMAIN) || (Rails.env.production? ? "hackclub.com" : "staging.hcb.hackclub.com")
+  USERNAME = Credentials.fetch(:SMTP, :USERNAME) || "hcb"
+
+  default from: "HCB <#{USERNAME}@#{DOMAIN}>"
   layout "mailer/default"
 
   # allow usage of application helper
@@ -19,8 +21,8 @@ class ApplicationMailer < ActionMailer::Base
     else
       name = "HCB"
     end
-
-    email_address_with_name("hcb@hackclub.com", name)
+    
+    email_address_with_name("#{USERNAME}@#{DOMAIN}", name)
   end
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -100,7 +100,6 @@ Rails.application.configure do
 
   # SMTP config
   config.action_mailer.delivery_method = Credentials.fetch(:SMTP, :ENABLED) == "true" ? :smtp : :letter_opener_web
-  
   # Bullet for finding N+1s
   config.after_initialize do
     Bullet.enable        = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,8 +99,8 @@ Rails.application.configure do
   Rails.application.routes.default_url_options[:host] = Credentials.fetch(:TEST_URL_HOST)
 
   # SMTP config
-  config.action_mailer.delivery_method = :letter_opener_web
-
+  config.action_mailer.delivery_method = Credentials.fetch(:SMTP, :ENABLED) == "true" ? :smtp : :letter_opener_web
+  
   # Bullet for finding N+1s
   config.after_initialize do
     Bullet.enable        = true


### PR DESCRIPTION
Recreation of #9958 cause github disassociated my fork from this repo :(

This PR unhardcodes the selection between letter opener or SMTP on dev, by making some env vars.
- If SMTP__ENABLED is false or not set, it will use letter opener

It also un-harcodes the emails in app/mailers/application_mailer.rb!
- If SMTP__DOMAIN is not set, it falls back to hcb.hackclub.com for prod, and staging.hcb.hackclub.com for dev
- If SMTP__USERNAME is not set, it falls back to "hcb"

