### PR TITLE
Disable/hide the help button and command menu for logged out users

### DIFF
--- a/app/views/application/_command_bar.html.erb
+++ b/app/views/application/_command_bar.html.erb
@@ -1,4 +1,4 @@
-<% if signed_in? && (auditor_signed_in? || Flipper.enabled?(:command_bar_2024_02_05, current_user)) %>
+<% if signed_in? %>
    <% @admin_urls = current_user&.auditor? ? {
         "Applications"              => "https://airtable.com/tblctmRFEeluG4do7/viwGhv19cV1ZRj61a",
         "OnBoard ID"                => "https://airtable.com/app4Bs8Tjwvk5qcD4/tblVZwB8QMUSDAd41/viwJ15CT6VHCZ0UZ4",

--- a/app/views/application/_command_bar.html.erb
+++ b/app/views/application/_command_bar.html.erb
@@ -1,4 +1,4 @@
-<% if auditor_signed_in? || Flipper.enabled?(:command_bar_2024_02_05, current_user) %>
+<% if signed_in? && (auditor_signed_in? || Flipper.enabled?(:command_bar_2024_02_05, current_user)) %>
    <% @admin_urls = current_user&.auditor? ? {
         "Applications"              => "https://airtable.com/tblctmRFEeluG4do7/viwGhv19cV1ZRj61a",
         "OnBoard ID"                => "https://airtable.com/app4Bs8Tjwvk5qcD4/tblVZwB8QMUSDAd41/viwJ15CT6VHCZ0UZ4",

--- a/app/views/application/_support_button.html.erb
+++ b/app/views/application/_support_button.html.erb
@@ -1,3 +1,4 @@
+<% if signed_in? %>
 <div data-controller="menu" data-menu-placement-value="top-end">
   <button data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle" type="button" class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer" style="z-index: 2" aria-label="Need help?" data-action="class#toggle focus#focus">
     <%= inline_icon "question-mark", size: 18 %>
@@ -23,3 +24,4 @@
     <%= inline_icon "question-mark", size: 18 %>
   </button>
 </div>
+<% end %>

--- a/app/views/application/_support_button.html.erb
+++ b/app/views/application/_support_button.html.erb
@@ -1,27 +1,27 @@
 <% if signed_in? %>
-<div data-controller="menu" data-menu-placement-value="top-end">
-  <button data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle" type="button" class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer" style="z-index: 2" aria-label="Need help?" data-action="class#toggle focus#focus">
-    <%= inline_icon "question-mark", size: 18 %>
-  </button>
   <div data-controller="menu" data-menu-placement-value="top-end">
-  <% routing = begin
-       Rails.application.routes.recognize_path(request.original_fullpath, method: request.env["REQUEST_METHOD"])
-     rescue
-       {}
-     end %>
-
-  <% url_params = {
-       url: "#{request.base_url}#{request.original_fullpath}",
-       location: "#{routing[:controller]}##{routing[:action]} #{routing[:id]}".strip,
-       user_id: current_user&.id
-     } %>
-
-  <button
-    type="button"
-    class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer"
-    style="z-index: 2" aria-label="Get help"
-    onclick="window.Beacon && (window.Beacon('identify', { name: <%= current_user&.name.to_json %>, email: <%= current_user&.email.to_json %> }), window.Beacon('session-data', { url: <%= url_params[:url].to_json %>, location: <%= url_params[:location].to_json %>, user_id: <%= url_params[:user_id].to_json %> }), window.Beacon('toggle'))">
-    <%= inline_icon "question-mark", size: 18 %>
-  </button>
-</div>
+    <button data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle" type="button" class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer" style="z-index: 2" aria-label="Need help?" data-action="class#toggle focus#focus">
+      <%= inline_icon "question-mark", size: 18 %>
+    </button>
+    <div data-controller="menu" data-menu-placement-value="top-end">
+    <% routing = begin
+         Rails.application.routes.recognize_path(request.original_fullpath, method: request.env["REQUEST_METHOD"])
+       rescue
+         {}
+       end %>
+  
+    <% url_params = {
+         url: "#{request.base_url}#{request.original_fullpath}",
+         location: "#{routing[:controller]}##{routing[:action]} #{routing[:id]}".strip,
+         user_id: current_user&.id
+       } %>
+  
+    <button
+      type="button"
+      class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer"
+      style="z-index: 2" aria-label="Get help"
+      onclick="window.Beacon && (window.Beacon('identify', { name: <%= current_user&.name.to_json %>, email: <%= current_user&.email.to_json %> }), window.Beacon('session-data', { url: <%= url_params[:url].to_json %>, location: <%= url_params[:location].to_json %>, user_id: <%= url_params[:user_id].to_json %> }), window.Beacon('toggle'))">
+      <%= inline_icon "question-mark", size: 18 %>
+    </button>
+  </div>
 <% end %>

--- a/app/views/application/_support_button.html.erb
+++ b/app/views/application/_support_button.html.erb
@@ -9,13 +9,13 @@
        rescue
          {}
        end %>
-  
+
     <% url_params = {
          url: "#{request.base_url}#{request.original_fullpath}",
          location: "#{routing[:controller]}##{routing[:action]} #{routing[:id]}".strip,
          user_id: current_user&.id
        } %>
-  
+
     <button
       type="button"
       class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The help button doesn't work for logged out users (which i assume it's intended) but they're shown while visiting a transparent org.

The command menu doesn't make much sense to a logged out user since most of the option requires them to be logged in, also taking over the cmd+k keybind on a simple static page visit can be an unexpected and potentially disruptive user experience esp while it's a default chrome shortcut for searching.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

