### PR TITLE
[Admin] Add tags when creating organizations

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -86,8 +86,7 @@ class AdminController < ApplicationController
       approved: params[:approved].to_i == 1,
       is_public: params[:is_public].to_i == 1,
       plan: params[:plan],
-      organized_by_hack_clubbers: params[:organized_by_hack_clubbers].to_i == 1,
-      organized_by_teenagers: params[:organized_by_teenagers].to_i == 1,
+      tags: params[:tags],
       risk_level: params[:risk_level],
       demo_mode: params[:demo_mode].to_i == 1
     ).run

--- a/app/models/event_tag.rb
+++ b/app/models/event_tag.rb
@@ -38,16 +38,18 @@ class EventTag < ApplicationRecord
   end
 
   module Tags
-    ORGANIZED_BY_HACK_CLUBBERS = "Organized by Hack Clubbers"
-    ORGANIZED_BY_TEENAGERS = "Organized by Teenagers"
-    CLIMATE = "Climate"
-    PARTNER_128_COLLECTIVE_FUNDED = "128 Collective Funded"
-    PARTNER_128_COLLECTIVE_RECOMMENDED = "128 Collective Recommended"
-    VERMONT_BASED = "Vermont-based"
-    ROBOTICS_TEAM = "Robotics Team"
-    HACKATHON = "Hackathon"
-    HACK_CLUB = "Hack Club"
-    YSWS = "YSWS"
+    ALL = [
+      ORGANIZED_BY_HACK_CLUBBERS = "Organized by Hack Clubbers",
+      ORGANIZED_BY_TEENAGERS = "Organized by Teenagers",
+      CLIMATE = "Climate",
+      PARTNER_128_COLLECTIVE_FUNDED = "128 Collective Funded",
+      PARTNER_128_COLLECTIVE_RECOMMENDED = "128 Collective Recommended",
+      VERMONT_BASED = "Vermont-based",
+      ROBOTICS_TEAM = "Robotics Team",
+      HACKATHON = "Hackathon",
+      HACK_CLUB = "Hack Club",
+      YSWS = "YSWS"
+    ].to_set
   end
 
 end

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -24,10 +24,11 @@ module EventService
 
       ActiveRecord::Base.transaction do
         event = ::Event.create!(attrs)
-        # ensure blank tags are not parsed
-        @tags.reject(&:blank?).each do |tag|
-          event.event_tags << ::EventTag.find_or_create_by!(name: tag)
-        end
+        @tags
+          .filter { |tag| EventTag::Tags::ALL.include?(tag) }
+          .each do |tag|
+            event.event_tags << ::EventTag.find_or_create_by!(name: tag)
+          end
 
 
         # Event aasm_state is already approved by default.

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -2,7 +2,7 @@
 
 module EventService
   class Create
-    def initialize(name:, point_of_contact_id:, emails: [], is_signee: true, country: [], is_public: true, is_indexable: true, approved: false, plan: Event::Plan::Standard, organized_by_hack_clubbers: false, organized_by_teenagers: false, can_front_balance: true, demo_mode: false, risk_level: 0)
+    def initialize(name:, point_of_contact_id:, emails: [], is_signee: true, country: [], is_public: true, is_indexable: true, approved: false, plan: Event::Plan::Standard, tags: [], can_front_balance: true, demo_mode: false, risk_level: 0)
       @name = name
       @emails = emails
       @is_signee = is_signee
@@ -12,8 +12,7 @@ module EventService
       @is_indexable = is_indexable
       @approved = approved || false
       @plan = plan
-      @organized_by_hack_clubbers = organized_by_hack_clubbers
-      @organized_by_teenagers = organized_by_teenagers
+      @tags = tags
       @can_front_balance = can_front_balance
       @demo_mode = demo_mode
       @risk_level = risk_level
@@ -25,8 +24,11 @@ module EventService
 
       ActiveRecord::Base.transaction do
         event = ::Event.create!(attrs)
-        event.event_tags << ::EventTag.find_or_create_by!(name: EventTag::Tags::ORGANIZED_BY_HACK_CLUBBERS) if @organized_by_hack_clubbers
-        event.event_tags << ::EventTag.find_or_create_by!(name: EventTag::Tags::ORGANIZED_BY_TEENAGERS) if @organized_by_teenagers
+        # ensure blank tags are not parsed
+        @tags.reject(&:blank?).each do |tag|
+          event.event_tags << ::EventTag.find_or_create_by!(name: tag)
+        end
+
 
         # Event aasm_state is already approved by default.
         # event.mark_approved! if @approved

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -37,7 +37,7 @@
     <div class="field mb2">
       <%= form.label :tags, "Organization Tags" %>
       <br>
-      <%= form.select(:tags, EventTag::Tags.constants.map { |tag| [tag.to_s.titleize, EventTag::Tags.const_get(tag)] }, selected: params[:tags], multiple: true) %>
+      <%= form.select(:tags, EventTag::Tags::ALL.map { |tag| [tag.to_s.titleize, tag] }, selected: params[:tags], multiple: true) %>
     </div>
 
     <div class="field">

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -37,7 +37,7 @@
     <div class="field mb2">
       <%= form.label :tags, "Organization Tags" %>
       <br>
-      <%= form.select(:tags, EventTag::Tags.constants.map { |tag| [tag.to_s.titleize, EventTag::Tags.const_get(tag)] }, selected: params[:tags],  multiple: true) %>
+      <%= form.select(:tags, EventTag::Tags.constants.map { |tag| [tag.to_s.titleize, EventTag::Tags.const_get(tag)] }, selected: params[:tags], multiple: true) %>
     </div>
 
     <div class="field">

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -34,6 +34,12 @@
       <%= form.select(:plan, Event::Plan.available_plans.map { |p| [p.new.label, p.name] }, selected: params[:plan]) %>
     </div>
 
+    <div class="field mb2">
+      <%= form.label :tags, "Organization Tags" %>
+      <br>
+      <%= form.select(:tags, EventTag::Tags.constants.map { |tag| [tag.to_s.titleize, EventTag::Tags.const_get(tag)] }, selected: params[:tags],  multiple: true) %>
+    </div>
+
     <div class="field">
       <%= form.label :point_of_contact_id, "Point of contact" %>
       <%= form.collection_select :point_of_contact_id, User.admin.all, :id, :email, selected: @current_user.id %>
@@ -52,17 +58,6 @@
     <p>
       <%= form.check_box :demo_mode %>
       <%= form.label :demo_mode, "Playground Mode?" %>
-    </p>
-
-    <p>
-      <%= form.check_box :organized_by_hack_clubbers, { checked: false } %>
-      <%= form.label :organized_by_hack_clubbers, "Organized by Hack Clubbers?" %>
-    </p>
-
-    <p>
-      <%= form.check_box :organized_by_teenagers, { checked: false } %>
-      <%= form.label :organized_by_teenagers, "Organized by teenagers?" %>
-    </p>
 
     <p>
       <%= form.label :risk_level %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Currently you can not tag organizations when creating them and rather have to go into the admin tab of the organization and create it there. 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
created a drop down multiselect that allows you to select multiple organization tags when creating an organization. Removed the 2 buttons that says created by teenagers and hack clubbers since it's now in the multiselect.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/2d9d4804-4d2a-4bb7-81fa-76882a16cfbc)
