### PR TITLE
Remove tags feature preview

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -133,7 +133,7 @@ class EventsController < ApplicationController
     @users = BreakdownEngine::Users.new(@event).run
     @tags = BreakdownEngine::Tags.new(@event).run
 
-    @empty_tags = @tags.empty? || !Flipper.enabled?(:transaction_tags_2022_07_29, @event)
+    @empty_tags = @tags.empty?
     @empty_users = @users.empty?
 
     render partial: "events/home/tags_users", locals: { users: @users, tags: @tags, event: @event }
@@ -1042,7 +1042,7 @@ class EventsController < ApplicationController
     # to `q`. This following line retains backwards compatibility.
     params[:q] ||= params[:search]
 
-    if params[:tag] && Flipper.enabled?(:transaction_tags_2022_07_29, @event)
+    if params[:tag]
       @tag = Tag.find_by(event_id: @event.id, label: params[:tag])
     end
 

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -8,7 +8,6 @@ class FeaturesController < ApplicationController
     transactions_background_2024_06_05: %w[🌈 🔴 🟢],
     rename_on_homepage_2023_12_06: %w[🖊️ ⚡ ⌨️],
     command_bar_2024_02_05: %w[🔍 🔎 ✨ 💸],
-    transaction_tags_2022_07_29: %w[🏷️],
     user_permissions_2024_03_09: %w[📛 🧑‍💼 🪪 🎉],
     recently_on_hcb_2024_05_23: %w[👀 🤑 🙈],
     spending_controls_2024_06_03: %w[✅ ❌ 💷],

--- a/app/mailboxes/hcb_code_mailbox.rb
+++ b/app/mailboxes/hcb_code_mailbox.rb
@@ -65,7 +65,7 @@ class HcbCodeMailbox < ApplicationMailbox
       @hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: command["argument"]) }
       @renamed_to = command["argument"]
     when "@tag"
-      return unless command["argument"] && Flipper.enabled?(:transaction_tags_2022_07_29, @hcb_code.event)
+      return unless command["argument"]
 
       event = @hcb_code.event
       tag = event.tags.search_label(command["argument"]).first

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -337,11 +337,7 @@ class StripeCard < ApplicationRecord
 
   def hcb_codes
     all_hcb_codes = canonical_transaction_hcb_codes + canonical_pending_transaction_hcb_codes
-    if Flipper.enabled?(:transaction_tags_2022_07_29, self.event)
-      @hcb_codes ||= ::HcbCode.where(hcb_code: all_hcb_codes).includes(:tags)
-    else
-      @hcb_codes ||= ::HcbCode.where(hcb_code: all_hcb_codes)
-    end
+    @hcb_codes ||= ::HcbCode.where(hcb_code: all_hcb_codes).includes(:tags)
   end
 
   def remote_shipping_status

--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -33,7 +33,7 @@ module PendingTransactionEngine
         @canonical_pending_transactions ||=
           begin
             included_local_hcb_code_associations = [:receipts, :comments, :canonical_transactions, { canonical_pending_transactions: [:canonical_pending_declined_mapping] }]
-            included_local_hcb_code_associations << :tags if Flipper.enabled?(:transaction_tags_2022_07_29, event)
+            included_local_hcb_code_associations << :tags
             cpts = CanonicalPendingTransaction.includes(:raw_pending_stripe_transaction,
                                                         local_hcb_code: included_local_hcb_code_associations)
                                               .unsettled

--- a/app/services/transaction_grouping_engine/transaction/association_preloader.rb
+++ b/app/services/transaction_grouping_engine/transaction/association_preloader.rb
@@ -22,7 +22,7 @@ module TransactionGroupingEngine
           { canonical_pending_transactions: [:event, :canonical_pending_declined_mapping, :raw_pending_stripe_transaction] },
           { reimbursement_expense_payout: { expense: [:report] } }
         ]
-        included_models << :tags if Flipper.enabled?(:transaction_tags_2022_07_29, @event)
+        included_models << :tags
         hcb_code_objects = HcbCode
                            .includes(included_models)
                            .where(hcb_code: hcb_code_codes)

--- a/app/services/transaction_grouping_engine/transaction/running_balance_association_preloader.rb
+++ b/app/services/transaction_grouping_engine/transaction/running_balance_association_preloader.rb
@@ -17,7 +17,7 @@ module TransactionGroupingEngine
         included_models = [:receipts, :comments,
                            { canonical_transactions: :canonical_event_mapping },
                            { canonical_pending_transactions: [:event, :canonical_pending_declined_mapping] }]
