### PR TITLE
Move card grant cancelling into an AASM callback and fix bug

### DIFF
--- a/app/controllers/card_grant/pre_authorizations_controller.rb
+++ b/app/controllers/card_grant/pre_authorizations_controller.rb
@@ -20,8 +20,7 @@ class CardGrant
     def organizer_reject
       authorize @pre_authorization
 
-      @pre_authorization.mark_rejected!
-      @pre_authorization.card_grant.cancel!(hcb_user: current_user)
+      @pre_authorization.mark_rejected!(current_user)
 
       flash[:success] = "Pre-authorization rejected, card grant canceled"
       redirect_to card_grant_pre_authorizations_path(@card_grant)

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -69,6 +69,9 @@ class CardGrant
 
       event :mark_rejected do
         transitions from: :fraudulent, to: :rejected
+        after do |rejected_by|
+          card_grant.cancel!(rejected_by)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary of the problem
Right now, card grants aren't getting cancelled when a pre-authorization is declined. 

## Describe your changes
This fixes that by removing an error from the cancellation code and moving the line of code that cancels it into an AASM callback.