### PR TITLE
Fix development packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,4 +23,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libgirepository1.0-dev \
     libpoppler-glib-dev \
     libcairo-gobject2 \
-    yarn
+    yarn \
+    imagemagick

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -144,13 +144,6 @@ HCB-specific setup instructions.
 
 **Additional installs for local development:**
 
-Install [wkhtmltopdf](https://wkhtmltopdf.org/)
-
-```bash
-# Mac specific instruction:
-brew install wkhtmltopdf
-```
-
 Install [ImageMagick](https://imagemagick.org/)
 
 ```bash


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Got an error in development when `convert` wasn't found - `imagemagick` was not included in the Dockerfile for the devcontainer. Also, I noticed `wkhtmltopdf` was included in the packages you need to install if setting up HCB locally, but it seems that binary is provided by the `wkhtmltopdf-binary` in the `Gemfile`.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added `imagemagick` to the Dockerfile and removed the `wkhtmltopdf` package from `development.md`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

