### PR TITLE
Fix error in control policy

### DIFF
--- a/app/policies/organizer_position/spending/control_policy.rb
+++ b/app/policies/organizer_position/spending/control_policy.rb
@@ -34,7 +34,7 @@ class OrganizerPosition
       private
 
       def current_user_manager?
-        OrganizerPosition.find_by(user:, event: record.organizer_position.event).manager?
+        OrganizerPosition.find_by(user:, event: record.organizer_position.event)&.manager?
       end
 
       def own_control?


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
There is currently an error raised when a user not in an event tries to access a spending control page, when it should just display the normal "You are not authorized to perform this action." toast.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a `&` to the policy method that finds the organizer position in case it does not exist.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

