### PR TITLE
[Org Documents] Sort by `created_at: desc`

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,10 +13,8 @@ class DocumentsController < ApplicationController
   end
 
   def index
-    @active_documents = @event.documents.includes(:user).active
-    @active_common_documents = Document.common.active
-    @archived_documents = @event.documents.includes(:user).archived
-    @archived_common_documents = Document.common.archived
+    @active_documents = @event.documents.active.includes(:user).order(created_at: :desc)
+    @archived_documents = @event.documents.archived.includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,8 +13,10 @@ class DocumentsController < ApplicationController
   end
 
   def index
-    @active_documents = @event.documents.active.includes(:user).order(created_at: :desc)
-    @archived_documents = @event.documents.archived.includes(:user).order(created_at: :desc)
+    @active_documents = @event.documents.includes(:user).active.order(created_at: :desc)
+    @active_common_documents = Document.common.active.order(created_at: :desc)
+    @archived_documents = @event.documents.includes(:user).archived.order(created_at: :desc)
+    @archived_common_documents = Document.common.archived.order(created_at: :desc)
   end
 
   def new

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -21,6 +21,7 @@
 
 <ul class="grid">
   <%= render partial: "document", collection: @active_documents %>
+  <%= render partial: "document", collection: @active_common_documents %>
 
   <% if @event.approved? && !@event.demo_mode? %>
     <%= link_to event_verification_letter_path(event_id: @event.slug, format: "pdf") do %>
@@ -47,7 +48,7 @@
   <% end %>
 </ul>
 
-<% if @archived_documents.any? %>
+<% if @archived_documents.any? || @archived_common_documents.any? %>
   <ul class="list-reset">
     <li class="mb3">
       <details>
@@ -57,6 +58,7 @@
         <article>
           <ul class="grid">
             <%= render partial: "document", collection: @archived_documents %>
+            <%= render partial: "document", collection: @archived_common_documents %>
           </ul>
         </article>
       </details>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -21,7 +21,6 @@
 
 <ul class="grid">
   <%= render partial: "document", collection: @active_documents %>
-  <%= render partial: "document", collection: @active_common_documents %>
 
   <% if @event.approved? && !@event.demo_mode? %>
     <%= link_to event_verification_letter_path(event_id: @event.slug, format: "pdf") do %>
@@ -48,7 +47,7 @@
   <% end %>
 </ul>
 
-<% if @archived_documents.any? || @archived_common_documents.any? %>
+<% if @archived_documents.any? %>
   <ul class="list-reset">
     <li class="mb3">
       <details>
@@ -58,7 +57,6 @@
         <article>
           <ul class="grid">
             <%= render partial: "document", collection: @archived_documents %>
-            <%= render partial: "document", collection: @archived_common_documents %>
           </ul>
         </article>
       </details>


### PR DESCRIPTION
Closes #10684

This PR orders org documents by their creation date, descending