### PR TITLE
Add tooltip to describe onetime grants

### DIFF
--- a/app/views/card_grants/actions/_toggle_one_time_use.html.erb
+++ b/app/views/card_grants/actions/_toggle_one_time_use.html.erb
@@ -1,11 +1,11 @@
 <%# locals: (card_grant:) %>
 
 <% if policy(card_grant).toggle_one_time_use? %>
-
-  <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
+  <div class="tooltipped tooltipped--n" aria-label="Locks the card after a purchase">
+    <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               class: "btn bg-slate" do %>
-    <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
-  <% end %>
-
+      <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
+    <% end %>
+  </div>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

How does someone figure out what a one-time-use grant is?

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Sets the tooltip for the one time use button on grants to "Locks the card after a purchase" which helps people figure out what the heck it does

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

