### PR TITLE
Grammar and info fixes on roles page

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -94,9 +94,9 @@ class StaticPagesController < ApplicationController
           "View the organization's account & routing numbers": :manager
         },
         "HCB Transfers": {
-          "Create an HCB Transfer": :manager,
-          "Cancel an HCB Transfer": :manager,
-          "View an HCB Transfer": :member
+          "Create a HCB Transfer": :manager,
+          "Cancel a HCB Transfer": :manager,
+          "View a HCB Transfer": :member
         },
         _preface: "As a general rule, only managers can create/modify financial transfers"
       },

--- a/app/views/static_pages/roles.html.erb
+++ b/app/views/static_pages/roles.html.erb
@@ -22,7 +22,7 @@
       <strong>Members</strong> can <em>spend</em>, but not <em>send</em> money,
       and can't edit the organization's settings.
     </li>
-    <li><strong>Readers</strong> can only view basic information on an organization.
+    <li><strong>Readers</strong> have read-only access to an organization.
     </li>
   </ul>
 

--- a/app/views/static_pages/roles.html.erb
+++ b/app/views/static_pages/roles.html.erb
@@ -10,8 +10,8 @@
   </p>
 
   <p>
-    Now, in an organization on HCB, users can have one of two roles:
-    <strong>member</strong> or <strong>manager</strong>.
+    Now, in an organization on HCB, users can have one of three roles:
+    <strong>manager</strong>, <strong>member</strong>, or <strong>reader</strong>.
     When you're inviting a user, you may select the role they receive.
   </p>
 
@@ -21,6 +21,8 @@
     <li>
       <strong>Members</strong> can <em>spend</em>, but not <em>send</em> money,
       and can't edit the organization's settings.
+    </li>
+    <li><strong>Readers</strong> can only view basic information on an organization.
     </li>
   </ul>
 


### PR DESCRIPTION
https://hcb.hackclub.com/roles
It was missing readers and also said "an HCB" instead of "a HCB"