### PR TITLE
[Receipts] Send SMS on card locking and allow sorting receipts by time

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -121,26 +121,6 @@ class MyController < ApplicationController
     end
   end
 
-  def inbox_v2
-    @count = current_user.transactions_missing_receipt.count
-    @locking_count = current_user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
-
-    hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
-    @hcb_codes = Kaminari.paginate_array(HcbCode.where(id: hcb_code_ids_missing_receipt)
-                 .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT
-                 .index_by(&:id).slice(*hcb_code_ids_missing_receipt).values)
-                         .page(params[:page]).per(params[:per] || 15)
-
-    @mailbox_address = current_user.active_mailbox_address
-    @receipts = Receipt.in_receipt_bin.with_attached_file.where(user: current_user)
-    @pairings = current_user.receipt_bin.suggested_receipt_pairings
-
-    if flash[:popover]
-      @popover = flash[:popover]
-      flash.delete(:popover)
-    end
-  end
-
   def reimbursements
     @my_reports = current_user.reimbursement_reports
     @my_reports = @my_reports.search(params[:q]) if params[:q].present?

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -90,21 +90,50 @@ class MyController < ApplicationController
     @count = current_user.transactions_missing_receipt.count
     @locking_count = current_user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
 
+    @time_based_sorting = ActiveModel::Type::Boolean.new.cast(params[:sort_by_time])
+
+    hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
+    hcb_codes_missing_receipt = HcbCode.where(id: hcb_code_ids_missing_receipt)
+                 .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT
+                 .index_by(&:id).slice(*hcb_code_ids_missing_receipt).values
+
+    if @time_based_sorting
+      hcb_codes_missing_receipt = hcb_codes_missing_receipt.sort_by(&:created_at).reverse
+    end
+
+    @hcb_codes = Kaminari.paginate_array(hcb_codes_missing_receipt)
+                         .page(params[:page]).per(params[:per] || 15)
+
+    unless @time_based_sorting
+      @card_hcb_codes = @hcb_codes.group_by { |hcb| hcb.card.to_global_id.to_s }
+      @cards = GlobalID::Locator.locate_many(@card_hcb_codes.keys, includes: :event)
+                                # Order by cards with least transactions first
+                                .sort_by { |card| @card_hcb_codes[card.to_global_id.to_s].count }
+    end
+
+    @mailbox_address = current_user.active_mailbox_address
+    @receipts = Receipt.in_receipt_bin.with_attached_file.where(user: current_user)
+    @pairings = current_user.receipt_bin.suggested_receipt_pairings
+
+    if flash[:popover]
+      @popover = flash[:popover]
+      flash.delete(:popover)
+    end
+  end
+
+  def inbox_v2
+    @count = current_user.transactions_missing_receipt.count
+    @locking_count = current_user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
+
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
     @hcb_codes = Kaminari.paginate_array(HcbCode.where(id: hcb_code_ids_missing_receipt)
                  .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT
                  .index_by(&:id).slice(*hcb_code_ids_missing_receipt).values)
                          .page(params[:page]).per(params[:per] || 15)
 
-    @card_hcb_codes = @hcb_codes.group_by { |hcb| hcb.card.to_global_id.to_s }
-    @cards = GlobalID::Locator.locate_many(@card_hcb_codes.keys, includes: :event)
-                              # Order by cards with least transactions first
-                              .sort_by { |card| @card_hcb_codes[card.to_global_id.to_s].count }
-
     @mailbox_address = current_user.active_mailbox_address
     @receipts = Receipt.in_receipt_bin.with_attached_file.where(user: current_user)
     @pairings = current_user.receipt_bin.suggested_receipt_pairings
-
 
     if flash[:popover]
       @popover = flash[:popover]

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -94,8 +94,8 @@ class MyController < ApplicationController
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
     hcb_codes_missing_receipt = HcbCode.where(id: hcb_code_ids_missing_receipt)
