### PR TITLE
Add receipt deletion to v4 API

### DIFF
--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -17,6 +17,17 @@ module Api
         render "show"
       end
 
+      def destroy
+        @receipt = Receipt.find(params[:id])
+        
+        if policy(@receipt).destroy?
+          @receipt.destroy!
+          render json: { message: "Receipt successfully deleted" }, status: :ok
+        else
+          render json: { error: "You are not authorized to delete this receipt" }, status: :forbidden
+        end
+      end
+      
     end
   end
 end

--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       def destroy
         @receipt = Receipt.find(params[:id])
-        
+
         if policy(@receipt).destroy?
           @receipt.destroy!
           render json: { message: "Receipt successfully deleted" }, status: :ok
@@ -27,7 +27,8 @@ module Api
           render json: { error: "You are not authorized to delete this receipt" }, status: :forbidden
         end
       end
-      
+
+
     end
   end
 end

--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -19,13 +19,10 @@ module Api
 
       def destroy
         @receipt = Receipt.find(params[:id])
+        authorize @receipt
 
-        if policy(@receipt).destroy?
-          @receipt.destroy!
-          render json: { message: "Receipt successfully deleted" }, status: :ok
-        else
-          render json: { error: "You are not authorized to delete this receipt" }, status: :forbidden
-        end
+        @receipt.destroy!
+        render json: { message: "Receipt successfully deleted" }, status: :ok
       end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -575,7 +575,7 @@ Rails.application.routes.draw do
           resources :stripe_cards, path: "cards", only: [:index]
           resources :card_grants, only: [:index, :create]
           resources :transactions, only: [:show, :update] do
-            resources :receipts, only: [:create, :index]
+            resources :receipts, only: [:create, :index, :destroy]
             resources :comments, only: [:index]
 
             member do


### PR DESCRIPTION
## Summary of the problem
In HCB Mobile you can add receipt but not delete it



## Describe your changes
This allows me to delete individual receipts. 

