### PR TITLE
Skip RSpec PR run if the PR is from an external repo 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         run: yarn format:check
   rspec:
     name: RSpec
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
It is better to skip the PR run as it fails every time I make a PR as I make it on my own repo. Also a failed run emails me every time which is kinda annoying. This fixes that :) 