### PR TITLE
[Card Grants] Improve actions with meatball menu

### DIFF
--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -3,7 +3,8 @@
 <% if card_grant.active? %>
   <div class="mt3 flex flex-wrap align-items-center justify-start g1 justify-center">
     <% if !organizer_signed_in?(as: :member) || card_grant.user == current_user %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? && !organizer_signed_in?(as: :member)  %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
+      <%= render "card_grants/actions/edit", card_grant: card_grant.stripe_card if organizer_signed_in?(as: :member) %>
       <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: "Get reimbursed" if !organizer_signed_in?(as: :member) %>
       <%= render "card_grants/actions/return", card_grant: %>
     <% end %>

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -2,22 +2,9 @@
 
 <% if card_grant.active? %>
   <div class="mt3 flex flex-wrap align-items-center justify-start g1 justify-center">
-    <% if organizer_signed_in?(as: :member) %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
-      <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
-      <%= render "card_grants/actions/topup", card_grant: %>
-      <%= render "card_grants/actions/withdraw", card_grant: %>
-      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
-      <%= render "card_grants/actions/edit", card_grant: %>
-      <% if card_grant.user == current_user %>
-        <%= render "card_grants/actions/return", card_grant: %>
-      <% else %>
-        <%= render "card_grants/actions/cancel", card_grant: %>
-      <% end %>
-      <%= render "card_grants/actions/dejigamaflip", card_grant: %>
-    <% elsif card_grant.user == current_user %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
-      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: "Get reimbursed" %>
+    <% if !organizer_signed_in?(as: :member) || card_grant.user == current_user %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? && !organizer_signed_in?(as: :member)  %>
+      <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: "Get reimbursed" if !organizer_signed_in?(as: :member) %>
       <%= render "card_grants/actions/return", card_grant: %>
     <% end %>
   </div>

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -13,7 +13,7 @@
           data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
       <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
          <%= render "card_grants/actions/convert_to_reimbursement_report", as_menu: true, card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
-         
+
         <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
         <% if card_grant.active? %>
           <%= link_to "#",

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -12,7 +12,8 @@
           class: "align-middle", "aria-label": "More Options",
           data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
       <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
-        <%= render "stripe_cards/actions/freeze", as_menu: true, stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
+         <%= render "card_grants/actions/convert_to_reimbursement_report", as_menu: true, card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
+         
         <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
         <% if card_grant.active? %>
           <%= link_to "#",
@@ -28,14 +29,7 @@
             <%= inline_icon "minus", size: 24 %> Withdraw
           <% end %>
         <% end %>
-        <%= render "card_grants/actions/convert_to_reimbursement_report", as_menu: true, card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
-        <%= link_to edit_card_grant_path(card_grant),
-                    class: "menu__action",
-                    data: { behavior: "modal_trigger", modal: "edit_card_grant", action: "menu#close" },
-                    disabled: !policy(card_grant).edit? do %>
-          <%= inline_icon "edit", size: 24 %>
-          Set purpose
-        <% end %>
+
         <% if card_grant.user != current_user %>
           <%= render "card_grants/actions/cancel", card_grant: %>
         <% end %>
@@ -46,7 +40,6 @@
 
   <%= render "card_grants/actions/topup", card_grant: %>
   <%= render "card_grants/actions/withdraw", card_grant: %>
-  <%= render "card_grants/actions/edit", card_grant: %>
 
   <section class="card__banner card__darker details-horiz border-top border-bottom">
     <p>

--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -6,7 +6,48 @@
         [:edit, card_grant.disbursement.local_hcb_code],
         class: "mr2 align-middle", "aria-label": "Rename transaction" if organizer_signed_in?(as: :member) %>
     Grant to &nbsp; <%= user_mention card_grant.user %>
