### PR TITLE
Expire impersonated sessions after 1 hour

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,6 +10,10 @@ module SessionsHelper
     "30 days" => 30.days.to_i
   }.freeze
 
+  # For security reasons we severely restrict the duration of impersonated
+  # sessions
+  IMPERSONATED_SESSION_DURATION = SESSION_DURATION_OPTIONS.fetch("1 hour")
+
   def impersonate_user(user)
     sign_out
     sign_in(user:, impersonate: true)
@@ -24,7 +28,13 @@ module SessionsHelper
   # DEPRECATED - begin to start deprecating and ultimately replace with sign_in_and_set_cookie
   def sign_in(user:, fingerprint_info: {}, impersonate: false, webauthn_credential: nil)
     session_token = SecureRandom.urlsafe_base64
-    expiration_at = Time.now + user.session_duration_seconds
+    session_duration =
+      if impersonate
+        IMPERSONATED_SESSION_DURATION
+      else
+        user.session_duration_seconds
+      end
+    expiration_at = Time.now + session_duration
     cookies.encrypted[:session_token] = { value: session_token, expires: expiration_at }
     cookies.encrypted[:signed_user] = user.signed_id(expires_in: 2.months, purpose: :signin_avatar)
     user_session = user.user_sessions.build(

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsersController do
+  include SessionSupport
+
+  describe "#impersonate" do
+    it "allows admins to switch to an impersonated session" do
+      freeze_time do
+        # Manually set a long session expiration so we can make sure
+        # impersonated sessions are short
+        session_duration_seconds = 30.days.seconds.to_i
+
+        admin_user = create(:user, :make_admin, full_name: "Admin User", session_duration_seconds:)
+        impersonated_user = create(:user, full_name: "Impersonated User", session_duration_seconds:)
+
+        initial_session = sign_in(admin_user)
+
+        # This is a normal session which should last for the duration that the
+        # user configured
+        expect(initial_session.expiration_at).to eq(30.days.from_now)
+
+        post(:impersonate, params: { id: impersonated_user.id })
+        expect(response).to redirect_to(root_path)
+        expect(flash[:info]).to eq("You're now impersonating Impersonated User.")
+
+        new_session = current_session!
+        expect(new_session.id).not_to eq(initial_session.id) # make sure the session was replaced
+        expect(new_session.user_id).to eq(impersonated_user.id)
+        expect(new_session.impersonated_by_id).to eq(admin_user.id)
+        expect(new_session.expiration_at).to eq(1.hour.from_now) # make sure we capped the session length
+      end
+    end
+  end
+end

--- a/spec/factories/user_session_factory.rb
+++ b/spec/factories/user_session_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :user_session do
     association :user
-    expiration_at { Time.now + 7.days.to_i }
+    expiration_at { 7.days.from_now }
+    session_token { SecureRandom.urlsafe_base64 }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,7 @@ require "paper_trail/frameworks/rspec"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
-require_relative "support/factory_bot"
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # see https://github.com/public-activity/public_activity#testing
 # for context around testing PublicActivity

--- a/spec/support/session_support.rb
+++ b/spec/support/session_support.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SessionSupport
+  # Implements just enough of the logic in `SessionHelper#sign_in` to make it
+  # easier to make authenticated requests in controller tests.
+  #
+  # @param user [User]
+  # @return [UserSession]
+  def sign_in(user)
+    expiration_at = user.session_duration_seconds.seconds.from_now
+
+    user_session = create(:user_session, user:, expiration_at:)
+
+    cookies.encrypted[:session_token] = {
+      value: user_session.session_token,
+      expires: expiration_at,
+      httponly: true,
+      secure: true,
+    }
+
+    user_session
+  end
+
+  # Mimics the logic in `SessionHelper#current_session` so the active
+  # `UserSession` record can easily be retrieved in tests.
+  #
+  # @return [UserSession]
+  # @raise [ActiveRecord::RecordNotFound]
+  def current_session!
+    session_token = cookies.encrypted[:session_token]
+    UserSession.find_by!(session_token:)
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Admin users have the ability to impersonate other users for debugging and support purposes. However while thinking through the implications of implementing a sudo mode (see https://github.com/hackclub/hcb/pull/10653#discussion_r2155544529) we realized these impersonated sessions live for as long as the impersonated user's `session_duration_seconds`, which could be much longer than necessary.

## Describe your changes

- `spec/rails_helper.rb` now eagerly-loads all files in `spec/support` so we can put shared code in there
- Added `SessionSupport` module to make writing controller tests easier
- Updated the `:user_session` factory to populate the `session_token` field
- Updated the logic in `SessionHelper#sign_in` to cap impersonated sessions to one hour
- Added a test for the above