### PR TITLE
[Announcements] Fix publish path and missing text

### DIFF
--- a/app/views/announcements/_announcement_card.html.erb
+++ b/app/views/announcements/_announcement_card.html.erb
@@ -14,7 +14,7 @@
     <% if organizer_signed_in?(as: :member) && !show_event %>
       <div class="flex gap-2">
         <% if announcement.draft? %>
-          <%= pop_icon_to "send", publish_announcement_path(announcement), data: { turbo_confirm: "Are you sure you would like to publish this announcement?", turbo_method: :post }, class: "tooltipped success", "aria-label": "Publish draft", disabled: !policy(announcement).publish? %>
+          <%= pop_icon_to "send", announcement_publish_path(announcement), data: { turbo_confirm: "Are you sure you would like to publish this announcement?", turbo_method: :post }, class: "tooltipped success", "aria-label": "Publish draft", disabled: !policy(announcement).publish? %>
         <% end %>
         <%= pop_icon_to "edit", edit_announcement_path(announcement), class: "tooltipped", "aria-label": "Edit announcement", disabled: !policy(announcement).edit? %>
         <%= pop_icon_to "delete", announcement_path(announcement), data: { turbo_confirm: "Are you sure you would like to delete this announcement?", turbo_method: :delete }, class: "error tooltipped", "aria-label": "Delete announcement", disabled: !policy(announcement).destroy? %>

--- a/app/views/events/announcement_overview.html.erb
+++ b/app/views/events/announcement_overview.html.erb
@@ -20,9 +20,15 @@
       <h3 class="text-2xl font-bold mb-0">
         It's quiet here...
       </h3>
-      <p class="text-gray-500 my-1 max-w-sm">
-        Create a new announcement to keep your followers up to date!
-      </p>
+      <% if organizer_signed_in?(as: :manager) %>
+        <p class="text-gray-500 my-1 max-w-sm">
+          Create a new announcement to keep your followers up to date!
+        </p>
+      <% else %>
+        <p class="text-gray-500 my-1 max-w-sm">
+          No announcements are posted yet.
+        </p>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -689,7 +689,9 @@ Rails.application.routes.draw do
 
   resources :follows, only: [:destroy], controller: "event/follows"
 
-  resources :announcements, path: "/announcements", except: [:index, :new]
+  resources :announcements, path: "/announcements", except: [:index, :new] do
+    post "publish"
+  end
 
   get "/events" => "events#index"
   resources :events, except: [:new, :create, :edit], concerns: :commentable, path: "/" do


### PR DESCRIPTION
Publish path was causing a 500 when loading the overview page in certain ways.
The missing text was only targeted at organizers originally.

