### PR TITLE
Fix order of permissions checking on card grants

### DIFF
--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -10,22 +10,8 @@
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
 
-  <%# Grantee view after accepting invite %>
-  <% elsif @card_grant.user == current_user %>
-    <div>
-      <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
-      <% if @card_grant.purpose.present? %>
-        <h2><%= @card_grant.purpose %></h2>
-      <% end %>
-      <%= render @card_grant.stripe_card, headless: true, show_card_number: true %>
-      <%= render partial: "balance", locals: { card_grant: @card_grant } %>
-      <div class="flex items-center mt3 justify-center">
-        <%= render "card_grants/actions/return", card_grant: @card_grant %>
-      </div>
-    </div>
-    <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
   <%# Organizers and admins' view %>
-  <% else %>
+  <% elsif @card_grant.user.admin? || organizer_signed_in? %>
     <% if @card_grant.stripe_card %>
       <div>
         <%= render @card_grant.stripe_card %>
@@ -47,6 +33,21 @@
       <% end %>
       <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } unless @card_grant.stripe_card %>
     </div>
+
+  <%# Grantee view after accepting invite %>
+  <% elsif @card_grant.user == current_user %>
+    <div>
+      <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
+      <% if @card_grant.purpose.present? %>
+        <h2><%= @card_grant.purpose %></h2>
+      <% end %>
+      <%= render @card_grant.stripe_card, headless: true, show_card_number: true %>
+      <%= render partial: "balance", locals: { card_grant: @card_grant } %>
+      <div class="flex items-center mt3 justify-center">
+        <%= render "card_grants/actions/return", card_grant: @card_grant %>
+      </div>
+    </div>
+    <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
   <% end %>
 </div>
 


### PR DESCRIPTION
## Summary of the problem
When organizers visited card grants they had received from the same organization they were an organizer for, they would receive the lower permission view instead of the higher permission view.



## Describe your changes
I modified the code to check for organizer or admin status before grantee status.