### PR TITLE
Remove "event" from disbursements#show

### DIFF
--- a/app/views/disbursements/show.html.erb
+++ b/app/views/disbursements/show.html.erb
@@ -48,12 +48,12 @@
 
     <section class="details">
       <p>
-        <strong>Source event</strong>
+        <strong>Source</strong>
         <%= link_to @disbursement.source_event.name, @disbursement.source_event %>
       </p>
 
       <p>
-        <strong>Destination event</strong>
+        <strong>Destination</strong>
         <%= link_to @disbursement.event.name, @disbursement.event %>
       </p>
 


### PR DESCRIPTION
Before:

<img width="648" alt="Screenshot 2025-04-10 at 10 23 46 AM" src="https://github.com/user-attachments/assets/0631bca4-716e-4da9-aadc-6eceae93f17b" />

After:

<img width="590" alt="Screenshot 2025-04-10 at 10 24 03 AM" src="https://github.com/user-attachments/assets/c9d33b18-c79c-4db7-977e-ef16c65477b7" />

Make it a little cleaner, and we don't use "event" elsewhere in the HCB interface.