### PR TITLE
Fix overflows in user and event navs

### DIFF
--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -141,11 +141,6 @@
       event_transactions_path(event_id: @event.slug),
       icon: "transactions",
       selected: local_assigns[:selected] == :transactions if policy(@event).transactions? %>
-    <%= dock_item "Announcements",
-      event_announcements_path(event_id: @event.slug),
-      tooltip: "View your announcements",
-      icon: "announcement",
-      selected: local_assigns[:selected] == :announcements if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) %>
     <% if policy(@event).donation_overview? || ( @event.approved? && @event.plan.invoices_enabled? ) || policy(@event).account_number? || policy(@event.check_deposits.build).index? %>
       <button class="dock__item <%= "dock__item--selected" if local_assigns[:selected].in? [:donations, :invoices, :account_number, :deposit_check] %> bg-transparent border-none menu__toggle" data-behavior="menu_toggle" data-tour-step="receive">
         <div class="line-height-0 relative"><%= inline_icon "support", size: 32, class: "primary" %></div>
@@ -186,6 +181,7 @@
       <div class="menu__content" data-behavior="menu_content">
         <h4 class="mb0 h5 muted left-align pl1 mt1">More</h4>
         <div class="menu__divider"></div>
+        <%= link_to "Announcements", event_announcements_path(event_id: @event.slug) if policy(@event).show? if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) %>
         <%= link_to "Team", event_team_path(event_id: @event.slug) if policy(@event).show? %>
         <%= link_to "Promotions & perks", event_promotions_path(event_id: @event.slug) if policy(@event).promotions? %>
         <%= link_to "Google Workspace", event_g_suite_overview_path(event_id: @event.slug) if policy(@event).g_suite_overview? %>

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -181,9 +181,9 @@
       <div class="menu__content" data-behavior="menu_content">
         <h4 class="mb0 h5 muted left-align pl1 mt1">More</h4>
         <div class="menu__divider"></div>
-        <%= if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) && policy(@event).show?
-              link_to "Announcements", event_announcements_path(event_id: @event.slug)
-            end %>
+        <% if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) && policy(@event).show? %>      
+          <%= link_to "Announcements", event_announcements_path(event_id: @event.slug) %>
+        <% end %>
         <%= link_to "Team", event_team_path(event_id: @event.slug) if policy(@event).show? %>
         <%= link_to "Promotions & perks", event_promotions_path(event_id: @event.slug) if policy(@event).promotions? %>
         <%= link_to "Google Workspace", event_g_suite_overview_path(event_id: @event.slug) if policy(@event).g_suite_overview? %>

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -181,7 +181,9 @@
       <div class="menu__content" data-behavior="menu_content">
         <h4 class="mb0 h5 muted left-align pl1 mt1">More</h4>
         <div class="menu__divider"></div>
-        <%= link_to "Announcements", event_announcements_path(event_id: @event.slug) if policy(@event).show? if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) %>
+        <%= if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) && policy(@event).show?
+              link_to "Announcements", event_announcements_path(event_id: @event.slug)
+            end %>
         <%= link_to "Team", event_team_path(event_id: @event.slug) if policy(@event).show? %>
         <%= link_to "Promotions & perks", event_promotions_path(event_id: @event.slug) if policy(@event).promotions? %>
         <%= link_to "Google Workspace", event_g_suite_overview_path(event_id: @event.slug) if policy(@event).g_suite_overview? %>

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -181,7 +181,7 @@
       <div class="menu__content" data-behavior="menu_content">
         <h4 class="mb0 h5 muted left-align pl1 mt1">More</h4>
         <div class="menu__divider"></div>
-        <% if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) && policy(@event).announcement_overview? %>      
+        <% if Flipper.enabled?(:organization_announcements_tier_1_2025_07_07, @event) && policy(@event).announcement_overview? %>
           <%= link_to "Announcements", event_announcements_path(event_id: @event.slug) %>
         <% end %>
         <%= link_to "Team", event_team_path(event_id: @event.slug) if policy(@event).show? %>

