### PR TITLE
Switch to `7-2-stable` branch of Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby File.read(File.join(File.dirname(__FILE__), ".ruby-version")).strip
 
 gem "dotenv-rails", groups: [:development, :test]
 
-gem "rails", "~> 7.2"
+gem "rails", git: "https://github.com/rails/rails.git", branch: "7-2-stable"
 
 gem "puma", "~> 6.6" # app server
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,26 @@ GIT
   specs:
     yellow_pages (0.4.0)
 
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 21ef9d1554eb1fa8f3ecf997fdf165add8df0917
+  branch: 7-2-stable
+  specs:
+    rails (7.2.2.1)
+      actioncable (= 7.2.2.1)
+      actionmailbox (= 7.2.2.1)
+      actionmailer (= 7.2.2.1)
+      actionpack (= 7.2.2.1)
+      actiontext (= 7.2.2.1)
+      actionview (= 7.2.2.1)
+      activejob (= 7.2.2.1)
+      activemodel (= 7.2.2.1)
+      activerecord (= 7.2.2.1)
+      activestorage (= 7.2.2.1)
+      activesupport (= 7.2.2.1)
+      bundler (>= 1.15.0)
+      railties (= 7.2.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -610,20 +630,6 @@ GEM
     rackup (1.0.1)
       rack (< 3)
       webrick
-    rails (7.2.2.1)
-      actioncable (= 7.2.2.1)
-      actionmailbox (= 7.2.2.1)
-      actionmailer (= 7.2.2.1)
-      actionpack (= 7.2.2.1)
-      actiontext (= 7.2.2.1)
-      actionview (= 7.2.2.1)
-      activejob (= 7.2.2.1)
-      activemodel (= 7.2.2.1)
-      activerecord (= 7.2.2.1)
-      activestorage (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
-      bundler (>= 1.15.0)
-      railties (= 7.2.2.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -955,7 +961,7 @@ DEPENDENCIES
   rack-cors
   rack-mini-profiler (~> 3.3)
   rack-timeout
-  rails (~> 7.2)
+  rails!
   react-rails
   recursive-open-struct
   redcarpet


### PR DESCRIPTION
## Summary of the problem

We are running into a Rails issue in production (https://github.com/rails/rails/issues/51780, https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1136/samples/6596247683eb67648f30f807-897217264893116276917507606401) for which there are as-yet-unreleased mitigations in `7-2-stable` branch (https://github.com/rails/rails/commit/7fef4ae61ea80786b6f02f2f96b85d3eb72b510c).

We could wait for a `7.2.3` release but given that `7.2.2.1` dates back to December it could be awhile (and the 7.2.x series is nearing the end of its maintenance window: https://rubyonrails.org/maintenance).

## Describe your changes

Switches the `rails` dependency from Rubygems to Git on the `7-2-stable` branch (https://github.com/rails/rails/compare/v7.2.2.1...7-2-stable).