### PR TITLE
Check if Grant card flipper is enabled in v4 org API

### DIFF
--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -11,6 +11,7 @@ json.playground_mode_meeting_requested event.demo_mode_request_meeting_at.presen
 json.transparent event.is_public?
 json.fee_percentage event.revenue_fee.to_f
 json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
+json.grant_enabled Flipper.enabled?(:card_grants_2023_05_25, event)
 
 if expand?(:balance_cents)
   json.balance_cents event.balance_available


### PR DESCRIPTION
I want to be able to check if grant cards are supported in a specific organization before allowing organizers to create grant cards in hcb mobile