### PR TITLE
Fix organizer position policy

### DIFF
--- a/app/policies/organizer_position_policy.rb
+++ b/app/policies/organizer_position_policy.rb
@@ -27,10 +27,7 @@ class OrganizerPositionPolicy < ApplicationPolicy
   end
 
   def can_request_removal?
-    return true if record.user == user
-    return true if user&.admin?
-    return true if OrganizerPosition.find_by(user:, event: record.event)&.manager? && !OrganizerPosition.find_by(user: record.user, event: record.event)&.manager?
-    return true if OrganizerPosition.find_by(user:, event: record.event)&.is_signee && !OrganizerPosition.find_by(user: record.user, event: record.event)&.is_signee
+    admin_or_manager? || record.user == user
   end
 
   def view_allowances?

--- a/app/policies/organizer_position_policy.rb
+++ b/app/policies/organizer_position_policy.rb
@@ -21,11 +21,16 @@ class OrganizerPositionPolicy < ApplicationPolicy
     return false unless user
     return false if record.user == user
 
-    admin_or_manager?
+    return true if user&.admin?
+    return true if OrganizerPosition.find_by(user:, event: record.event)&.manager? && !OrganizerPosition.find_by(user: record.user, event: record.event)&.manager?
+    return true if OrganizerPosition.find_by(user:, event: record.event)&.is_signee && !OrganizerPosition.find_by(user: record.user, event: record.event)&.is_signee
   end
 
   def can_request_removal?
-    admin_or_manager? || record.user == user
+    return true if record.user == user
+    return true if user&.admin?
+    return true if OrganizerPosition.find_by(user:, event: record.event)&.manager? && !OrganizerPosition.find_by(user: record.user, event: record.event)&.manager?
+    return true if OrganizerPosition.find_by(user:, event: record.event)&.is_signee && !OrganizerPosition.find_by(user: record.user, event: record.event)&.is_signee
   end
 
   def view_allowances?


### PR DESCRIPTION
## Summary of the problem
Managers could demote and remove other managers. Same with contract signees and other contract signees.



## Describe your changes
It checks if you are currently a manager and if the user you are attempting to modify is not a manager.
Same process for contract signee check.
change_position_role? and can_request_removal? have been updated.

