### PR TITLE
Remove aliases from job renames

### DIFF
--- a/app/jobs/ach_transfer/daily_job.rb
+++ b/app/jobs/ach_transfer/daily_job.rb
@@ -12,7 +12,3 @@ class AchTransfer
   end
 
 end
-
-module AchTransferJob
-  Daily = AchTransfer::DailyJob
-end

--- a/app/jobs/ach_transfer/nightly_job.rb
+++ b/app/jobs/ach_transfer/nightly_job.rb
@@ -10,7 +10,3 @@ class AchTransfer
   end
 
 end
-
-module AchTransferJob
-  Nightly = AchTransfer::NightlyJob
-end

--- a/app/jobs/bank_fee/nightly_job.rb
+++ b/app/jobs/bank_fee/nightly_job.rb
@@ -10,7 +10,3 @@ class BankFee
   end
 
 end
-
-module BankFeeJob
-  Nightly = BankFee::NightlyJob
-end

--- a/app/jobs/bank_fee/weekly_job.rb
+++ b/app/jobs/bank_fee/weekly_job.rb
@@ -10,7 +10,3 @@ class BankFee
   end
 
 end
-
-module BankFeeJob
-  Weekly = BankFee::WeeklyJob
-end

--- a/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
+++ b/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
@@ -59,7 +59,3 @@ class CanonicalPendingTransaction
   end
 
 end
-
-module CanonicalPendingTransactionJob
-  SendTwilioDeclinedMessage = CanonicalPendingTransaction::SendTwilioDeclinedMessageJob
-end

--- a/app/jobs/canonical_pending_transaction/send_twilio_receipt_message_job.rb
+++ b/app/jobs/canonical_pending_transaction/send_twilio_receipt_message_job.rb
@@ -41,7 +41,3 @@ class CanonicalPendingTransaction
   end
 
 end
-
-module CanonicalPendingTransactionJob
-  SendTwilioReceiptMessage = CanonicalPendingTransaction::SendTwilioReceiptMessageJob
-end

--- a/app/jobs/disbursement/daily_job.rb
+++ b/app/jobs/disbursement/daily_job.rb
@@ -23,7 +23,3 @@ class Disbursement
   end
 
 end
-
-module DisbursementJob
-  Daily = Disbursement::DailyJob
-end

--- a/app/jobs/disbursement/hourly_job.rb
+++ b/app/jobs/disbursement/hourly_job.rb
@@ -10,7 +10,3 @@ class Disbursement
   end
 
 end
-
-module DisbursementJob
-  Hourly = Disbursement::HourlyJob
-end

--- a/app/jobs/disbursement/nightly_job.rb
+++ b/app/jobs/disbursement/nightly_job.rb
@@ -10,7 +10,3 @@ class Disbursement
   end
 
 end
-
-module DisbursementJob
-  Nightly = Disbursement::NightlyJob
-end

--- a/app/jobs/donation/nightly_job.rb
+++ b/app/jobs/donation/nightly_job.rb
@@ -10,7 +10,3 @@ class Donation
   end
 
 end
-
-module DonationJob
-  Nightly = Donation::NightlyJob
-end

--- a/app/jobs/donation/refund_job.rb
+++ b/app/jobs/donation/refund_job.rb
@@ -17,7 +17,3 @@ class Donation
   end
 
 end
-
-module DonationJob
-  Refund = Donation::RefundJob
-end

--- a/app/jobs/event_mapping_engine/nightly_job.rb
+++ b/app/jobs/event_mapping_engine/nightly_job.rb
@@ -9,7 +9,3 @@ module EventMappingEngine
 
   end
 end
-
-module EventMappingEngineJob
-  Nightly = EventMappingEngine::NightlyJob
-end

--- a/app/jobs/fee_engine/hourly_job.rb
+++ b/app/jobs/fee_engine/hourly_job.rb
@@ -9,7 +9,3 @@ module FeeEngine
 
   end
 end
-
-module FeeEngineJob
-  Hourly = FeeEngine::HourlyJob
-end

--- a/app/jobs/fee_reimbursement/nightly_job.rb
+++ b/app/jobs/fee_reimbursement/nightly_job.rb
@@ -10,7 +10,3 @@ class FeeReimbursement
   end
 
 end
-
-module FeeReimbursementJob
-  Nightly = FeeReimbursement::NightlyJob
-end

--- a/app/jobs/g_suite/mark_verifieds_job.rb
+++ b/app/jobs/g_suite/mark_verifieds_job.rb
@@ -18,7 +18,3 @@ class GSuite
   end
 
 end
-
-module GSuiteJob
-  MarkVerifieds = GSuite::MarkVerifiedsJob
-end