-        included_models << :tags if Flipper.enabled?(:transaction_tags_2022_07_29, @event)
+        included_models << :tags
         hcb_code_objects = HcbCode
                            .includes(included_models)
                            .where(hcb_code: hcb_code_codes)

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -12,13 +12,9 @@ json.memo hcb_code.memo(event: @event)
 json.has_custom_memo hcb_code.custom_memo.present?
 json.pending (tx.is_a?(CanonicalPendingTransaction) && tx.unsettled?) || (tx.is_a?(HcbCode) && !tx.pt&.fronted? && tx.pt&.unsettled?)
 json.declined (tx.is_a?(CanonicalPendingTransaction) && tx.declined?) || (tx.is_a?(HcbCode) && tx.pt&.declined?)
-if Flipper.enabled?(:transaction_tags_2022_07_29, @event)
-  json.tags hcb_code.tags do |tag|
-    json.id tag.public_id
-    json.label tag.label
-  end
-else
-  json.tags []
+json.tags hcb_code.tags do |tag|
+  json.id tag.public_id
+  json.label tag.label
 end
 json.code hcb_code.hcb_i1
 json.missing_receipt hcb_code.missing_receipt?

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -69,14 +69,14 @@
           <% end %>
         </div>
 
-        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
+        <% if !@event&.demo_mode? %>
           <div class="flex flex-wrap pending_transactions_tags tags hcb_code_<%= pt.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: pt.local_hcb_code } %>
           </div>
         <% end %>
       </div>
 
-      <% if !defined?(receipt_upload_button) && !defined?(hide_tags) && organizer_signed_in? && !pt.instance_of?(OpenStruct) && Flipper.enabled?(:transaction_tags_2022_07_29, @event || pt.local_hcb_code.event) %>
+      <% if !defined?(receipt_upload_button) && !defined?(hide_tags) && organizer_signed_in? && !pt.instance_of?(OpenStruct) %>
         <% if suggestion = pt.local_hcb_code.suggested_hcb_code_tag_suggestions.last %>
           <div class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless b--ai suggested_tag tooltipped tooltippped--s" style="border: 1.5px dashed #a633d6" id="tag_suggestion_<%= suggestion.id %>" aria-label="Click to apply HCB's suggestion">
             <%= link_to "#{suggestion.tag.emoji} #{suggestion.tag.label}", tag_suggestion_accept_path(suggestion), style: "text-decoration: none", class: "ai", data: { turbo_method: :POST } %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -67,14 +67,14 @@
           <% end %>
         </div>
 
-        <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
+        <% if !@event&.demo_mode? %>
           <div class="flex flex-wrap pending_transactions_tags tags hcb_code_<%= ct.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: ct.local_hcb_code } %>
           </div>
         <% end %>
       </div>
 
-      <% if !defined?(receipt_upload_button) && !defined?(hide_tags) && organizer_signed_in? && !ct.instance_of?(OpenStruct) && Flipper.enabled?(:transaction_tags_2022_07_29, @event || ct.local_hcb_code.event) %>
+      <% if !defined?(receipt_upload_button) && !defined?(hide_tags) && organizer_signed_in? && !ct.instance_of?(OpenStruct) %>
         <% if suggestion = ct.local_hcb_code.suggested_hcb_code_tag_suggestions.last %>
           <div class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless b--ai suggested_tag tooltipped tooltippped--s" style="border: 1.5px dashed #a633d6" id="tag_suggestion_<%= suggestion.id %>" aria-label="Click to apply HCB's suggestion">
             <%= link_to "#{suggestion.tag.emoji} #{suggestion.tag.label}", tag_suggestion_accept_path(suggestion), style: "text-decoration: none", class: "ai", data: { turbo_method: :POST } %>

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -29,7 +29,7 @@
     </div>
   <% end %>
 
-  <% if organizer_signed_in? && Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0 %>
+  <% if organizer_signed_in? && @event.tags.size > 0 %>
     <div
       data-controller="menu"
       data-menu-append-to-value="turbo-frame#ledger"

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -7,8 +7,8 @@
     <%= inline_icon "filter", size: 28 %>
   </button>
   <div class="menu__content menu__content--2 menu__content--compact h5" style="width: 320px; padding: 0.5rem;" data-menu-target="content" data-controller="filter">
-    <div data-controller="tabs" data-tabs-default-tab-value="<%= @tag ? "tags" : @user ? "user" : @type ? "type" : @start_date || @end_date ? "date" : @maximum_amount || @minimum_amount ? "amount" : Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0 ? "tags" : "user" %>">
-      <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0 %>
+    <div data-controller="tabs" data-tabs-default-tab-value="<%= @tag ? "tags" : @user ? "user" : @type ? "type" : @start_date || @end_date ? "date" : @maximum_amount || @minimum_amount ? "amount" : @event.tags.size > 0 ? "tags" : "user" %>">
+      <% if @event.tags.size > 0 %>
         <button id="tags" data-tabs-target="btn" data-action="click->tabs#select">Tag</button>
       <% end %>
       <button id="user" data-tabs-target="btn" data-action="click->tabs#select">User</button>
