### PR TITLE
Fix event tag creation

### DIFF
--- a/app/controllers/event_tags_controller.rb
+++ b/app/controllers/event_tags_controller.rb
@@ -10,8 +10,7 @@ class EventTagsController < ApplicationController
 
     @event_tag.save!
 
-    if params[:event_id]
-      @event = Event.find_by(slug: params[:event_id])
+    if @event.present?
       authorize @event, :toggle_event_tag?
 
       suppress ActiveRecord::RecordNotUnique do

--- a/app/controllers/event_tags_controller.rb
+++ b/app/controllers/event_tags_controller.rb
@@ -11,7 +11,7 @@ class EventTagsController < ApplicationController
     @event_tag.save!
 
     if params[:event_id]
-      @event = Event.find(params[:event_id])
+      @event = Event.find_by(slug: params[:event_id])
       authorize @event, :toggle_event_tag?
 
       suppress ActiveRecord::RecordNotUnique do

--- a/app/views/events/settings/admin/_tags.html.erb
+++ b/app/views/events/settings/admin/_tags.html.erb
@@ -38,7 +38,6 @@
             <div class="menu__divider"></div>
           <% end %>
           <%= form_with url: event_event_tags_path(@event), data: { turbo: true } do |form| %>
-            <%= form.hidden_field :event_id, value: @event.id %>
             <%= form.text_field :name, data: { "behavior" => @event.event_tags.none? ? "autofocus" : "" }, class: "menu__input", placeholder: "+ Create tag", autocomplete: "off", required: true %>
           <% end %>
         </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Event tag creation seemed to be a little broken - when you created one from the admin tab of an event's settings, it would create the tag but wouldn't link it due to the slug that rails sets as `params[:event_id]` being used as a numeric record ID.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removed the redundant hidden field from the new event tag form and changed the controller to interpret the ID as the event's slug.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

