### PR TITLE
Prevent contract signees from removing themselves

### DIFF
--- a/app/policies/organizer_position_policy.rb
+++ b/app/policies/organizer_position_policy.rb
@@ -2,7 +2,7 @@
 
 class OrganizerPositionPolicy < ApplicationPolicy
   def destroy?
-    admin_or_contract_signee?
+    admin_or_contract_signee? && record.user != user
   end
 
   def set_index?


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Contract signees should not be able to remove themselves from the org without an OPDR


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the policy to disable contract signees from removing themselves without an OPDR


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

