### PR TITLE
[Admin] Modify balances export query to include total raised

### DIFF
--- a/app/models/export/event/balances.rb
+++ b/app/models/export/event/balances.rb
@@ -58,7 +58,7 @@ class Export
       end
 
       def header
-        ::CSV::Row.new(headers, ["id", "name", "postal_code", "contact email", "organizers", "revenue fee", "url", "balance", "omitted?"], true)
+        ::CSV::Row.new(headers, ["id", "name", "postal_code", "contact email", "organizers", "revenue fee", "url", "balance", "total raised", "omitted?"], true)
       end
 
       def row(event)
@@ -73,6 +73,7 @@ class Export
             event.plan.revenue_fee_label,
             Rails.application.routes.url_helpers.url_for(event),
             event.balance,
+            event.total_raised,
             event.omit_stats?
           ]
         )


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
When exporting to a CSV, the balances sheet does not include the amount raised.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added line when exporting CSV so it includes the total amount raised in a column next to balances.
