### PR TITLE
[Loops] Add "Hcb Has Card Grant" property

### DIFF
--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -21,6 +21,7 @@ module UserService
         hcbLastSeenAt: format_unix(@user.last_seen_at),
         hcbLastLoginAt: format_unix(@user.last_login_at),
         hcbHasActiveOrg: @user.events.active.any?,
+        hcbHasCardGrant: @user.card_grants.any?,
         mailingLists: {
           # https://loops.so/docs/contacts/mailing-lists#api
           Credentials.fetch(:LOOPS, :MAILING_LIST) => true


### PR DESCRIPTION
## Summary of the problem
Loops doesn't have information about whether or not a user has card grants. Knowing this information can help us tailor marketing emails to users who have or don't have card grants. This is part of an ongoing effort to convert users from card grant users to nonprofit organizers.



## Describe your changes
Adds `hcbHasCardGrant` to `UserService::SyncWithLoops`

https://github.com/hackclub/hcb/blob/1fc9db243bf7b597975d0b0670f14a6a4657a4d4/app/services/user_service/sync_with_loops.rb#L24