### PR TITLE
[Receipt Bin] Fix `per` param

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -92,7 +92,7 @@ class MyController < ApplicationController
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
 
-    @time_based_sorting = hcb_code_ids_missing_receipt.count > (params[:per] || 15)
+    @time_based_sorting = hcb_code_ids_missing_receipt.count > (params[:per] || 15).to_i
 
     hcb_codes_missing_receipt = HcbCode.where(id: hcb_code_ids_missing_receipt)
                                        .includes(:canonical_transactions, canonical_pending_transactions: :raw_pending_stripe_transaction) # HcbCode#card uses CT and PT


### PR DESCRIPTION

## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

We use the `per` param to determine the layout of the page (whether transactions are rendered in groups, or a single list). Unfortunately, it 500s at the moment because we're comparing an integer to a string (`params[:per` is a string).

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

This fixes it by casting `per` to an int.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

