### PR TITLE
Add event links to stripe events in public activity

### DIFF
--- a/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   <% elsif hcb_code.pt&.declined? %>
     <%= render layout: "/public_activity/common", locals: { possessive: true, current_user:, activity:, url: hcb_code_path(hcb_code) } do %>
-      <%= link_to hcb_code.event&.name, hcb_code.event %> card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i> 
+      <%= link_to hcb_code.event&.name, hcb_code.event %> card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i>
     <% end %>
   <% elsif hcb_code.stripe_cash_withdrawal? %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>

--- a/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   <% elsif hcb_code.pt&.declined? %>
     <%= render layout: "/public_activity/common", locals: { possessive: true, current_user:, activity:, url: hcb_code_path(hcb_code) } do %>
-      card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
+      <%= link_to hcb_code.event&.name, hcb_code.event %> card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i> 
     <% end %>
   <% elsif hcb_code.stripe_cash_withdrawal? %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>

--- a/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
@@ -4,19 +4,19 @@
 <% if hcb_code %>
   <% if hcb_code.stripe_refund? %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
-      was refunded <%= render_money hcb_code.amount_cents.abs %> from <i><%= hcb_code.memo %></i>
+      was refunded <%= render_money hcb_code.amount_cents.abs %> from <i><%= hcb_code.memo %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% elsif hcb_code.pt&.declined? %>
     <%= render layout: "/public_activity/common", locals: { possessive: true, current_user:, activity:, url: hcb_code_path(hcb_code) } do %>
-      card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i>
+      card was declined for <%= render_money activity.trackable.amount_cents.abs %> at <i><%= hcb_code.memo %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% elsif hcb_code.stripe_cash_withdrawal? %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
-      withdrew <%= render_money hcb_code.stripe_atm_fee ? hcb_code.amount_cents.abs - hcb_code.stripe_atm_fee : hcb_code.amount_cents.abs %> from <i><%= humanized_merchant_name(hcb_code.stripe_merchant) %></i>
+      withdrew <%= render_money hcb_code.stripe_atm_fee ? hcb_code.amount_cents.abs - hcb_code.stripe_atm_fee : hcb_code.amount_cents.abs %> from <i><%= humanized_merchant_name(hcb_code.stripe_merchant) %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% else %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
-      spent <%= render_money hcb_code.amount_cents.abs %> on <i><%= hcb_code.memo %></i>
+      spent <%= render_money hcb_code.amount_cents.abs %> on <i><%= hcb_code.memo %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% end %>
 <% else %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Stripe events in the activities view don't tell you which event they were for


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added links to the associated event on the hcb code
![image](https://github.com/user-attachments/assets/3a9c1dd5-d383-43f3-ad93-36b80f225bf3)



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

