### PR TITLE
Convert options positional arguments to keyword arguments

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,23 +58,23 @@ module ApplicationHelper
     content_tag(:span, content.join.html_safe)
   end
 
-  def blankslate(text, options = {})
+  def blankslate(text, **options)
     other_options = options.except(:class)
     content_tag(:p, text, class: "center mt0 mb0 pt4 pb4 slate bold h3 mx-auto rounded-lg border #{options[:class]}", **other_options)
   end
 
-  def list_badge_for(count, item, glyph, options = { optional: false, required: false })
-    return nil if options[:optional] && count == 0
+  def list_badge_for(count, item, glyph, optional: false, required: false, **options)
+    return nil if optional && count == 0
 
     icon = inline_icon(glyph, size: 20, 'aria-hidden': true)
 
     content_tag(:span,
                 icon + count.to_s,
                 'aria-label': pluralize(count, item),
-                class: "list-badge tooltipped tooltipped--w #{options[:required] && count == 0 ? 'b--warning warning' : ''} #{options[:class]}")
+                class: "list-badge tooltipped tooltipped--w #{required && count == 0 ? 'b--warning warning' : ''} #{options[:class]}")
   end
 
-  def badge_for(value, options = {})
+  def badge_for(value, **options)
     content_tag :span, value, class: "badge #{options[:class]} #{'bg-muted' if [0, "Pending"].include?(value)}"
   end
 
@@ -86,7 +86,7 @@ module ApplicationHelper
     status_badge(type) if condition
   end
 
-  def pop_icon_to(icon, url, options = { class: "info" })
+  def pop_icon_to(icon, url, class: "info", **options)
     link_to url, options.merge(class: "pop #{options[:class]}") do
       inline_icon icon, size: options[:icon_size] || 28
     end
@@ -151,7 +151,7 @@ module ApplicationHelper
     end
   end
 
-  def relative_timestamp(time, options = {})
+  def relative_timestamp(time, **options)
     content_tag :span, "#{options[:prefix]}#{time_ago_in_words time} ago#{options[:suffix]}", options.merge(title: time)
   end
 
@@ -163,7 +163,7 @@ module ApplicationHelper
     content_tag :pre, pp(item.attributes.to_yaml)
   end
 
-  def inline_icon(filename, options = {})
+  def inline_icon(filename, **options)
     # cache parsed SVG files to reduce file I/O operations
     @icon_svg_cache ||= {}
     if !@icon_svg_cache.key?(filename)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,9 +86,9 @@ module ApplicationHelper
     status_badge(type) if condition
   end
 
-  def pop_icon_to(icon, url, options = { class: "info" })
-    link_to url, options.merge(class: "pop #{options[:class]}") do
-      inline_icon icon, size: options[:icon_size] || 28
+  def pop_icon_to(icon, url, icon_size: 28, **options)
+    link_to url, options.merge(class: "pop #{options[:class] || "info"}") do
+      inline_icon icon, size: icon_size
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,7 +86,7 @@ module ApplicationHelper
     status_badge(type) if condition
   end
 
-  def pop_icon_to(icon, url, class: "info", **options)
+  def pop_icon_to(icon, url, options = { class: "info" })
     link_to url, options.merge(class: "pop #{options[:class]}") do
       inline_icon icon, size: options[:icon_size] || 28
     end

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -43,7 +43,7 @@ module DonationsHelper
     content_tag(:p) { strong_tag + date_tag }
   end
 
-  def donation_payment_method_mention(donation = @donation, options = {})
+  def donation_payment_method_mention(donation = @donation, **options)
     payout = donation&.payout
     payout_t = donation&.payout&.t_transaction
 

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -83,7 +83,7 @@ module InvoicesHelper
   end
 end
 
-def invoice_payment_method_mention(invoice = @invoice, options = {})
+def invoice_payment_method_mention(invoice = @invoice, **options)
   return "–" unless invoice&.manually_marked_as_paid? || invoice&.payment_method_type
 
   if invoice.manually_marked_as_paid?

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -3,7 +3,7 @@
 module StaticPagesHelper
   extend ActionView::Helpers::NumberHelper
 
-  def card_to(name, path, options = {})
+  def card_to(name, path, **options)
     badge = if options[:badge].present?
               badge_for(options[:badge], class: options[:subtle_badge].present? || options[:badge] == 0 ? "bg-muted h-fit-content" : "bg-accent h-fit-content")
             elsif options[:async_badge].present?

--- a/app/helpers/stripe_cards_helper.rb
+++ b/app/helpers/stripe_cards_helper.rb
@@ -11,8 +11,8 @@ module StripeCardsHelper
 
   def stripe_card_mention(stripe_card, size: 24)
     icon = inline_icon "card",
