### PR TITLE
Implement dropdown buttons

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -463,10 +463,15 @@ input:where([data-behavior='otp_input']) {
   left: 0px;
 
   overflow: clip;
-  border-color: $dark;
   border-width: 2px;
   border-style: solid;
-  background-color: $darker;
+  background-color: $smoke;
+  border-color: $white;
+
+  [data-dark='true'] & {
+    background-color: $darker;
+    border-color: $dark;
+  }
 
   display: none;
 }
@@ -502,17 +507,12 @@ input:where([data-behavior='otp_input']) {
 
 .btn-dropdown {
   border-radius: 0.75rem 0px 0px 0.75rem;
-  border-right-color: $darker;
-  border-right-width: 2px;
-  border-right-style: solid;
 }
 
 .btn-dropdown-toggle {
   border-radius: 0px 0.75rem 0.75rem 0px;
-  border-left-color: $darker;
-  border-left-width: 2px;
-  border-left-style: solid;
   width: 3rem;
+  margin-left: 2px;
 }
 
 .btn-dropdown-toggle svg {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -462,15 +462,10 @@ input:where([data-behavior='otp_input']) {
   top: 105%;
   left: 0px;
 
-  overflow: clip;
-  border-width: 2px;
-  border-style: solid;
   background-color: $smoke;
-  border-color: $white;
 
   [data-dark='true'] & {
     background-color: $darker;
-    border-color: $dark;
   }
 
   display: none;
@@ -507,14 +502,34 @@ input:where([data-behavior='otp_input']) {
 
 .btn-dropdown {
   border-radius: 0.75rem 0px 0px 0.75rem;
+  transform: unset !important;
 }
 
 .btn-dropdown-toggle {
   border-radius: 0px 0.75rem 0.75rem 0px;
   width: 3rem;
   margin-left: 2px;
+  transform: unset !important;
 }
 
 .btn-dropdown-toggle svg {
   margin-right: 0px;
+}
+
+.dropdown-button-container {
+  display: flex;
+  border-radius: 0.75rem;
+
+  transform: scale(1);
+  transition:
+    transform 0.125s ease-in-out,
+    box-shadow 0.25s ease-in-out;
+    
+  &:hover,
+  &:focus,
+  &[aria-expanded='true'] {
+    color: $white;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1875);
+    transform: scale(1.0625);
+  }
 }

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -455,6 +455,11 @@ input:where([data-behavior='otp_input']) {
   color: inherit !important;
 }
 
+.dropdown-button {
+  position: relative;
+  width: fit-content;
+}
+
 .dropdown-button-menu {
   width: 100%;
 
@@ -470,6 +475,8 @@ input:where([data-behavior='otp_input']) {
 
   display: none;
   opacity: 0;
+
+  z-index: 10;
 }
 
 .dropdown-button-menu-hidden {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -474,7 +474,7 @@ input:where([data-behavior='otp_input']) {
   opacity: 0;
 
   z-index: 10;
-  
+
   margin-top: 8px;
 }
 

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -454,3 +454,37 @@ input:where([data-behavior='otp_input']) {
   border: none !important;
   color: inherit !important;
 }
+
+.button-variant-select {
+  position: absolute;
+  top: 0px;
+  padding-left: 2.5rem;
+  width: calc(2.5rem + 100%);
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid #000;
+}
+
+.button-variant-select:after {
+  width: 0; 
+  height: 0; 
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid #f00;
+  position: absolute;
+  top: 40%;
+  right: 5px;
+  content: "";
+  z-index: 98;
+}
+
+.select-bg-success {
+  background-color: $green !important;
+}
+
+.button-variant-btn {
+  border-radius: 0.75rem 0px 0px 0.75rem;
+  border-right-color: $dark;
+  border-right-width: 2px;
+  border-right-style: solid;
+}

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -455,12 +455,7 @@ input:where([data-behavior='otp_input']) {
   color: inherit !important;
 }
 
-.dropdown-button {
-  position: relative;
-  width: fit-content;
-}
-
-.dropdown-button-menu {
+.dropdown-button__menu {
   width: 100%;
 
   position: absolute;
@@ -479,16 +474,16 @@ input:where([data-behavior='otp_input']) {
   z-index: 10;
 }
 
-.dropdown-button-menu-hidden {
-  animation: dropdown-button-menu-close 0.1s ease-out forwards;
+.dropdown-button__menu--hidden {
+  animation: dropdown-button__menu--close 0.1s ease-out forwards;
 }
 
-.dropdown-button-menu-show {
-  animation: dropdown-button-menu-open 0.1s ease-out forwards;
+.dropdown-button__menu--show {
+  animation: dropdown-button__menu--open 0.1s ease-out forwards;
   display: flex;
 }
 
-@keyframes dropdown-button-menu-open {
+@keyframes dropdown-button__menu--open {
   from {
     opacity: 0;
     display: none;
@@ -500,7 +495,7 @@ input:where([data-behavior='otp_input']) {
   }
 }
 
-@keyframes dropdown-button-menu-close {
+@keyframes dropdown-button__menu--close {
   from {
     opacity: 1;
     display: flex;
@@ -512,7 +507,7 @@ input:where([data-behavior='otp_input']) {
   }
 }
 
-.dropdown-button-menu div {
+.dropdown-button__menu div {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -521,43 +516,27 @@ input:where([data-behavior='otp_input']) {
   border-radius: 0.3rem;
 }
 
-.dropdown-button-menu input {
+.dropdown-button__menu input {
   display: none;
 }
 
-.dropdown-button-menu label {
+.dropdown-button__menu label {
   padding: 0.5rem 1rem;
   border-radius: inherit;
 }
 
-.dropdown-button-menu label p {
+.dropdown-button__menu label p {
   margin: 3px 0px;
 }
 
-.dropdown-button-menu label:hover {
+.dropdown-button__menu label:hover {
   background-color: color-mix(in srgb, $slate 20%, transparent);
 }
-.dropdown-button-menu input:checked+label {
+.dropdown-button__menu input:checked+label {
   background-color: color-mix(in srgb, $green-dark 20%, transparent);
 }
 
-.btn-dropdown {
-  border-radius: 0.75rem 0px 0px 0.75rem;
-  transform: unset !important;
-}
-
-.btn-dropdown-toggle {
-  border-radius: 0px 0.75rem 0.75rem 0px;
-  width: 3rem;
-  margin-left: 2px;
-  transform: unset !important;
-}
-
-.btn-dropdown-toggle svg {
-  margin-right: 0px;
-}
-
-.dropdown-button-container {
+.dropdown-button__container {
   display: flex;
   border-radius: 0.75rem;
 

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -455,36 +455,66 @@ input:where([data-behavior='otp_input']) {
   color: inherit !important;
 }
 
-.button-variant-select {
+.dropdown-button-menu {
+  width: 100%;
+
   position: absolute;
-  top: 0px;
-  padding-left: 2.5rem;
-  width: calc(2.5rem + 100%);
+  top: 105%;
+  left: 0px;
+
+  overflow: clip;
+  border-color: $dark;
+  border-width: 2px;
+  border-style: solid;
+  background-color: $darker;
+
+  display: none;
+}
+
+.dropdown-button-menu div {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
   height: 100%;
-  overflow: hidden;
-  border: 1px solid #000;
+
+  border-radius: 0.3rem;
 }
 
-.button-variant-select:after {
-  width: 0; 
-  height: 0; 
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 6px solid #f00;
-  position: absolute;
-  top: 40%;
-  right: 5px;
-  content: "";
-  z-index: 98;
+.dropdown-button-menu input {
+  display: none;
 }
 
-.select-bg-success {
-  background-color: $green !important;
+.dropdown-button-menu label {
+  padding: 0.5rem 1rem;
+  border-radius: inherit;
 }
 
-.button-variant-btn {
+.dropdown-button-menu label p {
+  margin: 3px 0px;
+}
+
+.dropdown-button-menu label:hover {
+  background-color: color-mix(in srgb, $slate 20%, transparent);
+}
+.dropdown-button-menu input:checked+label {
+  background-color: color-mix(in srgb, $green-dark 20%, transparent);
+}
+
+.btn-dropdown {
   border-radius: 0.75rem 0px 0px 0.75rem;
-  border-right-color: $dark;
+  border-right-color: $darker;
   border-right-width: 2px;
   border-right-style: solid;
+}
+
+.btn-dropdown-toggle {
+  border-radius: 0px 0.75rem 0.75rem 0px;
+  border-left-color: $darker;
+  border-left-width: 2px;
+  border-left-style: solid;
+  width: 3rem;
+}
+
+.btn-dropdown-toggle svg {
+  margin-right: 0px;
 }

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -459,7 +459,7 @@ input:where([data-behavior='otp_input']) {
   width: 100%;
 
   position: absolute;
-  top: 105%;
+  top: 110%;
   left: 0px;
 
   background-color: $smoke;
@@ -469,6 +469,40 @@ input:where([data-behavior='otp_input']) {
   }
 
   display: none;
+  opacity: 0;
+}
+
+.dropdown-button-menu-hidden {
+  animation: dropdown-button-menu-close 0.1s ease-out forwards;
+}
+
+.dropdown-button-menu-show {
+  animation: dropdown-button-menu-open 0.1s ease-out forwards;
+  display: flex;
+}
+
+@keyframes dropdown-button-menu-open {
+  from {
+    opacity: 0;
+    display: none;
+  }
+
+  to {
+    opacity: 1;
+    display: flex;
+  }
+}
+
+@keyframes dropdown-button-menu-close {
+  from {
+    opacity: 1;
+    display: flex;
+  }
+
+  to {
+    opacity: 0;
+    display: none;
+  }
 }
 
 .dropdown-button-menu div {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -532,7 +532,7 @@ input:where([data-behavior='otp_input']) {
 .dropdown-button__menu label:hover {
   background-color: color-mix(in srgb, $slate 20%, transparent);
 }
-.dropdown-button__menu input:checked+label {
+.dropdown-button__menu input:checked + label {
   background-color: color-mix(in srgb, $green-dark 20%, transparent);
 }
 
@@ -544,7 +544,7 @@ input:where([data-behavior='otp_input']) {
   transition:
     transform 0.125s ease-in-out,
     box-shadow 0.25s ease-in-out;
-    
+
   &:hover,
   &:focus,
   &[aria-expanded='true'] {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -462,6 +462,8 @@ input:where([data-behavior='otp_input']) {
   top: 110%;
   left: 0px;
 
+  border-radius: 0.75rem;
+
   background-color: $smoke;
 
   [data-dark='true'] & {
@@ -513,7 +515,7 @@ input:where([data-behavior='otp_input']) {
   width: 100%;
   height: 100%;
 
-  border-radius: 0.3rem;
+  border-radius: inherit;
 }
 
 .dropdown-button__menu input {

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -474,6 +474,8 @@ input:where([data-behavior='otp_input']) {
   opacity: 0;
 
   z-index: 10;
+  
+  margin-top: 8px;
 }
 
 .dropdown-button__menu--hidden {

--- a/app/controllers/reimbursement/expenses_controller.rb
+++ b/app/controllers/reimbursement/expenses_controller.rb
@@ -6,7 +6,9 @@ module Reimbursement
 
     def create
       @report = Reimbursement::Report.find(params[:report_id])
-      @expense = @report.expenses.build(amount_cents: 0)
+
+      type = params[:type] == "mileage" ? "Reimbursement::Expense::Mileage" : "Reimbursement::Expense"
+      @expense = @report.expenses.build(amount_cents: 0, type:)
 
       authorize @expense
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -389,4 +389,28 @@ module ApplicationHelper
     capture { link_to(name, uri.to_s, *options) }
   end
 
+  def dropdown_button(button_class: "bg-success", template: "[VALUE]", **options)
+    return content_tag :div, class: "dropdown-button #{options[:class]}", data: { controller: "dropdown-button", "dropdown-button-target": "container" } do
+      (content_tag :div, class: "dropdown-button-container", **options[:button_container_options] do
+        (content_tag :button, class: "btn btn-dropdown #{button_class}" do
+          (inline_icon options[:button_icon]) +
+          (content_tag :span, template.gsub("[VALUE]", options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
+        end) +
+        (content_tag :button, type: "button", class: "btn btn-dropdown btn-dropdown-toggle #{button_class}", data: { action: "click->dropdown-button#toggle" } do
+          inline_icon "down-caret"
+        end)
+      end) +
+      (content_tag :div, class: "dropdown-button-menu dropdown-button-menu-hidden", data: { "dropdown-button-target": "menu" } do
+        content_tag :div do
+          (options[:options].map do |option|
+            (options[:form].radio_button options[:name], option[1], { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } }) +
+            (options[:form].label options[:name], value: option[1] do
+              (tag.strong option[0]) + (tag.p option[2])
+            end)
+          end).join.html_safe
+        end
+      end)
+    end
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -390,17 +390,17 @@ module ApplicationHelper
   end
 
   def dropdown_button(button_class: "bg-success", template: "[VALUE]", **options)
-    return content_tag :div, class: "dropdown-button #{options[:class]}", data: { controller: "dropdown-button", "dropdown-button-target": "container" } do
-      (content_tag :div, class: "dropdown-button-container", **options[:button_container_options] do
-        (content_tag :button, class: "btn btn-dropdown #{button_class}" do
+    return content_tag :div, class: "relative w-fit #{options[:class]}", data: { controller: "dropdown-button", "dropdown-button-target": "container" } do
+      (content_tag :div, class: "dropdown-button__container", **options[:button_container_options] do
+        (content_tag :button, class: "btn !transform-none rounded-l-xl rounded-r-none #{button_class}" do
           (inline_icon options[:button_icon]) +
           (content_tag :span, template.gsub("[VALUE]", options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
         end) +
-        (content_tag :button, type: "button", class: "btn btn-dropdown btn-dropdown-toggle #{button_class}", data: { action: "click->dropdown-button#toggle" } do
-          inline_icon "down-caret"
+        (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none w-12 ml-1 #{button_class}", data: { action: "click->dropdown-button#toggle" } do
+          inline_icon "down-caret", class: "!mr-0"
         end)
       end) +
-      (content_tag :div, class: "dropdown-button-menu dropdown-button-menu-hidden", data: { "dropdown-button-target": "menu" } do
+      (content_tag :div, class: "dropdown-button__menu dropdown-button__menu--hidden", data: { "dropdown-button-target": "menu" } do
         content_tag :div do
           (options[:options].map do |option|
             (options[:form].radio_button options[:name], option[1], { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } }) +

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -389,7 +389,7 @@ module ApplicationHelper
     capture { link_to(name, uri.to_s, *options) }
   end
 
-  def dropdown_button(button_class: "bg-success", template: ->(value) {value}, **options)
+  def dropdown_button(button_class: "bg-success", template: ->(value) { value }, **options)
     return content_tag :div, class: "relative w-fit #{options[:class]}", data: { controller: "dropdown-button", "dropdown-button-target": "container" } do
       (content_tag :div, class: "dropdown-button__container", **options[:button_container_options] do
         (content_tag :button, class: "btn !transform-none rounded-l-xl rounded-r-none #{button_class}" do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -389,12 +389,12 @@ module ApplicationHelper
     capture { link_to(name, uri.to_s, *options) }
   end
 
-  def dropdown_button(button_class: "bg-success", template: "[VALUE]", **options)
+  def dropdown_button(button_class: "bg-success", template: ->(value) {value}, **options)
     return content_tag :div, class: "relative w-fit #{options[:class]}", data: { controller: "dropdown-button", "dropdown-button-target": "container" } do
       (content_tag :div, class: "dropdown-button__container", **options[:button_container_options] do
         (content_tag :button, class: "btn !transform-none rounded-l-xl rounded-r-none #{button_class}" do
           (inline_icon options[:button_icon]) +
-          (content_tag :span, template.gsub("[VALUE]", options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
+          (content_tag :span, template.call(options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
         end) +
         (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none w-12 ml-1 #{button_class}", data: { action: "click->dropdown-button#toggle" } do
           inline_icon "down-caret", class: "!mr-0"
@@ -403,7 +403,7 @@ module ApplicationHelper
       (content_tag :div, class: "dropdown-button__menu dropdown-button__menu--hidden", data: { "dropdown-button-target": "menu" } do
         content_tag :div do
           (options[:options].map do |option|
-            (options[:form].radio_button options[:name], option[1], { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } }) +
+            (options[:form].radio_button options[:name], option[1], { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select", "label": template.call(option[1]) } }) +
             (options[:form].label options[:name], value: option[1] do
               (tag.strong option[0]) + (tag.p option[2])
             end)

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
   change(event) {
     const newType = event.target.value;
     this.updateText(newType);
+    this.toggle();
   }
 
   updateText(value) {

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -1,10 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "button", "select" ]
+  static targets = [ "text", "menu" ]
+
+  open = false
 
   connect() {
     this.updateText(this.selectTarget.value);
+  }
+
+  toggle() {
+    this.open = !this.open;
+    this.updateMenu();
   }
 
   change(event) {
@@ -13,6 +20,10 @@ export default class extends Controller {
   }
 
   updateText(value) {
-    this.buttonTarget.innerText = this.buttonTarget.dataset.template.replaceAll("[VALUE]", value);
+    this.textTarget.innerText = this.textTarget.dataset.template.replaceAll("[VALUE]", value);
+  }
+
+  updateMenu() {
+    this.menuTarget.style = this.open ? "display: block;" : "display: none;"
   }
 }

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -1,12 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "text", "menu" ]
+  static targets = [ "text", "menu", "container" ]
 
   open = false
 
   connect() {
-    this.updateText(this.selectTarget.value);
+    document.addEventListener("click", this.handleDocumentClick.bind(this));
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleDocumentClick.bind(this));
   }
 
   toggle() {
@@ -26,5 +30,11 @@ export default class extends Controller {
 
   updateMenu() {
     this.menuTarget.style = this.open ? "display: block;" : "display: none;"
+  }
+
+  handleDocumentClick(event) {
+    if (!this.containerTarget.contains(event.target) && this.open == true) {
+      this.toggle();
+    }
   }
 }

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "button", "select" ]
+
+  connect() {
+    this.updateText(this.selectTarget.value);
+  }
+
+  change(event) {
+    const newType = event.target.value;
+    this.updateText(newType);
+  }
+
+  updateText(value) {
+    this.buttonTarget.innerText = this.buttonTarget.dataset.template.replaceAll("[VALUE]", value);
+  }
+}

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -29,8 +29,8 @@ export default class extends Controller {
   }
 
   updateMenu() {
-    this.menuTarget.classList.remove(this.open ? "dropdown-button-menu-hidden" : "dropdown-button-menu-show");
-    this.menuTarget.classList.add(this.open ? "dropdown-button-menu-show" : "dropdown-button-menu-hidden");
+    this.menuTarget.classList.remove(this.open ? "dropdown-button__menu--hidden" : "dropdown-button__menu--show");
+    this.menuTarget.classList.add(this.open ? "dropdown-button__menu--show" : "dropdown-button__menu--hidden");
   }
 
   handleDocumentClick(event) {

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -19,16 +19,13 @@ export default class extends Controller {
   }
 
   change(event) {
-    const newType = event.target.value
-    this.updateText(newType)
+    const newButtonText = event.target.dataset.label
+    this.updateText(newButtonText)
     this.toggle()
   }
 
   updateText(value) {
-    this.textTarget.innerText = this.textTarget.dataset.template.replaceAll(
-      '[VALUE]',
-      value
-    )
+    this.textTarget.innerText = value
   }
 
   updateMenu() {

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -29,7 +29,8 @@ export default class extends Controller {
   }
 
   updateMenu() {
-    this.menuTarget.style = this.open ? "display: block;" : "display: none;"
+    this.menuTarget.classList.remove(this.open ? "dropdown-button-menu-hidden" : "dropdown-button-menu-show");
+    this.menuTarget.classList.add(this.open ? "dropdown-button-menu-show" : "dropdown-button-menu-hidden");
   }
 
   handleDocumentClick(event) {

--- a/app/javascript/controllers/dropdown_button_controller.js
+++ b/app/javascript/controllers/dropdown_button_controller.js
@@ -1,41 +1,52 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = [ "text", "menu", "container" ]
+  static targets = ['text', 'menu', 'container']
 
   open = false
 
   connect() {
-    document.addEventListener("click", this.handleDocumentClick.bind(this));
+    document.addEventListener('click', this.handleDocumentClick.bind(this))
   }
 
   disconnect() {
-    document.removeEventListener("click", this.handleDocumentClick.bind(this));
+    document.removeEventListener('click', this.handleDocumentClick.bind(this))
   }
 
   toggle() {
-    this.open = !this.open;
-    this.updateMenu();
+    this.open = !this.open
+    this.updateMenu()
   }
 
   change(event) {
-    const newType = event.target.value;
-    this.updateText(newType);
-    this.toggle();
+    const newType = event.target.value
+    this.updateText(newType)
+    this.toggle()
   }
 
   updateText(value) {
-    this.textTarget.innerText = this.textTarget.dataset.template.replaceAll("[VALUE]", value);
+    this.textTarget.innerText = this.textTarget.dataset.template.replaceAll(
+      '[VALUE]',
+      value
+    )
   }
 
   updateMenu() {
-    this.menuTarget.classList.remove(this.open ? "dropdown-button__menu--hidden" : "dropdown-button__menu--show");
-    this.menuTarget.classList.add(this.open ? "dropdown-button__menu--show" : "dropdown-button__menu--hidden");
+    this.menuTarget.classList.remove(
+      this.open
+        ? 'dropdown-button__menu--hidden'
+        : 'dropdown-button__menu--show'
+    )
+    this.menuTarget.classList.add(
+      this.open
+        ? 'dropdown-button__menu--show'
+        : 'dropdown-button__menu--hidden'
+    )
   }
 
   handleDocumentClick(event) {
     if (!this.containerTarget.contains(event.target) && this.open == true) {
-      this.toggle();
+      this.toggle()
     }
   }
 }

--- a/app/models/reimbursement/expense/mileage.rb
+++ b/app/models/reimbursement/expense/mileage.rb
@@ -34,7 +34,7 @@ module Reimbursement
   class Expense
     class Mileage < ::Reimbursement::Expense
       def rate
-        event.plan.mileage_rate(created_at || Date.today)
+        event.plan.mileage_rate(created_at || Date.today) # rate may be used on creation, however, created_at isn't set at that point.
       end
 
       def value_label

--- a/app/models/reimbursement/expense/mileage.rb
+++ b/app/models/reimbursement/expense/mileage.rb
@@ -34,7 +34,7 @@ module Reimbursement
   class Expense
     class Mileage < ::Reimbursement::Expense
       def rate
-        event.plan.mileage_rate(created_at)
+        event.plan.mileage_rate(created_at || Date.today)
       end
 
       def value_label

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,12 +14,12 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <div class="relative">
-              <button class="btn bg-success add-expense-dropzone z-10 button-variant-btn" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
+            <div class="relative" data-controller="dropdown-button">
+              <button class="btn bg-success add-expense-dropzone z-10 button-variant-btn" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense" data-dropdown-button-target="button" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
                   <%= inline_icon "plus" %>
-                  Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> expense
+                  Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense
               </button>
-              <%= form.select :type, ["Standard", "Mileage"], {}, { class: "button-variant-select select-bg-success" } %>
+              <%= form.select :type, [["Standard", "standard"], ["Mileage", "mileage"]], {}, { class: "button-variant-select select-bg-success", data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -15,16 +15,15 @@
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
             <div class="add-expense-dropzone">
-              <%= dropdown_button
-                  form:,
+              <%= dropdown_button form:,
                   options: [
-                    ["Standard expense", "standard", "Generic expense with a specified amount."],
+                    ["Standard expense", "standard", "Expense with a monetary amount."],
                     ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]
                   ],
                   button_icon: "plus",
                   name: "type",
                   button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" } },
-                  template: "Add #{report.expenses.count > 0 ? "another" : "an"} [VALUE] expense" %>
+                  template: ->(value) {"Add #{report.expenses.count > 0 ? "another" : "an"} #{value} expense"} %>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,31 +14,16 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <div class="relative" data-controller="dropdown-button" data-dropdown-button-target="container">
-              <div class="dropdown-button-container">
-                <button class="btn bg-success add-expense-dropzone btn-dropdown" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
-                    <%= inline_icon "plus" %>
-                    <span data-dropdown-button-target="text" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense">Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense</span>
-                </button>
-                <button type="button" class="btn bg-success btn-dropdown-toggle" data-action="click->dropdown-button#toggle">
-                  <%= inline_icon "down-caret" %>
-                </button>
-              </div>
-              <div class="dropdown-button-menu dropdown-button-menu-hidden" data-dropdown-button-target="menu">
-                <div>
-                  <%= form.radio_button :type, :standard, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
-                  <%= form.label :type, value: :standard do %>
-                    <strong>Standard expense</strong>
-                    <p>Generic expense with a specified amount.</p>
-                  <% end %>
-
-                  <%= form.radio_button :type, :mileage, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
-                  <%= form.label :type, value: :mileage do %>
-                    <strong>Mileage expense</strong>
-                    <p>Expense for miles traveled based on the standard mileage rate.</p>
-                  <% end %>
-                </div>
-              </div>
+            <div class="add-expense-dropzone">
+              <%= dropdown_button form:,
+                options: [
+                  ["Standard expense", "standard", "Generic expense with a specified amount."],
+                  ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]],
+                button_icon: "plus",
+                name: "type",
+                button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" }},
+                template: "Add #{report.expenses.count > 0 ? "another" : "an"} [VALUE] expense"
+              %>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,17 +14,20 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <button class="btn bg-success add-expense-dropzone" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
-                <%= inline_icon "plus" %>
-                Add <%= report.expenses.count > 0 ? "another" : "an" %> expense
-            </button>
-            <%= form.file_field :file,
-                multiple: true,
-                include_hidden: false,
-                required: false,
-                accept: "image/*,image/heic,.pdf",
-                class: "display-none",
-                data: { "file-drop-target" => "fileInput" } %>
+            <div class="relative">
+              <button class="btn bg-success add-expense-dropzone z-10 button-variant-btn" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
+                  <%= inline_icon "plus" %>
+                  Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> expense
+              </button>
+              <%= form.select :type, ["Standard", "Mileage"], {}, { class: "button-variant-select select-bg-success" } %>
+              <%= form.file_field :file,
+                  multiple: true,
+                  include_hidden: false,
+                  required: false,
+                  accept: "image/*,image/heic,.pdf",
+                  class: "display-none",
+                  data: { "file-drop-target" => "fileInput" } %>
+            </div>
           <% end %>
         <% elsif current_user == report.user && !admin_signed_in? %>
           <div class="btn bg-success disabled" class="tooltipped tooltipped--n" aria-label="Expenses can't be added to locked reports">

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -24,7 +24,7 @@
                   <%= inline_icon "down-caret" %>
                 </button>
               </div>
-              <div class="dropdown-button-menu" data-dropdown-button-target="menu">
+              <div class="dropdown-button-menu dropdown-button-menu-hidden" data-dropdown-button-target="menu">
                 <div>
                   <%= form.radio_button :type, :standard, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
                   <%= form.label :type, value: :standard do %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -15,15 +15,16 @@
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
             <div class="add-expense-dropzone">
-              <%= dropdown_button form:,
-                options: [
-                  ["Standard expense", "standard", "Generic expense with a specified amount."],
-                  ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]],
-                button_icon: "plus",
-                name: "type",
-                button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" }},
-                template: "Add #{report.expenses.count > 0 ? "another" : "an"} [VALUE] expense"
-              %>
+              <%= dropdown_button
+                  form:,
+                  options: [
+                    ["Standard expense", "standard", "Generic expense with a specified amount."],
+                    ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]
+                  ],
+                  button_icon: "plus",
+                  name: "type",
+                  button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" } },
+                  template: "Add #{report.expenses.count > 0 ? "another" : "an"} [VALUE] expense" %>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -16,14 +16,14 @@
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
             <div class="add-expense-dropzone">
               <%= dropdown_button form:,
-                  options: [
-                    ["Standard expense", "standard", "Expense with a monetary amount."],
-                    ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]
-                  ],
-                  button_icon: "plus",
-                  name: "type",
-                  button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" } },
-                  template: ->(value) {"Add #{report.expenses.count > 0 ? "another" : "an"} #{value} expense"} %>
+                                  options: [
+                                    ["Standard expense", "standard", "Expense with a monetary amount."],
+                                    ["Mileage expense", "mileage", "Expense for miles traveled based on the standard mileage rate."]
+                                  ],
+                                  button_icon: "plus",
+                                  name: "type",
+                                  button_container_options: { data: { "file-drop-target": "dropzone", action: "dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave" } },
+                                  template: ->(value) { "Add #{report.expenses.count > 0 ? "another" : "an"} #{value} expense" } %>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,12 +14,29 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <div class="relative" data-controller="dropdown-button">
-              <button class="btn bg-success add-expense-dropzone z-10 button-variant-btn" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense" data-dropdown-button-target="button" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
+            <div class="relative flex" data-controller="dropdown-button">
+              <button class="btn bg-success add-expense-dropzone btn-dropdown" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
                   <%= inline_icon "plus" %>
-                  Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense
+                  <span data-dropdown-button-target="text" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense">Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense</span>
               </button>
-              <%= form.select :type, [["Standard", "standard"], ["Mileage", "mileage"]], {}, { class: "button-variant-select select-bg-success", data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
+              <button type="button" class="btn bg-success btn-dropdown-toggle" data-action="click->dropdown-button#toggle">
+                <%= inline_icon "down-caret" %>
+              </button>
+              <div class="dropdown-button-menu" data-dropdown-button-target="menu">
+                <div>
+                  <%= form.radio_button :type, :standard, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
+                  <%= form.label :type, value: :standard do %>
+                    <strong>Standard expense</strong>
+                    <p>Generic expense with a specified amount.</p>
+                  <% end %>
+
+                  <%= form.radio_button :type, :mileage, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>
+                  <%= form.label :type, value: :mileage do %>
+                    <strong>Mileage expense</strong>
+                    <p>Expense for miles traveled based on the standard mileage rate.</p>
+                  <% end %>
+                </div>
+              </div>
               <%= form.file_field :file,
                   multiple: true,
                   include_hidden: false,

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,7 +14,7 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <div class="relative" data-controller="dropdown-button">
+            <div class="relative" data-controller="dropdown-button" data-dropdown-button-target="container">
               <div class="dropdown-button-container">
                 <button class="btn bg-success add-expense-dropzone btn-dropdown" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
                     <%= inline_icon "plus" %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -14,14 +14,16 @@
       <div class="flex justify-start">
         <% if !report.locked? %>
           <%= form_with(method: :post, url: reimbursement_expenses_path(report_id: report.id), data: { controller: "form file-drop", turbo: "true" }, class: "tooltipped tooltipped--n", html: { "aria-label": "Drag a file into this button to create a new expense with a receipt attached." }) do |form| %>
-            <div class="relative flex" data-controller="dropdown-button">
-              <button class="btn bg-success add-expense-dropzone btn-dropdown" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
-                  <%= inline_icon "plus" %>
-                  <span data-dropdown-button-target="text" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense">Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense</span>
-              </button>
-              <button type="button" class="btn bg-success btn-dropdown-toggle" data-action="click->dropdown-button#toggle">
-                <%= inline_icon "down-caret" %>
-              </button>
+            <div class="relative" data-controller="dropdown-button">
+              <div class="dropdown-button-container">
+                <button class="btn bg-success add-expense-dropzone btn-dropdown" data-file-drop-target="dropzone" data-action="dragover->file-drop#dragover drop->file-drop#drop dragenter->file-drop#dragenter dragleave->file-drop#dragleave">
+                    <%= inline_icon "plus" %>
+                    <span data-dropdown-button-target="text" data-template="Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> [VALUE] expense">Add <%= report.expenses.count > 0 ? "another" : "an" %> <%= %> standard expense</span>
+                </button>
+                <button type="button" class="btn bg-success btn-dropdown-toggle" data-action="click->dropdown-button#toggle">
+                  <%= inline_icon "down-caret" %>
+                </button>
+              </div>
               <div class="dropdown-button-menu" data-dropdown-button-target="menu">
                 <div>
                   <%= form.radio_button :type, :standard, { data: { action: "change->dropdown-button#change", "dropdown-button-target": "select" } } %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Better UI! Similar actions should be able to be grouped in a single dropdown button, like how GitHub does it.

Closes #8219 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a helper and corresponding Stimulus controller and CSS for dropdown buttons, which are implemented in the reimbursement page for standard/mileage expenses.

https://github.com/user-attachments/assets/f54a9524-cd3f-47e4-a394-ed59e8f44673