### PR TITLE
Add `return_to` for initial user creation

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -145,7 +145,7 @@ class LoginsController < ApplicationController
     if @login.complete? && @login.user_session.nil?
       @login.update(user_session: sign_in(user: @login.user, fingerprint_info:))
       if @user.full_name.blank? || @user.phone_number.blank?
-        redirect_to edit_user_path(@user.slug)
+        redirect_to edit_user_path(@user.slug, return_to: params[:return_to])
       else
         redirect_to(params[:return_to] || root_path)
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -207,6 +207,7 @@ class UsersController < ApplicationController
   end
 
   def update
+    return_to = params[:return_to]
     @states = ISO3166::Country.new("US").subdivisions.values.map { |s| [s.translations["en"], s.code] }
     @user = User.friendly.find(params[:id])
     authorize @user
@@ -260,7 +261,7 @@ class UsersController < ApplicationController
 
       if @user.full_name_before_last_save.blank?
         flash[:success] = "Profile created!"
-        redirect_to root_path
+        redirect_to(return_to || root_path)
       else
         if @user.payout_method&.saved_changes? && @user == current_user
           flash[:success] = "Your payout details have been updated. We'll use this information for all payouts going forward."

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -78,6 +78,8 @@
               <%= form.file_field :profile_picture, accept: "image/png, image/jpeg", class: "field--fileupload__field" %>
             </div>
           </div>
+          <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to] %>
+
           <div class="actions flex">
             <button type="submit" class="btn w-full gap-2">
               Start using HCB


### PR DESCRIPTION
## Summary of the problem
After onboarding, the `return_to` parameter is no longer kept


## Describe your changes
This allows you to pass a `return_to` parameter to the user edit page