### PR TITLE
Unpin IRB version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -225,6 +225,4 @@ gem "whitesimilarity"
 
 gem "rack-timeout", require: "rack/timeout/base"
 
-# IRB is pinned to 1.14.3 because Console1984 is incompatible with >=1.15.0.
-# https://github.com/basecamp/console1984/issues/127
-gem "irb", "~> 1.14.3"
+gem "irb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -921,7 +921,7 @@ DEPENDENCIES
   htmlbeautifier
   image_processing (~> 1.2)
   invisible_captcha
-  irb (~> 1.14.3)
+  irb
   jbuilder (~> 2.13)
   jquery-rails
   jsbundling-rails (~> 1.3)


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The IRB version was pinned to 1.14.3 since console1984 did not work with the latest version. This has been fixed in the latest version of console1984.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Unpinned IRB in the Gemfile. Tested in development with console1984 enabled to make sure it works.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