+    <div data-controller="menu" data-menu-placement-value="bottom-end" class="ml-auto">
+      <%= pop_icon_to "more",
+          "#",
+          class: "align-middle", "aria-label": "More Options",
+          data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
+      <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
+        <%= render "stripe_cards/actions/freeze", as_menu: true, stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
+        <%= render "card_grants/actions/toggle_one_time_use", card_grant: %>
+        <% if card_grant.active? %>
+          <%= link_to "#",
+                      data: { behavior: "modal_trigger", modal: "topup", action: "menu#close" },
+                      class: "menu__action",
+                      disabled: !policy(card_grant).topup? do %>
+            <%= inline_icon "plus", size: 24 %> Topup
+          <% end %>
+          <%= link_to "#",
+                      data: { behavior: "modal_trigger", modal: "withdrawl", action: "menu#close" },
+                      class: "menu__action",
+                      disabled: !policy(card_grant).withdraw? do %>
+            <%= inline_icon "minus", size: 24 %> Withdraw
+          <% end %>
+        <% end %>
+        <%= render "card_grants/actions/convert_to_reimbursement_report", as_menu: true, card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
+        <%= link_to edit_card_grant_path(card_grant),
+                    class: "menu__action",
+                    data: { behavior: "modal_trigger", modal: "edit_card_grant", action: "menu#close" },
+                    disabled: !policy(card_grant).edit? do %>
+          <%= inline_icon "edit", size: 24 %>
+          Set purpose
+        <% end %>
+        <% if card_grant.user != current_user %>
+          <%= render "card_grants/actions/cancel", card_grant: %>
+        <% end %>
+        <%= render "card_grants/actions/dejigamaflip", card_grant: %>
+      </div>
+    </div>
   </h2>
+
+  <%= render "card_grants/actions/topup", card_grant: %>
+  <%= render "card_grants/actions/withdraw", card_grant: %>
+  <%= render "card_grants/actions/edit", card_grant: %>
+
   <section class="card__banner card__darker details-horiz border-top border-bottom">
     <p>
       <strong>Sent by</strong>

--- a/app/views/card_grants/actions/_cancel.html.erb
+++ b/app/views/card_grants/actions/_cancel.html.erb
@@ -5,9 +5,9 @@
   <%= link_to cancel_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               data: { confirm: "Are you sure? This will irreversibly transfer the remaining balance on this grant BACK to your account." },
-              class: "btn bg-error",
+              class: "menu__action",
               disabled: !policy(card_grant).cancel? do %>
-    <%= inline_icon "reply", size: 20 %> Cancel grant
+    <%= inline_icon "reply", size: 24 %> Cancel grant
   <% end %>
 
 <% end %>

--- a/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
+++ b/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
@@ -1,13 +1,13 @@
-<%# locals: (card_grant:, label: "Create reimbursement report") %>
+<%# locals: (card_grant:, label: "Create reimbursement report", as_menu: nil) %>
 
 <% if card_grant.card_grant_setting.reimbursement_conversions_enabled? %>
 
   <%= link_to convert_to_reimbursement_report_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               data: { confirm: "Are you sure? This will cancel your card grant and convert it into a reimbursement report." },
-              class: "btn bg-purple",
+                class: as_menu ? "menu__action" : "btn bg-purple",
               disabled: !policy(card_grant).convert_to_reimbursement_report? do %>
-    <%= inline_icon "attachment", size: 20 %> <%= label %>
+    <%= inline_icon "attachment", size: 24 %> <%= label %>
   <% end %>
 
 <% end %>

--- a/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
+++ b/app/views/card_grants/actions/_convert_to_reimbursement_report.html.erb
@@ -5,7 +5,7 @@
   <%= link_to convert_to_reimbursement_report_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
               method: :post,
               data: { confirm: "Are you sure? This will cancel your card grant and convert it into a reimbursement report." },
-                class: as_menu ? "menu__action" : "btn bg-purple",
+              class: as_menu ? "menu__action" : "btn bg-purple",
               disabled: !policy(card_grant).convert_to_reimbursement_report? do %>
     <%= inline_icon "attachment", size: 24 %> <%= label %>
   <% end %>

