### PR TITLE
Fix link for ACH transfer help page

### DIFF
--- a/app/javascript/controllers/transfer_form_controller.js
+++ b/app/javascript/controllers/transfer_form_controller.js
@@ -38,7 +38,7 @@ export default class extends Controller {
       question: 'Do you have their account & routing number?',
       yes: {
         type: 'ach',
-        link: 'https://help.hcb.hackclub.com/article/59-what-is-an-ach-transfer',
+        link: 'https://help.hcb.hackclub.com/article/60-what-is-an-ach-transfer',
       },
       no: {
         type: 'check',


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The link to the ACH transfer help page on the transfer form was directing to the wrong page.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I updated the link to go to the correct page.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

