### PR TITLE
Revert "Add missing raffle annotation and schema index (#10782)"

### DIFF
--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -13,7 +13,6 @@
 # Indexes
 #
 #  index_raffles_on_program_and_user_id  (program,user_id) UNIQUE
-#  index_raffles_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1496,7 +1496,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_30_174849) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["program", "user_id"], name: "index_raffles_on_program_and_user_id", unique: true
-    t.index ["user_id"], name: "index_raffles_on_user_id"
   end
 
   create_table "raw_column_transactions", force: :cascade do |t|


### PR DESCRIPTION
This reverts commit a9a891ed82b932c0937fd4a76e33da4af5b42623.

## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
This index was intentionally removed previously and shouldn't be added back.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

