### PR TITLE
Add Referral system and "Explore Hack Club" section

### DIFF
--- a/app/controllers/referral/programs_controller.rb
+++ b/app/controllers/referral/programs_controller.rb
@@ -1,0 +1,26 @@
+module Referral
+  class ProgramsController < ApplicationController
+    before_action :set_program, only: :show
+
+    def show
+      if @program
+        authorize(@program)
+
+        Rails.error.handle do
+          Referral::Attribution.create!(user: current_user, program: @program)
+        end
+      else
+        skip_authorization
+      end
+
+      redirect_to params[:return_to] || root_path
+    end
+
+    private
+
+    def set_program
+      @program = Referral::Program.find_by_hashid(params[:id])
+    end
+
+  end
+end

--- a/app/controllers/referral/programs_controller.rb
+++ b/app/controllers/referral/programs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Referral
   class ProgramsController < ApplicationController
     before_action :set_program, only: :show

--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: raffles
+#
+#  id         :bigint           not null, primary key
+#  program    :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_raffles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Raffle < ApplicationRecord
   belongs_to :user
   validates :program, presence: true

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,0 +1,5 @@
+module Referral
+  def self.table_name_prefix
+    "referral_"
+  end
+end

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Referral
   def self.table_name_prefix
     "referral_"

--- a/app/models/referral/attribution.rb
+++ b/app/models/referral/attribution.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: referral_attributions
+#
+#  id                  :bigint           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  referral_program_id :bigint           not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_referral_attributions_on_referral_program_id  (referral_program_id)
+#  index_referral_attributions_on_user_id              (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (referral_program_id => referral_programs.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Referral::Attribution < ApplicationRecord
+  belongs_to :program, class_name: "Referral::Program", foreign_key: "referral_program_id"
+  belongs_to :user # Referee (person being referred)
+
+end

--- a/app/models/referral/attribution.rb
+++ b/app/models/referral/attribution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: referral_attributions
@@ -18,8 +20,10 @@
 #  fk_rails_...  (referral_program_id => referral_programs.id)
 #  fk_rails_...  (user_id => users.id)
 #
-class Referral::Attribution < ApplicationRecord
-  belongs_to :program, class_name: "Referral::Program", foreign_key: "referral_program_id"
-  belongs_to :user # Referee (person being referred)
+module Referral
+  class Attribution < ApplicationRecord
+    belongs_to :program, class_name: "Referral::Program", foreign_key: "referral_program_id", inverse_of: :attributions
+    belongs_to :user # Referee (person being referred)
 
+  end
 end

--- a/app/models/referral/program.rb
+++ b/app/models/referral/program.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: referral_programs
+#
+#  id                     :bigint           not null, primary key
+#  name                   :string           not null
+#  show_explore_hack_club :boolean          default(FALSE), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+module Referral
+  class Program < ApplicationRecord
+    include Hashid::Rails
+
+    validates :name, presence: true
+    validates :show_explore_hack_club, inclusion: { in: [true, false] }
+
+  end
+end

--- a/app/models/referral/program.rb
+++ b/app/models/referral/program.rb
@@ -17,7 +17,7 @@ module Referral
     validates :name, presence: true
     validates :show_explore_hack_club, inclusion: { in: [true, false] }
 
-    has_many :attributions, dependent: :destroy, foreign_key: :referral_program_id, inverse_of: :referral_program
+    has_many :attributions, dependent: :destroy, foreign_key: :referral_program_id, inverse_of: :program
     has_many :users, -> { distinct }, through: :attributions, source: :user
 
   end

--- a/app/models/referral/program.rb
+++ b/app/models/referral/program.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: referral_programs
@@ -14,6 +16,9 @@ module Referral
 
     validates :name, presence: true
     validates :show_explore_hack_club, inclusion: { in: [true, false] }
+
+    has_many :attributions, dependent: :destroy, foreign_key: :referral_program_id, inverse_of: :referral_program
+    has_many :users, -> { distinct }, through: :attributions, source: :user
 
   end
 end

