### PR TITLE
[2/3] Lockbox encryption for authorization_token and verification_token

### DIFF
--- a/app/models/user/email_update.rb
+++ b/app/models/user/email_update.rb
@@ -40,10 +40,11 @@ class User
 
     belongs_to :user
     belongs_to :updated_by, class_name: "User"
-    has_secure_token :authorization_token
-    has_secure_token :verification_token
-    has_encrypted :authorization_token, migrating: true
-    has_encrypted :verification_token, migrating: true
+
+    has_encrypted :authorization_token
+    has_encrypted :verification_token
+    self.ignored_columns += ["authorization_token", "verification_token"]
+    before_validation :ensure_tokens
 
     validate :non_hcb_email
     validate :non_existing_email
@@ -91,6 +92,11 @@ class User
     end
 
     private
+
+    def ensure_tokens
+      self.authorization_token ||= SecureRandom.base58(24)
+      self.verification_token  ||= SecureRandom.base58(24)
+    end
 
     def non_hcb_email
       if GSuiteAccount.where(address: replacement).any?


### PR DESCRIPTION
### 🔐 Step 2: Finalize Lockbox encryption for `authorization_token` and `verification_token`

This PR finalizes the migration to Lockbox-encrypted storage for the `User::EmailUpdate` model.

#### Changes:

* Removes `migrating: true` from encrypted token fields
* Adds `self.ignored_columns` to ignore the legacy plaintext columns
* Adds `before_validation` fallback to ensure secure tokens are still generated as needed

> Assumes `Lockbox.migrate(User::EmailUpdate)` has been run and all encrypted values are in place. (This was completed in my last sync with @garyhtou)

Previous PR for reference: #10450