### PR TITLE
Fix card grant expiration warnings

### DIFF
--- a/app/jobs/card_grant/expiration_job.rb
+++ b/app/jobs/card_grant/expiration_job.rb
@@ -25,5 +25,7 @@ class CardGrant
         end
       end
     end
+
   end
+
 end

--- a/app/jobs/card_grant/expiration_job.rb
+++ b/app/jobs/card_grant/expiration_job.rb
@@ -4,23 +4,20 @@ class CardGrant
   class ExpirationJob < ApplicationJob
     queue_as :low
     def perform
+      # Expire grants that have passed their expiration date
       CardGrant.active.expired_before(Time.now).find_each do |card_grant|
         card_grant.expire!
       end
 
-      CardGrant.active.expires_on(6.hours.from_now).find_each do |card_grant|
-        CardGrantMailer.with(card_grant:, expiry_time: "6 hours").card_grant_expiry_notification.deliver_later
-      end
-
-      CardGrant.active.expires_on(1.day.from_now).find_each do |card_grant|
+      CardGrant.active.expires_between(Time.now, 24.hours.from_now).find_each do |card_grant|
         CardGrantMailer.with(card_grant:, expiry_time: "24 hours").card_grant_expiry_notification.deliver_later
       end
 
-      CardGrant.active.expires_on(3.days.from_now).find_each do |card_grant|
+      CardGrant.active.expires_between(Time.now, 3.days.from_now).find_each do |card_grant|
         CardGrantMailer.with(card_grant:, expiry_time: "3 days").card_grant_expiry_notification.deliver_later
       end
 
-      CardGrant.active.expires_on(1.month.from_now).find_each do |card_grant|
+      CardGrant.active.expires_between(Time.now, 1.month.from_now).find_each do |card_grant|
         CardGrantMailer.with(card_grant:, expiry_time: "1 month").card_grant_expiry_notification.deliver_later
       end
     end

--- a/app/jobs/card_grant/expiration_job.rb
+++ b/app/jobs/card_grant/expiration_job.rb
@@ -8,16 +8,21 @@ class CardGrant
         card_grant.expire!
       end
 
+      CardGrant.active.expires_on(6.hours.from_now).find_each do |card_grant|
+        CardGrantMailer.with(card_grant:, expiry_time: "6 hours").card_grant_expiry_notification.deliver_later
+      end
+
+      CardGrant.active.expires_on(1.day.from_now).find_each do |card_grant|
+        CardGrantMailer.with(card_grant:, expiry_time: "24 hours").card_grant_expiry_notification.deliver_later
+      end
+
       CardGrant.active.expires_on(3.days.from_now).find_each do |card_grant|
-        CardGrantMailer.with(card_grant:, expiry_time: "3 days").card_grant_days_expire_notification.deliver_later
+        CardGrantMailer.with(card_grant:, expiry_time: "3 days").card_grant_expiry_notification.deliver_later
       end
 
       CardGrant.active.expires_on(1.month.from_now).find_each do |card_grant|
-        CardGrantMailer.with(card_grant:, expiry_time: "1 month").card_grant_month_expire_notification.deliver_later
+        CardGrantMailer.with(card_grant:, expiry_time: "1 month").card_grant_expiry_notification.deliver_later
       end
-
     end
-
   end
-
 end

--- a/app/jobs/card_grant/expiration_job.rb
+++ b/app/jobs/card_grant/expiration_job.rb
@@ -17,9 +17,9 @@ class CardGrant
 
       NOTIFICATION_WINDOWS.each do |notification_text, window|
         CardGrant.active
