### PR TITLE
WIP: Split disbursement into two HcbCodes

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -116,7 +116,7 @@ class CanonicalPendingTransaction < ApplicationRecord
   scope :donation_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::DONATION_CODE}%'") }
   scope :ach_transfer_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::ACH_TRANSFER_CODE}%'") }
   scope :check_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::CHECK_CODE}%'") }
-  scope :disbursement_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::DISBURSEMENT_CODE}%'") }
+  scope :disbursement_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::DISBURSEMENT_CODE}%'") } # TODO:
   scope :stripe_card_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::STRIPE_CARD_CODE}%'") }
   scope :bank_fee_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::BANK_FEE_CODE}%'") }
   scope :fronted, -> { where(fronted: true) }

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -10,6 +10,7 @@
 #  email           :string           not null
 #  keyword_lock    :string
 #  merchant_lock   :string
+#  one_time_use    :boolean
 #  purpose         :string
 #  status          :integer          default("active"), not null
 #  created_at      :datetime         not null

--- a/app/services/disbursement_service/create_v2.rb
+++ b/app/services/disbursement_service/create_v2.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module DisbursementService
+  class CreateV2
+    include ::Shared::AmpleBalance
+
+    def initialize(source_event_id:, destination_event_id:,
+                   name:, amount:, requested_by_id:, fulfilled_by_id: nil,
+                   destination_subledger_id: nil, scheduled_on: nil, source_subledger_id: nil,
+                   should_charge_fee: false, skip_auto_approve: false, fronted: false)
+      @source_event_id = source_event_id
+      @source_event = Event.find(@source_event_id)
+      @destination_event_id = destination_event_id
+      @destination_event = Event.find(@destination_event_id)
+      @destination_subledger_id = destination_subledger_id
+      @source_subledger_id = source_subledger_id
+      @name = name
+      @amount = amount
+      @requested_by_id = requested_by_id
+      @fulfilled_by_id = fulfilled_by_id
+      @scheduled_on = scheduled_on
+      @should_charge_fee = should_charge_fee
+      @skip_auto_approve = skip_auto_approve
+      @fronted = fronted
+    end
+
+    def run
+      raise ArgumentError, "amount is required" unless @amount
+      raise ArgumentError, "amount_cents must be greater than 0" unless amount_cents > 0
+
+      if @source_subledger_id.present?
+        raise ArgumentError, "You don't have enough money to make this disbursement." unless Subledger.find(@source_subledger_id).balance_cents >= amount_cents || requested_by_admin?
+      else
+        raise ArgumentError, "You don't have enough money to make this disbursement." unless ample_balance?(amount_cents, @source_event) || requested_by_admin?
+      end
+
+      disbursement = Disbursement.create!(attrs)
+
+      # 1. Create the raw pending transactions
+      rpodt = ::PendingTransactionEngine::RawPendingOutgoingDisbursementTransactionService::Disbursement::ImportSingle.new(disbursement:).run
+      # 2. Canonize the newly added raw pending transactions
+      o_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::OutgoingDisbursement.new(raw_pending_outgoing_disbursement_transaction: rpodt).run
+      # 3. Map to event
+      ::PendingEventMappingEngine::Map::Single::OutgoingDisbursement.new(canonical_pending_transaction: o_cpt).run
+      # 4. Front if required
+      o_cpt.update(fronted: @fronted)
+
+      if disbursement.scheduled_on.nil?
+        # We only want to import Incoming Disbursements AFTER the scheduled date
+
+        # 1. Create the raw pending transactions
+        rpidt = ::PendingTransactionEngine::RawPendingIncomingDisbursementTransactionService::Disbursement::ImportSingle.new(disbursement:).run
+        # 2. Canonize the newly added raw pending transactions
+        i_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::IncomingDisbursement.new(raw_pending_incoming_disbursement_transaction: rpidt).run
+        # 3. Map to event
+        ::PendingEventMappingEngine::Map::Single::IncomingDisbursement.new(canonical_pending_transaction: i_cpt).run
+        # 4. Front if required
+        i_cpt.update(fronted: @fronted)
+      end
+
+      if requested_by_admin? || disbursement.source_event == disbursement.destination_event # Auto-fulfill disbursements between subledgers in the same event
+        disbursement.approve_by_admin(requested_by)
+      end
+
+      disbursement
+    end
+
+    private
+
+    def attrs
+      {
+        source_event_id: source_event.id,
+        event_id: destination_event.id,
+        destination_subledger_id: @destination_subledger_id,
+        source_subledger_id: @source_subledger_id,
+        scheduled_on: @scheduled_on,
+        name: @name,
+        amount: amount_cents,
+        requested_by:,
+        should_charge_fee: @should_charge_fee,
+        is_v2: true
+      }
+    end
+
+    def requested_by
+      @requested_by ||= User.find @requested_by_id if @requested_by_id
+    end
+
+    def requested_by_admin?
+      !@skip_auto_approve && requested_by&.admin?
+    end
+
+    def amount_cents
+      Monetize.parse(@amount).cents
+    end
+
+    def source_event
+      @source_event ||= Event.find(@source_event_id)
+    end
+
+    def destination_event
+      @destination_event ||= Event.find(@destination_event_id)
+    end
+
+  end
+end

