### PR TITLE
[Receipts] Card locking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ gem "strong_migrations", "~> 1" # protects against risky migrations
 # [@garyhtou] ^ We still use Postgres 11 in dev (not in prod). Strong Migrations
 #               2.x is incompatible with Postgres 11.
 gem "xxhash" # fast hashing
+gem "memo_wise"
 
 gem "diffy" # rendering diffs (comments)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    memo_wise (1.13.0)
     method_source (1.1.0)
     mini_magick (5.2.0)
       benchmark
@@ -932,6 +933,7 @@ DEPENDENCIES
   lockbox
   lograge
   loofah
+  memo_wise
   mini_magick
   monetize
   money-rails

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -88,7 +88,7 @@ class MyController < ApplicationController
 
   def inbox
     @count = current_user.transactions_missing_receipt.count
-    @locking_count = current_user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+    @locking_count = current_user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
     @hcb_codes = Kaminari.paginate_array(HcbCode.where(id: hcb_code_ids_missing_receipt)

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -88,6 +88,8 @@ class MyController < ApplicationController
 
   def inbox
     @count = current_user.transactions_missing_receipt.count
+    @locking_count = current_user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
     @hcb_codes = Kaminari.paginate_array(HcbCode.where(id: hcb_code_ids_missing_receipt)
                  .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT

--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -33,11 +33,13 @@ class StripeController < ActionController::Base
     # fire-and-forget update to grafana dashboard
     StatsD.increment("stripe_webhook_authorization", 1)
 
-    approved = ::StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(stripe_event: event).run
+    service = ::StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(stripe_event: event)
+    approved = service.run
 
     if approved
-      ::User::UpdateCardLockingJob.perform_later
-      ::User::SendCardLockingNotificationJob.perform_later
+      user = service.card.user
+      ::User::UpdateCardLockingJob.perform_later(user:)
+      ::User::SendCardLockingNotificationJob.perform_later(user:)
     end
 
     response.set_header "Stripe-Version", "2022-08-01"

--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -35,6 +35,11 @@ class StripeController < ActionController::Base
 
     approved = ::StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(stripe_event: event).run
 
+    if approved
+      ::User::UpdateCardLockingJob.perform_later
+      ::User::SendCardLockingNotificationJob.perform_later
+    end
+
     response.set_header "Stripe-Version", "2022-08-01"
 
     render json: {

--- a/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
+++ b/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
@@ -35,6 +35,8 @@ class CanonicalPendingTransaction
                              "because this card isn't allowed to make purchases at #{@merchant}"
                            when "cash_withdrawals_not_allowed"
                              "because cash withdrawals are not enabled on it"
+                           when "user_cards_locked"
+                             "because your cards are locked (you need to upload receipts)"
                            else
                              "at #{@merchant} due to insufficient funds"
                            end

--- a/app/jobs/user/send_card_locking_notification_job.rb
+++ b/app/jobs/user/send_card_locking_notification_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class User
+  class SendCardLockingNotificationJob < ApplicationJob
+    queue_as :low
+    def perform
+      ::UserService::SendCardLockingNotification.new.run
+    end
+
+  end
+
+end

--- a/app/jobs/user/send_card_locking_notification_job.rb
+++ b/app/jobs/user/send_card_locking_notification_job.rb
@@ -3,8 +3,8 @@
 class User
   class SendCardLockingNotificationJob < ApplicationJob
     queue_as :low
-    def perform
-      ::UserService::SendCardLockingNotification.new.run
+    def perform(user:)
+      ::UserService::SendCardLockingNotification.new(user:).run
     end
 
   end

--- a/app/jobs/user/update_card_locking_job.rb
+++ b/app/jobs/user/update_card_locking_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class User
+  class UpdateCardLockingJob < ApplicationJob
+    queue_as :low
+    def perform
+      ::UserService::UpdateCardLocking.new.run
+    end
+
+  end
+
+end

--- a/app/jobs/user/update_card_locking_job.rb
+++ b/app/jobs/user/update_card_locking_job.rb
@@ -3,8 +3,8 @@
 class User
   class UpdateCardLockingJob < ApplicationJob
     queue_as :low
-    def perform
-      ::UserService::UpdateCardLocking.new.run
+    def perform(user:)
+      ::UserService::UpdateCardLocking.new(user:).run
     end
 
   end

--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CardLockingMailer < ApplicationMailer
+  def cards_locked(missing_receipts:, email:)
+    @missing_receipts = missing_receipts
+    @email = email
+
+    mail to: @email, subject: "[Urgent] Your HCB cards have been locked until you upload your receipts"
+  end
+
+  def warning(missing_receipts:, email:)
+    @missing_receipts = missing_receipts
+    @email = email
+
+    mail to: @email, subject: "[Urgent] Your HCB cards will be locked soon"
+  end
+
+end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -59,7 +59,7 @@ class Receipt < ApplicationRecord
   # - @sampoder
   PREPROCESSED_SIZES = ["1024x1024"].freeze
 
-  CARD_LOCKING_START_DATE = Date.new(2025, 6, 9)
+  CARD_LOCKING_START_DATE = Date.new(2025, 6, 13)
 
   has_one_attached :file do |attachable|
     PREPROCESSED_SIZES.each do |resize|

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -87,7 +87,7 @@ class Receipt < ApplicationRecord
   end
 
   after_commit do
-    User::CardLockingJob.perform_later
+    User::UpdateCardLockingJob.perform_later
   end
 
   validate :has_owner

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -85,6 +85,11 @@ class Receipt < ApplicationRecord
       Receipt::SuggestPairingsJob.perform_later(self)
     end
   end
+
+  after_commit do
+    User::CardLockingJob.perform_later
+  end
+
   validate :has_owner
 
   enum :upload_method, {

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -59,6 +59,8 @@ class Receipt < ApplicationRecord
   # - @sampoder
   PREPROCESSED_SIZES = ["1024x1024"].freeze
 
+  CARD_LOCKING_START_DATE = Date.new(2025, 6, 9)
+
   has_one_attached :file do |attachable|
     PREPROCESSED_SIZES.each do |resize|
       attachable.variant(resize.to_sym, resize:, preprocessed: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -315,13 +315,17 @@ class User < ApplicationRecord
   end
 
   def transactions_missing_receipt(since: nil)
-    @transactions_missing_receipt ||= begin
-      return HcbCode.none unless hcb_code_ids_missing_receipt.any?
+    return HcbCode.none unless hcb_code_ids_missing_receipt.any?
 
+    transactions_missing_receipt = begin
       user_hcb_codes = HcbCode.where(id: hcb_code_ids_missing_receipt)
       user_hcb_codes = user_hcb_codes.where("created_at >= ?", since) if since
       user_hcb_codes = user_hcb_codes.order(created_at: :desc)
     end
+
+    return transactions_missing_receipt if since.present?
+
+    @transactions_missing_receipt ||= transactions_missing_receipt
   end
 
   def transactions_missing_receipt_count(since: nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   include Turbo::Broadcastable
 
   include ApplicationHelper
+  prepend MemoWise
 
   include PublicActivity::Model
   tracked owner: proc{ |controller, record| record }, recipient: proc { |controller, record| record }, only: [:create, :update]
@@ -314,33 +315,16 @@ class User < ApplicationRecord
     end
   end
 
-  def transactions_missing_receipt(since: nil)
+  memo_wise def transactions_missing_receipt(since: nil)
     return HcbCode.none unless hcb_code_ids_missing_receipt.any?
 
-    transactions_missing_receipt = begin
-      user_hcb_codes = HcbCode.where(id: hcb_code_ids_missing_receipt)
-      user_hcb_codes = user_hcb_codes.where("created_at >= ?", since) if since
-      user_hcb_codes = user_hcb_codes.order(created_at: :desc)
-    end
-
-    return transactions_missing_receipt if since.present?
-
-    @transactions_missing_receipt ||= transactions_missing_receipt
+    user_hcb_codes = HcbCode.where(id: hcb_code_ids_missing_receipt)
+    user_hcb_codes = user_hcb_codes.where("created_at >= ?", since) if since
+    user_hcb_codes.order(created_at: :desc)
   end
 
-  def transactions_missing_receipt_count(since: nil)
-    unless since
-      @transactions_missing_receipt_count ||= begin
-        transactions_missing_receipt.size
-      end
-
-      return @transactions_missing_receipt_count
-    end
-
-    @transactions_missing_receipt_count_since ||= {}
-    @transactions_missing_receipt_count_since[since] ||= begin
-      transactions_missing_receipt(since:).size
-    end
+  memo_wise def transactions_missing_receipt_count(since: nil)
+    transactions_missing_receipt(since:).size
   end
 
   def build_payout_method(params)

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -13,6 +13,10 @@ module StripeAuthorizationService
         approve?
       end
 
+      def card
+        @card ||= StripeCard.includes(:card_grant).find_by(stripe_id: stripe_card_id)
+      end
+
       private
 
       def auth
@@ -29,10 +33,6 @@ module StripeAuthorizationService
 
       def stripe_card_id
         auth[:card][:id]
-      end
-
-      def card
-        @card ||= StripeCard.includes(:card_grant).find_by(stripe_id: stripe_card_id)
       end
 
       def card_balance_available

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -63,6 +63,8 @@ module StripeAuthorizationService
 
         return decline_with_reason!("cash_withdrawals_not_allowed") if cash_withdrawal? && !card.cash_withdrawal_enabled?
 
+        return decline_with_reason!("user_cards_locked") if card.user.cards_locked?
+
         set_metadata!
 
         true

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -9,7 +9,7 @@ module UserService
     def run
       return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
 
-      count = @user.transactions_missing_receipt(since: Date.new(2025, 6, 9)).count
+      count = @user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
 
       if count.in?([5, 7, 9])
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -9,7 +9,7 @@ module UserService
     def run
       return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
 
-      count = @user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+      count = @user.transactions_missing_receipt(since: Date.new(2025, 6, 9)).count
 
       if count.in?([5, 7, 9])
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -15,7 +15,7 @@ module UserService
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later
 
         if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You now have #{count}/10 transactions missing receipts. After 10, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          message = "You now have #{count} transactions missing receipts. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
           TwilioMessageService::Send.new(@user, message).run!
         end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module UserService
+  class SendCardLockingNotification
+    def initialize(user:)
+      @user = user
+    end
+
+    def run
+      return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
+
+      count = @user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+
+      if count.in?([5, 7, 9])
+        CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later
+      end
+    end
+
+  end
+end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -13,6 +13,13 @@ module UserService
 
       if count.in?([5, 7, 9])
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later
+
+        if @user.phone_number.present? && @user.phone_number_verified?
+          message = "You now have #{count}/10 transactions missing receipts. After 10, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+
+          TwilioMessageService::Send.new(@user, message).run!
+        end
+
       end
     end
 

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module UserService
+  class UpdateCardLocking
+    def initialize(user:)
+      @user = user
+    end
+
+    def run
+      return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
+
+      count = @user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+
+      if count >= 10 && !@user.cards_locked?
+        CardLockingMailer.cards_locked(email: @user.email, missing_receipts: count).deliver_later
+      end
+
+      cards_locked = count >= 10
+      @user.update!(cards_locked:)
+    end
+
+  end
+end

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -9,7 +9,7 @@ module UserService
     def run
       return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
 
-      count = @user.transactions_missing_receipt(since: Date.parse("2025-06-09")).count
+      count = @user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
 
       if count >= 10 && !@user.cards_locked?
         CardLockingMailer.cards_locked(email: @user.email, missing_receipts: count).deliver_later

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -15,7 +15,7 @@ module UserService
       if cards_should_lock && !@user.cards_locked?
         CardLockingMailer.cards_locked(email: @user.email, missing_receipts: count).deliver_later
       end
-      
+
       @user.update!(cards_locked: cards_should_lock)
     end
 

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -11,12 +11,12 @@ module UserService
 
       count = @user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
 
-      if count >= 10 && !@user.cards_locked?
+      cards_should_lock = count >= 10
+      if cards_should_lock && !@user.cards_locked?
         CardLockingMailer.cards_locked(email: @user.email, missing_receipts: count).deliver_later
       end
-
-      cards_locked = count >= 10
-      @user.update!(cards_locked:)
+      
+      @user.update!(cards_locked: cards_should_lock)
     end
 
   end

--- a/app/views/application/_callout.html.erb
+++ b/app/views/application/_callout.html.erb
@@ -4,7 +4,10 @@
 <div class="<%= "card border b--#{color} #{"pb0" if local_assigns[:footer].present? } mt3 mb3 #{local_assigns[:class]}" %>">
   <div class="<%= "flex items-center #{color}" %>">
     <%= inline_icon icon, size: 32, class: "mr1" %>
-    <p class="bold mt0 mb0"><%= local_assigns[:title] %></p>
+    <p class="bold mt0 mb0">
+      <%= local_assigns[:title] %>
+      <%= local_assigns[:badge] if local_assigns[:badge].present? %>
+    </p>
   </div>
 
   <% unless (block = yield).empty? %>

--- a/app/views/card_locking_mailer/cards_locked.html.erb
+++ b/app/views/card_locking_mailer/cards_locked.html.erb
@@ -1,0 +1,3 @@
+Your HCB cards have been locked due to your <%= @missing_receipts %> outstanding missing receipts.
+<br><br>
+You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/card_locking_mailer/cards_locked.html.erb
+++ b/app/views/card_locking_mailer/cards_locked.html.erb
@@ -1,3 +1,3 @@
 Your HCB cards have been locked due to your <%= @missing_receipts %> outstanding missing receipts.
 <br><br>
-You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>.
+You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,0 +1,3 @@
+Your HCB cards will risk getting locked if you don't upload your <%= @missing_receipts %> outstanding missing receipts. Once you hit 10 missing receipts, your cards will be locked until you upload them.
+<br><br>
+You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,3 +1,3 @@
 Your HCB cards are at risk of getting locked if you don't upload your <%= @missing_receipts %> outstanding missing receipts. Once you hit 10 missing receipts, your cards will be locked until you upload them.
 <br><br>
-You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>.
+You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,3 +1,3 @@
-Your HCB cards will risk getting locked if you don't upload your <%= @missing_receipts %> outstanding missing receipts. Once you hit 10 missing receipts, your cards will be locked until you upload them.
+Your HCB cards are at risk of getting locked if you don't upload your <%= @missing_receipts %> outstanding missing receipts. Once you hit 10 missing receipts, your cards will be locked until you upload them.
 <br><br>
 You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -18,6 +18,7 @@
             <%= {
                   merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
                   cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
+                  user_cards_locked: "by HCB because you have too many missing receipts"
                 }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
         <% else %>
             <span>
@@ -40,6 +41,7 @@
             <%= {
                   merchant_not_allowed: "Merchant not allowed",
                   cash_withdrawals_not_allowed: "Cash withdrawals disabled",
+                    user_cards_locked: "Card locked due to missing receipts",
                 }[hcb_decline_reason] || "Insufficient funds" %>
         <% else %>
             <%= {
@@ -73,6 +75,8 @@
             If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
         <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>
             Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.
+        <% elsif hcb_decline_reason == :user_cards_locked %>
+            You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>. If you have more than 10 missing receipts, your cards will be locked until you submit them.
         <% elsif stripe_decline_reason == :authorization_controls %>
             This transaction exceeded daily limits set by our card issuer. Please try again later, or use a different card for this transaction.
         <% elsif stripe_decline_reason == :webhook_timeout %>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -41,7 +41,7 @@
             <%= {
                   merchant_not_allowed: "Merchant not allowed",
                   cash_withdrawals_not_allowed: "Cash withdrawals disabled",
-                    user_cards_locked: "Card locked due to missing receipts",
+                  user_cards_locked: "Card locked due to missing receipts",
                 }[hcb_decline_reason] || "Insufficient funds" %>
         <% else %>
             <%= {

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -76,7 +76,7 @@
         <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>
             Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.
         <% elsif hcb_decline_reason == :user_cards_locked %>
-            You can manage your receipts on HCB on the <%= link_to "receipts page", my_inbox_url %>. If you have more than 10 missing receipts, your cards will be locked until you submit them.
+            You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>. If you have 10 or more missing receipts, your cards will be locked until you submit them.
         <% elsif stripe_decline_reason == :authorization_controls %>
             This transaction exceeded daily limits set by our card issuer. Please try again later, or use a different card for this transaction.
         <% elsif stripe_decline_reason == :webhook_timeout %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -109,6 +109,13 @@
         </p>
       </div>
     <% end %>
+    <% if current_user.cards_locked? %>
+      <div class="w-100 px4 bg-white transparency-banner">
+        <p class="h5 medium center mt1 mb1">
+          Your cards are currently locked because you have 10 or more missing receipts. <%= link_to "Manage your receipts", my_inbox_path %>
+        </p>
+      </div>
+    <% end %>
     <% if @event&.is_public && !organizer_signed_in? && !@no_app_shell && !@no_transparency_header && !@use_user_nav %>
       <div class="w-100 px3 bg-white transparency-banner" data-behavior="hide_iframe">
         <p class="h5 font-medium text-center text-balance mt1 mb1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -109,7 +109,7 @@
         </p>
       </div>
     <% end %>
-    <% if current_user.cards_locked? %>
+    <% if current_user&.cards_locked? %>
       <div class="w-100 px4 bg-white transparency-banner">
         <p class="h5 medium center mt1 mb1">
           Your cards are currently locked because you have 10 or more missing receipts. <%= link_to "Manage your receipts", my_inbox_path %>

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -10,11 +10,8 @@
 
 <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
   <%= render "callout", type: "info", title: "Card locking", badge: badge_for("Beta", class: "bg-muted"), footer: :questions do %>
-    <p class="h5 muted my-0">
-      Starting Tuesday, June 10th, 2025, HCB will beta test locking cards for users who have more than 10 missing receipts at any given time. Receipts before this beta period do not count towards the limit, though they still need to be submitted.
-    </p>
-    <p class="h5 muted mb-0">
-      Your cards are currently <%= current_user.cards_locked? ? "locked" : "active" %>.
+    <p>
+      Starting Tuesday, June 10th, 2025, HCB will beta test locking cards for users who have more than 10 missing receipts at any given time. Receipts before this beta period do not count towards the limit, though they still need to be submitted. <strong>Your cards are currently <%= current_user.cards_locked? ? "locked" : "active" %>.</strong>
     </p>
   <% end %>
 <% end %>

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -9,15 +9,14 @@
 </h1>
 
 <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
-  <section class="card mb-4 border border-info">
-    <h3 class="mt-0">Card locking <%= badge_for("Beta", class: "bg-muted") %></h3>
+  <%= render "callout", type: "info", title: "Card locking", badge: badge_for("Beta", class: "bg-muted"), footer: :questions do %>
     <p class="h5 muted my-0">
       Starting Tuesday, June 10th, 2025, HCB will beta test locking cards for users who have more than 10 missing receipts at any given time. Receipts before this beta period do not count towards the limit, though they still need to be submitted.
     </p>
     <p class="h5 muted mb-0">
       Your cards are currently <%= current_user.cards_locked? ? "locked" : "active" %>.
     </p>
-  </section>
+  <% end %>
 <% end %>
 
 <section class="grid grid--split grid--spacious">

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -3,8 +3,24 @@
 <%= render "users/nav", selected: :receipts %>
 
 <h1 class="heading">
-  My receipts
+  <span>
+    My receipts
+  </span>
+
+  <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
+    <%= badge_for("Card status: #{current_user.cards_locked? ? "locked" : "active"}", class: "!ml-auto") %>
+  <% end %>
+
 </h1>
+
+<% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
+  <section class="card mb-4 border border-info">
+    <h3 class="mt-0">Card locking <%= badge_for("Beta", class: "bg-muted") %></h3>
+    <p class="h5 muted my-0">
+      Starting Tuesday, June 10th, 2025, HCB will beta test locking cards for users who have more than 10 missing receipts at any given time. Receipts before this beta period do not count towards the limit, though they still need to be submitted.
+    </p>
+  </section>
+<% end %>
 
 <section class="grid grid--split grid--spacious">
   <div>
@@ -68,7 +84,12 @@
 
 <h2 class="flex items-center mb2">
   Transactions
-  <%= badge_for @count %>
+  <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
+    <%= badge_for("#{@count} missing receipts") %>
+    <%= badge_for("#{@locking_count} / 10") %>
+  <% else %>
+    <%= badge_for(@count) %>
+  <% end %>
 </h2>
 
 <% @cards.each do |card| %>

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -6,11 +6,6 @@
   <span>
     My receipts
   </span>
-
-  <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
-    <%= badge_for("Card status: #{current_user.cards_locked? ? "locked" : "active"}", class: "!ml-auto") %>
-  <% end %>
-
 </h1>
 
 <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
@@ -18,6 +13,9 @@
     <h3 class="mt-0">Card locking <%= badge_for("Beta", class: "bg-muted") %></h3>
     <p class="h5 muted my-0">
       Starting Tuesday, June 10th, 2025, HCB will beta test locking cards for users who have more than 10 missing receipts at any given time. Receipts before this beta period do not count towards the limit, though they still need to be submitted.
+    </p>
+    <p class="h5 muted mb-0">
+      Your cards are currently <%= current_user.cards_locked? ? "locked" : "active" %>.
     </p>
   </section>
 <% end %>

--- a/db/migrate/20250610000245_add_cards_locked_to_users.rb
+++ b/db/migrate/20250610000245_add_cards_locked_to_users.rb
@@ -1,0 +1,5 @@
+class AddCardsLockedToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :cards_locked, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_03_011828) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_10_000245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -2185,6 +2185,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_03_011828) do
     t.boolean "use_two_factor_authentication", default: false
     t.boolean "teenager"
     t.integer "creation_method"
+    t.boolean "cards_locked", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end


### PR DESCRIPTION
## Summary of the problem
Zach requested that we prevent users from spending their funds when they have 10 missing receipts

## Describe your changes
Adds the following, Flipper flagged for testing:
- Checks how many missing receipts a user has after every authorization
- If 10 or more, the user's cards are locked
- At certain intervals, we alert the user that they're nearing the 10 transaction limit