### PR TITLE
Prevent `within_card_limit` from affecting card grants

### DIFF
--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -428,6 +428,7 @@ class StripeCard < ApplicationRecord
   def within_card_limit
     return if subledger.present?
 
+    # card grants don't count against the limit, hence the subledger_id: nil check
     user_cards_today = user.stripe_cards.where(subledger_id: nil, created_at: 1.day.ago..).count
     event_cards_today = event.stripe_cards.where(subledger_id: nil, created_at: 1.day.ago..).count
 
@@ -435,7 +436,7 @@ class StripeCard < ApplicationRecord
       errors.add(:base, "Your account has been rate-limited from creating new cards. Please try again tomorrow; for help, email hcb@hackclub.com.")
     end
 
-    if event_cards_today > 20 # card grants don't count against the limit
+    if event_cards_today > 20
       errors.add(:base, "Your organization has been rate-limited from creating new cards. Please try again tomorrow; for help, email hcb@hackclub.com.")
     end
   end

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -426,15 +426,16 @@ class StripeCard < ApplicationRecord
   end
 
   def within_card_limit
-    user_cards_today = user.stripe_cards.where(created_at: 1.day.ago..).count
-    event_cards_today = event.stripe_cards.where(created_at: 1.day.ago..).count
-    event_card_grants_today = event.card_grants.where(created_at: 1.day.ago..).count
+    return if subledger.present?
+
+    user_cards_today = user.stripe_cards.where(subledger_id: nil, created_at: 1.day.ago..).count
+    event_cards_today = event.stripe_cards.where(subledger_id: nil, created_at: 1.day.ago..).count
 
     if user_cards_today > 20
       errors.add(:base, "Your account has been rate-limited from creating new cards. Please try again tomorrow; for help, email hcb@hackclub.com.")
     end
 
-    if (event_cards_today - event_card_grants_today) > 20 # card grants don't count against the limit
+    if event_cards_today > 20 # card grants don't count against the limit
       errors.add(:base, "Your organization has been rate-limited from creating new cards. Please try again tomorrow; for help, email hcb@hackclub.com.")
     end
   end


### PR DESCRIPTION
Stripe cards don't get created at the same time as a `CardGrant`, now I'm doing this based on `subledger_id`