### PR TITLE
[Card Grants] Add instructions to pre-authorization AI prompt

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -133,7 +133,7 @@ class CardGrant
                                  content: [
                                    {
                                      type: "input_text",
-                                     text: "Product URL: #{product_url}"
+                                     text: "The user was given the following instructions:\n\n#{instructions}\n\nThe user provided the following URL: #{product_url}"
                                    },
                                    screenshots.map { |screenshot|
                                      {


### PR DESCRIPTION
Pre-authorizations aren't pulling from the instructions when checking a submission for fraud. (We just aren't adding it to the prompt 🙃) This PR fixes that. 