-                       size: options[:size],
-                       class: "muted #{options[:size] <= 24 ? 'pr1' : ''}"
+                       size:,
+                       class: "muted #{size <= 24 ? 'pr1' : ''}"
     if organizer_signed_in? || stripe_card.user == current_user
       text = content_tag :span, stripe_card.last_four
       return link_to(stripe_card, class: "mention", data: { turbo_frame: "_top" }) { icon + text }

--- a/app/helpers/stripe_cards_helper.rb
+++ b/app/helpers/stripe_cards_helper.rb
@@ -9,7 +9,7 @@ module StripeCardsHelper
     "#{stripe_card.stripe_exp_month.to_s.rjust(2, '0')}/#{stripe_card.stripe_exp_year.to_s[-2..]}"
   end
 
-  def stripe_card_mention(stripe_card, options = { size: 24 })
+  def stripe_card_mention(stripe_card, size: 24)
     icon = inline_icon "card",
                        size: options[:size],
                        class: "muted #{options[:size] <= 24 ? 'pr1' : ''}"
@@ -66,7 +66,7 @@ module StripeCardsHelper
     suggested(field)
   end
 
-  def card_shipping_map_url(card, options = {})
+  def card_shipping_map_url(card)
     address = "#{card.address_line1} #{card.address_line2}, #{card.address_city} #{card.address_state} #{card.address_country} #{card.address_postal_code}"
     geo = Geocoder.search(address)&.first
     return nil unless geo

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -58,7 +58,7 @@ module UsersHelper
     ]
   end
 
-  def avatar_for(user, size = 24, options = {}, click_to_mention: false, default_image: nil)
+  def avatar_for(user, size: 24, click_to_mention: false, default_image: nil, **options)
     src = profile_picture_for(user, size, default_image:)
     current_user = defined?(current_user) ? current_user : nil
 
@@ -76,10 +76,10 @@ module UsersHelper
     image_tag(src, options.merge(loading: "lazy", alt:, width: size, height: size, class: klass))
   end
 
-  def user_mention(user, options = {}, default_name = "No User", click_to_mention: false, comment_mention: false, default_image: nil)
+  def user_mention(user, default_name: "No User", click_to_mention: false, comment_mention: false, default_image: nil, **options)
     name = content_tag :span, (user&.initial_name || default_name)
     current_user = defined?(current_user) ? current_user : nil
-    avi = avatar_for(user, 24, options[:avatar] || {}, click_to_mention:, default_image:)
+    avi = avatar_for(user, click_to_mention:, default_image:, **options[:avatar])
 
     klasses = ["mention"]
     klasses << %w[mention--admin tooltipped tooltipped--n] if user&.auditor? && !options[:disable_tooltip]
@@ -126,7 +126,7 @@ module UsersHelper
     admin_tool(*args, **options, &block)
   end
 
-  def creator_bar(object, options = {})
+  def creator_bar(object, **options)
     creator = if defined?(object.creator)
                 object.creator
               elsif defined?(object.sender)
@@ -134,7 +134,7 @@ module UsersHelper
               else
                 object.user
               end
-    mention = user_mention(creator, options, default_name = "Anonymous User")
+    mention = user_mention(creator, default_name: "Anonymous User", **options)
     content_tag :div, class: "comment__name" do
       mention + relative_timestamp(object.created_at, prefix: options[:prefix], class: "h5 muted")
     end

--- a/app/views/admin/ach_start_approval.html.erb
+++ b/app/views/admin/ach_start_approval.html.erb
@@ -61,7 +61,7 @@
   <p>
     Processed by:
     <span>
-      <%= avatar_for @ach_transfer.processor, 24, { style: "margin: 0; vertical-align: bottom" } %>
+      <%= avatar_for @ach_transfer.processor, style: "margin: 0; vertical-align: bottom" %>
       <%= inline_icon "admin-badge", size: 20, style: "vertical-align: middle; margin: -0.2rem -0.3rem 0 -0.3rem;" if @ach_transfer.processor.auditor? %>
       <span><%= @ach_transfer.processor.initial_name %></span>
     </span>

--- a/app/views/admin/ledger_audits/tasks/index.html.erb
+++ b/app/views/admin/ledger_audits/tasks/index.html.erb
@@ -22,13 +22,13 @@
           <td><%= hcb_code.created_at.strftime("%Y-%m-%d") %></td>
           <td>
             <span style="display: flex; align-items: center; gap: 8px;">
-              <%= avatar_for task.reviewer, 24, { class: "avatar" } %>
+              <%= avatar_for task.reviewer, class: "avatar" %>
               <%= task.reviewer&.name %>
             </span>
           </td>
           <td>
             <span style="display: flex; align-items: center; gap: 8px;">
-              <%= avatar_for hcb_code.event.point_of_contact, 24, { class: "avatar" } %>
+              <%= avatar_for hcb_code.event.point_of_contact, class: "avatar" %>
               <%= hcb_code.event.point_of_contact&.name %>
             </span>
           </td>

