### PR TITLE
Disable the HCB card logo field for members

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -109,7 +109,8 @@ input[type='number'] {
   }
 
   &:has([disabled]) {
-    .field--fileupload__label, .field--fileupload__field {
+    .field--fileupload__label,
+    .field--fileupload__field {
       color: map-get($palette, slate);
       cursor: no-drop;
     }

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -107,6 +107,23 @@ input[type='number'] {
 
     color: $muted;
   }
+
+  &:has([disabled]) {
+    .field--fileupload__label, .field--fileupload__field {
+      color: map-get($palette, slate);
+      cursor: no-drop;
+    }
+
+    .field--fileupload__label {
+      transition: none;
+      color: $muted;
+      border-color: map-get($palette, smoke);
+
+      &:hover {
+        transform: none;
+      }
+    }
+  }
 }
 
 .field--image-upload {

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -154,7 +154,7 @@
       <% end %>
       <div class="field--fileupload mt2">
         <%= form.label :stripe_card_logo, "Choose file", class: "field--fileupload__label" %>
-        <%= form.file_field :stripe_card_logo, accept: "image/png,image/jpeg", class: "field--fileupload__field", direct_upload: true %>
+        <%= form.file_field :stripe_card_logo, accept: "image/png,image/jpeg", class: "field--fileupload__field", direct_upload: true, disabled: %>
       </div>
     </div>
     <%= form.submit "Update", disabled: %>


### PR DESCRIPTION
## Summary of the problem

Fixes https://github.com/hackclub/hcb/issues/10464.

When a member views the event settings page, the HCB card logo field appears enabled despite the action being permitted. 

Note that they still wouldn't be able to submit the form as that action would be blocked by the pundit policy: https://github.com/hackclub/hcb/blob/7481706275b9d1492fa60965775438e49ece4ec7/app/policies/event_policy.rb#L57-L59

## Describe your changes

1. I've set the `disabled` property on `form.file_field` (mirroring other fields on the page https://github.com/hackclub/hcb/blob/f333eb2c034cc38cd43720c324fa5c0620988eaf/app/views/events/settings/_details.html.erb#L46-L47
2. I've added CSS to style the `<label>` and `<input>` contained in a `.field--fileupload` when it contains an element with the `disabled` property.
    ![CleanShot 2025-06-17 at 10 37 57@2x](https://github.com/user-attachments/assets/c39fa0a5-f3e4-478a-8eab-e7ca02d084a4)