### PR TITLE
Remove browser_token column from logins and update schema

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -4,14 +4,14 @@
 #
 # Table name: logins
 #
-#  id                     :bigint           not null, primary key
-#  aasm_state             :string
-#  browser_token          :string
-#  authentication_factors :jsonb
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  user_id                :bigint           not null
-#  user_session_id        :bigint
+#  id                       :bigint           not null, primary key
+#  aasm_state               :string
+#  authentication_factors   :jsonb
+#  browser_token_ciphertext :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  user_id                  :bigint           not null
+#  user_session_id          :bigint
 #
 # Indexes
 #
@@ -26,7 +26,6 @@ class Login < ApplicationRecord
   belongs_to :user_session, optional: true
 
   has_encrypted :browser_token
-  self.ignored_columns += ["browser_token"]
   before_validation :ensure_browser_token
 
   store_accessor :authentication_factors, :sms, :email, :webauthn, :totp, prefix: :authenticated_with

--- a/db/migrate/20250515161504_remove_browser_token_from_logins.rb
+++ b/db/migrate/20250515161504_remove_browser_token_from_logins.rb
@@ -1,0 +1,5 @@
+class RemoveBrowserTokenFromLogins < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :logins, :browser_token, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_15_084915) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_15_161504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -1309,7 +1309,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_15_084915) do
     t.jsonb "authentication_factors"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "browser_token"
     t.text "browser_token_ciphertext"
     t.index ["user_id"], name: "index_logins_on_user_id"
     t.index ["user_session_id"], name: "index_logins_on_user_session_id"


### PR DESCRIPTION
### 🧹 Cleanup: Drop legacy `browser_token` column from `logins`

Now that `browser_token` is fully encrypted and no longer used in its original form, this PR removes the legacy unencrypted column from the `logins` table.

#### Changes:

* Drops the `browser_token` column
* Removes `self.ignored_columns += ["browser_token"]` from the model

This is the final step in the Lockbox migration process and completes the transition to encrypted storage for login tokens.

> Assumes that the previous finalization PR has been deployed and no remaining code references the unencrypted column.