### PR TITLE
fix docuseal server-side request forgery on `Faraday.get`

### DIFF
--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -19,7 +19,15 @@ class DocusealController < ActionController::Base
           name: "Fiscal sponsorship contract with #{contract.organizer_position_invite.user.name}"
         )
 
-        response = Faraday.get(params[:data][:documents][0][:url]) do |req|
+        allowed_domains = ["docuseal.com", "trusted-domain.com"]
+        document_url = params[:data][:documents][0][:url]
+        uri = URI.parse(document_url)
+
+        unless allowed_domains.include?(uri.host)
+          raise "Invalid document URL: #{document_url}"
+        end
+
+        response = Faraday.get(document_url) do |req|
           req.headers["X-Auth-Token"] = Credentials.fetch(:DOCUSEAL)
         end
 


### PR DESCRIPTION
https://github.com/hackclub/hcb/blob/ce07a7f458b6991e2e4f1b5f4f8f5d74137ac0f7/app/controllers/docuseal_controller.rb#L22-L22

Fix the SSRF vulnerability, the code should validate the `url` parameter against a whitelist of allowed domains or paths. This ensures that the server only makes requests to trusted destinations. Alternatively, the code can enforce restrictions to ensure the `url` belongs to a specific domain or matches a predefined pattern.

The best approach here is to:
1. Define a whitelist of allowed domains or URLs in the application configuration.
2. Validate the `url` parameter against this whitelist before using it in the `Faraday.get` request.
3. Reject or sanitize any `url` that does not match the whitelist.

---

Directly incorporating user input into an HTTP request without validating the input can facilitate server-side request forgery (SSRF) attacks. In these attacks, the request may be changed, directed at a different server, or via a different protocol. This can allow the attacker to obtain sensitive information or perform actions with escalated privilege.

References
[OWASP SSRF](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)
[CWE-918](https://cwe.mitre.org/data/definitions/918.html)