### PR TITLE
Set paper trials in v4 api base controller

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -13,6 +13,7 @@ module Api
 
       before_action :authenticate!
       before_action :set_expand
+      before_action :set_paper_trail_whodunnit
 
       rescue_from Pundit::NotAuthorizedError do |e|
         render json: { error: "not_authorized" }, status: :forbidden


### PR DESCRIPTION
## Summary of the problem
Right now in the API I've noticed when I freeze a grantee's card it shows as "Last frozen by no user"and that's due to not setting paper trials 


## Describe your changes
Added paper trials to the application controller


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