--- a/app/views/admin/ledger_audits/tasks/show.html.erb
+++ b/app/views/admin/ledger_audits/tasks/show.html.erb
@@ -68,7 +68,7 @@
         </div>
         <div class="avatar-row" style="max-width: 300px;">
           <% event.organizer_positions.each do |position| %>
-            <%= avatar_for position.user, 24 %>
+            <%= avatar_for position.user %>
           <% end %>
         </div>
         <section class="details mb0 mt2">

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -112,7 +112,7 @@
     <td>
       <div class="flex items-center justify-center <%= "tooltipped tooltipped--w" if author_name %>" aria-label="<%= author_name %>">
         <% if author.present? %>
-          <%= avatar_for author, 24, { class: "align-middle author" } %>
+          <%= avatar_for author, class: "align-middle author" %>
         <% elsif pt.local_hcb_code.fallback_avatar %>
           <%= image_tag(pt.local_hcb_code.fallback_avatar, loading: "lazy", width: 24, height: 24, class: "rounded-full shrink-none") %>
         <% end %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -132,7 +132,7 @@
     <td>
       <div class="flex items-center justify-center <%= "tooltipped tooltipped--w" if author_name %>" aria-label="<%= author_name %>">
         <% if author.present? %>
-          <%= avatar_for author, 24, { class: "align-middle author" } %>
+          <%= avatar_for author, class: "align-middle author" %>
         <% elsif ct.local_hcb_code.fallback_avatar %>
           <%= image_tag(ct.local_hcb_code.fallback_avatar, loading: "lazy", width: 24, height: 24, class: "rounded-full shrink-none") %>
         <% end %>

--- a/app/views/card_grants/_canceled_warning.html.erb
+++ b/app/views/card_grants/_canceled_warning.html.erb
@@ -7,7 +7,7 @@
       <p class="bold mt0 mb0">
         This grant has been canceled
         <% if canceled_by = card_grant.last_user_change_to(status: :canceled) %>
-          by <%= user_mention canceled_by, { disable_tooltip: true } %>
+          by <%= user_mention canceled_by, disable_tooltip: true %>
         <% end %>
         <% if canceled_at = card_grant.last_time_change_to(status: :canceled) %>
           <span class="tooltipped" aria-label="<%= canceled_at.to_formatted_s(:long) %>">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -16,7 +16,7 @@
   <ul role="listbox" class="mention-suggestions card" hidden popover>
     <% commentable.comment_mentionable(current_user:).each do |u| %>
       <li role="option" class="cursor-pointer mention-suggestion" data-value="@<%= u.email %>" data-search="<%= u.name %>">
-        <%= user_mention u, { disable_tooltip: true } %>
+        <%= user_mention u, disable_tooltip: true %>
       </li>
     <% end %>
   </ul>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -48,7 +48,7 @@
 </div>
 
 <div class="center mt2">
-  <div class="flex items-center justify-center muted">Signed in as <%= user_mention current_user, { class: "ml1" } %></div>
+  <div class="flex items-center justify-center muted">Signed in as <%= user_mention current_user, class: "ml1" %></div>
 
   <%= link_to "Switch accounts", auth_users_path(return_to: request.fullpath), class: "center" %>
 </div>

--- a/app/views/emburse_transactions/_emburse_transaction.html.erb
+++ b/app/views/emburse_transactions/_emburse_transaction.html.erb
@@ -8,7 +8,7 @@
         class="transaction__icon tooltipped tooltipped--e"
         aria-label="Card transaction by <%= et.card.user.initial_name %>">
         <%= link_to et.card do %>
-          <%= avatar_for et.card.user, 24 %>
+          <%= avatar_for et.card.user %>
         <% end %>
       </td>
     <% else %>

--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -61,7 +61,7 @@
         </div>
       <% end %>
       <% event.organizer_positions.first(event.organizer_positions.size > 9 ? 8 : 9).each do |position| %>
-        <%= avatar_for position.user, 24 %>
+        <%= avatar_for position.user %>
       <% end %>
     </div>
   </li>

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -106,7 +106,7 @@
       <% end %>
       <% if @user %>
         <div class="badge badge-large bg-muted">
-          <%= avatar_for @user, 18 %>
+          <%= avatar_for @user, size: 18 %>
           <%= @user.name %>
 
           <%= link_to upsert_query_params("user" => nil), class: "flex items-center", data: { turbo_prefetch: "false" } do %>

--- a/app/views/events/_filter_cards_menu.html.erb
+++ b/app/views/events/_filter_cards_menu.html.erb
@@ -35,7 +35,7 @@
         <% @all_unique_cardholders.each do |cardholder| %>
           <%= link_to upsert_query_params(user: cardholder.user), class: "flex-auto menu__action !border-t-0 #{"menu__action--active" if @user_id.to_i == cardholder.user.id}", data: { turbo_prefetch: "false" } do %>
             <div class="avatar-grow line-height-0 mr1">
