### PR TITLE
[Admin] Add risk level dropdown at org creation

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -88,6 +88,7 @@ class AdminController < ApplicationController
       plan: params[:plan],
       organized_by_hack_clubbers: params[:organized_by_hack_clubbers].to_i == 1,
       organized_by_teenagers: params[:organized_by_teenagers].to_i == 1,
+      risk_level: params[:risk_level],
       demo_mode: params[:demo_mode].to_i == 1
     ).run
 

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -34,9 +34,9 @@ module EventService
         @emails.each do |email|
           OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: email, is_signee: @is_signee).run!
         end
-        
-        
-        event.update!(risk_level: @risk_level) if !@risk_level.blank?  
+
+
+        event.update!(risk_level: @risk_level) if @risk_level.present?
         event
       end
     end

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -35,8 +35,6 @@ module EventService
           OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: email, is_signee: @is_signee).run!
         end
 
-
-        event.update!(risk_level: @risk_level) if @risk_level.present?
         event
       end
     end
@@ -54,7 +52,9 @@ module EventService
         point_of_contact_id: @point_of_contact_id,
         demo_mode: @demo_mode,
         plan: Event::Plan.new(type: @plan)
-      }
+      }.tap do |hash|
+        hash[:risk_level] = @risk_level if @risk_level.present?
+      end
     end
 
     def point_of_contact

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -2,7 +2,7 @@
 
 module EventService
   class Create
-    def initialize(name:, point_of_contact_id:, emails: [], is_signee: true, country: [], is_public: true, is_indexable: true, approved: false, plan: Event::Plan::Standard, organized_by_hack_clubbers: false, organized_by_teenagers: false, can_front_balance: true, demo_mode: false)
+    def initialize(name:, point_of_contact_id:, emails: [], is_signee: true, country: [], is_public: true, is_indexable: true, approved: false, plan: Event::Plan::Standard, organized_by_hack_clubbers: false, organized_by_teenagers: false, can_front_balance: true, demo_mode: false, risk_level: 0)
       @name = name
       @emails = emails
       @is_signee = is_signee
@@ -16,6 +16,7 @@ module EventService
       @organized_by_teenagers = organized_by_teenagers
       @can_front_balance = can_front_balance
       @demo_mode = demo_mode
+      @risk_level = risk_level
     end
 
     def run
@@ -33,7 +34,9 @@ module EventService
         @emails.each do |email|
           OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: email, is_signee: @is_signee).run!
         end
-
+        
+        
+        event.update!(risk_level: @risk_level) if !@risk_level.blank?  
         event
       end
     end

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -64,6 +64,11 @@
       <%= form.label :organized_by_teenagers, "Organized by teenagers?" %>
     </p>
 
+    <p>
+      <%= form.label :risk_level %>
+      <%= form.collection_select :risk_level, Event.risk_levels.map { |k, _v| [k.humanize.capitalize, k] }, :last, :first, { include_blank: "Select a risk level" }, selected: params[:risk_level] %>
+    </p>
+
   </fieldset>
 
   <p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
There is no easy way for operations to determine the risk level of an organization when creating it.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Created a dropdown at the bottom of admin org creation page that can be used to set the organization risk level

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
![image](https://github.com/user-attachments/assets/e9d6d799-3341-4ea9-ad05-33144d1f45de)