### PR TITLE
Add monthly donation summary

### DIFF
--- a/app/jobs/monthly_donation_summary_job.rb
+++ b/app/jobs/monthly_donation_summary_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class MonthlyDonationSummaryJob < ApplicationJob
+  queue_as :default
+  def perform
+    Event.includes(:donations).where("donations.created_at > ?", 1.month.ago).references(:donations).find_each do |event|
+      mailer = EventMailer.with(event: event)
+      mailer.monthly_donation_summary.deliver_later
+    end
+  end
+
+end

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -8,6 +8,9 @@ class EventMailer < ApplicationMailer
     @event = params[:event]
 
     @donations = @event.donations.where(created_at: Time.now.last_month.beginning_of_month..).order(:created_at)
+
+    return if @donations.none?
+
     @total = @donations.sum(:amount)
 
     mail to: @emails, subject: "Monthly donation summary for #{@event.name}"

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -13,7 +13,7 @@ class EventMailer < ApplicationMailer
 
     @total = @donations.sum(:amount)
 
-    mail to: @emails, subject: "Monthly donation summary for #{@event.name}"
+    mail to: @emails, subject: "#{@event.name} received #{@donations.length} donations this past month"
   end
 
   private

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -7,8 +7,8 @@ class EventMailer < ApplicationMailer
   def monthly_donation_summary
     @event = params[:event]
 
-    @donations = @event.donations.select { |donation| donation.created_at >= 1.month.ago }.sort_by(&:created_at)
-    @total = @donations.reduce(0) { |sum, donation| sum + donation.amount }
+    @donations = @event.donations.where(created_at: Time.now.last_month.beginning_of_month..).order(:created_at)
+    @total = @donations.sum(:amount)
 
     mail to: @emails, subject: "Monthly donation summary for #{@event.name}"
   end

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class EventMailer < ApplicationMailer
+  before_action { @event = params[:event] }
+  before_action :set_emails
+
+  def monthly_donation_summary
+    @event = params[:event]
+
+    @donations = @event.donations.select { |donation| donation.created_at >= 1.month.ago }.sort_by(&:created_at)
+    @total = @donations.reduce(0) { |sum, donation| sum + donation.amount }
+
+    mail to: @emails, subject: "Monthly donation summary for #{@event.name}"
+  end
+
+  private
+
+  def set_emails
+    @emails = @event.users.map(&:email_address_with_name)
+    @emails << @event.config.contact_email if @event.config.contact_email.present?
+  end
+
+end

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -1,0 +1,24 @@
+<p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
+
+<p>
+  Here's your monthly donation summary for <%= @event.name %>:
+</p>
+
+<ul>
+  <% @donations.each do |donation| %>
+    <li>
+      <%= donation.name(show_anonymous: true) %> <%= donation.anonymous ? "anonymously" : "" %> donated <%= render_money donation.amount %>
+      <% if donation.recurring? %>
+        <% recurring_times = (donation.recurring_donation.donations.find_index(donation) + 1) %>
+        - this is their <%= "#{recurring_times}#{recurring_times.ordinal}" %> monthly donation
+      <% end %>
+    </li>
+  <% end %>
+</ul>
+
+<p>In total, you raised <strong><%= render_money @total %></strong> last month - great job!</p>
+
+<p>
+  From,<br>
+  The HCB Team
+</p>

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -7,7 +7,7 @@
 <ul>
   <% @donations.each do |donation| %>
     <li>
-      <%= donation.name(show_anonymous: true) %> <%= donation.anonymous ? "anonymously" : "" %> donated <%= render_money donation.amount %>
+      <%= donation.name(show_anonymous: true) %> <%= "anonymously" if donation.anonymous %> donated <%= render_money donation.amount %>
       <% if donation.recurring? %>
         <% recurring_times = (donation.recurring_donation.donations.find_index(donation) + 1) %>
         - this is their <%= "#{recurring_times}#{recurring_times.ordinal}" %> monthly donation

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -183,3 +183,7 @@ stripe_missed_webhooks_job:
 events_sync_to_airtable_job:
   cron: "0 0 * * *" # run every 1 day
   class: "Event::SyncToAirtableJob"
+
+monthly_donation_summary_job:
+  cron: "0 0 1 * *" # run first day of each month
+  class: "MonthlyDonationSummaryJob"

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -1,0 +1,6 @@
+class EventMailerPreview < ActionMailer::Preview
+  def monthly_donation_summary
+    EventMailer.with(event: Event.not_demo_mode.first).monthly_donation_summary
+  end
+
+end

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -2,7 +2,7 @@
 
 class EventMailerPreview < ActionMailer::Preview
   def monthly_donation_summary
-    EventMailer.with(event: Event.not_demo_mode.first).monthly_donation_summary
+    EventMailer.with(event: Donation.last.event).monthly_donation_summary
   end
 
 end

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventMailerPreview < ActionMailer::Preview
   def monthly_donation_summary
     EventMailer.with(event: Event.not_demo_mode.first).monthly_donation_summary


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Previously, recurring donations sent an email to all organizers every month - this was a lot of emails and was disabled in #8407. However, organizers now do not get any notification of recurring donations after the initial donation.

Closes #8323 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I created a new EventMailer (as the monthly summaries don't really fit into the singular DonationMailer) with a monthly_donation_summary email. A new MonthlyDonationSummaryJob that is scheduled on the 1st of each month sends the summary email to the organizers of each event with at least 1 donation in the past month.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/5dabda0a-3121-4784-9def-8bd4871e0c04)

