### PR TITLE
Fix memo underline after stream

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -89,6 +89,10 @@ html[data-dark='true'] {
       vertical-align: top;
       text-overflow: ellipsis;
     }
+
+    &.memo-underline > span:hover {
+      text-decoration: underline;
+    }
   }
 
   .add-tag-badge {

--- a/app/views/hcb_codes/_memo.html.erb
+++ b/app/views/hcb_codes/_memo.html.erb
@@ -37,7 +37,7 @@
               data-navigation-location-param="<%= edit_hcb_code_path(hcb_code, inline: true, prepended_to_memo:, location:, ledger_instance:) %>"
               data-navigation-frame-param="<%= "#{location}:#{ActionView::RecordIdentifier.dom_id(hcb_code)}:memo" %>">
             <span
-              class="mr2 tooltipped tooltipped--s memo-underline"
+              class="mr2 tooltipped tooltipped--s <%= "memo-underline" if ledger_instance %>"
               style="color: inherit; text-decoration: none;"
               aria-label="Shift+click to rename this transaction">
               <%= prepended_to_memo %>

--- a/app/views/hcb_codes/_memo.html.erb
+++ b/app/views/hcb_codes/_memo.html.erb
@@ -41,7 +41,7 @@
               style="color: inherit; text-decoration: none;"
               aria-label="Shift+click to rename this transaction">
               <%= prepended_to_memo %>
-              <span data-memo-for="<%= dom_id(hcb_code) %>" class="<%= "hover:underline" if ledger_instance %>">
+              <span data-memo-for="<%= dom_id(hcb_code) %>">
                 <%= hcb_code.memo %>
               </span>
             </span>

--- a/app/views/hcb_codes/_memo.html.erb
+++ b/app/views/hcb_codes/_memo.html.erb
@@ -37,7 +37,7 @@
               data-navigation-location-param="<%= edit_hcb_code_path(hcb_code, inline: true, prepended_to_memo:, location:, ledger_instance:) %>"
               data-navigation-frame-param="<%= "#{location}:#{ActionView::RecordIdentifier.dom_id(hcb_code)}:memo" %>">
             <span
-              class="mr2 tooltipped tooltipped--s"
+              class="mr2 tooltipped tooltipped--s memo-underline"
               style="color: inherit; text-decoration: none;"
               aria-label="Shift+click to rename this transaction">
               <%= prepended_to_memo %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Underlines on linked memos were disappearing after a popover was opened. The `memo_stream` partial was rendering a turbo stream that replaced the memo with a memo without the underline.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moved the underline style to the parent of the span that is replaced by `memo_stream`.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

