### PR TITLE
Small tweaks to card grant views

### DIFF
--- a/app/views/card_grants/_details.html.erb
+++ b/app/views/card_grants/_details.html.erb
@@ -36,21 +36,8 @@
       <strong>Grant status</strong>
       <span><%= card_grant.state_text %></span>
     </p>
-    <% if (stripe_card = card_grant.stripe_card).present? %>
-      <p>
-        <strong>Card status</strong>
-        <span>
-          <%= stripe_card.state_text %>
-
-          <% if stripe_card.frozen? %>
-            <%# The condition above is written this way because `frozen?` is a method on `nil` %>
-            by <%= user_mention card_grant.stripe_card.last_frozen_by %>
-          <% end %>
-        </span>
-      </p>
-    <% end %>
     <p>
-      <strong>One time use?</strong>
+      <strong>One time use</strong>
       <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
     </p>
     <p>
@@ -58,16 +45,12 @@
       <span><%= render_money card_grant.amount %></span>
     </p>
     <p>
-      <strong>Balance remaining</strong>
-      <span><%= render_money card_grant.balance %></span>
-    </p>
-    <p>
       <strong>Expires on</strong>
       <span><%= format_date card_grant.expires_on %></span>
     </p>
     <p>
-      <strong>Sent to</strong>
-      <span><%= user_mention card_grant.user %></span>
+      <strong>Email</strong>
+      <span><%= mail_to card_grant.email %></span>
     </p>
 
     <p>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -9,8 +9,8 @@
     <% else %>
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
-  <%# Organizers and admins' view %>
-  <% elsif @card_grant.user.admin? || organizer_signed_in? %>
+  <%# Grantee has accepted invite %>
+  <% elsif @card_grant.user.admin? || organizer_signed_in? || @card_grant.user == current_user %>
     <% if @card_grant.stripe_card %>
       <div>
         <%= render @card_grant.stripe_card %>
@@ -29,18 +29,6 @@
       <% end %>
       <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } unless @card_grant.stripe_card %>
     </div>
-  <%# Grantee view after accepting invite %>
-  <% elsif @card_grant.user == current_user %>
-    <div>
-      <%= render partial: "canceled_warning", locals: { card_grant: @card_grant } %>
-      <% if @card_grant.purpose.present? %>
-        <h2><%= @card_grant.purpose %></h2>
-      <% end %>
-      <%= render @card_grant.stripe_card, headless: true, show_card_number: true %>
-      <%= render partial: "balance", locals: { card_grant: @card_grant } %>
-      <%= render partial: "actions", locals: { card_grant: @card_grant } %>
-    </div>
-    <%= render partial: "spending_instructions", locals: { card_grant: @card_grant } %>
   <% end %>
 </div>
 


### PR DESCRIPTION
Merging together the separate clauses makes the code easier to read and also adds back the details partial for grantees which caused crucial information to be missing.