### PR TITLE
[Rubocop] Ignore `tmp/` directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'db/**/*'
     - 'lib/tasks/**/*'
     - 'vendor/**/*'
+    - 'tmp/**/*'
 
 # The "offical" rubocop style guide is indeed quite strict. So intead, we use
 # the Relaxed Ruby Style guide. https://relaxed.ruby.style/


### PR DESCRIPTION

## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

The tmp directory contains migrations stored by `actual_db_schema`. Without this change, Rubocop attempts to scan/correct those migrations which is unnecessary.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Add `'tmp/**/*'` to ignore list

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

