### PR TITLE
Update donation input field styles for improved consistency

### DIFF
--- a/app/views/events/settings/_donations.html.erb
+++ b/app/views/events/settings/_donations.html.erb
@@ -95,7 +95,7 @@
           </span>
 
           <div class="flex items-center gap-2">
-            <div class="bg-gray-50 dark:bg-[#17171d] flex items-center border rounded-lg muted flex-1 dark:!border-[#17171d]">
+            <div class="bg-snow dark:bg-dark flex items-center border rounded-lg muted flex-1 dark:!border-dark">
               <span class="px-3">$</span>
               <%= form.number_field :amount_cents, placeholder: "1000",
                                                    class: "w-100 fit !border-none !bg-transparent !text-black dark:!text-white !pl-0",

--- a/app/views/events/settings/_donations.html.erb
+++ b/app/views/events/settings/_donations.html.erb
@@ -95,7 +95,7 @@
           </span>
 
           <div class="flex items-center gap-2">
-            <div class="bg-gray-100 dark:bg-neutral-700 flex items-center border rounded-lg muted flex-1">
+            <div class="bg-gray-50 dark:bg-[#17171d] flex items-center border rounded-lg muted flex-1 dark:!border-[#17171d]">
               <span class="px-3">$</span>
               <%= form.number_field :amount_cents, placeholder: "1000",
                                                    class: "w-100 fit !border-none !bg-transparent !text-black dark:!text-white !pl-0",


### PR DESCRIPTION
The goal of this PR is to adjust the donation goal input UI to match the aesthetic of regular input components.

(notice the color difference between the inputs below) 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0b297904-5103-4105-ac34-a4573a9cc903) | ![image](https://github.com/user-attachments/assets/96a3d67d-5802-4049-8516-82b28231e1ee) |
| ![image](https://github.com/user-attachments/assets/6744bf01-f2da-4a4e-8d2a-cc316c8cc05c) | ![image](https://github.com/user-attachments/assets/469b0bbe-5de3-4d6e-9e79-1c2ab7fb2ef0) |
