### PR TITLE
[EmailUpdate] Encrypt authorization_token & verification_token

### DIFF
--- a/app/models/user/email_update.rb
+++ b/app/models/user/email_update.rb
@@ -40,6 +40,8 @@ class User
 
     belongs_to :user
     belongs_to :updated_by, class_name: "User"
+    has_secure_token :authorization_token
+    has_secure_token :verification_token
     has_encrypted :authorization_token, migrating: true
     has_encrypted :verification_token, migrating: true
 

--- a/app/models/user/email_update.rb
+++ b/app/models/user/email_update.rb
@@ -4,18 +4,20 @@
 #
 # Table name: user_email_updates
 #
-#  id                  :bigint           not null, primary key
-#  aasm_state          :string           not null
-#  authorization_token :string           not null
-#  authorized          :boolean          default(FALSE), not null
-#  original            :string           not null
-#  replacement         :string           not null
-#  verification_token  :string           not null
-#  verified            :boolean          default(FALSE), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  updated_by_id       :bigint
-#  user_id             :bigint           not null
+#  id                             :bigint           not null, primary key
+#  aasm_state                     :string           not null
+#  authorization_token            :string           not null
+#  authorization_token_ciphertext :text
+#  authorized                     :boolean          default(FALSE), not null
+#  original                       :string           not null
+#  replacement                    :string           not null
+#  verification_token             :string           not null
+#  verification_token_ciphertext  :text
+#  verified                       :boolean          default(FALSE), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  updated_by_id                  :bigint
+#  user_id                        :bigint           not null
 #
 # Indexes
 #
@@ -38,8 +40,8 @@ class User
 
     belongs_to :user
     belongs_to :updated_by, class_name: "User"
-    has_secure_token :authorization_token
-    has_secure_token :verification_token
+    has_encrypted :authorization_token, migrating: true
+    has_encrypted :verification_token, migrating: true
 
     validate :non_hcb_email
     validate :non_existing_email

--- a/db/migrate/20250518005427_encrypt_authorization_and_cerification_codes.rb
+++ b/db/migrate/20250518005427_encrypt_authorization_and_cerification_codes.rb
@@ -1,0 +1,6 @@
+class EncryptAuthorizationAndCerificationCodes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :user_email_updates, :authorization_token_ciphertext, :text
+    add_column :user_email_updates, :verification_token_ciphertext, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_15_161504) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_18_005427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -2065,6 +2065,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_15_161504) do
     t.bigint "updated_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "authorization_token_ciphertext"
+    t.text "verification_token_ciphertext"
     t.index ["updated_by_id"], name: "index_user_email_updates_on_updated_by_id"
     t.index ["user_id"], name: "index_user_email_updates_on_user_id"
   end


### PR DESCRIPTION
### 🔐 Step 1: Begin encryption for `authorization_token` and `verification_token`

This PR starts the Lockbox encryption process for the `User::EmailUpdate` model.

#### Changes:
- Adds `*_ciphertext` columns for `authorization_token` and `verification_token`
- Enables Lockbox encryption in migrating mode
- Removes `has_secure_token` usage for both fields

No behavior is changed yet.

---

### ⏭️ Next:
Once deployed, someone with access to the production Rails console should run:
```ruby
Lockbox.migrate(User::EmailUpdate)
```
to backfill encrypted values.

**PR 1/3 for #9491** 