-              <%= avatar_for cardholder.user, 18 %>
+              <%= avatar_for cardholder.user, size: 18 %>
             </div>
             <%= cardholder.user.name %>
           <% end %>

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -42,7 +42,7 @@
             <%= link_to(upsert_query_params(user: position.user.id), class: "flex-auto flex items-center menu__action #{"menu__action--active" if @user&.id == position.user.id}", data: { turbo_prefetch: "false" }) do %>
 
               <div class="avatar-grow line-height-0 mr1">
-                <%= avatar_for position.user, 18 %>
+                <%= avatar_for position.user, size: 18 %>
               </div>
               <%= position.user.name %>
             <% end %>

--- a/app/views/events/audit_log.html.erb
+++ b/app/views/events/audit_log.html.erb
@@ -2,7 +2,7 @@
   <ul class="list-reset">
     <% @event.versions.select { |version| version.changeset.any? { |field, changes| changes.any?(&:present?) } }.map do |version| %>
       <li>
-        <div><%= user_mention User.find_by(id: version.whodunnit), {}, "Unknown User" %> <%= version.event %>d <span class="muted tooltipped tooltipped--n" style="cursor: default" aria-label="<%= version.created_at.strftime("%b %e, %Y") %>"><%= time_ago_in_words version.created_at %> ago</span></div>
+        <div><%= user_mention User.find_by(id: version.whodunnit), default_name: "Unknown User" %> <%= version.event %>d <span class="muted tooltipped tooltipped--n" style="cursor: default" aria-label="<%= version.created_at.strftime("%b %e, %Y") %>"><%= time_ago_in_words version.created_at %> ago</span></div>
         <% if version.event == "update" %>
           <ul class="list-reset">
             <% version.changeset.excluding("updated_at").select { |field, changes| changes.any?(&:present?) }.each do |field, changes| %>

--- a/app/views/events/home/_team.html.erb
+++ b/app/views/events/home/_team.html.erb
@@ -10,7 +10,7 @@
     <div class="flex gap-3 w-full w-100 py-2 sm:pt-0 px-4 avatar-row avatar-row--no-transform" style="padding-left: 25px">
       <% @organizers.first(@organizers.length == 12 ? 12 : 11).each do |position| %>
         <div style="transform:none" class="avatar-grow line-height-0 tooltipped tooltipped--e" aria-label="<%= position.user == current_user ? current_user_flavor_text.sample : position.user.name %>">
-          <%= avatar_for position.user, 40, { style: "margin-left: -10px" } %>
+          <%= avatar_for position.user, size: 40, style: "margin-left: -10px" %>
         </div>
       <% end %>
       <% if @organizers.length > 12 %>

--- a/app/views/events/transactions.html.erb
+++ b/app/views/events/transactions.html.erb
@@ -112,7 +112,7 @@
           <div class="flex items-center">
             <% @organizers.limit(5).each do |position| %>
               <div class="avatar-grow line-height-0 tooltipped tooltipped--s mr1" aria-label="<%= position.user == current_user ? current_user_flavor_text.sample : position.user.name %>">
-                <%= avatar_for position.user, 36 %>
+                <%= avatar_for position.user, size: 36 %>
               </div>
             <% end %>
           </div>

--- a/app/views/logins/_badge.html.erb
+++ b/app/views/logins/_badge.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (user:) %>
 <% if cookies.encrypted[:signed_user] && User.find_signed(cookies.encrypted[:signed_user], purpose: :signin_avatar) == user %>
   <% mention = capture do %>
-    <%= user_mention user, { class: "badge bg-muted pl-1 m-0 tooltipped tooltipped--e", aria_label: "Switch account" } %>
+    <%= user_mention user, class: "badge bg-muted pl-1 m-0 tooltipped tooltipped--e", aria_label: "Switch account" %>
   <% end %>
   <% if signed_in? %>
     <%= link_to(logout_users_path, method: :delete) { mention } %>

--- a/app/views/organizer_position/spending/controls/_spending_item.html.erb
+++ b/app/views/organizer_position/spending/controls/_spending_item.html.erb
@@ -4,7 +4,7 @@
   <td><%= format_date(spending_item_created_date(item)) %></td>
   <td style="max-width: 400px; overflow: hidden; text-overflow: elipsis;"><%= item.memo %></td>
   <td class="flex items-center g1">
-    <%= avatar_for item_user, 24 %>
+    <%= avatar_for item_user %>
     <%= item_user.name %>
   </td>
   <td><%= render_money item.amount_cents %></td>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -10,7 +10,7 @@
   <div class="flex justify-center flex-wrap">
     <% @organizers.each do |position| %>
       <div class="tooltipped tooltipped--s mr1" aria-label="<%= position.user.name %>">
