### PR TITLE
Fix announcement policies

### DIFF
--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -18,7 +18,7 @@ class AnnouncementPolicy < ApplicationPolicy
   end
 
   def edit?
-    admin? || (record.author == user && user.reader?)
+    admin? || record.author == user
   end
 
   def update?
@@ -26,11 +26,11 @@ class AnnouncementPolicy < ApplicationPolicy
   end
 
   def destroy?
-    admin? || record.author == user
+    admin_or_manager?
   end
 
   def publish?
-    admin? || record.author == user
+    admin_or_manager?
   end
 
   private


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
`user.reader?` does not exist and was not needed. Any manager should be able to destroy or publish (but not edit to avoid concurrent editing)


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Fixed policies


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

