### PR TITLE
Add link to event in receipt bin list

### DIFF
--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -77,7 +77,7 @@
 <% @cards.each do |card| %>
   <section class="mb3 card p0 receipt-card">
     <h2 class="heading line-height-4 p1 pl2 mt0 ml0 flex justify-between items-center">
-      <%= link_to card.event.name, event_path(card.event) %>
+      <%= link_to card.event.name, event_path(card.event), class: "no-underline" %>
 
       <%= link_to card, class: "regular h3 mention flex items-center" do %>
         <%= inline_icon "card", class: "mr1", size: 25 %>

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -77,7 +77,7 @@
 <% @cards.each do |card| %>
   <section class="mb3 card p0 receipt-card">
     <h2 class="heading line-height-4 p1 pl2 mt0 ml0 flex justify-between items-center">
-      <%= card.event.name %>
+      <%= link_to card.event.name, event_path(card.event) %>
 
       <%= link_to card, class: "regular h3 mention flex items-center" do %>
         <%= inline_icon "card", class: "mr1", size: 25 %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
I was in the receipt bin and thought it would be useful to link to the event there!


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the event name text to be a link (without an underline, matching the stripe card link next to it)

![image](https://github.com/user-attachments/assets/2e5b1110-e92b-4de5-a782-0645ddbb04a0)
![image](https://github.com/user-attachments/assets/cf2f4f56-21e0-47f6-b3c5-9c814bd8f82c)


