### PR TITLE
[Card Grants] Add instructions to card grant & pre-authorization

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -25,7 +25,7 @@ class CardGrantsController < ApplicationController
 
   def create
     params[:card_grant][:amount_cents] = Monetize.parse(params[:card_grant][:amount_cents]).cents
-    @card_grant = @event.card_grants.build(params.require(:card_grant).permit(:amount_cents, :email, :keyword_lock, :purpose, :one_time_use, :pre_authorization_required).merge(sent_by: current_user))
+    @card_grant = @event.card_grants.build(params.require(:card_grant).permit(:amount_cents, :email, :keyword_lock, :purpose, :one_time_use, :pre_authorization_required, :instructions).merge(sent_by: current_user))
 
     authorize @card_grant
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -8,6 +8,7 @@
 #  amount_cents               :integer
 #  category_lock              :string
 #  email                      :string           not null
+#  instructions               :text
 #  keyword_lock               :string
 #  merchant_lock              :string
 #  one_time_use               :boolean

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -115,7 +115,9 @@ class CardGrant
         valid_purchase // a boolean value indicating whether the purchase is a valid use of funds based on the purpose provided. This should be true or false.
         fraud_rating // a number between 1 and 10, where 1 is very likely to be valid and 10 is very likely to be fraudulent.
 
-        Please make sure that both the product URL and screenshots are in line with the instructions provided to the user. If there isn't enough information, or these 3 fields are not all aligned, you should reject the purchase as fraudulent.
+        Please make sure that both the product URL and screenshots are in line with the instructions provided to the user. If there isn't enough information, or these 3 fields are not all aligned, you should reject the purchase as fraudulent. Here are the instructions provided to the user:
+
+        #{card_grant.instructions}
       PROMPT
 
       response = conn.post("/v1/responses", {

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -103,7 +103,7 @@ class CardGrant
       end
 
       prompt = <<~PROMPT
-        You are a helpful assistant that extracts information from a provided product URL and shopping cart screenshots. Once you've extracted the necessary information, you must decide whether the purchase is a valid use of funds based on a given purpose. You must respond in the following JSON format:
+        You are a helpful assistant that extracts information from a provided product URL and shopping cart screenshots. Once you've extracted the necessary information, you must decide whether the purchase is a valid use of funds based on a set of user-facing instructions. You must respond in the following JSON format:
 
         product_name // the name of the product, if available
         product_description // a short description of the product, if available
@@ -114,6 +114,8 @@ class CardGrant
         validity_reasoning // a short explanation of why the purchase is valid or not, based on the purpose provided. This should be a concise sentence explaining the reasoning behind the decision.
         valid_purchase // a boolean value indicating whether the purchase is a valid use of funds based on the purpose provided. This should be true or false.
         fraud_rating // a number between 1 and 10, where 1 is very likely to be valid and 10 is very likely to be fraudulent.
+
+        Please make sure that both the product URL and screenshots are in line with the instructions provided to the user. If there isn't enough information, or these 3 fields are not all aligned, you should reject the purchase as fraudulent.
       PROMPT
 
       response = conn.post("/v1/responses", {

--- a/app/views/card_grant/pre_authorizations/show.html.erb
+++ b/app/views/card_grant/pre_authorizations/show.html.erb
@@ -35,6 +35,14 @@
   </div>
 <% end %>
 
+<% if @card_grant.instructions.present? %>
+  <%= render "callout", title: "Instructions from #{@card_grant.event.name}", type: "info", class: "mb-4" do %>
+    <p class="m-0">
+      <%= @card_grant.instructions %>
+    </p>
+  <% end %>
+<% end %>
+
 <%= render partial: "card_grant/pre_authorizations/organizer_info", locals: { pre_authorization: @pre_authorization, link_to_pre_authorization: false } %>
 
 <%= form_with model: @pre_authorization, id: "pre_authorization_form", url: card_grant_pre_authorizations_path(@card_grant), method: :patch, class: "flex flex-col", data: { turbo: true } do |form| %>

--- a/app/views/card_grants/_create_form.html.erb
+++ b/app/views/card_grants/_create_form.html.erb
@@ -24,6 +24,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :instructions, "Instructions", class: "bold" %>
+    <%= form.text_area :instructions, placeholder: "Please only purchase a soldering iron…" %>
+  </div>
+
+  <div class="field">
     <%= form.label :one_time_use do %>
       <%= form.check_box :one_time_use, disabled: %>
       One time use? (freezes after first charge)

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -1,13 +1,6 @@
 <% title "Grant to #{@card_grant.user.name}" %>
 <%= render "events/nav", selected: :transfers if organizer_signed_in? %>
 
-<% if @card_grant.pre_authorization_required? && @card_grant.pre_authorization&.draft? && organizer_signed_in? %>
-  <div class="card">
-    <p class="mt-0">You were not auto redirected to the pre-authorization form because you are an organizer.</p>
-    <%= button_to "Open pre-authorization form", card_grant_pre_authorizations_path(@card_grant), class: "btn" %>
-  </div>
-<% end %>
-
 <div class="mt4 mb4 check--form flex justify-center <%= "flex-wrap" if @frame %>" style="gap: 3rem">
   <%# Grantee has pending invite %>
   <% if @card_grant.user == current_user && @card_grant.pending_invite? %>

--- a/db/migrate/20250707203932_add_instructions_to_card_grant.rb
+++ b/db/migrate/20250707203932_add_instructions_to_card_grant.rb
@@ -1,0 +1,5 @@
+class AddInstructionsToCardGrant < ActiveRecord::Migration[7.2]
+  def change
+    add_column :card_grants, :instructions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_03_194503) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_07_203932) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -453,6 +453,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_03_194503) do
     t.string "purpose"
     t.boolean "one_time_use"
     t.boolean "pre_authorization_required", default: false, null: false
+    t.text "instructions"
     t.index ["disbursement_id"], name: "index_card_grants_on_disbursement_id"
     t.index ["event_id"], name: "index_card_grants_on_event_id"
     t.index ["sent_by_id"], name: "index_card_grants_on_sent_by_id"


### PR DESCRIPTION
## Summary of the problem
We're not currently passing in any instructions into AI, and users can't see any instructions from grant issuers.


## Describe your changes
This PR adds the `instructions` text field, which we allow organizers to populate and show to users and OpenAI.