### PR TITLE
[Google Workspace] Disambiguate sort-by column on admin page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -939,7 +939,7 @@ class AdminController < ApplicationController
     relation = relation.joins(:revocation).where(revocation: { aasm_state: "revoked" }) if @pending_deletion
 
     @count = relation.count
-    @g_suites = relation.page(@page).per(@per).order("created_at desc")
+    @g_suites = relation.page(@page).per(@per).order("g_suites.created_at desc")
 
   end
 


### PR DESCRIPTION
fix error from ambiguous column name for sort-by due to both g_suites and revocations having `created_at` column.