### PR TITLE
Explictly pass transaction optional columns to ReceiptsController

### DIFF
--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -42,6 +42,9 @@ class HcbCodesController < ApplicationController
 
     if params[:frame]
       @frame = true
+      @transaction_show_receipt_button = params[:transaction_show_receipt_button].nil? ? false : params[:transaction_show_receipt_button]
+      @transaction_show_author_img = params[:transaction_show_author_img].nil? ? false : params[:transaction_show_author_img]
+
       render :show, layout: false
     else
       @frame = false

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -130,6 +130,8 @@ class ReceiptsController < ApplicationController
 
     if %w[transaction_popover transaction_popover_drag_and_drop].include?(params[:upload_method])
       @frame = true
+      @show_receipt_button = params[:show_receipt_button] == "true"
+      @show_author_img = params[:show_author_img] == "true"
     end
 
     streams += generate_streams
@@ -244,7 +246,7 @@ class ReceiptsController < ApplicationController
           streams.append(turbo_stream.replace(
                            ct.local_hcb_code.hashid,
                            partial: "canonical_transactions/canonical_transaction",
-                           locals: @frame && @event ? { ct:, event: @event, show_amount: true, updated_via_turbo_stream: true, show_author_column: true } : { ct:, force_display_details: true, receipt_upload_button: true, show_event_name: true, updated_via_turbo_stream: true }
+                           locals: @frame && @event ? { ct:, event: @event, show_amount: true, updated_via_turbo_stream: true, show_author_column: @show_author_img, receipt_upload_button: @show_receipt_button, } : { ct:, force_display_details: true, show_author_column: @show_author_img, receipt_upload_button: @show_receipt_button, show_event_name: true, updated_via_turbo_stream: true }
                          ))
         end
       else
@@ -253,7 +255,7 @@ class ReceiptsController < ApplicationController
           streams.append(turbo_stream.replace(
                            pt.local_hcb_code.hashid,
                            partial: "canonical_pending_transactions/canonical_pending_transaction",
-                           locals: @frame && @event ? { pt:, event: @event, show_amount: true, updated_via_turbo_stream: true, show_author_column: true } : { pt:, force_display_details: true, receipt_upload_button: !@frame, show_event_name: true, updated_via_turbo_stream: true }
+                           locals: @frame && @event ? { pt:, event: @event, show_amount: true, updated_via_turbo_stream: true, show_author_column: @show_author_img, receipt_upload_button: @show_receipt_button, } : { pt:, force_display_details: true, show_author_column: @show_author_img, receipt_upload_button: @show_receipt_button, show_event_name: true, updated_via_turbo_stream: true }
                          ))
         end
       end

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -46,6 +46,9 @@ class ReceiptsController < ApplicationController
 
     @receipt.update!(receiptable: @receiptable)
 
+    @show_receipt_button = params[:show_receipt_button] == "true"
+    @show_author_img = params[:show_author_img] == "true"
+
     respond_to do |format|
       format.turbo_stream { render turbo_stream: generate_streams }
       format.html         {
@@ -79,6 +82,9 @@ class ReceiptsController < ApplicationController
     if params[:popover].present?
       @popover = params[:popover]
     end
+
+    @show_author_img = params[:show_author_img]
+    @show_receipt_button = params[:show_receipt_button]
 
     if @receiptable.instance_of?(HcbCode)
       pairings_sql = <<~SQL

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -127,11 +127,11 @@ class ReceiptsController < ApplicationController
                      ))
     end
 
+    @show_receipt_button = params[:show_receipt_button] == "true"
+    @show_author_img = params[:show_author_img] == "true"
 
     if %w[transaction_popover transaction_popover_drag_and_drop].include?(params[:upload_method])
       @frame = true
-      @show_receipt_button = params[:show_receipt_button] == "true"
-      @show_author_img = params[:show_author_img] == "true"
     end
 
     streams += generate_streams

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -63,8 +63,10 @@ class HcbCode < ApplicationRecord
     receipts "Has receipt?" do |receipts| receipts.exists? end
   end
 
