### PR TITLE
[Card grants] Link to card grant on transactions page no longer 404s

### DIFF
--- a/app/views/hcb_codes/_disbursement.html.erb
+++ b/app/views/hcb_codes/_disbursement.html.erb
@@ -74,7 +74,7 @@
       </p>
       <p>
         <strong>Grant</strong>
-        <%= link_to card_grant_path(@subledger.card_grant), "Grant to #{@subledger.card_grant.user.name}" %>
+        <%= link_to "Grant to #{@subledger.card_grant.user.name}", card_grant_path(@subledger.card_grant) %>
       </p>
     <% else %>
       <p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The link to the card grant in the transactions page gives an invalid link to a page that doesn't exist.
<img width="637" height="237" alt="image" src="https://github.com/user-attachments/assets/90bfa53f-18b9-44e2-800a-0e687df162be" />
Grant /grants/AFIDxK <- invalid link

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Flipped text and link_to params so that the text renders with the link properly.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="553" height="282" alt="image" src="https://github.com/user-attachments/assets/fe093d2b-456b-4a85-81f1-776e68f0513f" />

