### PR TITLE
Add one time job to cancel the stripe cards for old returned and expired grants

### DIFF
--- a/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
+++ b/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
@@ -5,7 +5,7 @@ module OneTimeJobs
     def self.perform()
       CardGrant.where(status: :canceled).or(CardGrant.where(status: :expired)).find_each do |card_grant|
         @card = StripeCard.find(card_grant.stripe_card_id)
-        if !@card.canceled?
+        unless @card.canceled?
           @card.cancel!
         end
       end

--- a/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
+++ b/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
@@ -10,6 +10,7 @@ module OneTimeJobs
         end
       end
     end
+
   end
 
 end

--- a/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
+++ b/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
@@ -2,7 +2,7 @@
 
 module OneTimeJobs
   class CancelLegacyReturnedGrants
-    def self.perform()
+    def self.perform
       CardGrant.where(status: :canceled).or(CardGrant.where(status: :expired)).find_each do |card_grant|
         @card = StripeCard.find(card_grant.stripe_card_id)
         unless @card.canceled?
@@ -11,4 +11,5 @@ module OneTimeJobs
       end
     end
   end
+
 end

--- a/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
+++ b/app/jobs/one_time_jobs/cancel_legacy_returned_grants.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class CancelLegacyReturnedGrants
+    def self.perform()
+      CardGrant.where(status: :canceled).or(CardGrant.where(status: :expired)).find_each do |card_grant|
+        @card = StripeCard.find(card_grant.stripe_card_id)
+        if !@card.canceled?
+          @card.cancel!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When card grants were returned or expired in the past, their associated stripe cards would be frozen rather than canceled. This has since been changed but those cards still remain frozen. This job will go through and cancel all cards associated with returned or expired grants that have not already been canceled.

Closes #9077 