-                 .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT
-                 .index_by(&:id).slice(*hcb_code_ids_missing_receipt).values
+                                       .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT
+                                       .index_by(&:id).slice(*hcb_code_ids_missing_receipt).values
 
     if @time_based_sorting
       hcb_codes_missing_receipt = hcb_codes_missing_receipt.sort_by(&:created_at).reverse

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -14,6 +14,10 @@ module UserService
       cards_should_lock = count >= 10
       if cards_should_lock && !@user.cards_locked?
         CardLockingMailer.cards_locked(email: @user.email, missing_receipts: count).deliver_later
+
+        message = "Urgent: Your HCB cards have been locked because you have #{count} transactions missing receipts. To unlock your cards, upload your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+
+        TwilioMessageService::Send.new(@user, message).run!
       end
 
       @user.update!(cards_locked: cards_should_lock)

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -86,35 +86,57 @@
   <% end %>
 </h2>
 
-<% @cards.each do |card| %>
+<% if @time_based_sorting %>
   <section class="mb3 card p0 receipt-card">
-    <h2 class="heading line-height-4 p1 pl2 mt0 ml0 flex justify-between items-center">
-      <%= link_to card.event.name, event_path(card.event), class: "no-underline" %>
-
-      <%= link_to card, class: "regular h3 mention flex items-center" do %>
-        <%= inline_icon "card", class: "mr1", size: 25 %>
-        <%= card.last_four %>
-      <% end %>
-    </h2>
-
     <div class="table-container">
-      <table>
+        <table>
         <tbody data-behavior="transactions">
-          <% @card_hcb_codes[card.to_global_id.to_s].each do |hcb_code| %>
+            <% @hcb_codes.each do |hcb_code| %>
             <% if hcb_code.canonical_transactions.any? %>
-              <% hcb_code.canonical_transactions.each do |ct| %>
+                <% hcb_code.canonical_transactions.each do |ct| %>
                 <%= render partial: "canonical_transactions/canonical_transaction", locals: { ct:, force_display_details: true, receipt_upload_button: true, show_event_name: true } %>
-              <% end %>
+                <% end %>
             <% else %>
-              <% hcb_code.canonical_pending_transactions.each do |pt| %>
+                <% hcb_code.canonical_pending_transactions.each do |pt| %>
                 <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", locals: { pt:, force_display_details: true, receipt_upload_button: true, show_event_name: true } %>
-              <% end %>
+                <% end %>
             <% end %>
-          <% end %>
+            <% end %>
         </tbody>
-      </table>
+        </table>
     </div>
   </section>
+<% else %>
+  <% @cards.each do |card| %>
+    <section class="mb3 card p0 receipt-card">
+      <h2 class="heading line-height-4 p1 pl2 mt0 ml0 flex justify-between items-center">
+        <%= link_to card.event.name, event_path(card.event), class: "no-underline" %>
+
+        <%= link_to card, class: "regular h3 mention flex items-center" do %>
+          <%= inline_icon "card", class: "mr1", size: 25 %>
+          <%= card.last_four %>
+        <% end %>
+      </h2>
+
+      <div class="table-container">
+        <table>
+          <tbody data-behavior="transactions">
+            <% @card_hcb_codes[card.to_global_id.to_s].each do |hcb_code| %>
+              <% if hcb_code.canonical_transactions.any? %>
+                <% hcb_code.canonical_transactions.each do |ct| %>
+                  <%= render partial: "canonical_transactions/canonical_transaction", locals: { ct:, force_display_details: true, receipt_upload_button: true, show_event_name: true } %>
+                <% end %>
+              <% else %>
+                <% hcb_code.canonical_pending_transactions.each do |pt| %>
+                  <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", locals: { pt:, force_display_details: true, receipt_upload_button: true, show_event_name: true } %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
 <% end %>
 
 <% if @count == 0 %>


### PR DESCRIPTION
## Summary of the problem
Users aren't notified when their cards are locked, and transactions aren't sorted by time.


## Describe your changes
Add a parameter for sorting by time and send SMS notifications when cards are locked.