### PR TITLE
fix stored cross-site scripting on `@transaction.local_hcb_code`

### DIFF
--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -8,7 +8,7 @@
     <p>
       <strong>HCB Code:</strong>
       <span>
-        <%= link_to @transaction.hcb_code, @transaction.local_hcb_code %>
+        <%= link_to @transaction.hcb_code, URI.encode(@transaction.local_hcb_code) %>
       </span>
     </p>
   <% end %>


### PR DESCRIPTION
https://github.com/hackclub/hcb/blob/17579c5797a29f3d89293fd3c5231cf97db033aa/app/views/transactions/show.html.erb#L11-L11

Fix the issue need to ensure that the value of `@transaction.local_hcb_code` is properly escaped before being used in the `link_to` helper. In Rails, the `ERB::Util.html_escape` method (or its alias `h`) can be used to escape potentially unsafe content. However, since `link_to` is used to generate a URL, we should use `URI.encode` or a similar method to ensure the URL is safe.

The best approach is to sanitize `@transaction.local_hcb_code` by encoding it as a URL. This ensures that any special characters or potentially malicious content are safely escaped.

**References**
[XSS Ruby on Rails Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#cross-site-scripting-xss)

