### PR TITLE
Fix blog unread indicator

### DIFF
--- a/app/javascript/controllers/blog_controller.js
+++ b/app/javascript/controllers/blog_controller.js
@@ -9,13 +9,13 @@ export default class extends Controller {
 
   async updateBadge() {
     try {
-      const url = window.location.hostname === 'localhost' ? 'http://localhost:3001' : 'https://blog.hcb.hackclub.com'
-      const { count } = await fetch(
-        `${url}/api/unreads`,
-        {
-          credentials: 'include',
-        }
-      ).then(res => res.json())
+      const url =
+        window.location.hostname === 'localhost'
+          ? 'http://localhost:3001'
+          : 'https://blog.hcb.hackclub.com'
+      const { count } = await fetch(`${url}/api/unreads`, {
+        credentials: 'include',
+      }).then(res => res.json())
 
       if (count < 1) return
 

--- a/app/javascript/controllers/blog_controller.js
+++ b/app/javascript/controllers/blog_controller.js
@@ -9,8 +9,9 @@ export default class extends Controller {
 
   async updateBadge() {
     try {
+      const url = window.location.hostname === 'localhost' ? 'http://localhost:3001' : 'https://blog.hcb.hackclub.com'
       const { count } = await fetch(
-        'https://blog.hcb.hackclub.com/api/unreads',
+        `${url}/api/unreads`,
         {
           credentials: 'include',
         }

--- a/app/views/application/_blog_widget.html.erb
+++ b/app/views/application/_blog_widget.html.erb
@@ -9,7 +9,7 @@
     data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">
     <%= inline_icon "rep", size: home_action_size %>
     <% if Flipper.enabled?(:changelog_widget_2025_04_24, current_user) %>
-      <span class="badge bg-red hidden absolute top-[-2px] right-[-2px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
+      <span class="badge !bg-red !text-white hidden absolute top-[-1px] right-[-4px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
     <% end %>
   </a>
   <div
@@ -17,7 +17,7 @@
     data-menu-target="content">
     <p class="font-bold text-lg my-0 pb-3 w-full text-center">✨ What's new?</p>
 
-    <iframe src="<%= "#{Rails.env.development? ? "http://localhost:3001" : "https://blog.hcb.hackclub.com"}/embed?theme=light" %>" class="border-0 w-full min-h-96" style="zoom: 0.9;" data-blog-target="embed"></iframe>
+    <iframe loading="lazy" src="<%= "#{Rails.env.development? ? "http://localhost:3001" : "https://blog.hcb.hackclub.com"}/embed?theme=light" %>" class="border-0 w-full min-h-96" style="zoom: 0.9;" data-blog-target="embed"></iframe>
 
     <div class="px-5 pt-2 w-full">
       <a href="https://blog.hcb.hackclub.com" target="_blank" class="flex justify-center items-center"><%= inline_icon :external, size: 26 %> See all posts</a>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
You can't fetch unreads from production in development due to CORS, and it's useful to have any development changes as well. The iframe was also loading every time the page loaded, even when the user did not open the widget, causing the indicator to reset

Closes #10777


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Expects blog to be on `localhost:3001` and fetches unreads from that host when in development. Enforced color and added lazy loading to iframe


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/2d8642cd-7537-4ef9-8b1c-2f22be33c7ab)

