### PR TITLE
Don't include OS version in fingerprint if it doesn't exist

### DIFF
--- a/app/assets/javascripts/fingerprint.js
+++ b/app/assets/javascripts/fingerprint.js
@@ -14,6 +14,6 @@
 
   document.querySelector('#fingerprint').value = visitorId
   document.querySelector('#device_info').value = $.ua.browser.name + ' ' + $.ua.browser.version
-  document.querySelector('#os_info').value = $.ua.os.name + ' ' + $.ua.os.version
+  document.querySelector('#os_info').value = $.ua.os.name + ($.ua.os.version ? ' ' + $.ua.os.version : '')
   document.querySelector('#timezone').value = result.components.timezone.value
 })()


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
On Linux, there isn't an OS version included in the user agent string. This caused logins from Linux machines to show as coming from "Linux undefined".


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
`fingerprint.js` now only includes the OS version in the fingerprint if it is defined.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

