### PR TITLE
Revert "Enable Sidekiq in development (#10243)"

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -101,8 +101,6 @@ Rails.application.configure do
   # SMTP config
   config.action_mailer.delivery_method = :letter_opener_web
 
-  config.active_job.queue_adapter = :sidekiq
-
   # Bullet for finding N+1s
   config.after_initialize do
     Bullet.enable        = true

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -196,16 +196,6 @@ We've transitioned to using development keys and seed data in development, but h
 
 [Flipper](https://github.com/flippercloud/flipper) is used to toggle feature flags on HCB. Flipper can be accessed at [localhost:3000/flipper/features](http://localhost:3000/flipper/features). To enable a flag, press "Add Feature", paste in the name of a feature from [this list](https://hcb.hackclub.com/api/flags), and then press "Fully Enable".
 
-## Sidekiq
-
-[Sidekiq](https://github.com/sidekiq/sidekiq) is the Active Job backend used for HCB, with features such as scheduled jobs and a web UI. While it is enabled in development, you may need to manually load schedule jobs (located in `config/schedule.yml`) using:
-
-```ruby
-Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/schedule.yml")
-```
-
-in the Rails console (`bin/rails c`). The web UI is available at [localhost:3000/sidekiq](http://localhost:3000/sidekiq).
-
 ## Getting an OAuth token
 
 There is two different ways you can accomplish the first step of getting an OAuth token, either using a webpage, or the terminal depending on your preference.


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
See https://hackclub.slack.com/archives/C068U0JMV19/p1745893210473999 - tl;dr, Sidekiq requires an additional process to run in development and is overall more complex, so it'll be fine to stay with the default async backend in development.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
This reverts commit efefb2c9cd15a25aab7bc95576e6c1c0e8bb303b.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

