### PR TITLE
Always send ACHs & checks with an organisation's account number

### DIFF
--- a/app/jobs/process_column_check_deposit_job.rb
+++ b/app/jobs/process_column_check_deposit_job.rb
@@ -26,8 +26,11 @@ class ProcessColumnCheckDepositJob < ApplicationJob
       conn.post("/transfers/checks/image/back", { file: Faraday::Multipart::FilePart.new(file.path, check_deposit.back.content_type) }).body
     end
 
+    event = check_deposit.event
+    account_number_id = (event.column_account_number || event.create_column_account_number)&.column_id
+
     column_check_deposit = ColumnService.post("/transfers/checks/deposit", bank_account_id: ColumnService::Accounts::FS_MAIN,
-                                                                           account_number_id: Credentials.fetch(:COLUMN, ColumnService::ENVIRONMENT, :DEFAULT_ACCOUNT_NUMBER),
+                                                                           account_number_id:,
                                                                            deposited_amount: check_deposit.amount_cents,
                                                                            currency_code: "USD",
                                                                            micr_line: front["micr_line"],

--- a/app/models/ach_transfer.rb
+++ b/app/models/ach_transfer.rb
@@ -192,8 +192,7 @@ class AchTransfer < ApplicationRecord
   def send_ach_transfer!
     return unless may_mark_in_transit?
 
-    account_number_id = event.column_account_number&.column_id ||
-                        Credentials.fetch(:COLUMN, ColumnService::ENVIRONMENT, :DEFAULT_ACCOUNT_NUMBER)
+    account_number_id = (event.column_account_number || event.create_column_account_number)&.column_id
 
     column_ach_transfer = ColumnService.post("/transfers/ach", {
       idempotency_key: self.id.to_s,

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -227,8 +227,7 @@ class IncreaseCheck < ApplicationRecord
   private
 
   def send_column!
-    account_number_id = event.column_account_number&.column_id ||
-                        Credentials.fetch(:COLUMN, ColumnService::ENVIRONMENT, :DEFAULT_ACCOUNT_NUMBER)
+    account_number_id = (event.column_account_number || event.create_column_account_number)&.column_id
 
     column_check = ColumnService.post "/transfers/checks/issue",
                                       idempotency_key: self.id.to_s,


### PR DESCRIPTION
Progress towards https://github.com/hackclub/hcb/issues/9661. Also relevant for check deposits, however, it's not always (manual check deposits).