--- a/app/policies/referral/program_policy.rb
+++ b/app/policies/referral/program_policy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Referral
+  class ProgramPolicy < ApplicationPolicy
+    def show
+      user.present?
+    end
+
+  end
+end

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -110,16 +110,8 @@
         <% end %>
       </ul>
     <% end %>
-      <div class="flex flex-row w-full justify-between items-center">
-        <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">Explore HCB</h2>
-          <%= link_to "https://hackclub.com/fiscal-sponsorship/directory?utm_source=hcb&utm_medium=web&utm_campaign=explore", class: "muted", target: :_blank do %>
-          View all organizations<%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
-        <% end %>
-      </div>
 
-      <ul class="grid grid--medium-narrow left-align w-100 mt0">
-        <%= render partial: "events/event_card", collection: @featured_events, as: :event, locals: { show_category_badge: true, show_date_stat: true } %>
-      </ul>
+    <%= render "static_pages/index/explore" %>
 
     <% if current_user.organizer_position_contracts.sent.any? %>
       <h2 class="w-full text-left mt-4 pb-0 border-none">Your pending contracts</h2>

--- a/app/views/static_pages/index/_explore.html.erb
+++ b/app/views/static_pages/index/_explore.html.erb
@@ -1,0 +1,71 @@
+<%# EXPLORE HACK CLUB %>
+
+<div class="flex flex-row w-full justify-between items-center">
+  <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
+    Explore Hack Club
+  </h2>
+  <%= link_to "https://hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", class: "muted", target: :_blank do %>
+    Learn more
+    <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
+  <% end %>
+</div>
+
+<ul class="grid grid--medium-narrow left-align w-100 mt0">
+  <%= link_to "https://shipwrecked.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/a2daad374a6801ab8e6cffed1eb7dcc63732a43e_image.png')">
+      <div class="flex gap-2 items-center">
+        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/3a964b5cead6f54cf1ad231c4133057a049339cc_image.png" height="24" weight="24" class="rounded align-bottom" alt="Shipwrecked logo" />
+        <strong class="text-xl leading-tight">
+          Shipwrecked
+        </strong>
+      </div>
+      <p>
+        A free, 3-day high school hackathon where teenagers will be together
+        coding apps, games and websites.
+      </p>
+    </li>
+  <% end %>
+  <%= link_to "https://sprig.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/66c5fe262f184804a350fcecc44d77fd3d9d8944_image.png')">
+      <div class="flex gap-2 items-center">
+        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/de7a5973beecd3e2e4675d8b703ecbd7c9a4f6c6_image.png" height="24" weight="24" class="rounded align-bottom" alt="Sprig logo" />
+        <strong class="text-xl leading-tight">
+          Sprig
+        </strong>
+      </div>
+      <p>
+        Build a JavaScript game, share it with the community, and receive a free
+        Sprig gaming console.
+      </p>
+    </li>
+  <% end %>
+  <%= link_to "https://hackclub.com/slack?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://cloud-j0p07nviw-hack-club-bot.vercel.app/0image.png')">
+      <div class="flex gap-2 items-center">
+        <img src="https://assets.hackclub.com/icon-rounded.png" height="24" weight="24" class="rounded align-bottom" alt="Slack logo" />
+        <strong class="text-xl leading-tight">
+          Hack Club Slack
+        </strong>
+      </div>
+      <p>
+        Join the Slack to find the community for your favorite programming
+        language, ask for advice, or just hang out.
+      </p>
+    </li>
+  <% end %>
+</ul>
+
+<%# EXPLORE HCB %>
+<div class="flex flex-row w-full justify-between items-center">
+  <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
+    Explore HCB
+  </h2>
+  <%= link_to "https://hackclub.com/fiscal-sponsorship/directory?utm_source=hcb&utm_medium=web&utm_campaign=explore", class: "muted", target: :_blank do %>
+    View all organizations
+    <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
+  <% end %>
+</div>
+
+<ul class="grid grid--medium-narrow left-align w-100 mt0">
+  <%= render partial: "events/event_card", collection: @featured_events, as: :event, locals: {show_category_badge: true, show_date_stat: true} %>
+</ul>

