### PR TITLE
Commit missing `one_time_use` annotation

### DIFF
--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -10,6 +10,7 @@
 #  email           :string           not null
 #  keyword_lock    :string
 #  merchant_lock   :string
+#  one_time_use    :boolean
 #  purpose         :string
 #  status          :integer          default("active"), not null
 #  created_at      :datetime         not null


### PR DESCRIPTION
## Summary of the problem

https://github.com/hackclub/hcb/pull/10548 introduced a new `one_time_use` column on the `card_grants` table but the automatic annotation seems to be missing from the model file.

## Describe your changes

Commits the missing annotation