### PR TITLE
Fix IntraFi transaction import rounding

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -277,7 +277,7 @@ class AdminController < ApplicationController
       transactions << {
         date_posted: Date.strptime(date_posted, "%m/%d/%Y"),
         memo:,
-        amount_cents: amount.to_i * 100
+        amount_cents: (amount.to_f * 100).to_i
       }
     end
 


### PR DESCRIPTION
## Summary of the problem
IntraFi transactions, when imported, are currently importing without the cents. This causes inaccurate data and duplicate transactions.


## Describe your changes
Switch `.to_i` to `.to_f` 🥲