### PR TITLE
[v4 API][Organization] Add Total Spent & Total Raised

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -452,6 +452,10 @@ class Event < ApplicationRecord
     balance
   end
 
+  def total_spent_cents
+    (settled_outgoing_balance_cents + pending_outgoing_balance_v2_cents) * -1
+  end
+
   def balance_v2_cents(start_date: nil, end_date: nil)
     sum = settled_balance_cents(start_date:, end_date:)
     sum += pending_outgoing_balance_v2_cents(start_date:, end_date:)

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -17,6 +17,11 @@ if expand?(:balance_cents)
   json.fee_balance_cents event.fronted_fee_balance_v2_cents
 end
 
+if expand?(:reporting)
+  json.total_spent_cents event.total_spent_cents
+  json.total_raised_cents event.total_raised
+end
+
 if policy(event).account_number? && expand?(:account_number)
   json.account_number event.account_number
   json.routing_number event.routing_number

--- a/app/views/events/home/_number_stats.erb
+++ b/app/views/events/home/_number_stats.erb
@@ -5,6 +5,6 @@
   </div>
   <div class="stat stat--small flex flex-col">
     <span class="muted uppercase text-sm" style="font-weight: 700">Total spent</span>
-    <span class="stat__value"><%= render_money_amount @event.total_raised - @event.balance %></span>
+    <span class="stat__value"><%= render_money_amount @event.total_spent_cents %></span>
   </div>
 </div>


### PR DESCRIPTION
## Summary of the problem

@zachlatta would like a programmatic way to determine the total amount spent for an organization.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Adding the following keys to the Organization object in the v4 API:
- `total_spent_cents`
- `total_raised_cents`

In order for these keys to returned, you must expand `reporting`. Example:
```
http://localhost:3000/api/v4/organizations/hq?expand=reporting
```

It's important to note that both `total_spent_cents` and `total_raised_cents` are crude calculations. It's just summing transactions based on their amount cents. This means that a card charge refund would be included in `total_raised_cents` and a donation refund would be included in `total_spent_cents`. In an ideal world, we'd handle those edge cases. However, we don't have code that does that at the moment.