### PR TITLE
Hide last4 of card number in transparent mode

### DIFF
--- a/app/views/stripe_cards/_stripe_card.html.erb
+++ b/app/views/stripe_cards/_stripe_card.html.erb
@@ -29,11 +29,13 @@
     <% end %>
     <p class="stripe-card__number fs-mask">
       <% if stripe_card.user != current_user %>
-        <%= stripe_card.hidden_card_number_with_last_four %>
-      <% elsif local_assigns[:show_card_number] %>
+        <% if OrganizerPosition.role_at_least?(current_user, @event, :reader) %>
+          <%= stripe_card.hidden_card_number_with_last_four %>
+        <% else %>
+          <%= stripe_card.hidden_card_number %>
+        <% end %>
+      <% elsif local_assigns[:show_card_number] || @show_card_details %>
         <%= stripe_card.formatted_card_number %>
-      <% elsif @show_card_details %>
-          <%= stripe_card.formatted_card_number %>
       <% else %>
         <%= stripe_card.hidden_card_number_with_last_four %>
       <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Showing the last 4 digits of credit cards in transparency mode could be dangerous!


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removes showing the last 4 digits of a card number when a member of the event is not logged in - readers and up can still see last 4, but only the cardholder can see the full number.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

