### PR TITLE
[Card Grants] Fix details missing

### DIFF
--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (card_grant:) %>
 
-<% if card_grant.active? && (stripe_card = card_grant.stripe_card).present? %>
+<% if (stripe_card = card_grant.stripe_card).present? %>
   <div>
     <div class="card container--md">
       <h3 class="mt0 mb0 info bold">How do I make purchases on this card?</h3>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (card_grant:) %>
 
-<% if card_grant.active? && (stripe_card = card_grant.stripe_card).present? %>
+<% if (stripe_card = card_grant.stripe_card).present? %>
   <div>
     <div class="card container--md">
       <section class="details">

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -31,7 +31,7 @@
   <% if @card_grant.user == current_user && @card_grant.pending_invite? %>
     <% if @card_grant.canceled? %>
       <%= blankslate "Sorry, this grant was canceled!" %>
-  <% else %>
+    <% else %>
       <%= render partial: "invitation", locals: { card_grant: @card_grant } %>
     <% end %>
   <%# Grantee has accepted invite %>


### PR DESCRIPTION
This info is still relevant even after the card grant is canceled. It was also causing an empty admin tool.