### PR TITLE
Show sender available balance to admins on disbursement new

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -48,7 +48,7 @@ class DisbursementsController < ApplicationController
     user_event_ids = current_user.organizer_positions.reorder(sort_index: :asc).pluck(:event_id)
 
     @allowed_source_events = if admin_signed_in?
-                               Event.select(:name, :id, :demo_mode, :slug).all.reorder(Event::CUSTOM_SORT).includes(:plan)
+                               Event.select(:name, :id, :demo_mode, :slug, :can_front_balance).all.reorder(Event::CUSTOM_SORT).includes(:plan)
                              else
                                current_user.events.not_hidden.filter_demo_mode(false)
                              end.to_enum.with_index.sort_by { |e, i| [user_event_ids.index(e.id) || Float::INFINITY, i] }.map(&:first)

--- a/app/javascript/controllers/organization_select_controller.js
+++ b/app/javascript/controllers/organization_select_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
     'wrapper',
     'field',
     'other',
-    'balance'
+    'balance',
   ]
   static values = {
     state: Boolean,
@@ -132,12 +132,14 @@ export default class extends Controller {
         if (this.hasBalanceTarget) {
           let usdFormatter = new Intl.NumberFormat('en-US', {
             style: 'currency',
-            currency: 'USD'
-          });
+            currency: 'USD',
+          })
 
-          let formattedAmount = usdFormatter.format(Number(organization.dataset['balance']) / 100);
+          let formattedAmount = usdFormatter.format(
+            Number(organization.dataset['balance']) / 100
+          )
 
-          this.balanceTarget.innerText = formattedAmount;
+          this.balanceTarget.innerText = formattedAmount
         }
 
         close()

--- a/app/javascript/controllers/organization_select_controller.js
+++ b/app/javascript/controllers/organization_select_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     'wrapper',
     'field',
     'other',
+    'balance'
   ]
   static values = {
     state: Boolean,
@@ -127,6 +128,17 @@ export default class extends Controller {
         fieldValue.dataset.fee = fee
         this.dropdownTarget.value = newValue
         this.dropdownTarget.dispatchEvent(new CustomEvent('feechange'))
+
+        if (this.hasBalanceTarget) {
+          let usdFormatter = new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: 'USD'
+          });
+
+          let formattedAmount = usdFormatter.format(Number(organization.dataset['balance']) / 100);
+
+          this.balanceTarget.innerText = formattedAmount;
+        }
 
         close()
       }

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -17,7 +17,7 @@
                     <% disabled_message = nil %>
                     <% disabled_message = "Insufficient balance" if sending && !admin_signed_in? && event.balance_available <= 0 %>
                     <% disabled_message = "HCB transfers disabled" if sending && !policy(event).create_transfer? %>
-                    <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
+                    <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>" data-balance="<%= sending && admin_signed_in? ? event.available_balance : 0 %>">
                         <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150">
                             <div class="text-left"><%= event.name %></div>
                             <div class="text-muted pl-2">
@@ -46,5 +46,8 @@
             </div>
         </div>
     </div>
+    <% if sending && admin_signed_in? %>
+      <p class="text-sm mt-0 text-muted">Available balance: <span data-organization-select-target="balance">$0.00</span></p>
+    <% end %>
 
 </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
@leowilkin requested to be able to see sender event balance when created a disbursement, which is currently hidden when an admin is signed in.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added the balance below the org select.

<img width="515" height="602" alt="image" src="https://github.com/user-attachments/assets/ae62c640-e661-424c-b2e0-138de59e0e22" />

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