@@ -18,7 +18,7 @@
       <button id="receipts" data-tabs-target="btn" data-action="click->tabs#select">Receipts</button>
       <div class="menu__divider--filter-tab"></div>
 
-      <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0 %>
+      <% if @event.tags.size > 0 %>
         <div data-tabs-target="tab" id="tags">
           <% @event.tags.order(label: :asc).each do |tag| %>
             <div class="flex items-center" data-tag="<%= tag.id %>">

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:nav) do %>
   <%= render "events/title" %>
-  <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) && !@event&.demo_mode? %>
+  <% if !@event&.demo_mode? %>
     <%= render partial: "hcb_codes/create_tag", locals: { button: false } %>
   <% end %>
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -27,10 +27,8 @@
         <% end %>
       <% end %>
     <% end %>
-    <% if Flipper.enabled?(:transaction_tags_2022_07_29, @event) %>
-      <%= settings_tab active: @settings_tab == "tags" do %>
-        <%= link_to "Tags", edit_event_path(@event, tab: "tags"), data: { turbo: true, turbo_action: "advance" } %>
-      <% end %>
+    <%= settings_tab active: @settings_tab == "tags" do %>
+      <%= link_to "Tags", edit_event_path(@event, tab: "tags"), data: { turbo: true, turbo_action: "advance" } %>
     <% end %>
     <%= settings_tab active: @settings_tab == "features" do %>
       <%= link_to "Feature previews", edit_event_path(@event, tab: "features"), data: { turbo: true, turbo_action: "advance" } %>

--- a/app/views/events/home/_tags_users.html.erb
+++ b/app/views/events/home/_tags_users.html.erb
@@ -5,15 +5,11 @@
         <div class="flex flex-1 flex-col items-center justify-center">
           <div class="text-center">
             <h3 class="text-2xl font-bold mb-0">
-              <%= Flipper.enabled?(:transaction_tags_2022_07_29, event) ? "It's quiet here..." : "Tags aren't enabled for this event" %>
+              It's quiet here...
             </h3>
             <p class="text-gray-500 my-1 max-w-sm">
-              <%= Flipper.enabled?(:transaction_tags_2022_07_29, event) ? "Either you don't have any tags, or you haven't categorized any transactions yet." : "With tags, you can neatly categorize your transactions." %>
+              Either you don't have any tags, or you haven't categorized any transactions yet.
             </p>
-
-            <% unless Flipper.enabled?(:transaction_tags_2022_07_29, event) %>
-              <%= link_to "Take me to the settings!", edit_event_path(event, tab: "features"), data: { turbo_frame: :_top }, class: "btn btn-primary mt-4" %>
-            <% end %>
           </div>
         </div>
       <% else %>

--- a/app/views/events/ledger.html.erb
+++ b/app/views/events/ledger.html.erb
@@ -20,9 +20,9 @@
           <tbody data-behavior="transactions">
           <%= render "pending_fee_transaction" if @event.fronted_fee_balance_v2_cents > 0 %>
 
-          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0, show_author_column: true } %>
+          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true } %>
 
-          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions, as: :ct, locals: { event: @event, show_amount: true, selectable: Flipper.enabled?(:transaction_tags_2022_07_29, @event) && @event.tags.size > 0, show_author_column: true } %>
+          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions, as: :ct, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true } %>
           </tbody>
         </table>
       </div>

--- a/app/views/events/settings/_features.html.erb
+++ b/app/views/events/settings/_features.html.erb
@@ -16,15 +16,6 @@
       event: @event
     } %>
 
-<%= render partial: "features/preview", locals: {
-      id: "transaction-tags",
-      classes: ["feature-transaction-tags"],
-      feature_flag: :transaction_tags_2022_07_29,
-      name: "Transaction Tags",
-      description: "Categorize and filter transactions using tags!",
-      event: @event
-    } %>
-
 <% active_spending_control_count = @event.organizer_positions.map(&:active_spending_control).compact.count %>
 <%= render partial: "features/preview", locals: {
       id: "spending-controls",
@@ -38,3 +29,17 @@
       disable_warning: active_spending_control_count > 0 ? "⚠️ #{active_spending_control_count} users have spending controls in place ⚠️\n\nAre you sure you want to disable this feature?" : nil
 
     } %>
