### PR TITLE
[Card Grants] Fix pre-authorization bug where pre-auths are incorrectly marked as fraud

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -165,7 +165,7 @@ class CardGrant
 
       update(**params)
 
-      if params[:extracted_valid_purchase] == "true"
+      if params[:extracted_valid_purchase]
         mark_approved!
       else
         mark_fraudulent!


### PR DESCRIPTION
## Summary of the problem
The parameter was being compared to the string "true", but it was actually a boolean.


## Describe your changes
This PR fixes that by checking the value directly and not comparing it to "true".