### PR TITLE
Remove PVSA from site

### DIFF
--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -182,57 +182,6 @@
   </section>
 </div>
 
-<div class="card pb0 mb3 <%= "muted" unless @event.country_US? && @perks_available %>" id="pvsa">
-  <div class="card__banner card__banner--top flex justify-between items-center promo-pvsa">
-    <%= image_tag "https://cloud-q7i8htyv7-hack-club-bot.vercel.app/0pvsa-logo-2x.png", width: 60 %>
-    <%= link_to @perks_available ? (@event.country_US? ? "Purchase" : "Ineligible") : "Purchase",
-      @perks_available ? fillout_form("dyHShKvTL1us", { "Event Name" => @event.name, "Bank URL" => event_url(@event), "Submitter Email" => current_user.email }, prefix: "prefill_") : root_path,
-      class: "btn mr1 #{'disabled' unless @perks_available && @event.country_US?}",
-      target: :_blank %>
-  </div>
-
-  <p>
-    Since you run on HCB, you can issue <a href="https://presidentialserviceawards.gov" target="_blank">Presidential Volunteer Service Awards</a> to volunteers (including to yourself and team members).
-    While applying you'll be asked to provide evidence for the submitted volunteer hours (instructions and examples are provided on the application form).
-  </p>
-
-  <p>
-    While HCB is registered with PVSA as a certifying organization and will submit rewards on your behalf, the costs charged by PVSA for certificates and medals will come from your own budget.
-    Certificates and medals are shipped to one address and you'll distribute them from there.
-  </p>
-
-  <h3 class="mb0 mt0">PVSA Cost Summary</h3>
-  <p class="italic muted mt0 mb0">All costs are from PVSA directly—we don't charge you a fee on top.</p>
-  <table class="mb2">
-    <tr>
-      <td>Certificate only</td>
-      <td>$6.25</td>
-    </tr>
-    <tr>
-      <td>Certificate + Pin</td>
-      <td>$10.00</td>
-    </tr>
-    <tr>
-      <td>Certificate + Coin</td>
-      <td>$11.75</td>
-    </tr>
-    <tr>
-      <td>Certificate + Medallion</td>
-      <td>$12.25</td>
-    </tr>
-    <tr>
-      <td>Shipping (per order)</td>
-      <td>Varies (up to $23.00)</td>
-    </tr>
-  </table>
-
-  <section class="card__banner card__darker secondary border-top">
-  <p class="my0">
-    Only 🇺🇸 US citizens and LPRs who currently reside within the US are eligible to receive the award. You can see all the <a href="https://presidentialserviceawards.gov/eligibility#volunteers" target="_blank">volunteer eligibility details</a> if you have any questions.
-  </p>
-  </section>
-</div>
-
 <details class="w-100 left-align">
   <summary><h3 class="inline-block pb0 border-none">Expired promotions</h3></summary>
   <div class="card mb3" id="wallets">
@@ -385,4 +334,55 @@
     </p>
   </div>
 
