### PR TITLE
Add one time use card grants

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -79,7 +79,7 @@ input[type='submit'],
   }
 
   &.bg-slate {
-    @include gradient(slate)
+    @include gradient(slate);
   }
 
   &.bg-ai {

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -78,6 +78,10 @@ input[type='submit'],
     @include gradient(purple);
   }
 
+  &.bg-slate {
+    @include gradient(slate)
+  }
+
   &.bg-ai {
     @include gradient(ai);
   }

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -31,7 +31,7 @@ class CardGrantsController < ApplicationController
 
   def create
     params[:card_grant][:amount_cents] = Monetize.parse(params[:card_grant][:amount_cents]).cents
-    @card_grant = @event.card_grants.build(params.require(:card_grant).permit(:amount_cents, :email, :merchant_lock, :category_lock, :keyword_lock, :purpose).merge(sent_by: current_user))
+    @card_grant = @event.card_grants.build(params.require(:card_grant).permit(:amount_cents, :email, :merchant_lock, :category_lock, :keyword_lock, :purpose, :one_time_use).merge(sent_by: current_user))
 
     authorize @card_grant
 
@@ -149,6 +149,14 @@ class CardGrantsController < ApplicationController
     report = @card_grant.convert_to_reimbursement_report!
 
     redirect_to report, flash: { success: "Successfully converted grant into a reimbursement report." }
+  end
+
+  def toggle_one_time_use
+    authorize @card_grant
+
+    @card_grant.update(one_time_use: !@card_grant.one_time_use)
+
+    redirect_to @card_grant, flash: { success: "#{@card_grant.one_time_use ? "Enabled" : "Disabled"} one time use for this card grant." }
   end
 
   def edit

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -202,6 +202,7 @@ class StripeCard < ApplicationRecord
     StripeService::Issuing::Card.update(self.stripe_id, status: :active)
     sync_from_stripe!
     save!
+    card_grant.update(one_time_use: false)
   end
 
   def cancel!

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -202,7 +202,7 @@ class StripeCard < ApplicationRecord
     StripeService::Issuing::Card.update(self.stripe_id, status: :active)
     sync_from_stripe!
     save!
-    card_grant.update(one_time_use: false)
+    card_grant.update(one_time_use: false) if card_grant&.one_time_use
   end
 
   def cancel!

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -41,6 +41,10 @@ class CardGrantPolicy < ApplicationPolicy
     (admin_or_manager? || record.user == user) && record.card_grant_setting.reimbursement_conversions_enabled?
   end
 
+  def toggle_one_time_use?
+    admin_or_manager? && record.active?
+  end
+
   def admin_or_user?
     user&.admin? || record.event.users.include?(user)
   end

--- a/app/services/stripe_authorization_service/create_from_webhook.rb
+++ b/app/services/stripe_authorization_service/create_from_webhook.rb
@@ -43,6 +43,10 @@ module StripeAuthorizationService
           if cpt.local_hcb_code&.stripe_cash_withdrawal?
             AdminMailer.with(hcb_code: cpt.local_hcb_code).cash_withdrawal_notification.deliver_later
           end
+
+          if cpt.stripe_card.card_grant.one_time_use
+            cpt.stripe_card.freeze!
+          end
         else
           unless cpt&.stripe_card&.frozen? || cpt&.stripe_card&.inactive?
             CanonicalPendingTransactionMailer.with(canonical_pending_transaction_id: cpt.id).notify_declined.deliver_later

--- a/app/services/stripe_authorization_service/create_from_webhook.rb
+++ b/app/services/stripe_authorization_service/create_from_webhook.rb
@@ -44,7 +44,7 @@ module StripeAuthorizationService
             AdminMailer.with(hcb_code: cpt.local_hcb_code).cash_withdrawal_notification.deliver_later
           end
 
-          if cpt.stripe_card.card_grant.one_time_use
+          if cpt&.stripe_card&.card_grant&.one_time_use
             cpt.stripe_card.freeze!
           end
         else

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -6,6 +6,7 @@
       <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card %>
     <% end %>
 
+    <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
     <%= render "card_grants/actions/topup", card_grant: %>
     <%= render "card_grants/actions/withdraw", card_grant: %>
     <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant: %>

--- a/app/views/card_grants/_create_form.html.erb
+++ b/app/views/card_grants/_create_form.html.erb
@@ -23,6 +23,13 @@
     <%= form.text_field :purpose, placeholder: "Pizza for a club meeting", disabled: %>
   </div>
 
+  <div class="field">
+    <%= form.label :one_time_use do %>
+      <%= form.check_box :one_time_use, disabled: %>
+      One time use? (freezes after first charge)
+    <% end %>
+  </div>
+
   <div class="actions">
     <%= form.submit "Send grant", disabled: %>
   </div>

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -28,6 +28,10 @@
       <strong>Grant Status</strong>
       <span><%= card_grant.state_text %></span>
     </p>
+    <p>
+      <strong>One time use?</strong>
+      <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
+    </p>
     <% if (stripe_card = card_grant.stripe_card).present? %>
       <p>
         <strong>Card Status</strong>

--- a/app/views/card_grants/actions/_toggle_one_time_use.html.erb
+++ b/app/views/card_grants/actions/_toggle_one_time_use.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (card_grant:) %>
+
+<% if policy(card_grant).toggle_one_time_use? %>
+
+  <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
+              method: :post,
+              class: "btn bg-slate" do %>
+    <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
+  <% end %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -756,6 +756,7 @@ Rails.application.routes.draw do
         post "withdraw"
         post "cancel"
         post "convert_to_reimbursement_report"
+        post "toggle_one_time_use"
       end
     end
 

--- a/db/migrate/20250602201214_add_one_time_use_to_card_grant.rb
+++ b/db/migrate/20250602201214_add_one_time_use_to_card_grant.rb
@@ -1,0 +1,5 @@
+class AddOneTimeUseToCardGrant < ActiveRecord::Migration[7.2]
+  def change
+    add_column :card_grants, :one_time_use, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_01_121459) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_02_201214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -430,6 +430,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_01_121459) do
     t.integer "status", default: 0, null: false
     t.string "keyword_lock"
     t.string "purpose"
+    t.boolean "one_time_use"
     t.index ["disbursement_id"], name: "index_card_grants_on_disbursement_id"
     t.index ["event_id"], name: "index_card_grants_on_event_id"
     t.index ["sent_by_id"], name: "index_card_grants_on_sent_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_02_201214) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_03_011828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/CN523HLKW/p1746313970709819
Closes #10508 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a one time use option to card grants that will automatically freeze its Stripe card when an authorization is approved. Managers can defrost, which will allow the grantee to make any amount of additional transactions on the card, but the option can be re-enabled with a new action on the card grant page.

![image](https://github.com/user-attachments/assets/3ede2996-465e-4ff7-bbc7-8105527c6189)
