### PR TITLE
Reduce negative margin on home page merchants graph

### DIFF
--- a/app/javascript/components/home/Merchants.js
+++ b/app/javascript/components/home/Merchants.js
@@ -16,7 +16,7 @@ export default function Merchants({ data }) {
   const isDark = useDarkMode()
 
   return (
-    <ResponsiveContainer width="100%" height={420} style={{ marginLeft: -50 }}>
+    <ResponsiveContainer width="100%" height={420}>
       <BarChart data={data}>
         <YAxis
           tickFormatter={n => USDollarNoCents.format(n)}

--- a/app/javascript/components/home/Merchants.js
+++ b/app/javascript/components/home/Merchants.js
@@ -16,7 +16,7 @@ export default function Merchants({ data }) {
   const isDark = useDarkMode()
 
   return (
-    <ResponsiveContainer width="100%" height={420}>
+    <ResponsiveContainer width="100%" height={420} style={{ marginLeft: -20 }}>
       <BarChart data={data}>
         <YAxis
           tickFormatter={n => USDollarNoCents.format(n)}

--- a/app/views/events/home/_merchants_categories.html.erb
+++ b/app/views/events/home/_merchants_categories.html.erb
@@ -11,7 +11,7 @@
           <h5 class="homepage-eyebrow mt0 mb0">All&nbsp;time</h5>
         <% end %>
       </div>
-      <div style="width: calc(100% + 50px)">
+      <div>
         <%= react_component "home/Merchants", { data: @merchants }, { camelize_props: false } %>
       </div>
     </div>

--- a/app/views/events/home/_merchants_categories.html.erb
+++ b/app/views/events/home/_merchants_categories.html.erb
@@ -11,7 +11,7 @@
           <h5 class="homepage-eyebrow mt0 mb0">All&nbsp;time</h5>
         <% end %>
       </div>
-      <div>
+      <div style="width: calc(100% + 20px)">
         <%= react_component "home/Merchants", { data: @merchants }, { camelize_props: false } %>
       </div>
     </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Negative margin was added to the home page merchants graph to avoid a lot of white space on the left, added by the graph library - but this cut off some of the labels when dealing with larger amounts:
![image](https://github.com/user-attachments/assets/a1a41946-572c-4d7e-8d0c-e426a1ce2fd1)



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Reduces the negative margin to avoid cutting off larger values on the merchants graph