### PR TITLE
[Disbursements] Short-term fix for showing admin fee checkbox

### DIFF
--- a/app/views/disbursements/_form.html.erb
+++ b/app/views/disbursements/_form.html.erb
@@ -7,10 +7,10 @@
   <%= render partial: "select_organization", locals: { form: form, field_name: "event_id", disabled: disabled, events: @allowed_destination_events, default_event: nil, receiving: true, allow_custom_events: @source_event&.plan&.unrestricted_disbursements_enabled? } %>
 
   <% if admin_signed_in? %>
-    <div class="admin-tools field field--checkbox" x-show="fee > 0" x-cloak x-transition.duration.500ms>
+    <div class="admin-tools field field--checkbox">
       <%= form.check_box :should_charge_fee %>
       <%= form.label :should_charge_fee do %>
-        Charge <span x-text="Math.round(fee * 100) || '0'"></span>% fiscal sponsorship fee?
+        Charge fiscal sponsorship fee?
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
## Summary of the problem
The "Charge fiscal sponsorship fee" checkbox isn't showing because the Alpine `fee` value isn't being updated.


## Describe your changes
This PR forces the "Charge fiscal sponsorship fee" checkbox to show no matter what when an admin makes a disbursement