### PR TITLE
Allow for members to view disbursement form

### DIFF
--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -5,7 +5,7 @@ class DisbursementPolicy < ApplicationPolicy
     user.auditor?
   end
 
-  def can_send?(role: :manager)
+  def can_send?
     return true if user&.admin?
     return true if record.source_event.nil?
     return true if OrganizerPosition.role_at_least?(user, record.source_event, :manager)
@@ -13,7 +13,7 @@ class DisbursementPolicy < ApplicationPolicy
     false
   end
 
-  def can_receive?(role: :manager)
+  def can_receive?
     return true if user&.admin?
     return true if record.source_event&.plan&.unrestricted_disbursements_enabled?
     return true if record.destination_event.nil?

--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -23,7 +23,7 @@ class DisbursementPolicy < ApplicationPolicy
   end
 
   def new?
-    can_send?(role: :reader) && can_receive?(role: :reader)
+    auditor_or_user?
   end
 
   def create?


### PR DESCRIPTION
It redirects as unauthorized for members currently but the page should load with fields disabled.

