### PR TITLE
Add message and UTM params to donation api

### DIFF
--- a/app/api/api/entities/donation.rb
+++ b/app/api/api/entities/donation.rb
@@ -22,7 +22,16 @@ module Api
           ]
         }
         expose :recurring?, as: :recurring, documentation: { type: "boolean" }
-
+        expose :message
+        
+        # Add UTM parameters
+        expose :utm_params do
+          expose :utm_source
+          expose :utm_medium
+          expose :utm_campaign
+          expose :utm_term
+          expose :utm_content
+        end
       end
 
     end


### PR DESCRIPTION
## Summary of the problem
My organization wants to check whether members have paid dues automatically through the API. To do so, they will put their ID number in the HCB message. However, there's no way to access the message through the API.


## Describe your changes
Expose the parameters on the API. In addition, expose utm params as they might be useful for analyzing donations



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

