### PR TITLE
Remove comments from grant card invite page

### DIFF
--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -24,12 +24,6 @@
       </div>
     </div>
     <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
-    <% if policy(@card_grant.comments.build).create? %>
-      <h2>Comments</h2>
-      <%= render "comments/list", comments: @card_grant.comments %>
-      <%= render "comments/form", commentable: @card_grant %>
-    <% end %>
-
   <%# Organizers and admins' view %>
   <% else %>
     <% if @card_grant.stripe_card %>
@@ -53,11 +47,6 @@
       <% end %>
       <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } unless @card_grant.stripe_card %>
     </div>
-    <% if policy(@card_grant.comments.build).create? %>
-      <h2>Comments</h2>
-      <%= render "comments/list", comments: @card_grant.comments %>
-      <%= render "comments/form", commentable: @card_grant %>
-    <% end %>
   <% end %>
 </div>
 
@@ -65,4 +54,10 @@
 
 <% unless @card_grant.user == current_user && @card_grant.pending_invite? %>
   <%= render partial: "transactions", locals: { hcb_codes: @hcb_codes } %>
+<% end %>
+
+<% if policy(@card_grant.comments.build).create? %>
+  <h2>Comments</h2>
+  <%= render "comments/list", comments: @card_grant.comments %>
+  <%= render "comments/form", commentable: @card_grant %>
 <% end %>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -24,8 +24,8 @@
       </div>
     </div>
     <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
-    <h2>Comments</h2>
     <% if policy(@card_grant.comments.build).create? %>
+      <h2>Comments</h2>
       <%= render "comments/list", comments: @card_grant.comments %>
       <%= render "comments/form", commentable: @card_grant %>
     <% end %>
@@ -53,8 +53,8 @@
       <% end %>
       <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } unless @card_grant.stripe_card %>
     </div>
-    <h2>Comments</h2>
     <% if policy(@card_grant.comments.build).create? %>
+      <h2>Comments</h2>
       <%= render "comments/list", comments: @card_grant.comments %>
       <%= render "comments/form", commentable: @card_grant %>
     <% end %>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -3,13 +3,13 @@
 
 <div class="mt4 mb4 check--form flex justify-center <%= "flex-wrap" if @frame %>" style="gap: 3rem">
   <%# Grantee has pending invite %>
-
   <% if @card_grant.user == current_user && @card_grant.pending_invite? %>
     <% if @card_grant.canceled? %>
       <%= blankslate "Sorry, this grant was canceled!" %>
     <% else %>
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
+
   <%# Grantee view after accepting invite %>
   <% elsif @card_grant.user == current_user %>
     <div>
@@ -23,8 +23,12 @@
         <%= render "card_grants/actions/return", card_grant: @card_grant %>
       </div>
     </div>
-
     <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
+    <h2>Comments</h2>
+    <% if policy(@card_grant.comments.build).create? %>
+      <%= render "comments/list", comments: @card_grant.comments %>
+      <%= render "comments/form", commentable: @card_grant %>
+    <% end %>
 
   <%# Organizers and admins' view %>
   <% else %>
@@ -49,6 +53,11 @@
       <% end %>
       <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } unless @card_grant.stripe_card %>
     </div>
+    <h2>Comments</h2>
+    <% if policy(@card_grant.comments.build).create? %>
+      <%= render "comments/list", comments: @card_grant.comments %>
+      <%= render "comments/form", commentable: @card_grant %>
+    <% end %>
   <% end %>
 </div>
 
@@ -56,10 +65,4 @@
 
 <% unless @card_grant.user == current_user && @card_grant.pending_invite? %>
   <%= render partial: "transactions", locals: { hcb_codes: @hcb_codes } %>
-<% end %>
-
-<h2>Comments</h2>
-<% if policy(@card_grant.comments.build).create? %>
-  <%= render "comments/list", comments: @card_grant.comments %>
-  <%= render "comments/form", commentable: @card_grant %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
The comments section would be shown underneath the invite for a grant card. It does not make sense to give a user access to comments if they have not yet accepted the invite.


## Describe your changes
I moved the comments to be inside of the grantee view and the admin view. Before it was just at the bottom of the file outside of any logic checking the grant status so it would always be showing.
