### PR TITLE
Create card grant settings when the plan is set to affiliate

### DIFF
--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -91,7 +91,7 @@ class Event
         errors.add(:type, "is invalid")
       end
     end
-    
+
     after_create :create_card_grant_setting_if_affiliate
 
     def create_card_grant_setting_if_affiliate

--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -91,6 +91,14 @@ class Event
         errors.add(:type, "is invalid")
       end
     end
+    
+    after_create :create_card_grant_setting_if_affiliate
+
+    def create_card_grant_setting_if_affiliate
+      if type == "Event::Plan::HackClubAffiliate" && event.card_grant_setting.nil?
+        event.create_card_grant_setting!
+      end
+    end
 
   end
 


### PR DESCRIPTION
## Summary of the problem
Currently, when you create an affiliated org you don't see the card grants page until you create a grant which builds the settings. 


## Describe your changes
I added a condition in the modal to build settings when that event's plan is set to affiliate. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

