### PR TITLE
Remove expired promos from command bar and the airtable checky thing

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1350,20 +1350,12 @@ class AdminController < ApplicationController
       case task_name
       when :pending_hackathons_airtable
         hackathons_task_size
-      when :pending_grant_airtable
-        airtable_task_size :grant
       when :pending_bank_applications_airtable
         airtable_task_size :bank_applications
       when :pending_onboard_id_airtable
         airtable_task_size :onboard_id
-      when :pending_stickermule_airtable
-        airtable_task_size :stickermule
       when :pending_stickers_airtable
         airtable_task_size :stickers
-      when :pending_wallets_airtable
-        airtable_task_size :wallets
-      when :pending_replit_airtable
-        airtable_task_size :replit
       when :pending_onepassword_airtable
         airtable_task_size :onepassword
       when :pending_domains_airtable
@@ -1418,13 +1410,9 @@ class AdminController < ApplicationController
   def pending_tasks
     # This method could take upwards of 10 seconds. USE IT SPARINGLY
     pending_task :pending_hackathons_airtable
-    pending_task :pending_grant_airtable
     pending_task :pending_bank_applications_airtable
     pending_task :pending_onboard_id_airtable
-    pending_task :pending_stickermule_airtable
     pending_task :pending_stickers_airtable
-    pending_task :pending_wallets_airtable
-    pending_task :pending_replit_airtable
     pending_task :pending_onepassword_airtable
     pending_task :pending_domains_airtable
     pending_task :pending_pvsa_airtable

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -38,12 +38,6 @@ module StaticPagesHelper
 
   def airtable_info
     {
-      grant: {
-        id: "appEzv7w2IBMoxxHe",
-        table: "Github%20Grant",
-        query: { filterByFormula: "Status='Pending'" },
-        destination: "https://airtable.com/tblsYQ54Rg1Pjz1xP/viwjETKo05TouqYev"
-      },
       onboard_id: {
         id: "app4Bs8Tjwvk5qcD4",
         table: "Verifications%20-%20Depreciated",
@@ -61,18 +55,6 @@ module StaticPagesHelper
         table: "Bank%20Stickers",
         query: { filterByFormula: "Status='Pending'" },
         destination: "https://airtable.com/tblyhkntth4OyQxiO/viwHcxhOKMZnPXUUU"
-      },
-      stickermule: {
-        id: "appEzv7w2IBMoxxHe",
-        table: "StickerMule",
-        query: { filterByFormula: "Status='Pending'" },
-        destination: "https://airtable.com/tblwYTdp2fiBv7JqA/viwET9tCYBwaZ3NIq"
-      },
-      replit: {
-        id: "appEzv7w2IBMoxxHe",
-        table: "Repl.it%20Hacker%20Plan",
-        query: { filterByFormula: "Status='Pending'" },
-        destination: "https://airtable.com/tbl6cbpdId4iA96mD/viw2T8d98ZhhacHCf"
       },
       domains: {
         id: "appEzv7w2IBMoxxHe",
@@ -115,12 +97,6 @@ module StaticPagesHelper
         table: "Feedback",
         query: { filterByFormula: "Status='Pending'" },
         destination: "https://airtable.com/tblOmqLjWtJZWXn4O/viwuk2j4xsKJo5EqA"
-      },
-      wallets: {
-        id: "appEzv7w2IBMoxxHe",
-        table: "Wallets",
-        query: { filterByFormula: "Status='Pending'" },
-        destination: "https://airtable.com/tblJtjtY9qAOG3FS8/viwUz9aheNAvXwzjg"
       },
       google_workspace_waitlist: {
         id: "appEzv7w2IBMoxxHe",

--- a/app/javascript/components/command_bar/actions.js
+++ b/app/javascript/components/command_bar/actions.js
@@ -230,28 +230,12 @@ export const adminActions = adminUrls => [
     perform: () => (window.location.href = '/admin/increase_checks'),
   },
   {
-    id: 'admin_tool_6',
-    section: 'Admin Tools',
-    priority: Priority.HIGH,
-    name: 'Grants',
-    icon: <Icon glyph="support" size={16} />,
-    perform: () => (window.location.href = '/admin/grants'),
-  },
-  {
     id: 'admin_tool_7',
     section: 'Admin Tools',
     priority: Priority.HIGH,
     name: 'Wires',
     icon: <Icon glyph="web" size={16} />,
     perform: () => (window.location.href = '/admin/wires'),
-  },
-  {
-    id: 'admin_tool_8',
-    section: 'Admin Tools',
-    priority: Priority.HIGH,
-    name: 'PayPal',
-    icon: <Icon glyph="grid" size={16} />,
-    perform: () => (window.location.href = '/admin/paypal_transfers'),
   },
   {
     id: 'admin_tool_9',
@@ -349,14 +333,6 @@ export const adminActions = adminUrls => [
     name: 'Stickers',
     icon: <Icon glyph="sticker" size={16} />,
     perform: () => (window.location.href = adminUrls['Stickers']),
-  },
-  {
-    id: 'admin_tool_22',
-    section: 'Admin Tools',
-    priority: Priority.HIGH,
-    name: 'Wallets',
-    icon: <Icon glyph="send" size={16} />,
-    perform: () => (window.location.href = adminUrls['Wallets']),
   },
   {
     id: 'admin_tool_23',

--- a/app/javascript/components/command_bar/actions.js
+++ b/app/javascript/components/command_bar/actions.js
@@ -238,6 +238,14 @@ export const adminActions = adminUrls => [
     perform: () => (window.location.href = '/admin/wires'),
   },
   {
+    id: 'admin_tool_8',
+    section: 'Admin Tools',
+    priority: Priority.HIGH,
+    name: 'PayPal',
+    icon: <Icon glyph="grid" size={16} />,
+    perform: () => (window.location.href = '/admin/paypal_transfers'),
+  },
+  {
     id: 'admin_tool_9',
     section: 'Admin Tools',
     priority: Priority.HIGH,

--- a/app/views/application/_command_bar.html.erb
+++ b/app/views/application/_command_bar.html.erb
@@ -5,7 +5,6 @@
         "Disputes"                  => "https://airtable.com/appEzv7w2IBMoxxHe/tblTqbwz5AUkzOcVb",
         "Feedback"                  => "https://airtable.com/tblOmqLjWtJZWXn4O/viwuk2j4xsKJo5EqA",
         "Stickers"                  => "https://airtable.com/tblyhkntth4OyQxiO/viwHcxhOKMZnPXUUU",
-        "Wallets"                   => "https://airtable.com/tblJtjtY9qAOG3FS8/viwUz9aheNAvXwzjg",
         "Hackathons"                => "https://dash.hackathons.hackclub.com/sign_in",
         "1Password"                 => "https://airtable.com/tblcHEZyos3V9DoeI/viwSapKZ8C4ByBuqT",
         "Domains"                   => "https://airtable.com/tbl22cXd3Bo9uo0wp/viwcnZyoctJTFGVY2",


### PR DESCRIPTION
## Summary of the problem
We don't do the wallet thing anymore, so why have it in the admin command bar?

see also: stickermule, github grants, replit, etc.

There was also a dead reference to /admin/grants/ that I nuked as well :)

## Describe your changes
I found the file that controls the command bar stuff, and i deleted the offending files.

RIP wallets