### PR TITLE
[MarkdownService] Handle case where `*_URL_HOST` is unset.

### DIFF
--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -144,7 +144,7 @@ class MarkdownService
       hosts << Credentials.fetch(:LIVE_URL_HOST)
       hosts << Credentials.fetch(:TEST_URL_HOST) if Rails.env.development?
 
-      hosts.map { |h| Regexp.escape h }
+      hosts.compact_blank.map { |h| Regexp.escape h }
     end
 
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

When the value is unset, it attempts `Regexp.escape(nil)` which raises an error.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Remove any nil or blank values.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

