### PR TITLE
[Card Grants] Hide actions for members

### DIFF
--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -31,7 +31,7 @@ class CardGrantPolicy < ApplicationPolicy
 
   def edit?
     admin_or_manager? && record.active?
-  end  
+  end
 
   def toggle_one_time_use?
     admin_or_manager? && record.active?

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -22,11 +22,11 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def cancel?
-    admin_or_user? || record.user == user
+    (admin_or_manager? || record.user == user) && record.active?
   end
 
   def convert_to_reimbursement_report?
-    (admin_or_manager? || record.user == user) && record.card_grant_setting.reimbursement_conversions_enabled?
+    (admin_or_manager? || record.user == user) && record.active? && record.card_grant_setting.reimbursement_conversions_enabled?
   end
 
   def edit?

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -25,6 +25,18 @@ class CardGrantPolicy < ApplicationPolicy
     admin_or_user? || record.user == user
   end
 
+  def convert_to_reimbursement_report?
+    (admin_or_manager? || record.user == user) && record.card_grant_setting.reimbursement_conversions_enabled?
+  end
+
+  def edit?
+    admin_or_manager? && record.active?
+  end  
+
+  def toggle_one_time_use?
+    admin_or_manager? && record.active?
+  end
+
   def topup?
     admin_or_manager? && record.active?
   end
@@ -34,14 +46,6 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def update?
-    admin_or_manager?
-  end
-
-  def convert_to_reimbursement_report?
-    (admin_or_manager? || record.user == user) && record.card_grant_setting.reimbursement_conversions_enabled?
-  end
-
-  def toggle_one_time_use?
     admin_or_manager? && record.active?
   end
 

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -1,5 +1,4 @@
 <%# locals: (card_grant:) %>
-<% disabled = card_grant.user != current_user %>
 
 <% if card_grant.active? %>
   <div class="mt3 flex flex-wrap align-items-center justify-start g1 justify-center">

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -2,14 +2,19 @@
 
 <% if card_grant.active? %>
   <div class="mt3 flex flex-wrap align-items-center justify-start g1 justify-center">
-    <% if card_grant.stripe_card %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card %>
+    <% if policy(card_grant).update? || card_grant.user == current_user %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card %>
+      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: %>
     <% end %>
 
-    <%= render "card_grants/actions/topup", card_grant: %>
-    <%= render "card_grants/actions/withdraw", card_grant: %>
-    <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: %>
-    <%= render "card_grants/actions/cancel", card_grant: %>
-    <%= render "card_grants/actions/edit", card_grant: %>
+    <% if policy(card_grant).update? %>
+      <%= render "card_grants/actions/topup", card_grant: %>
+      <%= render "card_grants/actions/withdraw", card_grant: %>
+      <%= render "card_grants/actions/edit", card_grant: %>
+      <%= render "card_grants/actions/cancel", card_grant: %>
+
+    <% elsif card_grant.user == current_user %>
+      <%= render "card_grants/actions/return", card_grant: %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -1,20 +1,23 @@
 <%# locals: (card_grant:) %>
+<% disabled = card_grant.user != current_user %>
 
 <% if card_grant.active? %>
   <div class="mt3 flex flex-wrap align-items-center justify-start g1 justify-center">
-    <% if policy(card_grant).update? || card_grant.user == current_user %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card %>
-      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: %>
-    <% end %>
-
-    <% if policy(card_grant).update? %>
+    <% if organizer_signed_in?(as: :member) %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card %>
       <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
       <%= render "card_grants/actions/topup", card_grant: %>
       <%= render "card_grants/actions/withdraw", card_grant: %>
+      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
       <%= render "card_grants/actions/edit", card_grant: %>
-      <%= render "card_grants/actions/cancel", card_grant: %>
-
+      <% if card_grant.user == current_user %>
+        <%= render "card_grants/actions/return", card_grant: %>
+      <% else %>
+        <%= render "card_grants/actions/cancel", card_grant: %>
+      <% end %>
     <% elsif card_grant.user == current_user %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card %>
