### PR TITLE
Add tags tab to organization settings

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,6 +23,16 @@ class TagsController < ApplicationController
     redirect_back fallback_location: @event
   end
 
+  def update
+    tag = Tag.find(params[:id])
+
+    authorize tag
+
+    tag.update(label: params[:label].strip, color: params[:color])
+
+    redirect_back fallback_location: @event
+  end
+
   def destroy
     tag = Tag.find(params[:id])
 

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -5,6 +5,10 @@ class TagPolicy < ApplicationPolicy
     OrganizerPosition.role_at_least?(user, record, :member)
   end
 
+  def update?
+    OrganizerPosition.role_at_least?(user, record.event, :member)
+  end
+
   def destroy?
     OrganizerPosition.role_at_least?(user, record.event, :member)
   end

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -27,6 +27,11 @@
         <% end %>
       <% end %>
     <% end %>
+    <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) %>
+      <%= settings_tab active: @settings_tab == "tags" do %>
+        <%= link_to "Tags", edit_event_path(@event, tab: "tags"), data: { turbo: true, turbo_action: "advance" } %>
+      <% end %>
+    <% end %>
     <%= settings_tab active: @settings_tab == "features" do %>
       <%= link_to "Feature previews", edit_event_path(@event, tab: "features"), data: { turbo: true, turbo_action: "advance" } %>
     <% end %>
@@ -45,6 +50,8 @@
   <%= render "events/settings/features", event: @event %>
 <% elsif @settings_tab == "donations" %>
   <%= render "events/settings/donations", event: @event %>
+<% elsif @settings_tab == "tags" %>
+  <%= render "events/settings/tags", event: @event %>
 <% elsif @settings_tab == "reimbursements" %>
   <%= render "events/settings/reimbursements", event: @event %>
 <% elsif @settings_tab == "card_grants" %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -6,13 +6,32 @@
           <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
           <p class="bold"><%= tag.label %></p>
         </div>
-        <div>
-          <%= pop_icon_to "edit",
-            nil,
-            class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
-            data: { turbo: true } %>
+        <div class="flex">
+          <div>
+            <%= pop_icon_to "edit",
+              "#",
+              class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
+              data: { behavior: "modal_trigger", modal: "edit_tag_#{tag.id}" } %>
+            <section class="modal modal--scroll max-w-md bg-snow" data-behavior="modal" role="dialog" id="edit_tag_<%= tag.id %>">
+              <%= modal_header("Edit tag") %>
+              <%= form_with url: event_tag_path(@event, tag.id), method: "patch", id: "edit_tag_form" do |form| %>
+                <div class="flex flex-col gap-3 mb-2">
+                  <%= form.text_field :label, autofocus: true, placeholder: "Tag name", value: tag.label, style: "max-width: 100%", autocomplete: "off", required: true %>
+                  <div class="flex gap-3">
+                    <% Tag::COLORS.each do |color| %>
+                      <label class="tags__radio">
+                        <%= form.radio_button :color, color, checked: color == tag.color %>
+                        <div class="radio__control tag-darker tag-<%= color %>"></div>
+                      </label>
+                    <% end %>
+                  </div>
+                </div>
+                <%= form.submit "Edit", class: "btn bg-info mt-2 float-right" %>
+              <% end %>
+            </section>
+          </div>
           <%= pop_icon_to "delete",
-            nil,
+            event_tag_path(@event, tag.id),
             method: :delete,
             icon_size: 26,
             class: "tooltipped tooltipped--w h-8 w-8",

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -1,0 +1,48 @@
+<%= turbo_frame_tag :tags_settings do %>
+  <div class="card event_settings__content">
+    <% @event.tags.each do |tag| %>
+      <div class="flex justify-between items-center">
+        <div class="flex items-center">
+          <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
+          <p class="bold"><%= tag.label %></p>
+        </div>
+        <div>
+          <%= pop_icon_to "edit",
+            nil,
+            class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
+            data: { turbo: true } %>
+          <%= pop_icon_to "delete",
+            nil,
+            method: :delete,
+            icon_size: 26,
+            class: "tooltipped tooltipped--w h-8 w-8",
+            style: "background: #ec375020; color: #ec3750",
+            'aria-label': "Delete this tag" %>
+        </div>
+      </div>
+    <% end %>
+    <h3 class="mb1">Create a new tag</h3>
+    <%= form_with(url: event_tags_path(@event)) do |form| %>
+      <div class="flex gap-5 justify-between items-end">
+        <div>
+          <%= form.label :label, "Tag name" %>
+          <%= form.text_field :label %>
+        </div>
+
+        <div>
+          <%= form.label :tag_name, "Tag color" %>
+      
+          <% Tag::COLORS.each do |color| %>
+            <label class="tags__radio w-8 mt-[2px] mx-1">
+              <%# Default color: Muted %>
+              <%= form.radio_button :color, color, checked: color == "muted" %>
+              <div class="radio__control tag-darker tag-<%= color %>"></div>
+            </label>
+          <% end %>
+        </div>
+
+        <%= form.submit "Create tag", class: "h-10 m-1" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -1,57 +1,14 @@
 <%= turbo_frame_tag :tags_settings do %>