--- a/app/jobs/g_suite/scan_verified_dns_job.rb
+++ b/app/jobs/g_suite/scan_verified_dns_job.rb
@@ -13,7 +13,3 @@ class GSuite
   end
 
 end
-
-module GSuiteJob
-  ScanVerifiedDns = GSuite::ScanVerifiedDnsJob
-end

--- a/app/jobs/g_suite/set_verification_key_job.rb
+++ b/app/jobs/g_suite/set_verification_key_job.rb
@@ -17,7 +17,3 @@ class GSuite
   end
 
 end
-
-module GSuiteJob
-  SetVerificationKey = GSuite::SetVerificationKeyJob
-end

--- a/app/jobs/g_suite/verify_all_job.rb
+++ b/app/jobs/g_suite/verify_all_job.rb
@@ -14,7 +14,3 @@ class GSuite
   end
 
 end
-
-module GSuiteJob
-  VerifyAll = GSuite::VerifyAllJob
-end

--- a/app/jobs/increase_check/remind_undeposited_recipient_job.rb
+++ b/app/jobs/increase_check/remind_undeposited_recipient_job.rb
@@ -15,7 +15,3 @@ class IncreaseCheck
   end
 
 end
-
-module IncreaseCheckJob
-  RemindUndepositedRecipient = IncreaseCheck::RemindUndepositedRecipientJob
-end

--- a/app/jobs/invoice/open_to_paid_job.rb
+++ b/app/jobs/invoice/open_to_paid_job.rb
@@ -10,7 +10,3 @@ class Invoice
   end
 
 end
-
-module InvoiceJob
-  OpenToPaid = Invoice::OpenToPaidJob
-end

--- a/app/jobs/invoice/opens_to_paids_job.rb
+++ b/app/jobs/invoice/opens_to_paids_job.rb
@@ -10,7 +10,3 @@ class Invoice
   end
 
 end
-
-module InvoiceJob
-  OpenToPaids = Invoice::OpensToPaidsJob
-end

--- a/app/jobs/invoice/refund_job.rb
+++ b/app/jobs/invoice/refund_job.rb
@@ -17,7 +17,3 @@ class Invoice
   end
 
 end
-
-module InvoiceJob
-  Refund = Invoice::RefundJob
-end

--- a/app/jobs/metric/calculate_app_wide_job.rb
+++ b/app/jobs/metric/calculate_app_wide_job.rb
@@ -25,7 +25,3 @@ class Metric
   end
 
 end
-
-module MetricJobs
-  CalculateAppWide = Metric::CalculateAppWideJob
-end

--- a/app/jobs/metric/calculate_single_job.rb
+++ b/app/jobs/metric/calculate_single_job.rb
@@ -11,7 +11,3 @@ class Metric
   end
 
 end
-
-module MetricJobs
-  CalculateSingle = Metric::CalculateSingleJob
-end

--- a/app/jobs/metric/calculate_stats_job.rb
+++ b/app/jobs/metric/calculate_stats_job.rb
@@ -11,7 +11,3 @@ class Metric
   end
 
 end
-
-module MetricJobs
-  CalculateStats = Metric::CalculateStatsJob
-end

--- a/app/jobs/metric/calculate_subjects_job.rb
+++ b/app/jobs/metric/calculate_subjects_job.rb
@@ -31,7 +31,3 @@ class Metric
   end
 
 end
-
-module MetricJobs
-  CalculateSubjects = Metric::CalculateSubjectsJob
-end

--- a/app/jobs/payout/donation_job.rb
+++ b/app/jobs/payout/donation_job.rb
@@ -9,7 +9,3 @@ module Payout
 
   end
 end
-
-module PayoutJob
-  Donation = Payout::DonationJob
-end

--- a/app/jobs/payout/invoice_job.rb
+++ b/app/jobs/payout/invoice_job.rb
@@ -9,7 +9,3 @@ module Payout
 
   end
 end
-
-module PayoutJob
-  Invoice = Payout::InvoiceJob
-end

--- a/app/jobs/payout/nightly_job.rb
+++ b/app/jobs/payout/nightly_job.rb
@@ -9,7 +9,3 @@ module Payout
 
   end
 end
-
-module PayoutJob
-  Nightly = Payout::NightlyJob
-end

--- a/app/jobs/payroll/nightly_job.rb
+++ b/app/jobs/payroll/nightly_job.rb
@@ -9,7 +9,3 @@ module Payroll
 
   end
 end
-
-module PayrollJob
-  Nightly = Payroll::NightlyJob
-end

--- a/app/jobs/pending_event_mapping_engine/nightly_job.rb
+++ b/app/jobs/pending_event_mapping_engine/nightly_job.rb
@@ -14,7 +14,3 @@ module PendingEventMappingEngine
 
   end
 end
