### PR TITLE
Fix API route for fetching unread blog posts

### DIFF
--- a/app/javascript/controllers/blog_notification_controller.js
+++ b/app/javascript/controllers/blog_notification_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   async updateBadge() {
     try {
-      const { count } = await fetch('https://blog.hcb.hackclub.com', {
+      const { count } = await fetch('https://blog.hcb.hackclub.com/api/unreads', {
         credentials: 'include',
       }).then(res => res.json())
 

--- a/app/javascript/controllers/blog_notification_controller.js
+++ b/app/javascript/controllers/blog_notification_controller.js
@@ -9,9 +9,12 @@ export default class extends Controller {
 
   async updateBadge() {
     try {
-      const { count } = await fetch('https://blog.hcb.hackclub.com/api/unreads', {
-        credentials: 'include',
-      }).then(res => res.json())
+      const { count } = await fetch(
+        'https://blog.hcb.hackclub.com/api/unreads',
+        {
+          credentials: 'include',
+        }
+      ).then(res => res.json())
 
       if (count < 1) return
 


### PR DESCRIPTION
## Summary of the problem
It was fetching `https://blog.hcb.hackclub.com/` instead of `https://blog.hcb.hackclub.com/api/unreads`


## Describe your changes
Changes `https://blog.hcb.hackclub.com/` to `https://blog.hcb.hackclub.com/api/unreads`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