+
+<details>
+  <summary class="mb2">Past feature previews</summary>
+
+  <%= render partial: "features/preview", locals: {
+        id: "transaction-tags",
+        classes: ["feature-transaction-tags"],
+        fully_shipped: true,
+        feature_flag: :transaction_tags_2022_07_29,
+        name: "Transaction Tags",
+        description: "Categorize and filter transactions using tags!",
+        event: @event
+      } %>
+</details>

--- a/app/views/hcb_codes/_bank_fee.html.erb
+++ b/app/views/hcb_codes/_bank_fee.html.erb
@@ -1,7 +1,7 @@
 <article class="card pb0 mt3 mb1">
   <%= render "heading", hcb_code: @hcb_code, render_memo: true %>
 
-  <section class="card__banner card__darker details-horiz border-top <%= "border-bottom" if Flipper.enabled?(:transaction_tags_2022_07_29, @event || @hcb_code.event) %>">
+  <section class="card__banner card__darker details-horiz border-top border-bottom">
     <p>
       <strong>Date</strong>
       <%= format_date @hcb_code.date %>

--- a/app/views/hcb_codes/_fee_revenue.html.erb
+++ b/app/views/hcb_codes/_fee_revenue.html.erb
@@ -1,7 +1,7 @@
 <article class="card pb0 mt3 mb1">
   <%= render "heading", hcb_code: @hcb_code, render_memo: true %>
 
-  <section class="card__banner card__darker details-horiz border-top <%= "border-bottom" if Flipper.enabled?(:transaction_tags_2022_07_29, @event || @hcb_code.event) %>">
+  <section class="card__banner card__darker details-horiz border-top border-bottom">
     <p>
       <strong>Date</strong>
       <%= format_date @hcb_code.date %>

--- a/app/views/hcb_codes/_tags.html.erb
+++ b/app/views/hcb_codes/_tags.html.erb
@@ -1,32 +1,30 @@
-<% if Flipper.enabled?(:transaction_tags_2022_07_29, event) %>
-  <div>
-    <strong>Tags</strong>
-    <div class="flex items-center flex-wrap" style="gap: 0.25rem">
-      <div class="flex items-center flex-wrap hcb_code_<%= hcb_code.hashid %>_tags" style="gap: 0.25rem">
-        <%= render partial: "canonical_transactions/tag", collection: hcb_code.tags, locals: { hcb_code: } %>
-      </div>
+<div>
+  <strong>Tags</strong>
+  <div class="flex items-center flex-wrap" style="gap: 0.25rem">
+    <div class="flex items-center flex-wrap hcb_code_<%= hcb_code.hashid %>_tags" style="gap: 0.25rem">
+      <%= render partial: "canonical_transactions/tag", collection: hcb_code.tags, locals: { hcb_code: } %>
+    </div>
 
-      <div data-controller="menu">
-        <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless h-full" style="height: 1.6rem" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
-        <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
-          <% @event.tags.each do |tag| %>
-            <div class="flex items-center" data-tag="<%= tag.id %>">
-              <%= button_to toggle_tag_hcb_code_path(id: hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
-                <%= render partial: "canonical_transactions/tag_icon", locals: { tag: } %>
-                <%= tag.label %>
-                <%= "✓" if hcb_code.tags.include?(tag) %>
-              <% end %>
-              <%= button_to event_tag_path(@event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message }  do %>
-                <%= inline_icon "delete", size: 16, style: "margin: 0" %>
-              <% end %>
-            </div>
-          <% end %>
-          <% if @event.tags.any? %>
-            <div class="menu__divider tags__divider"></div>
-          <% end %>
-          <%= render partial: "hcb_codes/create_tag", locals: { button: hcb_code.hashid } %>
-        </div>
+    <div data-controller="menu">
+      <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless h-full" style="height: 1.6rem" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
+      <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
+        <% @event.tags.each do |tag| %>
+          <div class="flex items-center" data-tag="<%= tag.id %>">
+            <%= button_to toggle_tag_hcb_code_path(id: hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
+              <%= render partial: "canonical_transactions/tag_icon", locals: { tag: } %>
+              <%= tag.label %>
+              <%= "✓" if hcb_code.tags.include?(tag) %>
+            <% end %>
+            <%= button_to event_tag_path(@event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message }  do %>
+              <%= inline_icon "delete", size: 16, style: "margin: 0" %>
+            <% end %>
+          </div>
+        <% end %>
+        <% if @event.tags.any? %>
+          <div class="menu__divider tags__divider"></div>
+        <% end %>
+        <%= render partial: "hcb_codes/create_tag", locals: { button: hcb_code.hashid } %>
       </div>
     </div>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Tags are now generally available! The flipper checks are no longer needed


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removes all flipper checks for tags, and moves the feature preview to a new "Past feature previews" section in event settings, like user settings


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