--- a/app/views/users/_nav.html.erb
+++ b/app/views/users/_nav.html.erb
@@ -19,7 +19,7 @@
     </button>
   </div>
 
-  <nav class="dock font-medium mt1">
+  <nav class="dock dock--desktop font-medium mt1">
     <%= dock_item "Home",
       root_path,
       tooltip: "See all your organizations",
@@ -29,7 +29,7 @@
       my_feed_path,
       tooltip: "See announcements for organizations you're following",
       icon: "announcement",
-      selected: local_assigns[:selected] == :feed %>
+      selected: local_assigns[:selected] == :feed if current_user.followed_events.any? %>
     <%= dock_item "Cards",
       my_cards_path,
       tooltip: "See all your cards",
@@ -69,6 +69,55 @@
         <i>Add To Home Screen</i>.
       </div>
     <% end %>
+  </nav>
+
+  <nav class="dock dock--mobile font-medium mt1">
+    <%= dock_item "Home",
+      root_path,
+      tooltip: "See all your organizations",
+      icon: "home",
+      selected: local_assigns[:selected] == :home %>
+    <%= dock_item "Cards",
+      my_cards_path,
+      tooltip: "See all your cards",
+      icon: "card",
+      selected: local_assigns[:selected] == :cards %>
+    <%= dock_item "Receipts",
+      my_inbox_path,
+      tooltip: "See transactions awaiting receipts",
+      icon: "payment-docs",
+      async_badge: my_missing_receipts_icon_path,
+      selected: local_assigns[:selected] == :receipts %>
+    <%= dock_item "Reimbursements",
+      my_reimbursements_path,
+      tooltip: "See expense reimbursements",
+      icon: "attachment",
+      async_badge: my_reimbursements_icon_path,
+      selected: local_assigns[:selected] == :reimbursements %>
+    <% if @first_visit %>
+      <div class="pwa__prompt" style="position: relative">
+        <div class="pwa__prompt__hide" onclick="hidePWAPrompt()">
+          <%= inline_icon "private-fill", size: 24, class: "pwa__prompt__icon" %>
+        </div>
+        <b>Looking for a mobile app?</b>
+        <br>
+        Click <%= inline_icon "share", size: 18, class: "pwa__prompt__icon" %>
+        and then <%= inline_icon "plus", size: 18, class: "pwa__prompt__icon" %>
+        <i>Add To Home Screen</i>.
+      </div>
+    <% end %>
+    <button class="dock__item bg-transparent border-none menu__toggle" data-behavior="menu_toggle">
+      <div class="line-height-0 relative"><%= inline_icon "more", size: 32, class: "primary" %></div>
+      <span class="line-height-3">More</span>
+
+      <div class="menu__content" data-behavior="menu_content">
+        <h4 class="mb0 h5 muted left-align pl1 mt1">More</h4>
+        <div class="menu__divider"></div>
+        <%= link_to "Feed", my_feed_path if current_user.followed_events.any? %>
+        <%= link_to "Pay", my_payroll_path if current_user.jobs.any? %>
+        <%= link_to "Settings", my_settings_path %>
+      </div>
+    </button>
   </nav>
 
   <% if (current_user.events.not_demo_mode.funded.exists? || current_user.card_grants.any? || current_user.reimbursement_reports.any?) && Flipper.enabled?(:bank_wrapped, current_user) %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The "More" menu was being cut off on the mobile event nav with the announcements button added, and Settings was being cut off on the mobile user nav.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moved announcements and feed to the More menu, and hide feed when no events are being followed.
![Screen Shot 2025-07-09 at 11 26 46](https://github.com/user-attachments/assets/5218d705-7afa-48c8-b55f-15544a58b051)
![Screen Shot 2025-07-09 at 11 42 40](https://github.com/user-attachments/assets/3f18c9c1-9d00-4250-af0b-2f1c986a3e01)




<!-- If there are any visual changes, please attach images, videos, or gifs. -->

