### PR TITLE
Mention required homebrew packages in setup docs

### DIFF
--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -121,6 +121,10 @@ HCB-specific setup instructions.
    ```bash
    bundle install
    ```
+    If you're on a Mac you may need to install a few Homebrew dependencies to get `bundle install` to succeed:
+   ```bash
+   brew install pkg-config cairo libpq
+   ```
 
 4. Install node packages
    ```bash


### PR DESCRIPTION
## Summary of the problem

On a fresh install, `bundle install` will fail because of missing native dependencies.

## Describe your changes

Adds an extra line to the setup instructions to mention them.