### PR TITLE
[Event] Sync stats to application's airtable record

### DIFF
--- a/app/jobs/event/sync_to_airtable_job.rb
+++ b/app/jobs/event/sync_to_airtable_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Event
+  class SyncToAirtableJob < ApplicationJob
+    queue_as :low
+
+    def perform
+      # Get all applications that have an HCB ID. May return null so we compact.
+      event_ids = ApplicationsTable.all(filter: '{HCB ID} != ""').pluck("HCB ID").compact
+
+      Event.where(id: event_ids).find_each(batch_size: 100) do |event|
+        SyncToAirtableSingleJob.perform_later(event)
+      end
+    end
+
+  end
+
+end

--- a/app/jobs/event/sync_to_airtable_single_job.rb
+++ b/app/jobs/event/sync_to_airtable_single_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Event
+  class SyncToAirtableSingleJob < ApplicationJob
+    queue_as :low
+
+    def perform(event)
+      event.sync_to_airtable
+    end
+
+  end
+
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -719,7 +719,7 @@ class Event < ApplicationRecord
 
   def sync_to_airtable
     # Sync stats to application's airtable record
-    ApplicationsTable.all(filter: "{HCB ID} = \"#{self.id}\"").each do |app|
+    ApplicationsTable.all(filter: "{HCB ID} = \"#{self.id}\"").each do |app| # rubocop:disable Rails/FindEach
       app["Active Teens (last 30 days)"] = users.where(teenager: true).last_seen_within(30.days.ago).size
       app.save
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -717,6 +717,14 @@ class Event < ApplicationRecord
     eligible_for_transparency? && !risk_level.in?(%w[moderate high])
   end
 
+  def sync_to_airtable
+    # Sync stats to application's airtable record
+    ApplicationsTable.all(filter: "{HCB ID} = \"#{self.id}\"").each do |app|
+      app["Active Teens (last 30 days)"] = users.where(teenager: true).last_seen_within(30.days.ago).size
+      app.save
+    end
+  end
+
   private
 
   def point_of_contact_is_admin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,7 +193,8 @@ class User < ApplicationRecord
     end
   end
 
-  scope :currently_online, -> { where(id: UserSession.where("last_seen_at > ?", 15.minutes.ago).pluck(:user_id)) }
+  scope :last_seen_within, ->(ago) { joins(:user_sessions).where(user_sessions: { last_seen_at: ago.. }).distinct }
+  scope :currently_online, -> { last_seen_within(15.minutes.ago) }
 
   # a auditor is an admin who can only view things.
   # auditor? takes into account an admin user's preference

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -179,3 +179,7 @@ column_sweep_job:
 stripe_missed_webhooks_job:
   cron: "0/5 * * * *" # run every 5 minutes
   class: "StripeMissedWebhooksJob"
+
+events_sync_to_airtable_job:
+  cron: "0 0 * * *" # run every 1 day
+  class: "Event::SyncToAirtableJob"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

To help operations track the number of active teens per org, we're pushing this data from HCB into Airtable so they can run their queries there.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Adds a daily job that syncs `Active Teens (last 30 days)`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

