### PR TITLE
Revert "Only send SMS notifs on IRL charges #3279"

### DIFF
--- a/app/jobs/canonical_pending_transaction/send_twilio_receipt_message_job.rb
+++ b/app/jobs/canonical_pending_transaction/send_twilio_receipt_message_job.rb
@@ -5,15 +5,10 @@ class CanonicalPendingTransaction
     queue_as :critical
     include HcbCodeHelper # for attach_receipt_url
 
-    # This is a heuristic to avoid sending SMS for online charges. This isn't
-    # always correct.
-    IN_PERSON_AUTH_METHODS = %w[keyed_in swipe chip contactless].freeze
-
     def perform(cpt_id:, user_id:)
       @cpt = CanonicalPendingTransaction.find(cpt_id)
       @user = User.find(user_id)
 
-      return unless IN_PERSON_AUTH_METHODS.include? auth_method
 
       return unless @user.phone_number.present? && @user.phone_number_verified?
 
@@ -28,12 +23,6 @@ class CanonicalPendingTransaction
 
     discard_on(Twilio::REST::RestError) do |job, error|
       Airbrake.notify(error) unless User.find(job.arguments.first[:user_id]).phone_number.starts_with?("+44") # we can't send text messages to the UK
-    end
-
-    private
-
-    def auth_method
-      @cpt&.raw_pending_stripe_transaction&.authorization_method
     end
 
   end


### PR DESCRIPTION
By Zach's request, we will now start sending SMS notifications for all transactions, even those done online.