### PR TITLE
Fix Airbrake message in  `Login` validation

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -39,7 +39,7 @@ class Login < ApplicationRecord
   validate do
     if user_session.present? && !complete?
       # how did we create session when it's not complete?!
-      Airbrake.notify("An incomplete login #{id} has a session #{session.id} present.")
+      Airbrake.notify("An incomplete login #{id} has a session #{user_session.id} present.")
       errors.add(:base, "An incomplete login has a session present.")
     end
   end


### PR DESCRIPTION
## Summary of the problem

When we generate a message for Airbrake we reference `session` which does not exist.

## Describe your changes

Replaces `session` with `user_session`.