+      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: "Get reimbursed" %>
       <%= render "card_grants/actions/return", card_grant: %>
     <% end %>
   </div>

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -89,7 +89,7 @@
       </p>
     <% end %>
   </section>
-  <% if card_grant.pending_invite? %>
+  <% if (card_grant.pending_invite? || @frame) && policy(@card_grant).update? %>
     <%# Once the user has accepted the invite, these action buttons are shown elsewhere %>
     <section>
       <%= render partial: "actions", locals: { card_grant: @card_grant } %>

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -93,8 +93,7 @@
       </p>
     <% end %>
   </section>
-  <% if (card_grant.pending_invite? || @frame) && policy(@card_grant).update? %>
-    <%# Once the user has accepted the invite, these action buttons are shown elsewhere %>
+  <% if card_grant.pending_invite? || @frame %>
     <section>
       <%= render partial: "actions", locals: { card_grant: @card_grant } %>
     </section>

--- a/app/views/card_grants/actions/_cancel.html.erb
+++ b/app/views/card_grants/actions/_cancel.html.erb
@@ -5,7 +5,8 @@
   <%= link_to cancel_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               data: { confirm: "Are you sure? This will irreversibly transfer the remaining balance on this grant BACK to your account." },
-              class: "btn bg-error" do %>
+              class: "btn bg-error",
+              disabled: !policy(card_grant).cancel? do %>
     <%= inline_icon "reply", size: 20 %> Cancel grant
   <% end %>
 

--- a/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
+++ b/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
@@ -5,7 +5,8 @@
   <%= link_to convert_to_reimbursement_report_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               data: { confirm: "Are you sure? This will cancel your card grant and convert it into a reimbursement report." },
-              class: "btn bg-purple" do %>
+              class: "btn bg-purple",
+              disabled: !policy(card_grant).convert_to_reimbursement_report? do %>
     <%= inline_icon "attachment", size: 20 %> <%= label %>
   <% end %>
 

--- a/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
+++ b/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (card_grant:, label: "Create reimbursement report") %>
 
-<% if card_grant.active? && policy(card_grant).convert_to_reimbursement_report? %>
+<% if card_grant.card_grant_setting.reimbursement_conversions_enabled? %>
 
   <%= link_to convert_to_reimbursement_report_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,

--- a/app/views/card_grants/actions/_edit.html.erb
+++ b/app/views/card_grants/actions/_edit.html.erb
@@ -1,18 +1,16 @@
 <%# locals: (card_grant:) %>
 
-<% if card_grant.active? && policy(card_grant).update? %>
-  <div class="tooltipped tooltipped--n" aria-label="Set this grant's purpose">
-    <%= link_to edit_card_grant_path(card_grant),
-                class: "btn bg-success",
-                data: { behavior: "modal_trigger", modal: "edit_card_grant" },
-                disabled: !policy(card_grant).edit? do %>
-      <%= inline_icon "edit" %>
-      Set purpose
-    <% end %>
-  </div>
+<div class="tooltipped tooltipped--n" aria-label="Set this grant's purpose">
+  <%= link_to edit_card_grant_path(card_grant),
+              class: "btn bg-success",
+              data: { behavior: "modal_trigger", modal: "edit_card_grant" },
+              disabled: !policy(card_grant).edit? do %>
+    <%= inline_icon "edit" %>
+    Set purpose
+  <% end %>
+</div>
 
-  <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="edit_card_grant">
-    <%= modal_header "What's this grant for?" %>
-    <%= render "card_grants/edit_form" %>
-  </section>
-<% end %>
+<section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="edit_card_grant">
+  <%= modal_header "What's this grant for?" %>
+  <%= render "card_grants/edit_form" %>
+</section>

