### PR TITLE
Fix capitalization of "ACH transfer" in payout method label

### DIFF
--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -7,7 +7,7 @@
       <%= form.radio_button :payout_method_type, "User::PayoutMethod::AchTransfer" %>
       <%= form.label :payout_method_type, value: "User::PayoutMethod::AchTransfer" do %>
         <%= inline_icon "payment-transfer", size: 28 %>
-        <strong>ACH Transfer</strong>
+        <strong>ACH transfer</strong>
         <small>(1-3 biz. days)</small>
       <% end %>
       <%= form.radio_button :payout_method_type, "User::PayoutMethod::Check" %>


### PR DESCRIPTION
Closes #10741 by fixing capitalization