### PR TITLE
Migrate from `store` to `store_accessor` for JSONB columns

### DIFF
--- a/app/models/concerns/has_wire_recipient.rb
+++ b/app/models/concerns/has_wire_recipient.rb
@@ -239,7 +239,7 @@ module HasWireRecipient
     end
 
 
-    store :recipient_information, accessors: self.recipient_information_accessors
+    store_accessor :recipient_information, *self.recipient_information_accessors
   end
 
   # IBAN & postal code formats sourced from https://column.com/docs/international-wires/country-specific-details

--- a/app/models/export/event/balances.rb
+++ b/app/models/export/event/balances.rb
@@ -22,7 +22,7 @@
 class Export
   module Event
     class Balances < Export
-      store :parameters, accessors: %w[], coder: JSON
+      store_accessor :parameters
       def async?
         true
       end

--- a/app/models/export/event/reimbursements/csv.rb
+++ b/app/models/export/event/reimbursements/csv.rb
@@ -23,7 +23,7 @@ class Export
   module Event
     module Reimbursements
       class Csv < Export
-        store :parameters, accessors: %w[event_id], coder: JSON
+        store_accessor :parameters, :event_id
         def async?
           false
         end

--- a/app/models/export/event/transactions/csv.rb
+++ b/app/models/export/event/transactions/csv.rb
@@ -23,7 +23,7 @@ class Export
   module Event
     module Transactions
       class Csv < Export
-        store :parameters, accessors: %w[event_id start_date end_date public_only], coder: JSON
+        store_accessor :parameters, :event_id, :start_date, :end_date, :public_only
         def async?
           event.canonical_transactions.size > 300
         end

--- a/app/models/export/event/transactions/json.rb
+++ b/app/models/export/event/transactions/json.rb
@@ -23,7 +23,7 @@ class Export
   module Event
     module Transactions
       class Json < Export
-        store :parameters, accessors: %w[event_id public_only], coder: JSON
+        store_accessor :parameters, :event_id, :public_only
         def async?
           event.canonical_transactions.size > 300
         end

--- a/app/models/export/event/transactions/ledger.rb
+++ b/app/models/export/event/transactions/ledger.rb
@@ -23,7 +23,7 @@ class Export
   module Event
     module Transactions
       class Ledger < Export
-        store :parameters, accessors: %w[event_id public_only], coder: JSON
+        store_accessor :parameters, :event_id, :public_only
         def async?
           event.canonical_transactions.size > 300
         end

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -69,6 +69,8 @@ class Login < ApplicationRecord
   end
 
   def authentication_factors_count
+    return 0 if authentication_factors.nil?
+
     authentication_factors.values.count(true)
   end
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -28,7 +28,7 @@ class Login < ApplicationRecord
   has_encrypted :browser_token, migrating: true
   has_secure_token :browser_token
 
-  store :authentication_factors, accessors: [:sms, :email, :webauthn, :totp], prefix: :authenticated_with
+  store_accessor :authentication_factors, :sms, :email, :webauthn, :totp, prefix: :authenticated_with
 
   EXPIRATION = 15.minutes
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -28,7 +28,7 @@ class Login < ApplicationRecord
   has_encrypted :browser_token, migrating: true
   has_secure_token :browser_token
 
-  store_accessor :authentication_factors, :sms, :email, :webauthn, :totp, prefix: :authenticated_with
+  store :authentication_factors, accessors: [:sms, :email, :webauthn, :totp], prefix: :authenticated_with
 
   EXPIRATION = 15.minutes
 
@@ -69,8 +69,6 @@ class Login < ApplicationRecord
   end
 
   def authentication_factors_count
-    return 0 if authentication_factors.nil?
-
     authentication_factors.values.count(true)
   end
 


### PR DESCRIPTION
Closes https://github.com/hackclub/hcb/issues/10254. I think we need to take down HCB to make this migration.

Here are some scripts I've written to help us make the migration:

```ruby
Export.all.each do |e|
  parameters = {}
  begin
    parameters = JSON.parse(e.parameters_before_type_cast || "\"{}\"")
    parameters = JSON.parse(parameters) if parameters.is_a?(String)
  rescue
    parameters = YAML.load(JSON.parse(e.parameters_before_type_cast))
  end
  e.update_attribute(:parameters, parameters)
end
```

```ruby
Wire.all.each do |w|
  next if w.recipient_information.nil?
  begin
    recipient_information = YAML.load(JSON.parse(w.recipient_information_before_type_cast))
    w.update_attribute(:recipient_information, recipient_information)
  rescue
    puts w.id
  end
end
```

Wires have some validations that now fail on old `Wire` objects

```ruby
User::PayoutMethod::Wire.all.each do |w|
  next if w.recipient_information.nil?
  begin
    recipient_information = YAML.load(JSON.parse(w.recipient_information_before_type_cast))
    w.update_attribute(:recipient_information, recipient_information)
  rescue
    puts w.id
  end
end
```

```ruby
Login.all.each do |l|
  next if l.authentication_factors.nil?
  begin
    authentication_factors = YAML.load(JSON.parse(l.authentication_factors_before_type_cast))
    l.update_attribute(:authentication_factors, authentication_factors)
  rescue
    puts l.id
  end
end
```