### PR TITLE
Fix remaining memo ellipsis bugs

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -88,10 +88,6 @@ html[data-dark='true'] {
       display: inline-block;
       vertical-align: top;
       text-overflow: ellipsis;
-
-      &:hover {
-        text-decoration-line: underline;
-      }
     }
   }
 

--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -79,10 +79,19 @@ html[data-dark='true'] {
   span:not(.badge):not(.list-badge):first-of-type {
     max-width: 100%;
     overflow: hidden;
-    text-overflow: ellipsis;
 
     @media screen and (max-width: 32em) {
       max-width: 32ch; // reduce character count on mobile
+    }
+
+    &:not(:has(span)) {
+      display: inline-block;
+      vertical-align: top;
+      text-overflow: ellipsis;
+
+      &:hover {
+        text-decoration-line: underline;
+      }
     }
   }
 

--- a/app/views/hcb_codes/_memo.html.erb
+++ b/app/views/hcb_codes/_memo.html.erb
@@ -47,7 +47,7 @@
             </span>
         </span>
       <% end %>
-      <%= ledger_instance ? link_to(contents, details_link, style: "color: inherit", class: "no-underline hover:underline", data: Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && !@force_no_popover ? { turbo_frame: "_top", behavior: "modal_trigger", modal: } : { turbo_frame: "_top" }) : content_tag(:span) { contents } %>
+      <%= ledger_instance ? link_to(contents, details_link, style: "color: inherit", class: "no-underline", data: Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && !@force_no_popover ? { turbo_frame: "_top", behavior: "modal_trigger", modal: } : { turbo_frame: "_top" }) : content_tag(:span) { contents } %>
       <% if renamed %>
         <%= render "hcb_codes/memo_stream", hcb_code: %>
       <% end %>

--- a/app/views/hcb_codes/_memo.html.erb
+++ b/app/views/hcb_codes/_memo.html.erb
@@ -41,13 +41,13 @@
               style="color: inherit; text-decoration: none;"
               aria-label="Shift+click to rename this transaction">
               <%= prepended_to_memo %>
-              <span data-memo-for="<%= dom_id(hcb_code) %>">
+              <span data-memo-for="<%= dom_id(hcb_code) %>" class="<%= "hover:underline" if ledger_instance %>">
                 <%= hcb_code.memo %>
               </span>
             </span>
         </span>
       <% end %>
-      <%= ledger_instance ? link_to(contents, details_link, style: "color: inherit", class: "no-underline", data: Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && !@force_no_popover ? { turbo_frame: "_top", behavior: "modal_trigger", modal: } : { turbo_frame: "_top" }) : content_tag(:span) { contents } %>
+      <%= ledger_instance ? link_to(contents, details_link, style: "color: inherit", data: Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && !@force_no_popover ? { turbo_frame: "_top", behavior: "modal_trigger", modal: } : { turbo_frame: "_top" }) : content_tag(:span) { contents } %>
       <% if renamed %>
         <%= render "hcb_codes/memo_stream", hcb_code: %>
       <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
@Luke-Oldenburg found there was still an issue with ellipsis appearing in memos when they shouldn't:
![image](https://github.com/user-attachments/assets/2f7b93e2-6c06-4075-a803-e2c5073ce612)



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The memo text is now an inline block so that the width can be set correctly. This also meant the underline for links has to be set manually on the span containing the text.

![image](https://github.com/user-attachments/assets/fa2d1cdb-218e-4e6f-9d03-0b307c2aecc7)




<!-- If there are any visual changes, please attach images, videos, or gifs. -->

