### PR TITLE
Switch config syntax for rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rails
+plugins:
+  - rubocop-rails
 inherit_from: .rubocop_todo.yml
 
 AllCops:


### PR DESCRIPTION
## Summary of the problem

We are currently getting this deprecation warning

![CleanShot 2025-06-27 at 16 26 11@2x](https://github.com/user-attachments/assets/e92044fb-0cb1-4bb9-91f3-bf96fb7edb9a)

https://docs.rubocop.org/rubocop/plugin_migration_guide.html

## Describe your changes

Switches `rubocop-rails` to the new `plugins:` field.