--- a/app/views/static_pages/index/_explore.html.erb
+++ b/app/views/static_pages/index/_explore.html.erb
@@ -1,59 +1,61 @@
 <%# EXPLORE HACK CLUB %>
 
-<div class="flex flex-row w-full justify-between items-center">
-  <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
-    Explore Hack Club
-  </h2>
-  <%= link_to "https://hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", class: "muted", target: :_blank do %>
-    Learn more
-    <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
-  <% end %>
-</div>
+<% if Referral::Attribution.includes(:program).where(user: current_user, program: {show_explore_hack_club: true}).any? %>
+  <div class="flex flex-row w-full justify-between items-center">
+    <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
+      Explore Hack Club
+    </h2>
+    <%= link_to "https://hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", class: "muted", target: :_blank do %>
+      Learn more
+      <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
+    <% end %>
+  </div>
 
-<ul class="grid grid--medium-narrow left-align w-100 mt0">
-  <%= link_to "https://shipwrecked.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
-    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/a2daad374a6801ab8e6cffed1eb7dcc63732a43e_image.png')">
-      <div class="flex gap-2 items-center">
-        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/3a964b5cead6f54cf1ad231c4133057a049339cc_image.png" height="24" weight="24" class="rounded align-bottom" alt="Shipwrecked logo" />
-        <strong class="text-xl leading-tight">
-          Shipwrecked
-        </strong>
-      </div>
-      <p>
-        A free, 3-day high school hackathon where teenagers will be together
-        coding apps, games and websites.
-      </p>
-    </li>
-  <% end %>
-  <%= link_to "https://sprig.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
-    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/66c5fe262f184804a350fcecc44d77fd3d9d8944_image.png')">
-      <div class="flex gap-2 items-center">
-        <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/de7a5973beecd3e2e4675d8b703ecbd7c9a4f6c6_image.png" height="24" weight="24" class="rounded align-bottom" alt="Sprig logo" />
-        <strong class="text-xl leading-tight">
-          Sprig
-        </strong>
-      </div>
-      <p>
-        Build a JavaScript game, share it with the community, and receive a free
-        Sprig gaming console.
-      </p>
-    </li>
-  <% end %>
-  <%= link_to "https://hackclub.com/slack?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
-    <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://cloud-j0p07nviw-hack-club-bot.vercel.app/0image.png')">
-      <div class="flex gap-2 items-center">
-        <img src="https://assets.hackclub.com/icon-rounded.png" height="24" weight="24" class="rounded align-bottom" alt="Slack logo" />
-        <strong class="text-xl leading-tight">
-          Hack Club Slack
-        </strong>
-      </div>
-      <p>
-        Join the Slack to find the community for your favorite programming
-        language, ask for advice, or just hang out.
-      </p>
-    </li>
-  <% end %>
-</ul>
+  <ul class="grid grid--medium-narrow left-align w-100 mt0">
+    <%= link_to "https://shipwrecked.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/a2daad374a6801ab8e6cffed1eb7dcc63732a43e_image.png')">
+        <div class="flex gap-2 items-center">
+          <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/3a964b5cead6f54cf1ad231c4133057a049339cc_image.png" height="24" weight="24" class="rounded align-bottom" alt="Shipwrecked logo">
+          <strong class="text-xl leading-tight">
+            Shipwrecked
+          </strong>
+        </div>
+        <p>
+          A free, 3-day high school hackathon where teenagers will be together
+          coding apps, games and websites.
+        </p>
+      </li>
+    <% end %>
+    <%= link_to "https://sprig.hackclub.com?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/66c5fe262f184804a350fcecc44d77fd3d9d8944_image.png')">
+        <div class="flex gap-2 items-center">
+          <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/de7a5973beecd3e2e4675d8b703ecbd7c9a4f6c6_image.png" height="24" weight="24" class="rounded align-bottom" alt="Sprig logo">
+          <strong class="text-xl leading-tight">
+            Sprig
+          </strong>
+        </div>
+        <p>
+          Build a JavaScript game, share it with the community, and receive a
+          free Sprig gaming console.
+        </p>
+      </li>
+    <% end %>
+    <%= link_to "https://hackclub.com/slack?utm_source=hcb&utm_medium=web&utm_campaign=explore", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://cloud-j0p07nviw-hack-club-bot.vercel.app/0image.png')">
+        <div class="flex gap-2 items-center">
+          <img src="https://assets.hackclub.com/icon-rounded.png" height="24" weight="24" class="rounded align-bottom" alt="Slack logo">
+          <strong class="text-xl leading-tight">
+            Hack Club Slack
+          </strong>
+        </div>
+        <p>
+          Join the Slack to find the community for your favorite programming
+          language, ask for advice, or just hang out.
+        </p>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 
 <%# EXPLORE HCB %>
 <div class="flex flex-row w-full justify-between items-center">
