### PR TITLE
[Admin] Added text to describe stripe issuing tiers

### DIFF
--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -27,7 +27,7 @@
     </details>
   <% end %>
 
-  <%= form_with(model: event, local: true) do |form| %>
+  <%= form_with(model: event, local: true, html: { "x-data" => "{ship_type: '#{event.stripe_card_shipping_type}'}" }) do |form| %>
     <%= form_errors event, "organization" %>
     <% admin_tool do %>
       <%= link_to (event.hidden? ? "Un-hide project" : "Hide project"),
@@ -60,7 +60,9 @@
 
       <div class="field">
         <%= form.label :stripe_card_shipping_type, "Card shipping method" %>
-        <%= form.collection_select :stripe_card_shipping_type, Event.stripe_card_shipping_types, :first, :first, {}, { disabled: } %>
+        <%= form.collection_select :stripe_card_shipping_type, Event.stripe_card_shipping_types, :first, :first, {}, { disabled:, "x-on:input" => "ship_type = $event.target.value" } %>
+        <p class="italic mt1" x-show="ship_type == 'express'">Express shiping will cost $13 per card and arrive in 4-5 buisness days (normal shipping costs $0.63 per card)</p>
+        <p class="italic mt1" x-show="ship_type == 'priority'">Priority shipping will cost $27 per card and arrive in 2-3 buisness days (normal shipping costs $0.63 per card)</p>
       </div>
 
       <div class="field">
@@ -101,7 +103,7 @@
       </div>
 
       <div class="action">
-        <%= form.submit "Update", disabled: %>
+        <%= form.submit "Update", disabled:, data: { turbo: false } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -61,8 +61,9 @@
       <div class="field">
         <%= form.label :stripe_card_shipping_type, "Card shipping method" %>
         <%= form.collection_select :stripe_card_shipping_type, Event.stripe_card_shipping_types, :first, :first, {}, { disabled:, "x-on:input" => "ship_type = $event.target.value" } %>
-        <p class="italic mt1" x-show="ship_type == 'express'">Express shiping will cost $13 per card and arrive in 4-5 buisness days (normal shipping costs $0.63 per card)</p>
-        <p class="italic mt1" x-show="ship_type == 'priority'">Priority shipping will cost $27 per card and arrive in 2-3 buisness days (normal shipping costs $0.63 per card)</p>
+        <p class="italic mt1" x-show="ship_type == 'standard'">Standard shipping will cost $0.63 per card and arrive in 5-8 business days</p>
+        <p class="italic mt1" x-show="ship_type == 'express'">Express shipping will cost $13 per card and arrive in 4-5 business days</p>
+        <p class="italic mt1" x-show="ship_type == 'priority'">Priority shipping will cost $27 per card and arrive in 2-3 business days</p>
       </div>
 
       <div class="field">


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
When admins change the card issuing type (Standard, Express or priority), there is no clear way to determine what it actually does

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
When you update the dropdown, It displays a p tag with info on the selected issuing type. Does not display anything for standard issuing type.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="677" height="104" alt="image" src="https://github.com/user-attachments/assets/13caad2e-3ab7-425c-b49b-9fb1bbf926f0" />
<img width="817" height="121" alt="image" src="https://github.com/user-attachments/assets/97810d68-e626-456c-aa07-d2feba51022e" />
<img width="831" height="117" alt="image" src="https://github.com/user-attachments/assets/7e49f3be-c396-4c13-8fdd-5fbd5f2509f8" />
P.S. Found that alpine variables break when using turbo so I disabled it to force a page reload so that the alpine variables could be set correctly. If a reload didn't occur, upon updating both p tags for express and priority would show.

FIxes #10814 
