### PR TITLE
[Card Grants] Check if card grant is already canceled before allowing it to be returned

### DIFF
--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -22,7 +22,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def cancel?
-    admin_or_user || record.user == user
+    (admin_or_user || record.user == user) && !record.canceled?
   end
 
   def topup?


### PR DESCRIPTION
## Summary of the problem
If a card grant was canceled by multiple people at the same time, it would return the money to the organization multiple times resulting in money being created for the organization out of thin air.



## Describe your changes
I made the card grant policy check if it was already canceled before allowing it to be returned.
