### PR TITLE
Link to hcb code in public activity

### DIFF
--- a/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
@@ -15,10 +15,8 @@
       withdrew <%= render_money hcb_code.stripe_atm_fee ? hcb_code.amount_cents.abs - hcb_code.stripe_atm_fee : hcb_code.amount_cents.abs %> from <i><%= humanized_merchant_name(hcb_code.stripe_merchant) %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% else %>
-    <% if !hcb_code.stripe_card&.card_grant %>
-      <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
-        spent <%= render_money hcb_code.amount_cents.abs %> on <%= link_to hcb_code.memo, hcb_code_path(hcb_code) %> for <%= link_to hcb_code.event&.name, hcb_code.event %>
-      <% end %>
+    <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
+      spent <%= render_money hcb_code.amount_cents.abs %> on <%= link_to hcb_code.memo, hcb_code_path(hcb_code) %> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create.html.erb
@@ -15,8 +15,10 @@
       withdrew <%= render_money hcb_code.stripe_atm_fee ? hcb_code.amount_cents.abs - hcb_code.stripe_atm_fee : hcb_code.amount_cents.abs %> from <i><%= humanized_merchant_name(hcb_code.stripe_merchant) %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
     <% end %>
   <% else %>
-    <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
-      spent <%= render_money hcb_code.amount_cents.abs %> on <i><%= hcb_code.memo %></i> for <%= link_to hcb_code.event&.name, hcb_code.event %>
+    <% if !hcb_code.stripe_card&.card_grant %>
+      <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: hcb_code_path(hcb_code) } do %>
+        spent <%= render_money hcb_code.amount_cents.abs %> on <%= link_to hcb_code.memo, hcb_code_path(hcb_code) %> for <%= link_to hcb_code.event&.name, hcb_code.event %>
+      <% end %>
     <% end %>
   <% end %>
 <% else %>


### PR DESCRIPTION
The card grant purchases were cluttering and I don't think were particularly relevant as they weren't by members of the organization. I think there should be a page somewhere for organizers that shows all transactions that have a subledger id set (ex. show all card grant transactions) to better stay on top of them for fraud.

![Screenshot From 2025-05-14 22-46-31](https://github.com/user-attachments/assets/d73d65ab-1814-409a-a846-5ce3de15747c)
