### PR TITLE
Include goal progress in donation summary email

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -12,6 +12,9 @@ class EventMailer < ApplicationMailer
 
     @total = @donations.sum(:amount)
 
+    @goal = @event.donation_goal
+    @percentage = (@goal.progress_amount_cents.to_f / @goal.amount_cents) if @goal.present?
+
     mail to: @emails, subject: "#{@event.name} received #{@donations.length} #{"donation".pluralize(@donations.length)} this past month"
   end
 

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -18,7 +18,7 @@
 
 <p>
   In total, you raised <strong><%= render_money @total %></strong> last month - great job!
-  <% if @goal.present? && @percentage < 1  %>
+  <% if @goal.present? && @percentage < 1 %>
     You're now <%= number_with_precision(@percentage * 100, precision: 1) %>% of the way to your goal of <strong><%= render_money @goal.amount_cents %></strong>.
   <% end %>
 </p>

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -17,10 +17,24 @@
 </ul>
 
 <p>
-  In total, you raised <strong><%= render_money @total %></strong> last month - great job!
   <% if @goal.present? && @percentage < 1 %>
-    You're now <%= number_with_precision(@percentage * 100, precision: 1) %>% of the way to your goal of <strong><%= render_money @goal.amount_cents %></strong>.
+    In total, you raised <strong><%= render_money @total %></strong> last month -
+      <% if @percentage <= 0.25 %>
+        you're making great progress!
+      <% elsif @percentage <= 0.5 %>
+        that's awesome!
+      <% elsif @percentage <= 0.6 %>
+        you're more than halfway there!
+      <% elsif @percentage <= 0.9 %>
+        you're getting close!
+      <% else %>
+        your goal is right around the corner!
+      <% end %>
+      You're now <%= number_with_precision(@percentage * 100, precision: 1) %>% of the way to your goal of <strong><%= render_money @goal.amount_cents %></strong>.
+  <% else %>
+    In total, you raised <strong><%= render_money @total %></strong> last month - great job!
   <% end %>
+  Take a look at your <%= link_to "donations page", event_donation_overview_url(@event) %> to share your organization with more donors.
 </p>
 
 <p>

--- a/app/views/event_mailer/monthly_donation_summary.html.erb
+++ b/app/views/event_mailer/monthly_donation_summary.html.erb
@@ -16,7 +16,12 @@
   <% end %>
 </ul>
 
-<p>In total, you raised <strong><%= render_money @total %></strong> last month - great job!</p>
+<p>
+  In total, you raised <strong><%= render_money @total %></strong> last month - great job!
+  <% if @goal.present? && @percentage < 1  %>
+    You're now <%= number_with_precision(@percentage * 100, precision: 1) %>% of the way to your goal of <strong><%= render_money @goal.amount_cents %></strong>.
+  <% end %>
+</p>
 
 <p>
   From,<br>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
We're already sending a summary each month about donations, but it doesn't include goal progress.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a line including donation goal progress to the donation summary email.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/a6c41bca-3adf-4ce0-bfe2-8c7c0c9a29cd)

