### PR TITLE
Enable `annotate_rendered_view_with_filenames` in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
## Summary of the problem

Rails has a built-in mechanism to insert HTML comments around rendered template which makes it easier to figure out where parts of a page come from.

![CleanShot 2025-06-16 at 16 47 43@2x](https://github.com/user-attachments/assets/56fb98b1-7450-42cc-911b-534ab32da5f4)

https://guides.rubyonrails.org/configuring.html#config-action-view-annotate-rendered-view-with-filenames

## Describe your changes

Flips the configuration setting to `true` in `config/environments/development.rb` (so it is only enabled in development mode).