### PR TITLE
Fix amount cents for unmapped HCB code

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -136,7 +136,7 @@ class HcbCode < ApplicationRecord
   end
 
   def amount_cents_by_event(event)
-    return amoount_cents unless event
+    return amount_cents unless event
     return stripe_atm_fee ? amount_cents.abs - stripe_atm_fee : amount_cents.abs if stripe_card?
     return invoice.item_amount if invoice?
 

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -136,6 +136,7 @@ class HcbCode < ApplicationRecord
   end
 
   def amount_cents_by_event(event)
+    return amoount_cents unless event
     return stripe_atm_fee ? amount_cents.abs - stripe_atm_fee : amount_cents.abs if stripe_card?
     return invoice.item_amount if invoice?
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
In the unmapped ledger, when you try to click on the hcb code link, it 500s since event_id is null before the transaction is mapped.
<img width="1286" height="646" alt="image" src="https://github.com/user-attachments/assets/40866637-d46f-4dbd-9866-bda9464741c2" />

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a line to default the amount_cents_by_event to amount_cents if the event does not exist.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

