### PR TITLE
block files larger than 25mb on comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,7 +10,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    if params[:comment][:file].present? && params[:comment][:file].size > 25.megabytes
+    if comment_params[:file].present? && comment_params[:file].size > 25.megabytes
       flash[:error] = "File size must be less than 25MB"
       redirect_back(fallback_location: @commentable) and return
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,6 +10,11 @@ class CommentsController < ApplicationController
   end
 
   def create
+    if params[:comment][:file].present? && params[:comment][:file].size > 25.megabytes
+      flash[:error] = "File size must be less than 25MB"
+      redirect_back(fallback_location: @commentable) and return
+    end
+
     @comment = @commentable.comments.build(comment_params)
     @comment.user = current_user
 


### PR DESCRIPTION
## Summary of the problem

comments on transactions allow you to upload almost any file, and any size, which is really bad for that aws bill

## Describe your changes

this adds a simple limit to comment creations, checking the file size to not be larger than 25mb (which should be very generous for most peeps)


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