@@ -67,5 +69,5 @@
 </div>
 
 <ul class="grid grid--medium-narrow left-align w-100 mt0">
-  <%= render partial: "events/event_card", collection: @featured_events, as: :event, locals: {show_category_badge: true, show_date_stat: true} %>
+  <%= render partial: "events/event_card", collection: @featured_events, as: :event, locals: { show_category_badge: true, show_date_stat: true } %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -787,6 +787,10 @@ Rails.application.routes.draw do
     get "balance_by_date"
   end
 
+  scope module: "referral" do
+    resources :programs, only: [:show], path: "referrals"
+  end
+
   # rewrite old event urls to the new ones not prefixed by /events/
   get "/events/*path", to: redirect("/%{path}", status: 302)
 

--- a/db/migrate/20250515084610_create_referral_programs.rb
+++ b/db/migrate/20250515084610_create_referral_programs.rb
@@ -1,0 +1,10 @@
+class CreateReferralPrograms < ActiveRecord::Migration[7.2]
+  def change
+    create_table :referral_programs do |t|
+      t.string :name, null: false
+      t.boolean :show_explore_hack_club, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250515084915_create_referral_attributions.rb
+++ b/db/migrate/20250515084915_create_referral_attributions.rb
@@ -1,0 +1,10 @@
+class CreateReferralAttributions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :referral_attributions do |t|
+      t.references :referral_program, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_14_174905) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_15_084915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -1712,6 +1712,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_174905) do
     t.index ["url_hash"], name: "index_recurring_donations_on_url_hash", unique: true
   end
 
+  create_table "referral_attributions", force: :cascade do |t|
+    t.bigint "referral_program_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["referral_program_id"], name: "index_referral_attributions_on_referral_program_id"
+    t.index ["user_id"], name: "index_referral_attributions_on_user_id"
+  end
+
+  create_table "referral_programs", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "show_explore_hack_club", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "reimbursement_expense_payouts", force: :cascade do |t|
     t.bigint "event_id", null: false
     t.string "hcb_code"
@@ -2347,6 +2363,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_174905) do
   add_foreign_key "raw_pending_outgoing_disbursement_transactions", "disbursements"
   add_foreign_key "receipts", "users"
   add_foreign_key "recurring_donations", "events"
+  add_foreign_key "referral_attributions", "referral_programs"
+  add_foreign_key "referral_attributions", "users"
   add_foreign_key "reimbursement_expense_payouts", "events"
   add_foreign_key "reimbursement_expenses", "reimbursement_reports"
   add_foreign_key "reimbursement_expenses", "users", column: "approved_by_id"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

1. Mel wants to be able to track users referred from a newsletter that's being sent out.
2. Only those users should be able to see an "Explore Hack Club" section on the home page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Adds a referral system:

- `Referral::Program`: There will only be one program for now (that newsletter mentioned above). But, it is flexible enough to handle more programs in the future, including having current users generate their own unique referral code to refer their friends.
- `Referral::Attribution`: It's just a join model/table between `Referral::Program` and `User` (the person being referred). I'm intentionally allowing "duplicate" records here (where a user is referred multiple times by the same program or different programs). It gives us more data. If we ever plan to provide referral benefits using this system, we'll just use the user's first referral.
- Program has a `show_explore_hack_club` column which determines whether the "Explore Hack Club" section is shown.


<img width="1438" alt="image" src="https://github.com/user-attachments/assets/c79be7e2-8003-4e33-86c7-16e9798c365c" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