-                .expires_between(Time.now, window.from_now)
-                .where("last_expiry_notification_sent_at IS NULL OR last_expiry_notification_sent_at < ?", (window/2).ago)
-                .find_each do |card_grant|
+                 .expires_between(Time.now, window.from_now)
+                 .where("last_expiry_notification_sent_at IS NULL OR last_expiry_notification_sent_at < ?", (window / 2).ago)
+                 .find_each do |card_grant|
           CardGrantMailer.with(card_grant:, expiry_time: notification_text).card_grant_expiry_notification.deliver_later
           card_grant.update!(last_expiry_notification_sent_at: Time.current)
         end

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -82,6 +82,7 @@ class CardGrant < ApplicationRecord
   scope :not_activated, -> { active.where(stripe_card_id: nil) }
   scope :activated, -> { active.where.not(stripe_card_id: nil) }
   scope :search_recipient, ->(q) { joins(:user).where("users.full_name ILIKE :query OR card_grants.email ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
+  scope :expires_on, ->(date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') = ?", date) }
   scope :expired_before, ->(date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') < ?", date) }
   scope :expires_between, ->(start_date, end_date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') BETWEEN ? AND ?", start_date, end_date) }
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -4,22 +4,23 @@
 #
 # Table name: card_grants
 #
-#  id              :bigint           not null, primary key
-#  amount_cents    :integer
-#  category_lock   :string
-#  email           :string           not null
-#  keyword_lock    :string
-#  merchant_lock   :string
-#  purpose         :string
-#  status          :integer          default("active"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  disbursement_id :bigint
-#  event_id        :bigint           not null
-#  sent_by_id      :bigint           not null
-#  stripe_card_id  :bigint
-#  subledger_id    :bigint
-#  user_id         :bigint           not null
+#  id                               :bigint           not null, primary key
+#  amount_cents                     :integer
+#  category_lock                    :string
+#  email                            :string           not null
+#  keyword_lock                     :string
+#  last_expiry_notification_sent_at :datetime
+#  merchant_lock                    :string
+#  purpose                          :string
+#  status                           :integer          default("active"), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  disbursement_id                  :bigint
+#  event_id                         :bigint           not null
+#  sent_by_id                       :bigint           not null
+#  stripe_card_id                   :bigint
+#  subledger_id                     :bigint
+#  user_id                          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -82,7 +82,7 @@ class CardGrant < ApplicationRecord
   scope :activated, -> { active.where.not(stripe_card_id: nil) }
   scope :search_recipient, ->(q) { joins(:user).where("users.full_name ILIKE :query OR card_grants.email ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
   scope :expired_before, ->(date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') < ?", date) }
-  scope :expires_on, ->(date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') = ?", date) }
+  scope :expires_between, ->(start_date, end_date) { joins(:card_grant_setting).where("card_grants.created_at + (card_grant_settings.expiration_preference * interval '1 day') BETWEEN ? AND ?", start_date, end_date) }
 
   monetize :amount_cents
 

--- a/app/views/card_grant_mailer/card_grant_expiry_notification.html.erb
+++ b/app/views/card_grant_mailer/card_grant_expiry_notification.html.erb
@@ -2,4 +2,8 @@
   Your <%= @card_grant.amount.format %> grant from <%= @card_grant.event.name %> will expire in <%= @expiry_time %>.
 </p>
 
+<p>
+  If you'd like to extend your grant, please contact the organizers of <%= @card_grant.event.name %> and they will be able to assist you further.
+</p>
+
 <%= link_to "View your grant", card_grant_url(@card_grant, email: @card_grant.user.email), style: "background-color: #ec3750; color: white; padding: 1rem; border-radius: 0.75rem; margin: 0 auto 2rem 0; text-decoration: none" %>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -173,7 +173,7 @@ update_teenager_column_job:
   class: "User::UpdateTeenagerColumnJob"
 
 card_grant_expiration_job:
-  cron: "0 7 * * *" # run every 1 day
+  cron: "0 */6 * * *" # run every 6 hours
   class: "CardGrant::ExpirationJob"
 
 card_grant_zero_job:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -173,7 +173,7 @@ update_teenager_column_job:
   class: "User::UpdateTeenagerColumnJob"
 
 card_grant_expiration_job:
-  cron: "0 */6 * * *" # run every 6 hours
+  cron: "0 5 * * *" # 5am UTC each morning
   class: "CardGrant::ExpirationJob"
 
 card_grant_zero_job:

--- a/db/migrate/20250523134852_add_last_expiry_notification_sent_at_to_card_grants.rb
+++ b/db/migrate/20250523134852_add_last_expiry_notification_sent_at_to_card_grants.rb
@@ -1,0 +1,5 @@
+class AddLastExpiryNotificationSentAtToCardGrants < ActiveRecord::Migration[7.2]
+  def change
+    add_column :card_grants, :last_expiry_notification_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_18_005427) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_23_134852) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -430,6 +430,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_18_005427) do
     t.integer "status", default: 0, null: false
     t.string "keyword_lock"
     t.string "purpose"
+    t.datetime "last_expiry_notification_sent_at"
     t.index ["disbursement_id"], name: "index_card_grants_on_disbursement_id"
     t.index ["event_id"], name: "index_card_grants_on_event_id"
     t.index ["sent_by_id"], name: "index_card_grants_on_sent_by_id"


### PR DESCRIPTION
## Summary of the problem
The code for card grant expiration emails was already there, but they didn't work because the job was checking if `expires_at` was exactly 3 days/1 month before now.


## Describe your changes
Checks if it expires between now and the notification window (1 month/3 days/24 hours). If it does, sends out the expiration warning email and sets the `last_expiry_notification_sent_at` field so that emails aren't re-sent every day for the 1 month/3 days warnings.
