### PR TITLE
Send donation summary correction emails

### DIFF
--- a/app/jobs/one_time_jobs/correct_donation_summaries.rb
+++ b/app/jobs/one_time_jobs/correct_donation_summaries.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class CorrectDonationSummaries
+    def self.perform
+      Event.includes(:donations)
+           .where("donations.created_at > ? and donations.aasm_state != 'in_transit' and donations.aasm_state != 'deposited'", Date.new(2025, 4, 1))
+           .references(:donations).find_each do |event|
+        mailer = EventMailer.with(event: event, correction: true)
+        mailer.monthly_donation_summary.deliver_later
+      end
+    end
+
+  end
+end

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -13,7 +13,7 @@ class EventMailer < ApplicationMailer
 
     @total = @donations.sum(:amount)
 
-    mail to: @emails, subject: "#{"[CORRECTION] " if params[:correction]} #{@event.name} received #{@donations.length} donations this past month"
+    mail to: @emails, subject: "#{"[CORRECTION] " if params[:correction]} #{@event.name} received #{@donations.length} #{"donation".pluralize(@donations.length)} this past month"
   end
 
   private

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -13,7 +13,7 @@ class EventMailer < ApplicationMailer
 
     @total = @donations.sum(:amount)
 
-    mail to: @emails, subject: "#{@event.name} received #{@donations.length} donations this past month"
+    mail to: @emails, subject: "#{"[CORRECTION] " if params[:correction]} #{@event.name} received #{@donations.length} donations this past month"
   end
 
   private

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -5,7 +5,7 @@ class EventMailer < ApplicationMailer
   before_action :set_emails
 
   def monthly_donation_summary
-    @event = params[:event]
+    @correction = params[:correction]
 
     @donations = @event.donations.where(aasm_state: [:in_transit, :deposited], created_at: Time.now.last_month.beginning_of_month..).order(:created_at)
 

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -1,8 +1,17 @@
 <p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
 
-<p>
-  Here's your monthly donation summary for <%= @event.name %>:
-</p>
+<% if @correction %>
+  <p>
+    Earlier today, we sent out an inaccurate donation summary email.
+    We’d like to apologize for any confusion this email may have caused.
+    The list of donations in the original email accidentally included donors who began the donation process, but never completed their donation.
+    This issue has been fixed, and we can confirm that your current balance and list of donations on HCB is correct. For a corrected donation list, please see below:
+  </p>
+<% else %>
+  <p>
+    Here's your monthly donation summary for <%= @event.name %>:
+  </p>
+<% end %>
 
 <ul>
   <% @donations.each do |donation| %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Monthly donation summaries that just got sent out included all donations, including not processed and refunded donations. Fixed for future summaries in #10289


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a one time job that will send a correction email to all events that were sent an incorrect summary. Also fixes the subject to correctly pluralize "donation".
This job will need to be run on production when merged (might want to wait until #10291 is merged as well)