-  def popover_path
-    "/hcb/#{hashid}?frame=true"
+  def popover_path(**params)
+    author_img_param = "&transaction_show_author_img=#{params[:transaction_show_author_img]}" if params[:transaction_show_author_img]
+    receipt_button_param = "&transaction_show_receipt_button=#{params[:transaction_show_receipt_button]}" if params[:transaction_show_receipt_button]
+    "/hcb/#{hashid}?frame=true#{author_img_param}#{receipt_button_param}"
   end
 
   def receipt_upload_email

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -169,7 +169,7 @@
   <% pretty_title = pt.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event_name: @event&.name, amount_cents: pt.amount) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(pt.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(pt.local_hcb_code)) %>
-    <%= turbo_frame_tag pt.local_hcb_code.public_id, src: pt.local_hcb_code.popover_path, loading: :lazy do %>
+    <%= turbo_frame_tag pt.local_hcb_code.public_id, src: pt.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy do %>
       <div class="shimmer mb1 mt3">
         <div class="shimmer__border"></div>
         <div class="shimmer__main">

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -132,6 +132,8 @@
           <%= form.hidden_field :receiptable_type, value: pt.local_hcb_code.class %>
           <%= form.hidden_field :receiptable_id, value: pt.local_hcb_code.id %>
           <%= form.hidden_field :upload_method, value: "receipts_page", data: { "file-drop-target" => "uploadMethod" } %>
+          <%= form.hidden_field :show_receipt_button, value: local_assigns[:receipt_upload_button] %>
+          <%= form.hidden_field :show_author_img, value: local_assigns[:show_author_column] %>
           <div class="<%= "btn-group btn-group--no-wrap w-100" if Flipper.enabled?(:receipt_bin_2023_04_07, current_user) %>">
             <%= form.label "file_#{pt.local_hcb_code.hashid}", class: "btn #{"disabled" if local_assigns[:receipt_upload_button_disabled]} flex-grow", style: "font-size: 0.875rem; font-weight: 600; padding: 0.25rem 1rem;" do %>
               <%= inline_icon "cloud-upload" %>

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -159,7 +159,7 @@
     <% if Flipper.enabled?(:receipt_bin_2023_04_07, current_user) && !local_assigns[:receipt_upload_button_disabled] %>
       <section class="modal modal--huge modal--scroll bg-snow" data-behavior="modal" role="dialog" id="link_receipt_<%= instance %>">
         <%= modal_header "Select receipt" %>
-        <%= turbo_frame_tag "link_modal_#{pt.local_hcb_code.id}", src: link_modal_receipts_path(receiptable_type: "HcbCode", receiptable_id: pt.local_hcb_code.id), turbo_frame: "_top" do %>
+        <%= turbo_frame_tag "link_modal_#{pt.local_hcb_code.id}", src: link_modal_receipts_path(receiptable_type: "HcbCode", receiptable_id: pt.local_hcb_code.id, show_receipt_button: local_assigns[:receipt_upload_button], show_author_img: local_assigns[:show_author_column]), turbo_frame: "_top" do %>
           <strong>Loading...</strong>
         <% end %>
       </section>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -190,7 +190,7 @@
   <% pretty_title = ct.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event_name: @event&.name, amount_cents: ct.amount) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(ct.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(ct.local_hcb_code)) %>
-    <%= turbo_frame_tag ct.local_hcb_code.public_id, src: ct.local_hcb_code.popover_path, loading: :lazy do %>
+    <%= turbo_frame_tag ct.local_hcb_code.public_id, src: ct.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy do %>
       <div class="shimmer mb1 mt3">
         <div class="shimmer__border"></div>
         <div class="shimmer__main">

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -152,6 +152,8 @@
           <%= form.hidden_field :receiptable_type, value: ct.local_hcb_code.class %>
           <%= form.hidden_field :receiptable_id, value: ct.local_hcb_code.id %>
           <%= form.hidden_field :upload_method, value: "receipts_page", data: { "file-drop-target" => "uploadMethod" } %>
+          <%= form.hidden_field :show_receipt_button, value: local_assigns[:receipt_upload_button] %>
+          <%= form.hidden_field :show_author_img, value: local_assigns[:show_author_column] %>
           <div class="<%= "btn-group btn-group--no-wrap w-100" if Flipper.enabled?(:receipt_bin_2023_04_07, current_user) %>">
             <%= form.label "file_#{ct.local_hcb_code.hashid}", class: "btn #{"disabled" if local_assigns[:receipt_upload_button_disabled]} flex-grow", style: "font-size: 0.875rem; font-weight: 600; padding: 0.25rem 1rem;" do %>
               <%= inline_icon "cloud-upload" %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -179,7 +179,7 @@
     <% if Flipper.enabled?(:receipt_bin_2023_04_07, current_user) && !local_assigns[:receipt_upload_button_disabled] %>
       <section class="modal modal--huge modal--scroll bg-snow" data-behavior="modal" role="dialog" id="link_receipt_<%= instance %>">
         <%= modal_header "Select receipt" %>