-        <%= avatar_for position.user, 64 %>
+        <%= avatar_for position.user, size: 64 %>
       </div>
     <% end %>
   </div>

--- a/app/views/organizer_positions/_organizer_position.html.erb
+++ b/app/views/organizer_positions/_organizer_position.html.erb
@@ -4,7 +4,7 @@
       <div class="flex justify-between">
         <div class="relative">
           <%= inline_icon("admin-badge", size: 48, class: "avatar-container__admin-bolt stroke-white dark:stroke-darkless") if organizer_position.user.auditor? %>
-          <%= avatar_for organizer_position.user, 64 %>
+          <%= avatar_for organizer_position.user, size: 64 %>
         </div>
       </div>
       <div class="flex flex-col justify-center">

--- a/app/views/public_activity/_common.html.erb
+++ b/app/views/public_activity/_common.html.erb
@@ -3,7 +3,7 @@
     <% if defined?(icon) && defined?(color) %>
       <%= inline_icon icon, width: 24, class: "bg-#{color}", style: "height: 24px; color: white; border-radius: 999px; padding: 4px;" %>
     <% else %>
-      <%= avatar_for(defined?(hide_owner) && hide_owner ? nil : activity.owner, 24, default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png") %>
+      <%= avatar_for(defined?(hide_owner) && hide_owner ? nil : activity.owner, default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png") %>
     <% end %>
     <div class="flex flex-col" style="transform: translateY(-3px); line-height: 1.6">
       <span>

--- a/app/views/receipts/_details.html.erb
+++ b/app/views/receipts/_details.html.erb
@@ -1,5 +1,5 @@
 <h2 class="mt-0">
-  <span style="vertical-align: text-bottom;"><%= user_mention(receipt.user, { avatar: { style: "vertical-align: baseline;" }, style: "color: red;" }) %></span>'s receipt
+  <span style="vertical-align: text-bottom;"><%= user_mention(receipt.user, avatar: { style: "vertical-align: baseline;" }, style: "color: red;") %></span>'s receipt
 </h2>
 
 <%= render partial: "receipts/extracted", locals: { receipt: } %>

--- a/app/views/reimbursement/expenses/_expense.html.erb
+++ b/app/views/reimbursement/expenses/_expense.html.erb
@@ -43,7 +43,7 @@
             <% else %>
               Approval removed by
             <% end %>
-            <%= user_mention expense.approved_by, { avatar: { style: "vertical-align: sub;" }, disable_tooltip: true }, "Unknown User" %>
+            <%= user_mention expense.approved_by, avatar: { style: "vertical-align: sub;" }, disable_tooltip: true, default_name: "Unknown User" %>
           <% end %>
           <% unless expense.report.reimbursed? %>
             <button class="edit-or-save pop pointer tooltipped tooltipped--w" data-expense-form-target="button" aria-label="<%= "This expense is read-only. #{"Mark it as a draft to edit." unless expense.report.closed? || read_only}" %>">

--- a/app/views/reimbursement/reports/_conversation.html.erb
+++ b/app/views/reimbursement/reports/_conversation.html.erb
@@ -61,7 +61,7 @@
                 </div>
                 <div class="conversation_item_text">
                   <span class="muted" style="margin-right: -0.25em;">
-                    <%= user_mention whodunnit, { avatar: { style: "vertical-align: sub;" } }, "HCB", default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png" %>
+                    <%= user_mention whodunnit, avatar: { style: "vertical-align: sub;" }, default_name: "HCB", default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png" %>
                   </span>
                   <% if state_change == "reimbursement_requested" %>
                     <span class="align-middle tooltipped tooltipped--n" aria-label="Still pending approval from the HCB team">
@@ -87,7 +87,7 @@
               </div>
               <div style="display: flex; align-items: center; gap: 4px">
                 <span class="muted; margin-right: -0.25em;">
-                  <%= user_mention User.find_by(id: item.whodunnit), { hide_avatar: true }, "HCB", default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png" %>
+                  <%= user_mention User.find_by(id: item.whodunnit), hide_avatar: true, default_name: "HCB", default_image: "https://cloud-odxy4yxov-hack-club-bot.vercel.app/0af21ff968edcc04557ff4106897e20f6.png" %>
                 </span>
                 <span class="align-middle"><%= item.event %>d this report</span>
                 <span class="tooltipped tooltipped--n align-middle timestamp" aria-label="<%= item.created_at.strftime("%b %e, %Y") %>">

--- a/app/views/reimbursement/reports/edit.html.erb
+++ b/app/views/reimbursement/reports/edit.html.erb
@@ -6,7 +6,7 @@
 <div class="mt4">
     <h3 class="mt2 mb1 muted flex" style="font-weight: 400; gap: 4px;">
       <span style="flex-grow: 1;">
-        <%= user_mention @user, { class: "tooltipped--s align-top" } %>is requesting <%= render_money @report.amount_cents %> for
+        <%= user_mention @user, class: "tooltipped--s align-top" %>is requesting <%= render_money @report.amount_cents %> for
       </span>
       <span class="ml0 badge bg-<%= @report.aasm_state %>"><%= @report.aasm_state&.capitalize %></span>
     </h3>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -8,7 +8,7 @@
 <div class="md:mt-12">
   <h3 class="mt2 mb1 muted flex items-center" style="font-weight: 400; gap: 8px;">
     <span style="flex-grow: 1;">
-      <%= user_mention @user, { class: "tooltipped--s align-top" } %>
+      <%= user_mention @user, class: "tooltipped--s align-top" %>
       <%= "will be reimbursed " if @report.reimbursement_approved? || @report.reimbursed? && !@report.payout_holding.sent? %>
       <%= "was reimbursed " if @report.reimbursed? && @report.payout_holding.sent? %>
       <%= "requested " if @report.rejected? || @report.reversed? %>

--- a/app/views/static_pages/_admin.html.erb
+++ b/app/views/static_pages/_admin.html.erb
@@ -37,49 +37,49 @@
     </div>
     <h2>Tasks</h2>
     <ul class="grid left-align w-100 mt0" id="task-grid">
-      <%= card_to "Applications", link_to_airtable_task(:bank_applications), { async_badge: :pending_bank_applications_airtable } %>
-      <%= card_to "OnBoard ID", link_to_airtable_task(:onboard_id), { async_badge: :pending_onboard_id_airtable } %>
-      <%= card_to "Ledger", ledger_admin_index_path, { badge: CanonicalTransaction.not_stripe_top_up.unmapped.count } %>
-      <%= card_to "ACH", ach_admin_index_path, { badge: AchTransfer.pending.count } %>
-      <%= card_to "Check", increase_checks_admin_index_path, { badge: IncreaseCheck.pending.count } %>
-      <%= card_to "Check deposits", admin_check_deposits_path, { badge: CheckDeposit.unprocessed.count } %>
-      <%= card_to "PayPal", paypal_transfers_admin_index_path, { badge: PaypalTransfer.pending.count } %>
-      <%= card_to "Wires", wires_admin_index_path, { badge: Wire.pending.count } %>
-      <%= card_to "Disbursements", disbursements_admin_index_path, { badge: Disbursement.reviewing.count } %>
-      <%= card_to "Reimbursements", reimbursements_admin_index_path, { badge: Reimbursement::Report.reimbursement_requested.count } %>
-      <%= card_to "Deletion requests", organizer_position_deletion_requests_path, { badge: OrganizerPositionDeletionRequest.under_review.count } %>
-      <%= card_to "Disputes", link_to_airtable_task(:disputed_transactions), { async_badge: :pending_disputed_transactions_airtable } %>
-      <%= card_to "Feedback", link_to_airtable_task(:feedback), { async_badge: :pending_feedback_airtable } %>
-      <%= card_to "Boba", link_to_airtable_task(:boba), { async_badge: :pending_boba_airtable } %>
-      <%= card_to "YSWS Verification", link_to_airtable_task(:you_ship_we_ship), { async_badge: :pending_you_ship_we_ship_airtable } %>
+      <%= card_to "Applications", link_to_airtable_task(:bank_applications), async_badge: :pending_bank_applications_airtable %>
+      <%= card_to "OnBoard ID", link_to_airtable_task(:onboard_id), async_badge: :pending_onboard_id_airtable %>
+      <%= card_to "Ledger", ledger_admin_index_path, badge: CanonicalTransaction.not_stripe_top_up.unmapped.count %>
+      <%= card_to "ACH", ach_admin_index_path, badge: AchTransfer.pending.count %>
+      <%= card_to "Check", increase_checks_admin_index_path, badge: IncreaseCheck.pending.count %>
+      <%= card_to "Check deposits", admin_check_deposits_path, badge: CheckDeposit.unprocessed.count %>
+      <%= card_to "PayPal", paypal_transfers_admin_index_path, badge: PaypalTransfer.pending.count %>
+      <%= card_to "Wires", wires_admin_index_path, badge: Wire.pending.count %>
+      <%= card_to "Disbursements", disbursements_admin_index_path, badge: Disbursement.reviewing.count %>
+      <%= card_to "Reimbursements", reimbursements_admin_index_path, badge: Reimbursement::Report.reimbursement_requested.count %>
+      <%= card_to "Deletion requests", organizer_position_deletion_requests_path, badge: OrganizerPositionDeletionRequest.under_review.count %>
+      <%= card_to "Disputes", link_to_airtable_task(:disputed_transactions), async_badge: :pending_disputed_transactions_airtable %>
+      <%= card_to "Feedback", link_to_airtable_task(:feedback), async_badge: :pending_feedback_airtable %>
+      <%= card_to "Boba", link_to_airtable_task(:boba), async_badge: :pending_boba_airtable %>
+      <%= card_to "YSWS Verification", link_to_airtable_task(:you_ship_we_ship), async_badge: :pending_you_ship_we_ship_airtable %>
       <%= card_to "Warehouse SKUs", link_to_airtable_task(:marketing_shipment_request) %>
     </ul>
     <h2>Info</h2>
     <ul class="grid left-align w-100 mt0" id="info-grid">
-      <%= card_to "Organizations", events_admin_index_path, { badge: Event.approved.count, subtle_badge: true } %>
+      <%= card_to "Organizations", events_admin_index_path, badge: Event.approved.count, subtle_badge: true %>
       <%= card_to "Users", users_admin_index_path %>
       <%= card_to "Donations", donations_admin_index_path %>
       <%= card_to "Invoices", invoices_admin_index_path %>
       <%= card_to "Sponsors", sponsors_admin_index_path %>
       <%= card_to "Cards", stripe_cards_admin_index_path %>
       <%= card_to "Card designs", stripe_card_personalization_designs_admin_index_path %>
-      <%= card_to "Emails", emails_admin_index_path, { badge: Ahoy::Message.count, subtle_badge: true } %>
+      <%= card_to "Emails", emails_admin_index_path, badge: Ahoy::Message.count, subtle_badge: true %>
     </ul>
     <h2>Perks</h2>
     <ul class="grid left-align w-100 mt0" id="perks-grid">
-      <%= card_to "Google Workspaces", google_workspaces_admin_index_path, { badge: GSuite.needs_ops_review.count } %>
-      <%= card_to "Stickers", link_to_airtable_task(:stickers), { async_badge: :pending_stickers_airtable } %>
-      <%= card_to "Hackathons", "https://dash.hackathons.hackclub.com/sign_in", { async_badge: :pending_hackathons_airtable } %>
-      <%= card_to "1Password", link_to_airtable_task(:onepassword), { async_badge: :pending_onepassword_airtable } %>
-      <%= card_to "Domains", link_to_airtable_task(:domains), { async_badge: :pending_domains_airtable } %>
-      <%= card_to "PVSA", link_to_airtable_task(:pvsa), { async_badge: :pending_pvsa_airtable } %>
-      <%= card_to "The Event Helper", link_to_airtable_task(:theeventhelper), { async_badge: :pending_theeventhelper_airtable } %>
-      <%= card_to "Google Workspace Waitlist", link_to_airtable_task(:google_workspace_waitlist), { async_badge: :pending_google_workspace_waitlist_airtable } %>
+      <%= card_to "Google Workspaces", google_workspaces_admin_index_path, badge: GSuite.needs_ops_review.count %>
+      <%= card_to "Stickers", link_to_airtable_task(:stickers), async_badge: :pending_stickers_airtable %>
+      <%= card_to "Hackathons", "https://dash.hackathons.hackclub.com/sign_in", async_badge: :pending_hackathons_airtable %>
+      <%= card_to "1Password", link_to_airtable_task(:onepassword), async_badge: :pending_onepassword_airtable %>
+      <%= card_to "Domains", link_to_airtable_task(:domains), async_badge: :pending_domains_airtable %>
+      <%= card_to "PVSA", link_to_airtable_task(:pvsa), async_badge: :pending_pvsa_airtable %>
+      <%= card_to "The Event Helper", link_to_airtable_task(:theeventhelper), async_badge: :pending_theeventhelper_airtable %>
+      <%= card_to "Google Workspace Waitlist", link_to_airtable_task(:google_workspace_waitlist), async_badge: :pending_google_workspace_waitlist_airtable %>
     </ul>
     <h2>Accounting</h2>
     <ul class="grid left-align w-100 mt0" id="accounting-grid">
-      <%= card_to "Bank Fees", bank_fees_admin_index_path, { badge: BankFee.in_transit_or_pending.count } %>
-      <%= card_to "Ledger audits", admin_ledger_audits_path, { badge: Admin::LedgerAudit.pending.count } %>
+      <%= card_to "Bank Fees", bank_fees_admin_index_path, badge: BankFee.in_transit_or_pending.count %>
+      <%= card_to "Ledger audits", admin_ledger_audits_path, badge: Admin::LedgerAudit.pending.count %>
       <%= render partial: "static_pages/card", locals: { task_path: balances_admin_index_path, human_name: "Organization Balances" } %>
       <%= render partial: "static_pages/card", locals: { task_path: blazer_path, human_name: "BI tool" } %>
       <%= card_to "Column Statements", admin_column_statements_path %>
@@ -88,9 +88,9 @@
     <ul class="grid left-align w-100 mt0" id="other-grid">
       <%= render partial: "static_pages/card", locals: { task_path: common_documents_path, human_name: "Common docs" } %>
       <%= render partial: "static_pages/card", locals: { task_path: flipper_path, human_name: "Flipper" } %>
-      <%= card_to "Pending Ledger", pending_ledger_admin_index_path, { badge: CanonicalPendingTransaction.unsettled.count } %>
-      <%= card_to "Account Numbers", account_numbers_admin_index_path, { badge: Column::AccountNumber.count, subtle_badge: true } %>
-      <%= card_to "Recurring donations", recurring_donations_admin_index_path, { badge: RecurringDonation.active.count } %>
+      <%= card_to "Pending Ledger", pending_ledger_admin_index_path, badge: CanonicalPendingTransaction.unsettled.count %>
+      <%= card_to "Account Numbers", account_numbers_admin_index_path, badge: Column::AccountNumber.count, subtle_badge: true %>
+      <%= card_to "Recurring donations", recurring_donations_admin_index_path, badge: RecurringDonation.active.count %>
     </ul>
     <details>
       <summary>Old cards</summary>
@@ -108,9 +108,9 @@
         <%= render partial: "static_pages/card", locals: { task_path: "https://hack.af/hcb-knowledgebase", human_name: "Knowledgebase" } %>
         <%= render partial: "static_pages/card", locals: { task_path: bank_accounts_path, human_name: "Bank accounts" } %>
         <%= render partial: "static_pages/card", locals: { task_path: new_bank_account_path, human_name: "Setup HCB" } %>
-        <%= card_to "Bank Accounts", bank_accounts_admin_index_path, { badge: BankAccount.failing.count } %>
+        <%= card_to "Bank Accounts", bank_accounts_admin_index_path, badge: BankAccount.failing.count %>
         <%= card_to "HCB Codes", hcb_codes_admin_index_path %>
-        <%= card_to "Raw Transactions", raw_transactions_admin_index_path, { badge: RawCsvTransaction.unhashed.count } %>
+        <%= card_to "Raw Transactions", raw_transactions_admin_index_path, badge: RawCsvTransaction.unhashed.count %>
       </ul>
     </details>
   </div>

--- a/app/views/stripe_cards/_details.html.erb
+++ b/app/views/stripe_cards/_details.html.erb
@@ -3,7 +3,7 @@
 <article class="card max-width-2 mx-auto">
   <h2 class="mt0 heading">
     <span class="flex-auto">
-      <%= user_mention stripe_card.user, { class: "align-bottom tooltipped--s" } %><span class="medium muted">'s</span>
+      <%= user_mention stripe_card.user, class: "align-bottom tooltipped--s" %><span class="medium muted">'s</span>
       <%= stripe_card.name %> <span class="medium muted">Card</span>
     </span>
   </h2>

--- a/app/views/stripe_cards/_shipping.html.erb
+++ b/app/views/stripe_cards/_shipping.html.erb
@@ -6,7 +6,7 @@
   <h3 class="m0 p2 inline-flex items-baseline g1" style="flex-wrap: wrap;">
     Card for
     <% if @event %>
-      <%= user_mention stripe_card.user, { class: style ? "smoke" : "", disable_tooltip: true } %>
+      <%= user_mention stripe_card.user, class: style ? "smoke" : "", disable_tooltip: true %>
     <% else %>
       <%= link_to stripe_card.event.name, stripe_card.event, class: style ? "smoke" : "" %>
     <% end %>

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:nav) do %>
   <h1 class="flex items-center xs-hide border-none h1 mt0 mb0 pt2">
-    <%= avatar_for current_user, 36, { class: "mr1" } %>
+    <%= avatar_for current_user, size: 36, class: "mr1" %>
     <%= current_user.initial_name %>
   </h1>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -72,7 +72,7 @@
           </div>
           <%= form.label :profile_picture %>
           <div class="flex items-center mt1">
-            <%= avatar_for @user, 48, { class: "mr2" } %>
+            <%= avatar_for @user, size: 48, class: "mr2" %>
             <div class="field--fileupload">
               <%= form.label :profile_picture, "Choose File", class: "field--fileupload__label" %>
               <%= form.file_field :profile_picture, accept: "image/png, image/jpeg", class: "field--fileupload__field" %>
@@ -198,7 +198,7 @@
         <div class="field">
           <%= form.label :profile_picture %>
           <p class="flex items-center mt1">
-            <%= avatar_for @user, 48, { class: "mr2" } %>
+            <%= avatar_for @user, size: 48, class: "mr2" %>
             <span>
               <% if @user.profile_picture.attached? %>
               You're currently using an uploaded profile picture.<br>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Using `options` positional arguments causes issues when used with default values as one provided value overrides the rest. Keyword arguments don't have this issue and don't require curly braces.

Closes #8292


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Went through all the helpers with `options` positional arguments, changed them to use keyword arguments, and updated where they are used. One exception was in commit `c599344` - see commit body for details.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

