### PR TITLE
[Org][Team] Only show active in teen counter

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -720,7 +720,7 @@ class Event < ApplicationRecord
   def sync_to_airtable
     # Sync stats to application's airtable record
     ApplicationsTable.all(filter: "{HCB ID} = \"#{self.id}\"").each do |app| # rubocop:disable Rails/FindEach
-      app["Active Teens (last 30 days)"] = users.where(teenager: true).last_seen_within(30.days.ago).size
+      app["Active Teens (last 30 days)"] = users.where(teenager: true).active.size
 
       # For Anish's TUB
       app["Referral New Signee Under 18"] = organizer_positions.includes(:user).where(is_signee: true, user: {teenager: true}).any?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,8 @@ class User < ApplicationRecord
 
   scope :last_seen_within, ->(ago) { joins(:user_sessions).where(user_sessions: { last_seen_at: ago.. }).distinct }
   scope :currently_online, -> { last_seen_within(15.minutes.ago) }
+  scope :active, -> { last_seen_within(30.days.ago) }
+  def active? = last_seen_at >= 30.days.ago
 
   # a auditor is an admin who can only view things.
   # auditor? takes into account an admin user's preference

--- a/app/views/events/team.html.erb
+++ b/app/views/events/team.html.erb
@@ -7,7 +7,7 @@
     Team
     <%= badge_for @all_positions.size, class: "bg-muted" %>
     <% admin_tool("p0 badge", "span") do %>
-      <%= badge_for "#{@all_positions.count { |op| op.user.teenager? }} teenagers", class: "bg-muted ml0" %>
+      <%= badge_for "#{@all_positions.count { |op| op.user.teenager? && op.user.active? }} active teenagers (30d)", class: "bg-muted ml0" %>
     <% end %>
   </span>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Update the teenager counter admin badge to only include active teenagers.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

![image](https://github.com/user-attachments/assets/c85ada36-ca81-4240-82f9-4cbb8d0a683c)


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