-
-module PendingEventMappingEngineJob
-  Nightly = PendingEventMappingEngine::NightlyJob
-end

--- a/app/jobs/pending_transaction_engine/nightly_job.rb
+++ b/app/jobs/pending_transaction_engine/nightly_job.rb
@@ -14,7 +14,3 @@ module PendingTransactionEngine
 
   end
 end
-
-module PendingTransactionEngineJob
-  Nightly = PendingTransactionEngine::NightlyJob
-end

--- a/app/jobs/receipt/extract_textual_content_job.rb
+++ b/app/jobs/receipt/extract_textual_content_job.rb
@@ -12,7 +12,3 @@ class Receipt
   end
 
 end
-
-module ReceiptJob
-  ExtractTextualContent = Receipt::ExtractTextualContentJob
-end

--- a/app/jobs/receipt/suggest_pairings_job.rb
+++ b/app/jobs/receipt/suggest_pairings_job.rb
@@ -10,7 +10,3 @@ class Receipt
   end
 
 end
-
-module ReceiptJob
-  SuggestPairings = Receipt::SuggestPairingsJob
-end

--- a/app/jobs/receipt_report/monthly_job.rb
+++ b/app/jobs/receipt_report/monthly_job.rb
@@ -11,7 +11,3 @@ module ReceiptReport
 
   end
 end
-
-module ReceiptReportJob
-  Monthly = ReceiptReport::MonthlyJob
-end

--- a/app/jobs/receipt_report/send_job.rb
+++ b/app/jobs/receipt_report/send_job.rb
@@ -27,7 +27,3 @@ module ReceiptReport
 
   end
 end
-
-module ReceiptReportJob
-  Send = ReceiptReport::SendJob
-end

--- a/app/jobs/receipt_report/weekly_job.rb
+++ b/app/jobs/receipt_report/weekly_job.rb
@@ -11,7 +11,3 @@ module ReceiptReport
 
   end
 end
-
-module ReceiptReportJob
-  Weekly = ReceiptReport::WeeklyJob
-end

--- a/app/jobs/reimbursement/nightly_job.rb
+++ b/app/jobs/reimbursement/nightly_job.rb
@@ -10,7 +10,3 @@ module Reimbursement
 
   end
 end
-
-module ReimbursementJob
-  Nightly = Reimbursement::NightlyJob
-end

--- a/app/jobs/reimbursement/one_day_reminder_job.rb
+++ b/app/jobs/reimbursement/one_day_reminder_job.rb
@@ -16,7 +16,3 @@ module Reimbursement
 
   end
 end
-
-module ReimbursementJob
-  OneDayReminder = Reimbursement::OneDayReminderJob
-end

--- a/app/jobs/reimbursement/seven_days_reminder_job.rb
+++ b/app/jobs/reimbursement/seven_days_reminder_job.rb
@@ -16,7 +16,3 @@ module Reimbursement
 
   end
 end
-
-module ReimbursementJob
-  SevenDaysReminder = Reimbursement::SevenDaysReminderJob
-end

--- a/app/jobs/stripe_authorization/create_from_webhook_job.rb
+++ b/app/jobs/stripe_authorization/create_from_webhook_job.rb
@@ -10,7 +10,3 @@ class StripeAuthorization
   end
 
 end
-
-module StripeAuthorizationJob
-  CreateFromWebhook = StripeAuthorization::CreateFromWebhookJob
-end

--- a/app/jobs/stripe_card/nightly_job.rb
+++ b/app/jobs/stripe_card/nightly_job.rb
@@ -10,7 +10,3 @@ class StripeCard
   end
 
 end
-
-module StripeCardJob
-  Nightly = StripeCard::NightlyJob
-end

--- a/app/jobs/transaction_engine/nightly_job.rb
+++ b/app/jobs/transaction_engine/nightly_job.rb
@@ -11,7 +11,3 @@ module TransactionEngine
 
   end
 end
-
-module TransactionEngineJob
-  Nightly = TransactionEngine::NightlyJob
-end

--- a/app/jobs/transaction_grouping_engine/nightly_job.rb
+++ b/app/jobs/transaction_grouping_engine/nightly_job.rb
@@ -12,7 +12,3 @@ module TransactionGroupingEngine
   end
 
 end
-
-module TransactionGroupingEngineJob
-  Nightly = TransactionGroupingEngine::NightlyJob
-end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Each job renamed in #10177 had an alias added to ensure that jobs already loaded in Sidekiq would not break. They should no longer be needed - **someone with admin on HCB should still check https://hcb.hackclub.com/sidekiq to make sure the old names are no longer there before merging this PR.**


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removed the remaining aliases from renamed jobs.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

