### PR TITLE
[Teen Raffle] Make UI more clear that you only join once

### DIFF
--- a/app/views/static_pages/index/_teen_raffle.html.erb
+++ b/app/views/static_pages/index/_teen_raffle.html.erb
@@ -1,7 +1,7 @@
-<% raffle_program = "teen-raffle-#{Date.current.strftime("%m-%Y")}" %>
-<% already_joined = Raffle.where(user: current_user, program: raffle_program).any? %>
+<% if current_user.teenager? %>
+  <% raffle_program = "teen-raffle-#{Date.current.strftime("%m-%Y")}" %>
+  <% already_joined = Raffle.where(user: current_user, program: raffle_program).any? %>
 
-<% if current_user.teenager? || already_joined %>
   <% current_month = Date.current.strftime("%B") %>
   <% next_month = Date.current.next_month.strftime("%B") %>
 

--- a/app/views/static_pages/index/_teen_raffle.html.erb
+++ b/app/views/static_pages/index/_teen_raffle.html.erb
@@ -1,7 +1,11 @@
-<% if current_user.teenager? %>
-  <% current_month = Date.current.strftime("%B") %>
+<% raffle_program = "teen-raffle-#{Date.current.strftime("%m-%Y")}" %>
+<% already_joined = Raffle.where(user: current_user, program: raffle_program).any? %>
 
-  <%= link_to new_raffle_path(program: "teen-raffle"), class: "w-full no-underline text-inherit" do %>
+<% if current_user.teenager? || already_joined %>
+  <% current_month = Date.current.strftime("%B") %>
+  <% next_month = Date.current.next_month.strftime("%B") %>
+
+  <%= link_to already_joined ? "javascript:void(0);" : new_raffle_path(program: raffle_program), class: "w-full no-underline text-inherit #{"cursor-default" if already_joined}" do %>
     <div class="card card--hover flex flex-col flex-wrap h-full mx-auto card--background-image text-left mt-4" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/38be05dd4accefb1708c06ba6f99401b4265e7a1_image.png')">
       <div class="flex gap-2 items-center mb-4">
         <span>🎟️</span>
@@ -14,7 +18,13 @@
           HCB is raffling away a $100 Amazon gift card, Raspberry Pi Pico, and a
           limited edition HCB t-shirt! Join the raffle for your chance to win!
           For teenagers only. Raffle winners will be selected
-          on <%= Date.current.end_of_month.strftime("%b %e, %Y") %>.
+          on <%= Date.current.end_of_month.strftime("%B %e, %Y") %>.
+          <% if already_joined %>
+            <span class="italic block mt-2 text-sm">
+              You have already joined the raffle this month. Remember to check
+              back in <%= next_month %> for the next Raffle!
+            </span>
+          <% end %>
         </p>
         <div class="flex gap-2">
           <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/c1f9773a3f6621650ade6d95c008e5eeb5e180c6_image.png" height="96" width="96" class="rounded align-bottom object-cover tooltipped tooltipped--w" alt="$100 Amazon Gift Card" aria-label="$100 Amazon Gift Card">


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

The UI wasn't stateful and still allowed u to join the raffle after u joined.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

If you've already joined, the UI now says, "You have already joined the raffle this month. Remember to check back in July for the next Raffle!". I'll still filter out duplicate entries when running the raffle selection.

<img width="927" alt="image" src="https://github.com/user-attachments/assets/3c75448f-99a5-465a-8a0f-bd5e9d4574a4" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

