### PR TITLE
Use public IDs for all book transfer `idempotency_key`s

### DIFF
--- a/app/models/bank_fee.rb
+++ b/app/models/bank_fee.rb
@@ -28,6 +28,9 @@ class BankFee < ApplicationRecord
   include AASM
   include HasBookTransfer
 
+  include PublicIdentifiable
+  set_public_id_prefix :bfe
+
   belongs_to :event
   belongs_to :fee_revenue, optional: true
 

--- a/app/models/fee_revenue.rb
+++ b/app/models/fee_revenue.rb
@@ -16,6 +16,9 @@ class FeeRevenue < ApplicationRecord
   include AASM
   include HasBookTransfer
 
+  include PublicIdentifiable
+  set_public_id_prefix :frv
+
   has_many :bank_fees
 
   # Eagerly create HcbCode object

--- a/app/models/reimbursement/expense_payout.rb
+++ b/app/models/reimbursement/expense_payout.rb
@@ -31,6 +31,9 @@ module Reimbursement
     include AASM
     include HasBookTransfer
 
+    include PublicIdentifiable
+    set_public_id_prefix :rep
+
     belongs_to :event
     belongs_to :expense, foreign_key: "reimbursement_expenses_id", inverse_of: :expense_payout
     belongs_to :payout_holding, optional: true, foreign_key: "reimbursement_payout_holdings_id", inverse_of: :expense_payouts
@@ -105,7 +108,7 @@ module Reimbursement
         receiver_bank_account_id = ColumnService::Accounts.id_of(book_transfer_originating_account)
 
         ColumnService.post "/transfers/book",
-                           idempotency_key: "#{self.id}_reversed",
+                           idempotency_key: "#{self.public_id}_reversed",
                            amount: amount_cents.abs,
                            currency_code: "USD",
                            sender_bank_account_id:,

--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -29,6 +29,9 @@ module Reimbursement
     include AASM
     include HasBookTransfer
 
+    include PublicIdentifiable
+    set_public_id_prefix :rph
+
     has_many :expense_payouts, class_name: "Reimbursement::ExpensePayout", foreign_key: "reimbursement_payout_holdings_id", inverse_of: :payout_holding
     belongs_to :report, foreign_key: "reimbursement_reports_id", inverse_of: :payout_holding
     belongs_to :ach_transfer, optional: true, inverse_of: :reimbursement_payout_holding
@@ -110,7 +113,7 @@ module Reimbursement
         receiver_bank_account_id = ColumnService::Accounts.id_of(book_transfer_originating_account)
 
         ColumnService.post "/transfers/book",
-                           idempotency_key: "#{self.id}_reversed",
+                           idempotency_key: "#{self.public_id}_reversed",
                            amount: amount_cents.abs,
                            currency_code: "USD",
                            sender_bank_account_id:,

--- a/app/services/bank_fee_service/process_single.rb
+++ b/app/services/bank_fee_service/process_single.rb
@@ -16,7 +16,7 @@ module BankFeeService
         receiver_bank_account_id = ColumnService::Accounts.id_of bank_fee.book_transfer_receiving_account
 
         ColumnService.post "/transfers/book",
-                           idempotency_key: bank_fee.id.to_s,
+                           idempotency_key: bank_fee.public_id,
                            amount: amount_cents.abs,
                            currency_code: "USD",
                            sender_bank_account_id:,

--- a/app/services/fee_revenue_service/process_single.rb
+++ b/app/services/fee_revenue_service/process_single.rb
@@ -16,7 +16,7 @@ module FeeRevenueService
         receiver_bank_account_id = ColumnService::Accounts.id_of fee_revenue.book_transfer_receiving_account
 
         ColumnService.post "/transfers/book",
-                           idempotency_key: fee_revenue.id.to_s,
+                           idempotency_key: fee_revenue.public_id,
                            amount: amount_cents.abs,
                            currency_code: "USD",
                            sender_bank_account_id:,

--- a/app/services/reimbursement/expense_payout_service/process_single.rb
+++ b/app/services/reimbursement/expense_payout_service/process_single.rb
@@ -17,7 +17,7 @@ module Reimbursement
           receiver_bank_account_id = ColumnService::Accounts.id_of expense_payout.book_transfer_receiving_account
 
           ColumnService.post "/transfers/book",
-                             idempotency_key: expense_payout.id.to_s,
+                             idempotency_key: expense_payout.public_id,
                              amount: amount_cents.abs,
                              currency_code: "USD",
                              sender_bank_account_id:,

--- a/app/services/reimbursement/payout_holding_service/process_single.rb
+++ b/app/services/reimbursement/payout_holding_service/process_single.rb
@@ -17,7 +17,7 @@ module Reimbursement
           receiver_bank_account_id = ColumnService::Accounts.id_of payout_holding.book_transfer_receiving_account
 
           ColumnService.post "/transfers/book",
-                             idempotency_key: payout_holding.id.to_s,
+                             idempotency_key: payout_holding.public_id,
                              amount: amount_cents.abs,
                              currency_code: "USD",
                              sender_bank_account_id:,


### PR DESCRIPTION
Will post more context in #hcb-engr shortly.