### PR TITLE
[Bug] Error when trying to create org from Airtable

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -105,7 +105,7 @@ class AdminController < ApplicationController
       country: country&.alpha2,
       point_of_contact_id: current_user.id,
       approved: true,
-      tags: [EventTag::Tags::ALL.ORGANIZED_BY_TEENAGERS] if application['TEEN'],
+      tags: application["TEEN"] ? [EventTag::Tags::ORGANIZED_BY_TEENAGERS] : [],
       demo_mode: true
     ).run
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -105,7 +105,7 @@ class AdminController < ApplicationController
       country: country&.alpha2,
       point_of_contact_id: current_user.id,
       approved: true,
-      organized_by_teenagers: application["TEEN"] == "Teen",
+      tags: [EventTag::Tags::ALL.ORGANIZED_BY_TEENAGERS] if application['TEEN'],
       demo_mode: true
     ).run
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
When trying to create an organization through airtable, it throws an error saying that "organized_by_teengers" does not exist.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I updated the event_create_from_airtable method to use the new tags parameter rather than the deprecated "organized_by_teenagers" parameter.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
Cannot display in development