### PR TITLE
Add setting for monthly donation summaries

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -357,6 +357,7 @@ class UsersController < ApplicationController
       :sessions_reported,
       :session_duration_seconds,
       :receipt_report_option,
+      :donation_summary_option,
       :birthday,
       :seasonal_themes_enabled,
       :payout_method_type,

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -19,7 +19,7 @@ class EventMailer < ApplicationMailer
   private
 
   def set_emails
-    @emails = @event.users.map(&:email_address_with_name)
+    @emails = @event.users.select{ |user| user.donation_summary_option == "on" }.map(&:email_address_with_name)
     @emails << @event.config.contact_email if @event.config.contact_email.present?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,11 @@ class User < ApplicationRecord
     monthly: 2,
   }, prefix: :receipt_report, default: :weekly
 
+  enum :donation_summary_option, {
+    off: 0,
+    on: 1
+  }, default: :on
+
   enum :access_level, { user: 0, admin: 1, superadmin: 2, auditor: 3 }, scopes: false, default: :user
 
   enum :creation_method, {

--- a/app/views/users/edit_notifications.html.erb
+++ b/app/views/users/edit_notifications.html.erb
@@ -17,6 +17,14 @@
                         (User.receipt_report_options.map { |k, v| [k.humanize, k] }) %>
       </fieldset>
       <fieldset class="field">
+        <%= form.label :donation_summary_option, "Donation summaries" %>
+        <p class="h5 muted mt0 mb1">
+          Get a monthly email summary of new donations to your organizations.
+        </p>
+        <%= form.select :donation_summary_option,
+                        (User.donation_summary_options.map { |k, v| [k.humanize, k] }) %>
+      </fieldset>
+      <fieldset class="field">
         <legend class="font-medium">Transaction comments</legend>
         <p class="h5 muted mt-0 mb-3">
           Get an email when someone comments on a transaction or reimbursement report.

--- a/db/migrate/20250420003243_add_donation_summary_setting_to_users.rb
+++ b/db/migrate/20250420003243_add_donation_summary_setting_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDonationSummarySettingToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :donation_summary_option, :integer, default: 1, null: false
+  end
+  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2149,7 +2149,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_20_003243) do
     t.boolean "use_two_factor_authentication", default: false
     t.boolean "teenager"
     t.integer "creation_method"
-    t.integer "donation_summary_option", default: 0, null: false
+    t.integer "donation_summary_option", default: 1, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_150425) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_20_003243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -2149,6 +2149,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_150425) do
     t.boolean "use_two_factor_authentication", default: false
     t.boolean "teenager"
     t.integer "creation_method"
+    t.integer "donation_summary_option", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Following #10148, all users are sent an email each month for each organization they are a member of that has received a donation, without any option to opt-out of these emails.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a setting to the notification settings that allows users to enable or disable being sent these emails.
![image](https://github.com/user-attachments/assets/7e08c37c-0215-4e7d-a600-e8136c66215d)



