### PR TITLE
Reduce the gap between button and arrow in dropdown buttons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -396,7 +396,7 @@ module ApplicationHelper
           (inline_icon options[:button_icon]) +
           (content_tag :span, template.call(options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
         end) +
-        (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none w-12 ml-1 #{button_class}", data: { action: "click->dropdown-button#toggle" } do
+        (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none w-12 ml-[2px] #{button_class}", data: { action: "click->dropdown-button#toggle" } do
           inline_icon "down-caret", class: "!mr-0"
         end)
       end) +


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Received feedback that the gap was a little big


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Reduced it a little! Looks better now


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/261536ce-8fe9-422d-9941-fba7557b92eb)

