### PR TITLE
Fix tags menu not appearing in popovers with receipts

### DIFF
--- a/app/assets/stylesheets/components/_menus.scss
+++ b/app/assets/stylesheets/components/_menus.scss
@@ -44,7 +44,7 @@
     0 -2px 4px rgba(0, 0, 0, 0.0625),
     0 6px 12px rgba(0, 0, 0, 0.125);
   overflow: auto;
-  z-index: 11;
+  z-index: 301;
 
   input[type='submit'].menu__action,
   button.menu__action {


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
#10482 was recently merged, but when I went to make sure it would work in production, the menu did not appear. Turns out the receipt partial raises the z-index of modals to 300.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Raises the z-index of menu content to 301 to always be above the modals.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