+  <div class="card pb0 mb3 <%= "muted" unless @event.country_US? && @perks_available %>" id="pvsa">
+    <div class="card__banner card__banner--top flex justify-between items-center promo-pvsa">
+      <%= image_tag "https://cloud-q7i8htyv7-hack-club-bot.vercel.app/0pvsa-logo-2x.png", width: 60 %>
+      <%= link_to @perks_available ? (@event.country_US? ? "Purchase" : "Ineligible") : "Purchase",
+        @perks_available ? fillout_form("dyHShKvTL1us", { "Event Name" => @event.name, "Bank URL" => event_url(@event), "Submitter Email" => current_user.email }, prefix: "prefill_") : root_path,
+        class: "btn mr1 #{'disabled' unless @perks_available && @event.country_US?}",
+        target: :_blank
+        disabled: true %>
+    </div>
+  
+    <p>
+      Since you run on HCB, you can issue <a href="https://presidentialserviceawards.gov" target="_blank">Presidential Volunteer Service Awards</a> to volunteers (including to yourself and team members).
+      While applying you'll be asked to provide evidence for the submitted volunteer hours (instructions and examples are provided on the application form).
+    </p>
+  
+    <p>
+      While HCB is registered with PVSA as a certifying organization and will submit rewards on your behalf, the costs charged by PVSA for certificates and medals will come from your own budget.
+      Certificates and medals are shipped to one address and you'll distribute them from there.
+    </p>
+  
+    <h3 class="mb0 mt0">PVSA Cost Summary</h3>
+    <p class="italic muted mt0 mb0">All costs are from PVSA directly—we don't charge you a fee on top.</p>
+    <table class="mb2">
+      <tr>
+        <td>Certificate only</td>
+        <td>$6.25</td>
+      </tr>
+      <tr>
+        <td>Certificate + Pin</td>
+        <td>$10.00</td>
+      </tr>
+      <tr>
+        <td>Certificate + Coin</td>
+        <td>$11.75</td>
+      </tr>
+      <tr>
+        <td>Certificate + Medallion</td>
+        <td>$12.25</td>
+      </tr>
+      <tr>
+        <td>Shipping (per order)</td>
+        <td>Varies (up to $23.00)</td>
+      </tr>
+    </table>
+  
+    <section class="card__banner card__darker secondary border-top">
+    <p class="my0">
+      Only 🇺🇸 US citizens and LPRs who currently reside within the US are eligible to receive the award. You can see all the <a href="https://presidentialserviceawards.gov/eligibility#volunteers" target="_blank">volunteer eligibility details</a> if you have any questions.
+    </p>
+    </section>
+  </div>
 </details>

--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -343,17 +343,17 @@
         target: :_blank,
         disabled: true %>
     </div>
-  
+
     <p>
       Since you run on HCB, you can issue <a href="https://presidentialserviceawards.gov" target="_blank">Presidential Volunteer Service Awards</a> to volunteers (including to yourself and team members).
       While applying you'll be asked to provide evidence for the submitted volunteer hours (instructions and examples are provided on the application form).
     </p>
-  
+
     <p>
       While HCB is registered with PVSA as a certifying organization and will submit rewards on your behalf, the costs charged by PVSA for certificates and medals will come from your own budget.
       Certificates and medals are shipped to one address and you'll distribute them from there.
     </p>
-  
+
     <h3 class="mb0 mt0">PVSA Cost Summary</h3>
     <p class="italic muted mt0 mb0">All costs are from PVSA directly—we don't charge you a fee on top.</p>
     <table class="mb2">
@@ -378,7 +378,7 @@
         <td>Varies (up to $23.00)</td>
       </tr>
     </table>
-  
+
     <section class="card__banner card__darker secondary border-top">
     <p class="my0">
       Only 🇺🇸 US citizens and LPRs who currently reside within the US are eligible to receive the award. You can see all the <a href="https://presidentialserviceawards.gov/eligibility#volunteers" target="_blank">volunteer eligibility details</a> if you have any questions.

--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -340,7 +340,7 @@
       <%= link_to @perks_available ? (@event.country_US? ? "Purchase" : "Ineligible") : "Purchase",
         @perks_available ? fillout_form("dyHShKvTL1us", { "Event Name" => @event.name, "Bank URL" => event_url(@event), "Submitter Email" => current_user.email }, prefix: "prefill_") : root_path,
         class: "btn mr1 #{'disabled' unless @perks_available && @event.country_US?}",
-        target: :_blank
+        target: :_blank,
         disabled: true %>
     </div>
   


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
PVSA is dead (temporarily, but I don't have much hope for it's return any time soon :( )
[https://presidentialserviceawards.gov/](https://presidentialserviceawards.gov/)
## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Move the PVSA card down to the expired promotions section,
Also disabled all PVSA forms and the button


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/3438d6c8-22c8-4997-badd-0153be47ced8)