-        <%= turbo_frame_tag "link_modal_#{ct.local_hcb_code.id}", src: link_modal_receipts_path(receiptable_type: "HcbCode", receiptable_id: ct.local_hcb_code.id), turbo_frame: "_top" do %>
+        <%= turbo_frame_tag "link_modal_#{ct.local_hcb_code.id}", src: link_modal_receipts_path(receiptable_type: "HcbCode", receiptable_id: ct.local_hcb_code.id, show_receipt_button: local_assigns[:receipt_upload_button], show_author_img: local_assigns[:show_author_column]), turbo_frame: "_top" do %>
           <strong>Loading...</strong>
         <% end %>
       </section>

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -35,6 +35,8 @@
                 receipt_upload_form_config[:inline_linking] = true if @frame
                 receipt_upload_form_config[:upload_method] = "transaction_popover" if @frame
                 receipt_upload_form_config[:popover] = "HcbCode:#{@hcb_code.hashid}" if @frame
+                receipt_upload_form_config[:show_receipt_button] = @transaction_show_receipt_button
+                receipt_upload_form_config[:show_author_img] = @transaction_show_author_img
                 render partial: "receipts/form_v3", locals: receipt_upload_form_config end %>
     <% end %>
   <% end %>

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -101,7 +101,7 @@
           <%= pop_icon_to "view-close", nil, class: "modal__close muted m1", tabindex: 0, onclick: "event.preventDefault(); $('#link_receipt_#{instance.to_json}_select').hide(); $('#link_receipt_#{instance.to_json}_form').show();" %>
           <h2 class="h1 mt0 mb0 pb0 border-none">Select receipt</h2>
         </header>
-        <%= turbo_frame_tag "link_modal_#{receiptable.id}", src: link_modal_receipts_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id, popover: local_assigns[:popover], streams: defined?(turbo) ? turbo : "false") do %>
+        <%= turbo_frame_tag "link_modal_#{receiptable.id}", src: link_modal_receipts_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id, popover: local_assigns[:popover], streams: defined?(turbo) ? turbo : "false", show_author_img: true) do %>
           <strong>Loading...</strong>
         <% end %>
       </section>

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -46,7 +46,8 @@
           <%= (form.hidden_field :popover, value: local_assigns[:popover]) %>
           <%= (form.hidden_field :show_link, value: true) if defined?(inline_linking) %>
           <%= form.hidden_field :upload_method, value: upload_method, data: { "file-drop-target" => "uploadMethod" } %>
-          <%= (form.hidden_field :s, value: secret) if defined?(secret) %>
+          <%= (form.hidden_field :show_receipt_button, value: local_assigns[:show_receipt_button]) %>
+          <%= (form.hidden_field :show_author_img, value: local_assigns[:show_author_img]) %>
 
           <%= form.file_field :file,
                               multiple: true,

--- a/app/views/receipts/link_modal.html.erb
+++ b/app/views/receipts/link_modal.html.erb
@@ -17,6 +17,8 @@
       <%= form.hidden_field :receiptable_type, value: @receiptable.class %>
       <%= form.hidden_field :show_link, value: @show_link %>
       <%= (form.hidden_field :popover, value: @popover) if defined?(@popover) %>
+      <%= form.hidden_field :show_receipt_button, value: @show_receipt_button %>
+      <%= form.hidden_field :show_author_img, value: @show_author_img %>
 
       <ul class="grid grid--narrow left-align w-100 grid--spacious mt0 justify-center">
         <% @receipts.each do |receipt| %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, assumptions were being made in ReceiptsController that resulted in certain transaction row columns (the receipt upload button and author pfp) being incorrectly displayed (or not) when a receipt was uploaded in the HcbCode popover. This is seen in the screenshots uploaded to #7211.

Closes #7211 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I had to pass the relevant locals from canonical transaction and canonical pending transaction rows through the HcbCode popover and receipts form to `ReceiptsController`, which now uses these values when updating the Turbo stream to replace the canonical (pending) transaction.
