### PR TITLE
Validate `User#session_duration_seconds`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,6 +165,8 @@ class User < ApplicationRecord
 
   validates :preferred_name, length: { maximum: 30 }
 
+  validates(:session_duration_seconds, presence: true, inclusion: { in: SessionsHelper::SESSION_DURATION_OPTIONS.values })
+
   validate :profile_picture_format
 
   validate on: :update do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -230,4 +230,25 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#session_duration_seconds" do
+    it "must be present" do
+      user = described_class.new(email: "test@example.com", session_duration_seconds: nil)
+      user.validate
+      expect(user.errors[:session_duration_seconds]).to include("can't be blank")
+    end
+
+    it "must be one of the valid values" do
+      user = described_class.new(email: "test@example.com")
+
+      SessionsHelper::SESSION_DURATION_OPTIONS.each_value do |valid_value|
+        user.session_duration_seconds = valid_value
+        user.validate
+        expect(user.errors[:session_duration_seconds]).to be_empty
+      end
+
+      user.session_duration_seconds = 1.year.seconds.to_i
+      user.validate
+      expect(user.errors[:session_duration_seconds]).to include("is not included in the list")
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

We allow users to pick from a fixed list of session durations

Setting | Options
---- | ----
![CleanShot 2025-06-18 at 10 30 28@2x](https://github.com/user-attachments/assets/4eb4fa63-a986-48ed-8ac1-ff3cc1b54884) | ![CleanShot 2025-06-18 at 10 30 36@2x](https://github.com/user-attachments/assets/09e8d960-3fce-4009-8710-e92fbd7baf2f)

which come from https://github.com/hackclub/hcb/blob/8508ac95625ca08aef11b7919596ddb8f68c0665/app/helpers/sessions_helper.rb#L4-L11

However, we don't actually validate this setting which means you can technically set it to anything (something I have confirmed in production).

## Describe your changes

For the sake of documentation and consistency, I've added basic validations to the field to make sure it is always a value from the list.

I've also checked the production database with `select session_duration_seconds, count(*) from users group by session_duration_seconds` to make sure all the current values are valid.