--- a/app/views/card_grants/actions/_dejigamaflip.html.erb
+++ b/app/views/card_grants/actions/_dejigamaflip.html.erb
@@ -1,9 +1,9 @@
 <% if organizer_signed_in? && (rand < 0.02) %>
   <div class="tooltipped tooltipped--n" aria-label="Dejigamaflip <%= card_grant.user.first_name %>'s card grant">
     <%= link_to "javascript:alert(\"#{card_grant.user.first_name}'s card grant has been successfully Dejigamaflipped courtesy of Porkbun\")",
-                class: "btn",
+                class: "menu__action",
                 style: "background-color: #EF7878; background-image: radial-gradient(ellipse farthest-corner at top left, #fdb7b7, #fa6d6d);" do %>
-      <%= inline_icon "emoji" %>
+      <%= inline_icon "emoji", size: 24 %>
       Dejigamaflip
     <% end %>
   </div>

--- a/app/views/card_grants/actions/_edit.html.erb
+++ b/app/views/card_grants/actions/_edit.html.erb
@@ -1,15 +1,5 @@
 <%# locals: (card_grant:) %>
 
-<div class="tooltipped tooltipped--n" aria-label="Set this grant's purpose">
-  <%= link_to edit_card_grant_path(card_grant),
-              class: "btn bg-success",
-              data: { behavior: "modal_trigger", modal: "edit_card_grant" },
-              disabled: !policy(card_grant).edit? do %>
-    <%= inline_icon "edit" %>
-    Set purpose
-  <% end %>
-</div>
-
 <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="edit_card_grant">
   <%= modal_header "What's this grant for?" %>
   <%= render "card_grants/edit_form" %>

--- a/app/views/card_grants/actions/_edit.html.erb
+++ b/app/views/card_grants/actions/_edit.html.erb
@@ -1,5 +1,15 @@
 <%# locals: (card_grant:) %>
 
+<div class="tooltipped tooltipped--n" aria-label="Set this grant's purpose">
+  <%= link_to edit_card_grant_path(card_grant),
+              class: "btn bg-success",
+              data: { behavior: "modal_trigger", modal: "edit_card_grant" },
+              disabled: !policy(card_grant).edit? do %>
+    <%= inline_icon "edit" %>
+    Set purpose
+  <% end %>
+</div>
+
 <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="edit_card_grant">
   <%= modal_header "What's this grant for?" %>
   <%= render "card_grants/edit_form" %>

--- a/app/views/card_grants/actions/_toggle_one_time_use.html.erb
+++ b/app/views/card_grants/actions/_toggle_one_time_use.html.erb
@@ -2,7 +2,7 @@
 
 <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
             method: :post,
-            class: "btn bg-slate",
+            class: "menu__action",
             disabled: !policy(card_grant).toggle_one_time_use? do %>
-  <%= inline_icon "private", size: 20 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
+  <%= inline_icon "private", size: 24 %> <%= card_grant.one_time_use ? "Disable" : "Enable" %> one time use
 <% end %>

--- a/app/views/card_grants/actions/_topup.html.erb
+++ b/app/views/card_grants/actions/_topup.html.erb
@@ -1,13 +1,6 @@
 <%# locals: (card_grant:) %>
 
 <% if card_grant.active? %>
-  <%= link_to "#",
-              data: { behavior: "modal_trigger", modal: "topup" },
-              class: "btn",
-              disabled: !policy(card_grant).topup? do %>
-    <%= inline_icon "plus", size: 20 %> Topup grant
-  <% end %>
-
   <div class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="topup">
     <%= modal_header "Topup grant" %>
     <%= form_with(url: topup_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug), class: "w-full") do |form| %>

--- a/app/views/card_grants/actions/_withdraw.html.erb
+++ b/app/views/card_grants/actions/_withdraw.html.erb
@@ -1,14 +1,6 @@
 <%# locals: (card_grant:) %>
 
 <% if card_grant.active? %>
