### PR TITLE
Improve confirmation logic for removing donation goals

### DIFF
--- a/app/views/events/settings/_donations.html.erb
+++ b/app/views/events/settings/_donations.html.erb
@@ -66,7 +66,7 @@
               data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
               disabled:,
               checked: @event.donation_goal.present?,
-              onchange: @event.donation_goal && "if (!this.checked && confirm('Remove donation goal?')) this.closest('form').requestSubmit();",
+              onchange: @event.donation_goal && "!this.checked && (!confirm('Remove donation goal?') ? (this.checked = true) : this.closest('form').requestSubmit())",
               switch: true %>
             <span class="slider"></span>
           <% end %>


### PR DESCRIPTION

https://github.com/user-attachments/assets/00f5c7ca-bf27-47cc-a709-4e1fb44e9905

Currently, when a user tries to toggle off donation goals, a confirmation modal appears. However, if the user cancels the modal, the donation goals accordion still collapses, which can be confusing.

This PR fixes that by ensuring the accordion only collapses if the user confirms the action.

