### PR TITLE
Check if Grant card flipper is enabled in v4 org API

### DIFF
--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -11,6 +11,7 @@ json.playground_mode_meeting_requested event.demo_mode_request_meeting_at.presen
 json.transparent event.is_public?
 json.fee_percentage event.revenue_fee.to_f
 json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
+json.grant_enabled Flipper.enabled?(:card_grants_2023_05_25, event)
 
 if expand?(:balance_cents)
   json.balance_cents event.balance_available

--- a/app/views/api/v4/users/_user.json.jbuilder
+++ b/app/views/api/v4/users/_user.json.jbuilder
@@ -4,5 +4,13 @@ json.id user.public_id
 json.name user.name
 json.email user.email
 json.avatar profile_picture_for(user, params[:avatar_size].presence&.to_i || 24)
+json.shipping_address do
+  json.line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
+  json.line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
+  json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
+  json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
+  json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country
+  json.postal_code user&.stripe_cards&.physical&.last&.stripe_shipping_address_postal_code
+end
 json.admin user.admin?
 json.auditor user.auditor?

--- a/app/views/api/v4/users/_user.json.jbuilder
+++ b/app/views/api/v4/users/_user.json.jbuilder
@@ -5,8 +5,8 @@ json.name user.name
 json.email user.email
 json.avatar profile_picture_for(user, params[:avatar_size].presence&.to_i || 24)
 json.shipping_address do
-  json.line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
-  json.line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
+  json.address_line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
+  json.address_line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
   json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
   json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
   json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country


### PR DESCRIPTION
I want to be able to check if grant cards are supported in a specific organization before allowing organizers to create grant cards in hcb mobile