### PR TITLE
[Changelog Widget] Update alignment

### DIFF
--- a/app/views/application/_blog_widget.html.erb
+++ b/app/views/application/_blog_widget.html.erb
@@ -9,7 +9,7 @@
     data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">
     <%= inline_icon "rep", size: home_action_size %>
     <% if Flipper.enabled?(:changelog_widget_2025_04_24, current_user) %>
-      <span class="badge !bg-red !text-white hidden absolute top-[-1px] right-[-4px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
+      <span class="badge !bg-red !text-white hidden absolute top-[-15px] right-[-4px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
     <% end %>
   </a>
   <div


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Blog badge notification symbol was positioned on the bottom right.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Notification symbol for the blog badge is now on the top right rather than the bottom right.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/a31081b3-b08b-47f4-a19c-09ab883645d3)