--- a/app/views/card_grants/actions/_edit.html.erb
+++ b/app/views/card_grants/actions/_edit.html.erb
@@ -1,8 +1,11 @@
+<%# locals: (card_grant:) %>
+
 <% if card_grant.active? && policy(card_grant).update? %>
   <div class="tooltipped tooltipped--n" aria-label="Set this grant's purpose">
     <%= link_to edit_card_grant_path(card_grant),
                 class: "btn bg-success",
-                data: { behavior: "modal_trigger", modal: "edit_card_grant" } do %>
+                data: { behavior: "modal_trigger", modal: "edit_card_grant" },
+                disabled: !policy(card_grant).edit? do %>
       <%= inline_icon "edit" %>
       Set purpose
     <% end %>

--- a/app/views/card_grants/actions/_return.html.erb
+++ b/app/views/card_grants/actions/_return.html.erb
@@ -1,4 +1,5 @@
 <%# locals: (card_grant:) %>
+
 <% if card_grant.active? %>
   <%= link_to "#", data: { behavior: "modal_trigger", modal: "return-grant" }, class: "btn" do %>
     <%= inline_icon "support", size: 20 %> Return grant to <%= card_grant.event.name %>

--- a/app/views/card_grants/actions/_toggle_one_time_use.html.erb
+++ b/app/views/card_grants/actions/_toggle_one_time_use.html.erb
@@ -1,11 +1,8 @@
 <%# locals: (card_grant:) %>
 
-<% if policy(card_grant).toggle_one_time_use? %>
-
-  <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
-              method: :post,
-              class: "btn bg-slate" do %>
-    <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
-  <% end %>
-
+<%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
+            method: :post,
+            class: "btn bg-slate",
+            disabled: !policy(card_grant).toggle_one_time_use? do %>
+  <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
 <% end %>

--- a/app/views/card_grants/actions/_topup.html.erb
+++ b/app/views/card_grants/actions/_topup.html.erb
@@ -1,10 +1,10 @@
 <%# locals: (card_grant:) %>
 
 <% if card_grant.active? %>
-
   <%= link_to "#",
               data: { behavior: "modal_trigger", modal: "topup" },
-              class: "btn" do %>
+              class: "btn",
+              disabled: !policy(card_grant).topup? do %>
     <%= inline_icon "plus", size: 20 %> Topup grant
   <% end %>
 

--- a/app/views/card_grants/actions/_withdraw.html.erb
+++ b/app/views/card_grants/actions/_withdraw.html.erb
@@ -4,7 +4,8 @@
 
   <%= link_to "#",
               data: { behavior: "modal_trigger", modal: "withdrawl" },
-              class: "btn bg-warning" do %>
+              class: "btn bg-warning",
+              disabled: !policy(card_grant).withdraw? do %>
     <%= inline_icon "minus", size: 20 %> Withdraw from grant
   <% end %>
 

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -10,15 +10,22 @@
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
   <%# Organizers and admins' view %>
-  <% elsif @card_grant.user.admin? || policy(@card_grant).update? %>
+  <% elsif @card_grant.user.admin? || organizer_signed_in? %>
     <% if @card_grant.stripe_card %>
       <div>
         <%= render @card_grant.stripe_card %>
         <%= render partial: "balance", locals: { card_grant: @card_grant } %>
 
         <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
-        <%= render partial: "actions", locals: { card_grant: @card_grant } %>
+        <% if policy(@card_grant).update? %>
+          <%= render partial: "actions", locals: { card_grant: @card_grant } %>
 
+        <% elsif @card_grant.user == current_user %>
+          <div class="flex items-center mt3 justify-center flex-wrap g1">
+            <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: @card_grant, label: "Get reimbursed" %>
+            <%= render "card_grants/actions/return", card_grant: @card_grant %>
+          </div>
+        <% end %>
       </div>
     <% end %>
     <div class="flex flex-col g2">

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -10,7 +10,7 @@
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
   <%# Organizers and admins' view %>
