### PR TITLE
Use wkhtmltopdf-binary to ensure consistent version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -171,6 +171,8 @@ gem "query_count"
 gem "rack-mini-profiler", "~> 3.3"
 gem "stackprof" # used by `rack-mini-profiler` to provide flamegraphs
 
+gem "wkhtmltopdf-binary", "0.12.6.8"
+
 group :development do
   gem "annotate" # comment models with database schema
   gem "actual_db_schema" # rolls back phantom migrations
@@ -180,8 +182,6 @@ group :development do
   gem "web-console", ">= 3.3.0"
 
   gem "letter_opener_web" # preview emails
-
-  gem "wkhtmltopdf-binary", "0.12.6.8" # version must match the wkhtmltopdf Heroku buildpack version (0.12.3 by default)
 
   # Ruby language server
   gem "solargraph", require: false

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -26,9 +26,7 @@ RUN apt-get update -qq && \
       libgirepository-1.0-1 \
       libpoppler-glib-dev \
       # OCR
-      tesseract-ocr \
-      # PDF generation
-      wkhtmltopdf && \
+      tesseract-ocr && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, `wkhtmltopdf` is being installed as an apt package on production but using the `wkhtmltopdf-binary` gem on development. There could be a version mismatch between production and development, which would make a bug related to this package confusing to solve.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removes installing `wkhtmltopdf` on production and always use the `wkhtmltopdf-binary` gem instead.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

