### PR TITLE
Enable Sidekiq in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -101,6 +101,8 @@ Rails.application.configure do
   # SMTP config
   config.action_mailer.delivery_method = :letter_opener_web
 
+  config.active_job.queue_adapter = :sidekiq
+
   # Bullet for finding N+1s
   config.after_initialize do
     Bullet.enable        = true

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -199,7 +199,9 @@ We've transitioned to using development keys and seed data in development, but h
 ## Sidekiq
 
 [Sidekiq](https://github.com/sidekiq/sidekiq) is the Active Job backend used for HCB, with features such as scheduled jobs and a web UI. While it is enabled in development, you may need to manually load schedule jobs (located in `config/schedule.yml`) using:
+
 ```ruby
 Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/schedule.yml")
 ```
-in the Rails console. The web UI is available at [localhost:3000/sidekiq](http://localhost:3000/sidekiq).
+
+in the Rails console (`bin/rails c`). The web UI is available at [localhost:3000/sidekiq](http://localhost:3000/sidekiq).

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -195,3 +195,11 @@ We've transitioned to using development keys and seed data in development, but h
 ## Flipper
 
 [Flipper](https://github.com/flippercloud/flipper) is used to toggle feature flags on HCB. Flipper can be accessed at [localhost:3000/flipper/features](http://localhost:3000/flipper/features). To enable a flag, press "Add Feature", paste in the name of a feature from [this list](https://hcb.hackclub.com/api/flags), and then press "Fully Enable".
+
+## Sidekiq
+
+[Sidekiq](https://github.com/sidekiq/sidekiq) is the Active Job backend used for HCB, with features such as scheduled jobs and a web UI. While it is enabled in development, you may need to manually load schedule jobs (located in `config/schedule.yml`) using:
+```ruby
+Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/schedule.yml")
+```
+in the Rails console. The web UI is available at [localhost:3000/sidekiq](http://localhost:3000/sidekiq).


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
HCB in development currently uses the default async backend for Active Job, which lacks Sidekiq's features like the dashboard and cron jobs.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I enabled using Sidekiq in the development environment file. While this makes it so that new jobs use Sidekiq, I couldn't figure out why it didn't automatically load the jobs from `schedule.yml` - which it should be doing automatically according to `sidekiq-cron`'s [README](https://github.com/sidekiq-cron/sidekiq-cron?tab=readme-ov-file#loading-jobs-from-schedule-file) (and if not, in the sidekiq initializer). For now, I've added dev docs on how to load the schedule manually.

