### PR TITLE
Fix truncation of ct memos

### DIFF
--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -59,7 +59,7 @@
       <div class="flex-auto">
         <div class="flex items-center justify-start" style="gap: 1ch;">
           <%= turbo_frame_tag "#{ct.local_hcb_code.hashid}:memo_frame", class: "memo-frame flex", style: "width:100%; overflow:hidden; text-overflow:ellipsis; flex-grow: 1" do %>
-            <span class="inline-flex g-2 items-center" title="<%= transaction_memo(ct) %>" style="flex-grow: 1;">
+            <span title="<%= transaction_memo(ct) %>" style="flex-grow: 1;">
               <%= ct.local_hcb_code.card_grant? && !organizer_signed_in? ? link_to(transaction_memo(ct), spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant), data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "card_grant_details_#{instance}" }) : content_tag(:span) do %>
                 <%= render "hcb_codes/memo", hcb_code: ct.local_hcb_code, location: "ledger", ledger_instance: instance, force_display_details: defined?(force_display_details) %>
               <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Made a mistake in #10337 and didn't completely fix the issue.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The memo styling in canonical transactions now completely matches that of canonical pending transactions, and both display the ellipsis properly.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

