### PR TITLE
[Admin][Org] Show # teenagers on team page

### DIFF
--- a/app/jobs/user/update_teenager_column_job.rb
+++ b/app/jobs/user/update_teenager_column_job.rb
@@ -6,17 +6,11 @@ class User
 
     def perform
       User.in_batches do |users_relation|
-        groups = users_relation.select(:id, :birthday_ciphertext).group_by(&method(:teenager?))
+        groups = users_relation.select(:id, :birthday_ciphertext).group_by(&:teenager?)
         groups.each do |value, users|
           User.where(id: users.pluck(:id)).update_all(teenager: value)
         end
       end
-    end
-
-    def teenager?(user)
-      # I'm allowing this method to return true, false, or nil. Allowing nil
-      # allows for more accurate stats.
-      user.birthday&.after?(19.years.ago)
     end
 
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -339,7 +339,7 @@ class User < ApplicationRecord
   end
 
   def teenager?
-    birthday&.after?(19.years.ago) || events.organized_by_teenagers.any?
+    birthday&.after?(19.years.ago)
   end
 
   def last_seen_at

--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -26,7 +26,7 @@ module UserService
         }
       }.compact_blank
 
-      body[:userGroup] = @user.teenager? ? "Hack Clubber" : "HCB Adult"
+      body[:userGroup] = (@user.teenager? || @user.events.organized_by_teenagers.any?) ? "Hack Clubber" : "HCB Adult"
       body[:subscribed] = true if @contact_details.nil?
       body[:source] = "HCB" if @contact_details.nil?
 

--- a/app/views/events/team.html.erb
+++ b/app/views/events/team.html.erb
@@ -6,6 +6,9 @@
   <span class="flex flex-grow items-center">
     Team
     <%= badge_for @all_positions.size, class: "bg-muted" %>
+    <% admin_tool("p0 badge", "span") do %>
+      <%= badge_for "#{@all_positions.count { |op| op.user.teenager? }} teenagers", class: "bg-muted ml0" %>
+    <% end %>
   </span>
 
   <%= pop_icon_to @view == "list" ? "grid" : "list",


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

As we work towards increasing the number of teens on HCB, Ops needs an easy way to see this data when viewing an org.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

![image](https://github.com/user-attachments/assets/1f373cd0-a457-45a7-b3b5-4f5f0e4887f8)


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