-  <div class="card event_settings__content">
-    <% @event.tags.each do |tag| %>
-      <div class="flex justify-between items-center">
-        <div class="flex items-center">
-          <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
-          <p class="bold"><%= tag.label %></p>
-        </div>
-        <div class="flex">
-          <div>
-            <%= pop_icon_to "edit",
-              "#",
-              class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
-              data: { behavior: "modal_trigger", modal: "edit_tag_#{tag.id}" } %>
-            <section class="modal modal--scroll max-w-md bg-snow" data-behavior="modal" role="dialog" id="edit_tag_<%= tag.id %>">
-              <%= modal_header("Edit tag") %>
-              <%= form_with url: event_tag_path(@event, tag.id), method: "patch", id: "edit_tag_form" do |form| %>
-                <div class="flex flex-col gap-3 mb-2">
-                  <%= form.text_field :label, autofocus: true, placeholder: "Tag name", value: tag.label, style: "max-width: 100%", autocomplete: "off", required: true %>
-                  <div class="flex gap-3">
-                    <% Tag::COLORS.each do |color| %>
-                      <label class="tags__radio">
-                        <%= form.radio_button :color, color, checked: color == tag.color %>
-                        <div class="radio__control tag-darker tag-<%= color %>"></div>
-                      </label>
-                    <% end %>
-                  </div>
-                </div>
-                <%= form.submit "Edit", class: "btn bg-info mt-2 float-right" %>
-              <% end %>
-            </section>
-          </div>
-          <%= pop_icon_to "delete",
-            event_tag_path(@event, tag.id),
-            method: :delete,
-            icon_size: 26,
-            class: "tooltipped tooltipped--w h-8 w-8",
-            style: "background: #ec375020; color: #ec3750",
-            'aria-label': "Delete this tag" %>
-        </div>
-      </div>
-    <% end %>
-  </div>
-
   <h3 class="mb1" id="cards_heading">Create a new tag</h3>
-  <div class="card mt-4">
+  <div class="card mb3">
     <%= form_with(url: event_tags_path(@event)) do |form| %>
       <div class="field">
-        <%= form.label :label, "Tag name" %>
-        <%= form.text_field :label, placeholder: "Food" %>
+        <%= form.label :label, "Tag name", class: "mb-1" %>
+        <%= form.text_field :label, placeholder: ["🧃 Food & drinks", "🧋 Bubble tea", "🚕 Transportation", "🛬 Flights", "🔨 Supplies"].sample %>
       </div>
 
       <div class="field">
-        <%= form.label :tag_name, "Tag color" %>
+        <%= form.label :tag_name, "Tag color", class: "mb-1" %>
 
         <% Tag::COLORS.each do |color| %>
           <label class="tags__radio w-8 mt-[2px] mx-1">
@@ -65,4 +22,47 @@
       <%= form.submit "Create tag" %>
     <% end %>
   </div>
