### PR TITLE
Fix announcement publishing emails

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -37,9 +37,9 @@ class Announcement < ApplicationRecord
   scope :published, -> { where.not(published_at: nil) }
 
   def publish!
-    AnnouncementPublishedJob.perform_later(announcement: self)
-
     update!(published_at: Time.now)
+
+    AnnouncementPublishedJob.perform_later(announcement: self)
   end
 
   def render_html


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The check in `AnnouncementPublishedJob` to make sure announcements are still published when the job runs was never sending emails since it had an old version of the record 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Updated the announcement record before passing it to the job


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

