### PR TITLE
Add email for when a donation goal is reached

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -15,6 +15,13 @@ class EventMailer < ApplicationMailer
     mail to: @emails, subject: "#{@event.name} received #{@donations.length} #{"donation".pluralize(@donations.length)} this past month"
   end
 
+  def donation_goal_hit
+    @goal = @event.donation_goal
+    @donations = @event.donations.succeeded.where(created_at: @goal.tracking_since..)
+
+    mail to: @emails, subject: "#{@event.name} has hit its donation goal!"
+  end
+
   private
 
   def set_emails

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -15,11 +15,11 @@ class EventMailer < ApplicationMailer
     mail to: @emails, subject: "#{@event.name} received #{@donations.length} #{"donation".pluralize(@donations.length)} this past month"
   end
 
-  def donation_goal_hit
+  def donation_goal_reached
     @goal = @event.donation_goal
     @donations = @event.donations.succeeded.where(created_at: @goal.tracking_since..)
 
-    mail to: @emails, subject: "#{@event.name} has hit its donation goal!"
+    mail to: @emails, subject: "#{@event.name} has reached its donation goal!"
   end
 
   private

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -366,7 +366,7 @@ class Donation < ApplicationRecord
     end
 
     if event.donation_goal.present? && (event.donation_goal.progress_amount_cents >= event.donation_goal.amount_cents)
-      EventMailer.with(event:).donation_goal_hit.deliver_later
+      EventMailer.with(event:).donation_goal_reached.deliver_later
     end
   end
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -364,6 +364,10 @@ class Donation < ApplicationRecord
     else
       DonationMailer.with(donation: self).notification.deliver_later
     end
+
+    if event.donation_goal.present? && (event.donation_goal.progress_amount_cents >= event.donation_goal.amount_cents)
+      EventMailer.with(event:).donation_goal_hit.deliver_later
+    end
   end
 
   def first_donation?

--- a/app/views/event_mailer/donation_goal_hit.html.erb
+++ b/app/views/event_mailer/donation_goal_hit.html.erb
@@ -1,0 +1,18 @@
+<p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
+
+<p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been hit after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now  %>!</p>
+<p>Here are all the donations that helped to contribute to this goal:</p>
+<ul>
+<% @donations.map do |donation| %>
+  <li>
+    <%= donation.name(show_anonymous: true) %> <%= "anonymously" if donation.anonymous %> donated <%= render_money donation.amount %>
+  </li>
+<% end %>
+</ul>
+
+<p>If you wish, you can adjust your donation goal on the <%= link_to "organization settings page", edit_event_url(@event) %>.</p>
+
+<p>
+  From,<br>
+  The HCB Team
+</p>

--- a/app/views/event_mailer/donation_goal_reached.html.erb
+++ b/app/views/event_mailer/donation_goal_reached.html.erb
@@ -1,6 +1,6 @@
 <p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
 
-<p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been hit after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now  %>!</p>
+<p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been reached after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now  %>!</p>
 <p>Here are all the donations that helped to contribute to this goal:</p>
 <ul>
 <% @donations.map do |donation| %>

--- a/app/views/event_mailer/donation_goal_reached.html.erb
+++ b/app/views/event_mailer/donation_goal_reached.html.erb
@@ -3,7 +3,7 @@
 <p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been reached after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now %>!</p>
 <p>Here are all the donations that helped to contribute to this goal:</p>
 <ul>
-<% @donations.map do |donation| %>
+<% @donations.each do |donation| %>
   <li>
     <%= donation.name(show_anonymous: true) %> <%= "anonymously" if donation.anonymous %> donated <%= render_money donation.amount %>
   </li>

--- a/app/views/event_mailer/donation_goal_reached.html.erb
+++ b/app/views/event_mailer/donation_goal_reached.html.erb
@@ -1,6 +1,6 @@
 <p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
 
-<p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been reached after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now  %>!</p>
+<p>Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been reached after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now %>!</p>
 <p>Here are all the donations that helped to contribute to this goal:</p>
 <ul>
 <% @donations.map do |donation| %>

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -5,4 +5,8 @@ class EventMailerPreview < ActionMailer::Preview
     EventMailer.with(event: Donation.last.event).monthly_donation_summary
   end
 
+  def donation_goal_hit
+    EventMailer.with(event: Donation::Goal.last.event).donation_goal_hit
+  end
+
 end

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -5,8 +5,8 @@ class EventMailerPreview < ActionMailer::Preview
     EventMailer.with(event: Donation.last.event).monthly_donation_summary
   end
 
-  def donation_goal_hit
-    EventMailer.with(event: Donation::Goal.last.event).donation_goal_hit
+  def donation_goal_reached
+    EventMailer.with(event: Donation::Goal.last.event).donation_goal_reached
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Organizers do not currently get any notification when their donation goal has been reached.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added an email that is sent to all organizers when the goal has been reached, along with a summary of the donations that contributed to it and a link to adjust the goal.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

