### PR TITLE
Fix the mega button

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -396,7 +396,7 @@ module ApplicationHelper
           (inline_icon options[:button_icon]) +
           (content_tag :span, template.call(options[:options][0][1]), data: { "dropdown-button-target": "text", "template": template })
         end) +
-        (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none w-12 ml-[2px] #{button_class}", data: { action: "click->dropdown-button#toggle" } do
+        (content_tag :button, type: "button", class: "btn !transform-none rounded-r-xl rounded-l-none !w-12 ml-[2px] #{button_class}", data: { action: "click->dropdown-button#toggle" } do
           inline_icon "down-caret", class: "!mr-0"
         end)
       end) +


### PR DESCRIPTION
## Summary of the problem
The reimbursement add expense dropdown button was rendering as a "mega button" on mobile.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Enforced the width of the right button with an `!important`
![image](https://github.com/user-attachments/assets/ece139af-2626-4107-a18d-607edf2e3796)



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

