### PR TITLE
Fix external receipt uploading

### DIFF
--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -48,6 +48,7 @@
           <%= form.hidden_field :upload_method, value: upload_method, data: { "file-drop-target" => "uploadMethod" } %>
           <%= (form.hidden_field :show_receipt_button, value: local_assigns[:show_receipt_button]) %>
           <%= (form.hidden_field :show_author_img, value: local_assigns[:show_author_img]) %>
+          <%= (form.hidden_field :s, value: local_assigns[:secret]) %>
 
           <%= form.file_field :file,
                               multiple: true,


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Receipt uploading on the attach receipt link by someone who isn't signed in as authorized to upload a receipt wasn't working.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Passed the secret from the upload form to the receipt controller.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

