### PR TITLE
Add codespaces setup script

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,4 +1,5 @@
 bundle install
+bin/rails db:migrate
 yarn install
 yarn build
 

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,5 +1,6 @@
 bundle install
 bin/rails db:migrate
+bin/rails db:create
 yarn install
 yarn build
 

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,6 +1,4 @@
 bundle install
-bin/rails db:migrate
-bin/rails db:create
 yarn install
 yarn build
 
@@ -9,3 +7,4 @@ sudo chown -R vscode:vscode /usr/local/bundle
 # Setup PostgreSQL
 bundle exec rails db:prepare
 bundle exec rails db:test:prepare
+bundle exec rails db:migrate

--- a/codespaces_setup.sh
+++ b/codespaces_setup.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-bundle install
-bin/rails db:migrate

--- a/codespaces_setup.sh
+++ b/codespaces_setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bundle install
+bin/rails db:migrate

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -22,8 +22,6 @@ Once HCB is running locally, log in into your local instance using the email `ad
 
 To get started, [whip up a codespace](https://docs.github.com/en/codespaces/getting-started/quickstart), open the command palette(<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd>), and search `Codespaces: Open in VS Code Desktop`. HCB does not work on the web version of Codespaces.
 
-After creating your codespace, run `./codespaces_setup.sh`. This will finish preparing HCB for development.
-
 You can then run `bin/dev` to launch HCB. If you can't open the link that is printed in the terminal, navigate to the `PORTS` tab in your terminal and set port `3000` to public and then back to private.
 
 ### Automated setup with Docker

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -22,7 +22,7 @@ Once HCB is running locally, log in into your local instance using the email `ad
 
 To get started, [whip up a codespace](https://docs.github.com/en/codespaces/getting-started/quickstart), open the command palette(<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd>), and search `Codespaces: Open in VS Code Desktop`. HCB does not work on the web version of Codespaces.
 
-After creating your codespace, run `bundle install` and `bin/rails db:migrate`. This will finish preparing HCB for development.
+After creating your codespace, run `./codespaces_setup.sh`. This will finish preparing HCB for development.
 
 You can then run `bin/dev` to launch HCB. If you can't open the link that is printed in the terminal, navigate to the `PORTS` tab in your terminal and set port `3000` to public and then back to private.
 


### PR DESCRIPTION
This PR adds a bash script that performs the final setup to prepare HCB for development on Codespaces. There was already a script made for Docker to make it a one liner to finish setup so I figured there should be an equivalent for Codespaces.

