### PR TITLE
[Card Grants] Fix pre-authorization instructions

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -137,7 +137,7 @@ class CardGrant
                                  content: [
                                    {
                                      type: "input_text",
-                                     text: "The user was given the following instructions:\n\n#{instructions}\n\nThe user provided the following URL: #{product_url}"
+                                     text: "The user was given the following instructions:\n\n#{card_grant.instructions}\n\nThe user provided the following URL: #{product_url}"
                                    },
                                    screenshots.map { |screenshot|
                                      {


### PR DESCRIPTION
## Summary of the problem
`instructions` is being called instead of `card_grant.instructions`, which errors because `instructions` is not defined on `pre_authorization`, while `card_grant` is.


## Describe your changes
`instructions` → `card_grant.instructions`