### PR TITLE
Set `autocomplete` attribute on totp + login code fields

### DIFF
--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -34,6 +34,7 @@
             "",
             placeholder: "Enter your login code",
             class: "!max-w-full w-max",
+            autocomplete: "one-time-code",
             required: true,
             autofocus: true
           ) %>

--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -16,9 +16,30 @@
     <%= @use_sms_auth ? "your phone number ending in " + @phone_last_four : mail_to(@email, { target: "_blank" }) %>
   </p>
   <%= form_tag complete_login_path(@login) do %>
-    <%= text_field :login_code, "", placeholder: "Enter your login code", name: "login_code", class: "!max-w-full w-max", required: true, autofocus: true unless Flipper.enabled?(:otp_single_input, @login.user) %>
+    <% if Flipper.enabled?(:otp_single_input, @login.user) %>
+      <%= text_field(
+            :login_code,
+            "",
+            class: "otp_code",
+            autocomplete: "one-time-code",
+            required: true,
+            inputmode: "numeric",
+            maxlength: "6",
+            autofocus: true,
+            data: { behavior: "otp_input" }
+          ) %>
+    <% else %>
+      <%= text_field(
+            :login_code,
+            "",
+            placeholder: "Enter your login code",
+            name: "login_code",
+            class: "!max-w-full w-max",
+            required: true,
+            autofocus: true
+          ) %>
+    <% end %>
 
-    <%= text_field :login_code, "", class: "otp_code", autocomplete: "one-time-code", required: true, inputmode: "numeric", maxlength: "6", autofocus: true, data: { behavior: "otp_input" } if Flipper.enabled?(:otp_single_input, @login.user) %>
     <%= hidden_field_tag :method, :login_code %>
     <%= hidden_field_tag :fingerprint %>
     <%= hidden_field_tag :device_info %>

--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -17,7 +17,7 @@
   </p>
   <%= form_tag complete_login_path(@login) do %>
     <% if Flipper.enabled?(:otp_single_input, @login.user) %>
-      <%= text_field(
+      <%= text_field_tag(
             :login_code,
             "",
             class: "otp_code",
@@ -29,11 +29,10 @@
             data: { behavior: "otp_input" }
           ) %>
     <% else %>
-      <%= text_field(
+      <%= text_field_tag(
             :login_code,
             "",
             placeholder: "Enter your login code",
-            name: "login_code",
             class: "!max-w-full w-max",
             required: true,
             autofocus: true

--- a/app/views/logins/totp.html.erb
+++ b/app/views/logins/totp.html.erb
@@ -13,9 +13,30 @@
       For additional security, e<% else %>E<% end %>nter the code from your authenticator app:
   </p>
   <%= form_tag complete_login_path(@login) do %>
-    <%= text_field :code, "", name: "code", placeholder: "Enter your one time password code", class: "left-align mb2 !max-w-full w-max", required: true, autofocus: true unless Flipper.enabled?(:otp_single_input, @login.user) %>
-
-    <%= text_field :code, "", name: "code", class: "otp_code", autocomplete: "one-time-code", required: true, autofocus: true, inputmode: "numeric", maxlength: "6", data: { behavior: "otp_input" } if Flipper.enabled?(:otp_single_input, @login.user) %>
+    <% if Flipper.enabled?(:otp_single_input, @login.user) %>
+      <%= text_field(
+            :code,
+            "",
+            name: "code",
+            class: "otp_code",
+            autocomplete: "one-time-code",
+            required: true,
+            autofocus: true,
+            inputmode: "numeric",
+            maxlength: "6",
+            data: { behavior: "otp_input" }
+          ) %>
+    <% else %>
+      <%= text_field(
+            :code,
+            "",
+            name: "code",
+            placeholder: "Enter your one time password code",
+            class: "left-align mb2 !max-w-full w-max",
+            required: true,
+            autofocus: true
+          ) %>
+    <% end %>
 
     <%= hidden_field_tag :email, @email %>
     <%= hidden_field_tag :method, :totp %>

--- a/app/views/logins/totp.html.erb
+++ b/app/views/logins/totp.html.erb
@@ -30,6 +30,7 @@
             :code,
             "",
             placeholder: "Enter your one time password code",
+            autocomplete: "one-time-code",
             class: "left-align mb2 !max-w-full w-max",
             required: true,
             autofocus: true

--- a/app/views/logins/totp.html.erb
+++ b/app/views/logins/totp.html.erb
@@ -14,10 +14,9 @@
   </p>
   <%= form_tag complete_login_path(@login) do %>
     <% if Flipper.enabled?(:otp_single_input, @login.user) %>
-      <%= text_field(
+      <%= text_field_tag(
             :code,
             "",
-            name: "code",
             class: "otp_code",
             autocomplete: "one-time-code",
             required: true,
@@ -27,10 +26,9 @@
             data: { behavior: "otp_input" }
           ) %>
     <% else %>
-      <%= text_field(
+      <%= text_field_tag(
             :code,
             "",
-            name: "code",
             placeholder: "Enter your one time password code",
             class: "left-align mb2 !max-w-full w-max",
             required: true,


### PR DESCRIPTION
## Summary of the problem

Browsers use the `autocomplete` attribute on input fields to suggest useful values. In the case of login codes, this can involve looking at the user's SMS messages or emails and suggesting codes that were sent to them (which is very handy).

We started doing this in https://github.com/hackclub/hcb/pull/9625 for a new version of these fields but that flag was never rolled out, so until we figure out what to do with that logic ([Slack discussion](https://hackclub.slack.com/archives/C047Y01MHJQ/p1752068620075929)) I figured this was a nice quality of life improvement.

## Describe your changes

- Cleans up template formatting
- Switches from `text_field` to `text_field_tag` as we aren't using `form_for`
- Adds `autocomplete="one-time-password"` to the appropriate fields