### PR TITLE
Log to STDOUT in development

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: rm -f tmp/pids/server.pid; bin/rails server -b "0.0.0.0"
+web: rm -f tmp/pids/server.pid; RAILS_LOG_TO_STDOUT=1 bin/rails server -b "0.0.0.0"
 js: NODE_ENV=development yarn build --watch
 stripe: stripe listen --events charge.dispute.funds_withdrawn,invoice.paid,issuing_authorization.created,issuing_authorization.request,issuing_authorization.updated,issuing_card.updated,issuing_transaction.created,payment_intent.succeeded,customer.subscription.updated,customer.subscription.deleted,setup_intent.succeeded,source.transaction.created,charge.refunded,payout.updated,payout.canceled,payout.failed,payout.paid --forward-to http://localhost:3000/stripe/webhook
 css: NODE_ENV=development yarn build:css --watch --verbose

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -108,4 +108,7 @@ Rails.application.configure do
     Bullet.rails_logger  = true
   end
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
+  end
 end


### PR DESCRIPTION
## Summary of the problem

- When running `bin/dev` we don't actually see Rails logs in the console as they to go `log/development.log` by default
- They also differ from production where we use `ActiveSupport::TaggedLogging` https://github.com/hackclub/hcb/blob/4ff2c08b46a88485d5efd67556e751d1e6358413/config/environments/production.rb#L133-L137

## Describe your changes

Mirror the production config in development and set `RAILS_LOG_TO_STDOUT` in `Procfile.dev`