### PR TITLE
Update subtitle to show "Earlier today" for recent transactions

### DIFF
--- a/app/views/events/home/_transactions.html.erb
+++ b/app/views/events/home/_transactions.html.erb
@@ -9,7 +9,7 @@
             <% if transaction.is_a?(CanonicalPendingTransaction) %>
               Pending &bull;
             <% end %>
-            <% subtitle = "#{time_ago_in_words(transaction.date)} ago" %>
+            <% subtitle = transaction.date > 24.hours.ago ? "Earlier today" : "#{time_ago_in_words(transaction.date)} ago" %>
             <% if transaction.try(:raw_stripe_transaction) || transaction.try(:raw_pending_stripe_transaction_id) %>
               <% subtitle += ", #{transaction.stripe_cardholder.user.name}" %>
             <% end %>


### PR DESCRIPTION
This pull request updates the logic for displaying transaction subtitles in the `app/views/events/home/_transactions.html.erb` file. The change improves the user experience by providing more human-readable timestamps for recent transactions.

* Updated subtitle logic to display "Earlier today" for transactions within the last 24 hours instead of showing a relative time (e.g., "2 hours ago"). Transactions older than 24 hours will still display the relative time (e.g., "3 days ago"). (`[app/views/events/home/_transactions.html.erbL12-R12](diffhunk://#diff-f4b1ba8fc2c80c69b587c22ee12857e311dc00dcaee1208323ad47d27b8200f9L12-R12)`)

![image](https://github.com/user-attachments/assets/40e3c9cb-421d-473f-9797-05625057337a)
