### PR TITLE
[Policy] Allow grant card holders to access stripe card info 

### DIFF
--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -26,7 +26,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || (record.stripe_cardholder.present? && record.stripe_cardholder.user == user)
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || cardholder?
   end
 
   def edit?

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -26,7 +26,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || (record.stripe_cardholder.present? && record.stripe_cardholder.user == user)
   end
 
   def edit?

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -26,7 +26,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || cardholder?
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || (cardholder? && record.card_grant)
   end
 
   def edit?


### PR DESCRIPTION
## Summary of the problem
For the v4 API you can't use v4/cards/crd_xxxxxxx for grant cards that you own. This policy fixes it by also allowing the card holder to have access.

