### PR TITLE
Increase text contrast on warning buttons

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -68,6 +68,7 @@ input[type='submit'],
 
   &.bg-warning {
     @include gradient(warning);
+    color: darken(map-get($palette, warning), 33.3%) !important;
   }
 
   &.bg-purple {

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -68,7 +68,10 @@ input[type='submit'],
 
   &.bg-warning {
     @include gradient(warning);
-    color: darken(map-get($palette, warning), 33.3%) !important;
+
+    html[data-dark='true'] & {
+      color: darken(map-get($palette, warning), 33.3%) !important;
+    }
   }
 
   &.bg-purple {


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
White text on the warning button background is hard to read:
![image](https://github.com/user-attachments/assets/61d05b06-3eb3-49ad-aa20-93e448dc8cb8)


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Used the same darkened filter as other button backgrounds on the warning background:

![image](https://github.com/user-attachments/assets/08b36546-69f8-409a-aa9a-e00785bfb91d)
