### PR TITLE
Fallback to hcb_code's event for flipper in transaction partials

### DIFF
--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -69,7 +69,7 @@
           <% end %>
         </div>
 
-        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
+        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event || pt.local_hcb_code.event) && !@event&.demo_mode? %>
           <div class="flex flex-wrap pending_transactions_tags tags" style="gap: 0.25rem" id="hcb_code_<%= pt.local_hcb_code.hashid %>_tags">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: pt.local_hcb_code } %>
           </div>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -67,7 +67,7 @@
           <% end %>
         </div>
 
-        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
+        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event || ct.local_hcb_code.event) && !@event&.demo_mode? %>
           <div class="flex flex-wrap tags" style="gap: 0.25rem" id="hcb_code_<%= ct.local_hcb_code.hashid %>_tags">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: ct.local_hcb_code } %>
           </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Small issue where tags won't show up if `@event` isn't defined (although the add tag button already did since the fallback was done correctly there)


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added the HCB code event fallback to the flipper check for the tags render


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

