### PR TITLE
Require a label before creating on the tag settings page

### DIFF
--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(url: event_tags_path(@event)) do |form| %>
       <div class="field">
         <%= form.label :label, "Tag name", class: "mb-1" %>
-        <%= form.text_field :label, placeholder: ["🧃 Food & drinks", "🧋 Bubble tea", "🚕 Transportation", "🛬 Flights", "🔨 Supplies"].sample, disabled: %>
+        <%= form.text_field :label, placeholder: ["🧃 Food & drinks", "🧋 Bubble tea", "🚕 Transportation", "🛬 Flights", "🔨 Supplies"].sample, disabled:, required: true %>
       </div>
 
       <div class="field">


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
There was a missing `required` on the tag settings page that let you submit without a tag label.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added `required: true`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

