### PR TITLE
[Feature Preview] Make org announcement emojis separated

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -16,7 +16,7 @@ class FeaturesController < ApplicationController
     event_home_page_redesign_2024_09_21: %w[🏠 📊 📉 💸],
     card_logos_2024_08_27: %w[🌈 💳 📸],
     donation_tiers_2025_06_24: %w[💖 🥇 🥈 🥉],
-    organization_announcements_tier_1_2025_07_07: %w[📢📣🔔📰⚠️❗🚨🎉🥳]
+    organization_announcements_tier_1_2025_07_07: %w[📢 📣 🔔 📰 ⚠️ ❗ 🚨 🎉 🥳]
   }.freeze
 
   def enable_feature


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Before:
<img width="1669" alt="image" src="https://github.com/user-attachments/assets/18f7ec3a-10c6-4098-bc1f-4abc8cc4549b" />

Emojis are stuck together in one string

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

After:
_use your imagination_

Emojis are confetti separately.

Since `%w[]` creates an array split by whitespace, you need whitespace between the emojis so that they're separate elements in the array

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

