### PR TITLE
[Login] Encrypt Browser Token (1/3)

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -25,7 +25,7 @@ class Login < ApplicationRecord
   belongs_to :user
   belongs_to :user_session, optional: true
 
-  has_secure_token :browser_token
+  has_encrypted :browser_token, migrating: true
 
   store :authentication_factors, accessors: [:sms, :email, :webauthn, :totp], prefix: :authenticated_with
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -26,6 +26,7 @@ class Login < ApplicationRecord
   belongs_to :user_session, optional: true
 
   has_encrypted :browser_token, migrating: true
+  has_secure_token :browser_token
 
   store :authentication_factors, accessors: [:sms, :email, :webauthn, :totp], prefix: :authenticated_with
 

--- a/db/migrate/20250430082411_add_browser_token_ciphertext.rb
+++ b/db/migrate/20250430082411_add_browser_token_ciphertext.rb
@@ -1,0 +1,5 @@
+class AddBrowserTokenCiphertext < ActiveRecord::Migration[7.2]
+  def change
+    add_column :logins, :browser_token_ciphertext, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_150425) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_30_082411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -1295,6 +1295,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_150425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "browser_token"
+    t.text "browser_token_ciphertext"
     t.index ["user_id"], name: "index_logins_on_user_id"
     t.index ["user_session_id"], name: "index_logins_on_user_session_id"
   end


### PR DESCRIPTION
This PR starts the migration to encrypt `logins.browser_token` using Lockbox.

#### Changes:
- Adds `browser_token_ciphertext` column
- Enables `has_encrypted :browser_token, migrating: true` in the model

This keeps current behavior unchanged while allowing encrypted values to be written in parallel. Safe to deploy with zero downtime.

---

### ⏭️ Next Step (after deploy):
Someone with production console access should run:

```ruby
Lockbox.migrate(Login)
```

---

### Upcoming PR:
A follow-up PR will:
- Finalize Lockbox usage
- Remove `has_secure_token`
- Drop the old column

A follow-up PR will be created once this is merged and run


(Let me know if this isn’t the right approach — happy to adjust)