### PR TITLE
Add job to destroy stale playground events

### DIFF
--- a/app/jobs/one_time_jobs/delete_stale_playground_events.rb
+++ b/app/jobs/one_time_jobs/delete_stale_playground_events.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class DeleteStalePlaygroundEvents
+    def self.perform
+      Event.demo_mode.where("created_at < ?", 6.months.ago).destroy_all
+    end
+
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -230,7 +230,6 @@ class Event < ApplicationRecord
 
   has_many :organizer_position_invites, dependent: :destroy
   has_many :organizer_positions, dependent: :destroy
-  has_many :all_organizer_positions, -> { with_deleted }, class_name: "OrganizerPosition"
   has_many :organizer_position_contracts, through: :organizer_position_invites, class_name: "OrganizerPosition::Contract"
   has_many :organizer_position_deletion_requests, through: :organizer_positions, dependent: :destroy
   has_many :users, through: :organizer_positions

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -371,7 +371,7 @@ class Event < ApplicationRecord
   # We can't do this through a normal dependent: :destroy since ActiveRecord does not support deleting records through indirect has_many associations
   # https://github.com/rails/rails/commit/05bcb8cecc8573f28ad080839233b4bb9ace07be
   after_destroy_commit do
-    all_organizer_positions.each do |position|
+    organizer_positions.with_deleted.each do |position|
       position.organizer_position_deletion_requests.destroy_all
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -231,6 +231,7 @@ class Event < ApplicationRecord
   has_many :organizer_position_invites, dependent: :destroy
   has_many :organizer_positions, dependent: :destroy
   has_many :organizer_position_contracts, through: :organizer_position_invites, class_name: "OrganizerPosition::Contract"
+  has_many :organizer_position_deletion_requests, through: :organizer_positions, dependent: :destroy
   has_many :users, through: :organizer_positions
   has_many :signees, -> { where(organizer_positions: { is_signee: true }) }, through: :organizer_positions, source: :user
   has_many :g_suites

--- a/app/models/organizer_position.rb
+++ b/app/models/organizer_position.rb
@@ -38,7 +38,7 @@ class OrganizerPosition < ApplicationRecord
 
   has_one :organizer_position_invite, required: true
   has_many :organizer_position_deletion_requests
-  has_many :tours, as: :tourable
+  has_many :tours, as: :tourable, dependent: :destroy
 
   validates :user, uniqueness: { scope: :event, conditions: -> { where(deleted_at: nil) } }
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
There's a ton of stale/unused playground events that could be (soft-)deleted!

Supersedes #5995 and closes #5332 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a job to destroy these events and related records, to be executed when we switch away from playground events. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

