### PR TITLE
Stop tracking encrypted browser_token in PaperTrail

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -34,7 +34,7 @@ class Login < ApplicationRecord
 
   scope :active, -> { where(created_at: EXPIRATION.ago..) }
 
-  has_paper_trail
+  has_paper_trail skip: [:browser_token]
 
   validate do
     if user_session.present? && !complete?


### PR DESCRIPTION
Just some additional cleanup from #10440. Now that browser_token is encrypted with Lockbox, we no longer want to track changes to it in version history. 