-
-  <%= link_to "#",
-              data: { behavior: "modal_trigger", modal: "withdrawl" },
-              class: "btn bg-warning",
-              disabled: !policy(card_grant).withdraw? do %>
-    <%= inline_icon "minus", size: 20 %> Withdraw from grant
-  <% end %>
-
   <div class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="withdrawl">
     <%= modal_header "Withdraw from grant" %>
     <%= form_with(url: withdraw_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug), class: "w-full") do |form| %>

--- a/app/views/stripe_cards/actions/_freeze.html.erb
+++ b/app/views/stripe_cards/actions/_freeze.html.erb
@@ -1,20 +1,20 @@
-<%# locals: (stripe_card:, as_menu: nil) %>
+<%# locals: (stripe_card:) %>
 
 <% if stripe_card.stripe_status == 'inactive' %>
-  <div <% if !as_menu %> class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>"<% end %>>
+  <div class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>">
     <%= link_to defrost_stripe_card_path(stripe_card),
                 method: :post,
-                class: as_menu ? "menu__action" : "btn bg-accent",
+                class: "btn bg-accent",
                 disabled: !policy(stripe_card).defrost? do %>
       <%= inline_icon "freeze", size: 24 %> Defrost card
     <% end %>
   </div>
 <% elsif stripe_card.stripe_status == 'active' %>
   <% freeze_tooltip = "You can instantly defrost #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>
-  <div <% if !as_menu %> class="tooltipped tooltipped--n" aria-label="<%= freeze_tooltip %>"<% end %>>
+  <div class="tooltipped tooltipped--n" aria-label="<%= freeze_tooltip %>">
     <%= link_to freeze_stripe_card_path(stripe_card),
                 method: :post,
-                class: as_menu ? "menu__action" : "btn bg-accent",
+                class: "btn bg-accent",
                 disabled: !policy(stripe_card).freeze? do %>
       <%= inline_icon "freeze", size: 24 %> Freeze card
     <% end %>

--- a/app/views/stripe_cards/actions/_freeze.html.erb
+++ b/app/views/stripe_cards/actions/_freeze.html.erb
@@ -1,22 +1,22 @@
-<%# locals: (stripe_card:) %>
+<%# locals: (stripe_card:, as_menu: nil) %>
 
 <% if stripe_card.stripe_status == 'inactive' %>
-  <div class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>">
+  <div <% if !as_menu %> class="tooltipped tooltipped--n" aria-label="<%= "You can instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>"<% end %>>
     <%= link_to defrost_stripe_card_path(stripe_card),
                 method: :post,
-                class: "btn bg-accent",
+                class: as_menu ? "menu__action" : "btn bg-accent",
                 disabled: !policy(stripe_card).defrost? do %>
-      <%= inline_icon "freeze" %> Defrost card
+      <%= inline_icon "freeze", size: 24 %> Defrost card
     <% end %>
   </div>
 <% elsif stripe_card.stripe_status == 'active' %>
   <% freeze_tooltip = "You can instantly defrost #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>
-  <div class="tooltipped tooltipped--n" aria-label="<%= freeze_tooltip %>">
+  <div <% if !as_menu %> class="tooltipped tooltipped--n" aria-label="<%= freeze_tooltip %>"<% end %>>
     <%= link_to freeze_stripe_card_path(stripe_card),
                 method: :post,
-                class: "btn bg-accent",
+                class: as_menu ? "menu__action" : "btn bg-accent",
                 disabled: !policy(stripe_card).freeze? do %>
-      <%= inline_icon "freeze" %> Freeze card
+      <%= inline_icon "freeze", size: 24 %> Freeze card
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
The goal of this PR is to reduce the visual clutter for card grant settings:

### Before
![image](https://github.com/user-attachments/assets/07888116-e9e0-4746-8261-900b1f927ee8)

### After
![image](https://github.com/user-attachments/assets/41b0fb3e-eb8e-4664-bb23-964f152c3eea)

