### PR TITLE
Fix events query in `WeeklyYswsEventSummaryJob`

### DIFF
--- a/app/jobs/weekly_ysws_event_summary_job.rb
+++ b/app/jobs/weekly_ysws_event_summary_job.rb
@@ -3,7 +3,7 @@
 class WeeklyYswsEventSummaryJob < ApplicationJob
   queue_as :default
   def perform
-    events = Event.ysws.where("created_at > ?", 7.days.ago)
+    events = Event.ysws.where("events.created_at > ?", 7.days.ago)
     return if events.none?
 
     AdminMailer.with(events:).weekly_ysws_event_summary.deliver_now


### PR DESCRIPTION
## Summary of the problem

The `created_at` condition was ambiguous because `.ysws` adds two `JOIN` clauses.

https://hackclub.slack.com/archives/C04LDFJ5X7S/p1751640227940719

## Describe your changes

Makes the `.where` more specific.