### PR TITLE
[Reimbursements] Only allow managers to be assigned reviewer

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -236,7 +236,7 @@ class Event < ApplicationRecord
   has_many :organizer_position_contracts, through: :organizer_position_invites, class_name: "OrganizerPosition::Contract"
   has_many :users, through: :organizer_positions
   has_many :signees, -> { where(organizer_positions: { is_signee: true }) }, through: :organizer_positions, source: :user
-  has_many :managers, -> { where(organizer_positions: { role: "manager" }) }, through: :organizer_positions, source: :user
+  has_many :managers, -> { where(organizer_positions: { role: :manager }) }, through: :organizer_positions, source: :user
   has_many :g_suites
   has_many :g_suite_accounts, through: :g_suites
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -236,6 +236,7 @@ class Event < ApplicationRecord
   has_many :organizer_position_contracts, through: :organizer_position_invites, class_name: "OrganizerPosition::Contract"
   has_many :users, through: :organizer_positions
   has_many :signees, -> { where(organizer_positions: { is_signee: true }) }, through: :organizer_positions, source: :user
+  has_many :managers, -> { where(organizer_positions: { role: "manager" }) }, through: :organizer_positions, source: :user
   has_many :g_suites
   has_many :g_suite_accounts, through: :g_suites
 

--- a/app/views/reimbursement/reports/_edit_form.html.erb
+++ b/app/views/reimbursement/reports/_edit_form.html.erb
@@ -28,7 +28,7 @@
   <% if organizer_signed_in? && (@report.submitted? || @report.draft?) && @report.event %>
    <div class="field">
       <%= form.label :reviewer_id, "Assigned reviewer", class: "mt2" %>
-      <%= form.collection_select :reviewer_id, @report.event.users, :id, :name, include_blank: "Anyone" %>
+      <%= form.collection_select :reviewer_id, @report.event.managers, :id, :name, include_blank: "Anyone" %>
     </div>
   <% end %>
   <%= form.submit "Update report", class: "left mt2" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Members can be requested to approve reimbursement requests despite not actually being able to.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Event now has a managers property to fetch all the managers in the current organization. 

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="567" height="179" alt="image" src="https://github.com/user-attachments/assets/ef16544f-f191-4a69-ad96-19af2c560b02" />
<img width="948" height="473" alt="image" src="https://github.com/user-attachments/assets/efcd2734-00ee-42bb-990e-7134d9954eac" />
^ member is not shown as an option in dropdown
Fixes #10739 