--- a/app/services/transaction_grouping_engine/calculate/hcb_code.rb
+++ b/app/services/transaction_grouping_engine/calculate/hcb_code.rb
@@ -23,6 +23,8 @@ module TransactionGroupingEngine
       INCREASE_CHECK_CODE = "401"
       CHECK_DEPOSIT_CODE = "402"
       DISBURSEMENT_CODE = "500"
+      OUTGOING_DISBURSEMENT_CODE = "501"
+      INCOMING_DISBURSEMENT_CODE = "502"
       STRIPE_CARD_CODE = "600"
       STRIPE_FORCE_CAPTURE_CODE = "601"
       STRIPE_SERVICE_FEE_CODE = "610"
@@ -178,11 +180,13 @@ module TransactionGroupingEngine
       end
 
       def disbursement_hcb_code
-        [
-          HCB_CODE,
-          DISBURSEMENT_CODE,
-          disbursement.id
-        ].join(SEPARATOR)
+        if !disbursement.is_v2?
+          disbursement.hcb_code
+        elsif @ct_or_cp.amount_cents.positive?
+          disbursement.incoming_hcb_code
+        else
+          disbursement.outgoing_hcb_code
+        end
       end
 
       def disbursement

--- a/db/migrate/20250605185230_add_v2_column_to_disbursement.rb
+++ b/db/migrate/20250605185230_add_v2_column_to_disbursement.rb
@@ -1,0 +1,5 @@
+class AddV2ColumnToDisbursement < ActiveRecord::Migration[7.2]
+  def change
+    add_column :disbursements, :is_v2, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_03_011828) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_05_185230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -603,6 +603,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_03_011828) do
     t.bigint "source_subledger_id"
     t.date "scheduled_on"
     t.boolean "should_charge_fee", default: false
+    t.boolean "is_v2", default: false, null: false
     t.index ["destination_subledger_id"], name: "index_disbursements_on_destination_subledger_id"
     t.index ["event_id"], name: "index_disbursements_on_event_id"
     t.index ["fulfilled_by_id"], name: "index_disbursements_on_fulfilled_by_id"


### PR DESCRIPTION
We were able to get a Two-HcbCode'ed Disbursement created using `DisbursementService::CreateV2`. It however errors when the async jobs are ran (largely due to error when rendering views for Turbostream broadcasts).

`Disbursement#hcb_code` and `Disbursement#local_hcb_code` may prove ot be a problem since it's likely called (duck-typing style) from the UI. Those two method currently don't have enough context as to which HcbCode to return (either outgoing/incoming) without adding a new parameter.