-  <% elsif @card_grant.user.admin? || organizer_signed_in? %>
+  <% elsif @card_grant.user.admin? || policy(@card_grant).update? %>
     <% if @card_grant.stripe_card %>
       <div>
         <%= render @card_grant.stripe_card %>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -15,17 +15,8 @@
       <div>
         <%= render @card_grant.stripe_card %>
         <%= render partial: "balance", locals: { card_grant: @card_grant } %>
-
         <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
-        <% if policy(@card_grant).update? %>
-          <%= render partial: "actions", locals: { card_grant: @card_grant } %>
-
-        <% elsif @card_grant.user == current_user %>
-          <div class="flex items-center mt3 justify-center flex-wrap g1">
-            <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: @card_grant, label: "Get reimbursed" %>
-            <%= render "card_grants/actions/return", card_grant: @card_grant %>
-          </div>
-        <% end %>
+        <%= render partial: "actions", locals: { card_grant: @card_grant } %>
       </div>
     <% end %>
     <div class="flex flex-col g2">
@@ -47,11 +38,7 @@
       <% end %>
       <%= render @card_grant.stripe_card, headless: true, show_card_number: true %>
       <%= render partial: "balance", locals: { card_grant: @card_grant } %>
-      <div class="flex items-center mt3 justify-center flex-wrap g1">
-        <%= render "stripe_cards/actions/freeze", stripe_card: @card_grant.stripe_card %>
-        <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: @card_grant, label: "Get reimbursed" %>
-        <%= render "card_grants/actions/return", card_grant: @card_grant %>
-      </div>
+      <%= render partial: "actions", locals: { card_grant: @card_grant } %>
     </div>
     <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
   <% end %>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -16,7 +16,7 @@
         <%= render @card_grant.stripe_card %>
         <%= render partial: "balance", locals: { card_grant: @card_grant } %>
         <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
-        <%= render partial: "actions", locals: { card_grant: @card_grant } %>
+        <%= render "actions", card_grant: @card_grant %>
       </div>
     <% end %>
     <div class="flex flex-col g2">

--- a/app/views/stripe_cards/actions/_freeze.html.erb
+++ b/app/views/stripe_cards/actions/_freeze.html.erb
@@ -1,21 +1,21 @@
 <%# locals: (stripe_card:) %>
 
 <% if stripe_card.stripe_status == 'inactive' %>
-  <% if policy(stripe_card).defrost? %>
-    <div class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>">
-      <%= link_to "Defrost card",
-                  defrost_stripe_card_path(stripe_card),
-                  method: :post,
-                  class: "btn bg-accent",
-                  disabled: !policy(stripe_card).defrost? %>
-    </div>
-  <% end %>
-<% elsif stripe_card.stripe_status == 'active' && policy(stripe_card).freeze? %>
+  <div class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>">
+    <%= link_to defrost_stripe_card_path(stripe_card),
+                method: :post,
+                class: "btn bg-accent",
+                disabled: !policy(stripe_card).defrost? do %>
+      <%= inline_icon "freeze" %> Defrost card
+    <% end %>
+  </div>
+<% elsif stripe_card.stripe_status == 'active' %>
   <% freeze_tooltip = "You can instantly defrost #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>
   <div class="tooltipped tooltipped--n" aria-label="<%= freeze_tooltip %>">
     <%= link_to freeze_stripe_card_path(stripe_card),
                 method: :post,
-                class: "btn bg-accent" do %>
+                class: "btn bg-accent",
+                disabled: !policy(stripe_card).freeze? do %>
       <%= inline_icon "freeze" %> Freeze card
     <% end %>
   </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Members don't have permissions to use the actions so they should see the regular view and not the organizer view.

manager/admin: 
![image](https://github.com/user-attachments/assets/b50b6472-ba53-4401-af42-44a356a55fbc)

member:
![image](https://github.com/user-attachments/assets/13a0a97a-704a-49a5-9865-089113ae96a6)


reader: 
![image](https://github.com/user-attachments/assets/018e2d18-9421-4933-b3d4-95739710e1f9)

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use card grant policy.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

