### PR TITLE
[UI] Make the "Jump to" keybinds change for Windows

### DIFF
--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -10,8 +10,8 @@
       style="border-radius: 8px"
       data-behavior="command_bar_trigger">
       <span class="flex-grow text-left font-medium">Jump to...</span>
-      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent&.to_s&.upcase&.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
-        <%= request.user_agent&.to_s&.upcase&.include?('MAC') ? '⌘'  : 'Ctrl' %>
+      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent.to_s.upcase.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
+        <%= request.user_agent.to_s.upcase.include?('MAC') ? '⌘'  : 'Ctrl' %>
       </span>
       <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md text-sm">
         K

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -10,8 +10,8 @@
       style="border-radius: 8px"
       data-behavior="command_bar_trigger">
       <span class="flex-grow text-left font-medium">Jump to...</span>
-      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md mr-2 text-sm">
-        ⌘
+      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-9 rounded-md mr-2 text-sm">
+        <%= request.user_agent.to_s.upcase.include?('WIN') ? 'Ctrl' : '⌘' %>
       </span>
       <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md text-sm">
         K

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -10,8 +10,8 @@
       style="border-radius: 8px"
       data-behavior="command_bar_trigger">
       <span class="flex-grow text-left font-medium">Jump to...</span>
-      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-9 rounded-md mr-2 text-sm">
-        <%= request.user_agent.to_s.upcase.include?('WIN') ? 'Ctrl' : '⌘' %>
+      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent.to_s.upcase.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
+        <%= request.user_agent.to_s.upcase.include?('WIN') || request.user_agent.to_s.upcase.include?('LINUX') ? 'Ctrl' : '⌘' %>
       </span>
       <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md text-sm">
         K

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -10,8 +10,8 @@
       style="border-radius: 8px"
       data-behavior="command_bar_trigger">
       <span class="flex-grow text-left font-medium">Jump to...</span>
-      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent.to_s.upcase.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
-        <%= request.user_agent.to_s.upcase.include?('MAC') ? '⌘'  : 'Ctrl' %>
+      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent.to_s.upcase.include?("MAC") ? "w-6" : "w-9" %> rounded-md mr-2 text-sm">
+        <%= request.user_agent.to_s.upcase.include?("MAC") ? "⌘" : "Ctrl" %>
       </span>
       <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md text-sm">
         K

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -10,8 +10,8 @@
       style="border-radius: 8px"
       data-behavior="command_bar_trigger">
       <span class="flex-grow text-left font-medium">Jump to...</span>
-      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent.to_s.upcase.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
-        <%= request.user_agent.to_s.upcase.include?('WIN') || request.user_agent.to_s.upcase.include?('LINUX') ? 'Ctrl' : '⌘' %>
+      <span class="bg-gray-300 dark:bg-gray-700 opacity-75 <%= request.user_agent&.to_s&.upcase&.include?('MAC') ? 'w-6' : 'w-9' %> rounded-md mr-2 text-sm">
+        <%= request.user_agent&.to_s&.upcase&.include?('MAC') ? '⌘'  : 'Ctrl' %>
       </span>
       <span class="bg-gray-300 dark:bg-gray-700 opacity-75 w-6 rounded-md text-sm">
         K


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
It used to show ⌘  K in the `Jump To...` menu even while on Windows



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

It now shows Ctrl K instead of ⌘ K while on Windows. On Mac, it stays as ⌘ K

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

Before on Windows
![image](https://github.com/user-attachments/assets/a2b00bc5-0b7a-43d1-917c-f8dd917d3528) 

After on Windows
![image](https://github.com/user-attachments/assets/29ce563d-69fc-4ab2-a6a6-e0fbd16d2026)

