### PR TITLE
Enable updating tags from HCB code popover

### DIFF
--- a/app/assets/stylesheets/components/_menus.scss
+++ b/app/assets/stylesheets/components/_menus.scss
@@ -44,7 +44,7 @@
     0 -2px 4px rgba(0, 0, 0, 0.0625),
     0 6px 12px rgba(0, 0, 0, 0.125);
   overflow: auto;
-  z-index: 6;
+  z-index: 11;
 
   input[type='submit'].menu__action,
   button.menu__action {

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -70,7 +70,7 @@
         </div>
 
         <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
-          <div class="flex flex-wrap pending_transactions_tags tags" style="gap: 0.25rem" id="hcb_code_<%= pt.local_hcb_code.hashid %>_tags">
+          <div class="flex flex-wrap pending_transactions_tags tags hcb_code_<%= pt.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: pt.local_hcb_code } %>
           </div>
         <% end %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -68,7 +68,7 @@
         </div>
 
         <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
-          <div class="flex flex-wrap tags" style="gap: 0.25rem" id="hcb_code_<%= ct.local_hcb_code.hashid %>_tags">
+          <div class="flex flex-wrap tags hcb_code_<%= ct.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: ct.local_hcb_code } %>
           </div>
         <% end %>

--- a/app/views/comments/_reaction_bar.html.erb
+++ b/app/views/comments/_reaction_bar.html.erb
@@ -3,7 +3,7 @@
     <button class="reactions-btn" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle">
       <%= inline_icon "emoji-add", size: 16 %>
     </button>
-    <div class="menu__content menu__content--2 rounded-full" data-menu-target="content" style="width: auto;z-index: 999">
+    <div class="menu__content menu__content--2 rounded-full" data-menu-target="content" style="width: auto;">
       <%
         Comment::Reaction::EMOJIS.each do |emoji|
         has_reacted = comment.reactions.any? { |r| r.emoji == emoji && r.reactor == current_user }

--- a/app/views/hcb_codes/_meatballs.html.erb
+++ b/app/views/hcb_codes/_meatballs.html.erb
@@ -10,7 +10,7 @@
         "#",
         class: "align-middle", "aria-label": "More Options",
         data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
-    <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content" style="z-index: 999;">
+    <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
       <% if pinnable %>
         <%= link_to pin_hcb_code_path(hcb_code, event: @event), method: :post, class: "flex items-center", data: { confirm: "This will #{is_pinned ? "unpin" : "pin" } this transaction for all team members. Continue?" } do %>
           <%= inline_icon "pin-fill", size: 24 %>

--- a/app/views/hcb_codes/_tags.html.erb
+++ b/app/views/hcb_codes/_tags.html.erb
@@ -1,34 +1,32 @@
-<% if Flipper.enabled?(:transaction_tags_2022_07_29, event) && !(defined?(@frame) && @frame && hcb_code.tags.count == 0) %>
+<% if Flipper.enabled?(:transaction_tags_2022_07_29, event) %>
   <div>
     <strong>Tags</strong>
     <div class="flex items-center flex-wrap" style="gap: 0.25rem">
-      <div class="flex items-center flex-wrap" style="gap: 0.25rem" id="hcb_code_<%= hcb_code.hashid %>_tags">
+      <div class="flex items-center flex-wrap hcb_code_<%= hcb_code.hashid %>_tags" style="gap: 0.25rem">
         <%= render partial: "canonical_transactions/tag", collection: hcb_code.tags, locals: { hcb_code: } %>
       </div>
 
-      <% unless defined?(@frame) && @frame %>
-        <div data-controller="menu">
-          <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless h-full" style="height: 1.6rem" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
-          <div class="menu__content menu__content--2 menu__content--compact menu__content--left h6" data-menu-target="content">
-            <% @event.tags.each do |tag| %>
-              <div class="flex items-center" data-tag="<%= tag.id %>">
-                <%= button_to toggle_tag_hcb_code_path(id: hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
-                  <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
-                  <%= tag.label %>
-                  <%= "✓" if hcb_code.tags.include?(tag) %>
-                <% end %>
-                <%= button_to event_tag_path(@event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message }  do %>
-                  <%= inline_icon "delete", size: 16, style: "margin: 0" %>
-                <% end %>
-              </div>
-            <% end %>
-            <% if @event.tags.any? %>
-              <div class="menu__divider tags__divider"></div>
-            <% end %>
-            <%= render partial: "hcb_codes/create_tag", locals: { button: hcb_code.hashid } %>
-          </div>
+      <div data-controller="menu">
+        <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless h-full" style="height: 1.6rem" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
+        <div class="menu__content menu__content--2 menu__content--compact menu__content--left h6" data-menu-target="content">
+          <% @event.tags.each do |tag| %>
+            <div class="flex items-center" data-tag="<%= tag.id %>">
+              <%= button_to toggle_tag_hcb_code_path(id: hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
+                <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
+                <%= tag.label %>
+                <%= "✓" if hcb_code.tags.include?(tag) %>
+              <% end %>
+              <%= button_to event_tag_path(@event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message }  do %>
+                <%= inline_icon "delete", size: 16, style: "margin: 0" %>
+              <% end %>
+            </div>
+          <% end %>
+          <% if @event.tags.any? %>
+            <div class="menu__divider tags__divider"></div>
+          <% end %>
+          <%= render partial: "hcb_codes/create_tag", locals: { button: hcb_code.hashid } %>
         </div>
-      <% end %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/reimbursement/expenses/_expense.html.erb
+++ b/app/views/reimbursement/expenses/_expense.html.erb
@@ -63,7 +63,7 @@
                   "aria-label": "More Options",
                   color: "muted",
                   data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
-              <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content" style="z-index: 999;">
+              <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
                 <% unless expense.is_standard? %>
                   <%= link_to reimbursement_expense_path(expense.id, reimbursement_expense: { type: "Reimbursement::Expense", value: 0 }), data: { turbo: true, "turbo-method": :patch, "action": "menu#close" } do %>
                     <%= inline_icon "payment-docs", size: 24 %>

--- a/app/views/tags/_create.turbo_stream.erb
+++ b/app/views/tags/_create.turbo_stream.erb
@@ -1,4 +1,7 @@
-<%= turbo_stream.append "hcb_code_#{hcb_code.hashid}_tags", partial: "canonical_transactions/tag", locals: { tag:, hcb_code:, streamed: local_assigns[:streamed] } %>
+<%= turbo_stream.update_all ".hcb_code_#{hcb_code.hashid}_tags" do %>
+  <%= render partial: "canonical_transactions/tag", collection: hcb_code.tags, locals: { hcb_code:, streamed: local_assigns[:streamed] } %>
+<% end %>
+
 <%= turbo_stream.update_all tag_dom_class(hcb_code, tag, "_toggle") do %>
   <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
   <%= tag.label %> ✓

--- a/app/views/tags/_destroy.turbo_stream.erb
+++ b/app/views/tags/_destroy.turbo_stream.erb
@@ -1,4 +1,6 @@
-<%= turbo_stream.remove tag_dom_id(hcb_code, tag) %>
+<%= turbo_stream.update_all ".hcb_code_#{hcb_code.hashid}_tags" do %>
+  <%= render partial: "canonical_transactions/tag", collection: hcb_code.tags, locals: { hcb_code:, streamed: local_assigns[:streamed] } %>
+<% end %>
 <%= turbo_stream.update_all tag_dom_class(hcb_code, tag, "_toggle") do %>
   <div class="tag__preview tag-<%= tag.color || "muted" %>"></div>
   <%= tag.label %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Tags cannot currently be updated in the HCB code popover, even though they display there.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Updated menus to have a z-index above that of modals so that the tag menu shows and removed `z-index: 999` styles from other menus already displaying on top of popovers. Also removed the checks that disabled updating tags from the popover and fixed the streams to update in all locations where tags are rendered.
![image](https://github.com/user-attachments/assets/1bb0da6d-1ce5-430e-b19a-e9498c698c41)




<!-- If there are any visual changes, please attach images, videos, or gifs. -->

