### PR TITLE
Corrected typo in email to add a receipt

### DIFF
--- a/app/views/canonical_pending_transaction_mailer/_attach_receipt.html.erb
+++ b/app/views/canonical_pending_transaction_mailer/_attach_receipt.html.erb
@@ -1,5 +1,5 @@
 <% if hcb_code.receipt_required? %>
-  <%= link_to "Upload your receipt for this charge (this link can used by anyone for two weeks)", upload_url %>.
+  <%= link_to "Upload your receipt for this charge (this link can be used by anyone for two weeks)", upload_url %>.
 
   <p>
     Alternatively, <em>reply to this email with an image or PDF receipt attached</em>. When responding with a receipt, include a line beginning with <em>@rename</em> to rename the transaction or with <em>@tag</em> to tag the transaction.


### PR DESCRIPTION
## Summary of the problem
I got an email to add a receipt but it had a typo and it bothered me :(



## Describe your changes
It said `Upload your receipt for this charge (this link can used by anyone for two weeks)`

Now it says `Upload your receipt for this charge (this link can be used by anyone for two weeks)`




<!-- If there are any visual changes, please attach images, videos, or gifs. -->