+  <% unless @event.tags.none? %>
+    <h3 class="mb2" id="cards_heading"><%= possessive(@event.name) %> tags</h3>
+  <% end %>
+  <% @event.tags.each do |tag| %>
+    <div class="card mb2 flex justify-between items-center">
+      <div class="flex items-center">
+        <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
+        <p class="bold mb0 mt0"><%= tag.label %></p>
+      </div>
+      <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center">
+          <%= pop_icon_to "edit",
+            "#",
+            class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
+            data: { behavior: "modal_trigger", modal: "edit_tag_#{tag.id}" } %>
+          <section class="modal modal--scroll max-w-md bg-snow" data-behavior="modal" role="dialog" id="edit_tag_<%= tag.id %>">
+            <%= modal_header("Edit tag") %>
+            <%= form_with url: event_tag_path(@event, tag.id), method: "patch", id: "edit_tag_form" do |form| %>
+              <div class="flex flex-col gap-3 mb-2">
+                <%= form.text_field :label, autofocus: true, placeholder: "Tag name", value: tag.label, style: "max-width: 100%", autocomplete: "off", required: true %>
+                <div class="flex gap-3">
+                  <% Tag::COLORS.each do |color| %>
+                    <label class="tags__radio">
+                      <%= form.radio_button :color, color, checked: color == tag.color %>
+                      <div class="radio__control tag-darker tag-<%= color %>"></div>
+                    </label>
+                  <% end %>
+                </div>
+              </div>
+              <%= form.submit "Edit", class: "btn bg-info mt-2 float-right" %>
+            <% end %>
+          </section>
+        </div>
+        <%= pop_icon_to "delete",
+          event_tag_path(@event, tag.id),
+          method: :delete,
+          icon_size: 26,
+          class: "tooltipped tooltipped--w h-8 w-8",
+          style: "background: #ec375020; color: #ec3750",
+          'aria-label': "Delete this tag" %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -50,7 +50,7 @@
 
         <div>
           <%= form.label :tag_name, "Tag color" %>
-      
+
           <% Tag::COLORS.each do |color| %>
             <label class="tags__radio w-8 mt-[2px] mx-1">
               <%# Default color: Muted %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -40,28 +40,29 @@
         </div>
       </div>
     <% end %>
-    <h3 class="mb1">Create a new tag</h3>
+  </div>
+
+  <h3 class="mb1" id="cards_heading">Create a new tag</h3>
+  <div class="card mt-4">
     <%= form_with(url: event_tags_path(@event)) do |form| %>
-      <div class="flex gap-5 justify-between items-end">
-        <div>
-          <%= form.label :label, "Tag name" %>
-          <%= form.text_field :label %>
-        </div>
-
-        <div>
-          <%= form.label :tag_name, "Tag color" %>
-
-          <% Tag::COLORS.each do |color| %>
-            <label class="tags__radio w-8 mt-[2px] mx-1">
-              <%# Default color: Muted %>
-              <%= form.radio_button :color, color, checked: color == "muted" %>
-              <div class="radio__control tag-darker tag-<%= color %>"></div>
-            </label>
-          <% end %>
-        </div>
-
-        <%= form.submit "Create tag", class: "h-10 m-1" %>
+      <div class="field">
+        <%= form.label :label, "Tag name" %>
+        <%= form.text_field :label, placeholder: "Food" %>
       </div>
+
+      <div class="field">
+        <%= form.label :tag_name, "Tag color" %>
+
+        <% Tag::COLORS.each do |color| %>
+          <label class="tags__radio w-8 mt-[2px] mx-1">
+            <%# Default color: Muted %>
+            <%= form.radio_button :color, color, checked: color == "muted" %>
+            <div class="radio__control tag-darker tag-<%= color %>"></div>
+          </label>
+        <% end %>
+      </div>
+
+      <%= form.submit "Create tag" %>
     <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -726,7 +726,7 @@ Rails.application.routes.draw do
     get "fiscal_sponsorship_letter", to: "documents#fiscal_sponsorship_letter"
     get "verification_letter", to: "documents#verification_letter"
     resources :invoices, only: [:new, :create, :index]
-    resources :tags, only: [:create, :destroy]
+    resources :tags, only: [:create, :update, :destroy]
     resources :event_tags, only: [:create, :destroy]
 
     namespace :donation do


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Organization members can't currently modify existing transaction tags or delete them without going to add one first.

Closes #9488 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a tab to organization settings if transaction tags are enabled that shows all tags that event has and allows members to create, modify, and delete them.

![Screenshot from 2025-05-01 22-54-11](https://github.com/user-attachments/assets/c3660805-7567-4ca0-8dd8-306711f3e441)
![Screenshot from 2025-05-01 22-54-24](https://github.com/user-attachments/assets/5bbe7859-7983-41aa-84d1-eb932ff6496c)


