### PR TITLE
show roles on team tabs for eveyone

### DIFF
--- a/app/views/organizer_positions/_organizer_position.html.erb
+++ b/app/views/organizer_positions/_organizer_position.html.erb
@@ -31,6 +31,8 @@
               <p class="h4 medium info"><%= organizer_position.role.capitalize %></p>
             <% end %>
           </div>
+        <% else %>
+          <p class="h4 medium info"><%= organizer_position.role.capitalize %></p>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C068U0JMV19/p1746288968205959
user roles are hidden on organization cards if you're not a member, even though you can still filter by roles


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
displays user roles on organization for everyone

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

