### PR TITLE
[v4 API] add user lookup routes, restricted oauth2 tokens

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -32,6 +32,14 @@ module Api
         render json: { error: "not_found" }, status: :not_found
       end
 
+      def self.require_oauth2_scope(required_scope, *actions)
+        @oauth_requirements ||= Hash.new { |h, k| h[k] = [] }
+
+        actions.each { |action| @oauth_requirements[action.to_sym] << required_scope }
+      end
+
+      append_before_action :check_restricted_scopes!
+
       private
 
       def authenticate!
@@ -47,6 +55,24 @@ module Api
         unless current_user&.admin?
           render json: { error: "invalid_auth" }, status: :unauthorized
         end
+      end
+
+      def check_restricted_scopes!
+        # only check scopes for tokens that have the "restricted" scope so as not to break existing apps
+        # this can roll out to all tokens later
+        return unless current_token&.scopes&.include?("restricted")
+
+        required_scopes = self.class.instance_variable_get(:@oauth_requirements)&.[](action_name.to_sym) || []
+
+        # restricted tokens shouldn't work on actions without explicit scopes (most of them)
+        if required_scopes.empty?
+          raise Pundit::NotAuthorizedError
+        end
+
+        current_scopes = current_token.scopes || []
+        has_required_scopes = required_scopes.all? { |scope| current_scopes.include?(scope) }
+
+        raise Pundit::NotAuthorizedError unless has_required_scopes
       end
 
       def set_expand

--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -43,6 +43,12 @@ module Api
         @current_user = current_token&.user
       end
 
+      def require_admin!
+        unless current_user&.admin?
+          render json: { error: "invalid_auth" }, status: :unauthorized
+        end
+      end
+
       def set_expand
         @expand = params[:expand].to_s.split(",").map { |e| e.strip.to_sym }
       end

--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -23,6 +23,8 @@ module Api
         render :show
       end
 
+      require_oauth2_scope "user_lookup", :show, :by_email
+
       def available_icons
         icons = {
           frc: current_user.events.robotics_team.any?,

--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -17,7 +17,6 @@ module Api
       end
 
       def by_email
-        puts params[:email]
         @user = User.find_by!(email: params[:email])
         authorize @user, :show?
         render :show

--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -4,9 +4,23 @@ module Api
   module V4
     class UsersController < ApplicationController
       skip_after_action :verify_authorized, only: [:available_icons]
+      before_action :require_admin!, only: [:show, :by_email]
+
+      def me
+        @user = authorize current_user, :show?
+        render :show
+      end
 
       def show
-        @user = authorize current_user
+        @user = User.find_by_public_id!(params[:id])
+        authorize @user
+      end
+
+      def by_email
+        puts params[:email]
+        @user = User.find_by!(email: params[:email])
+        authorize @user, :show?
+        render :show
       end
 
       def available_icons

--- a/app/views/api/v4/users/_user.json.jbuilder
+++ b/app/views/api/v4/users/_user.json.jbuilder
@@ -5,13 +5,15 @@ json.name user.name
 json.email user.email
 json.avatar profile_picture_for(user, params[:avatar_size].presence&.to_i || 24)
 json.birthday user.birthday
-json.shipping_address do
-  json.address_line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
-  json.address_line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
-  json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
-  json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
-  json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country
-  json.postal_code user&.stripe_cards&.physical&.last&.stripe_shipping_address_postal_code
+if expand?(:shipping_address)
+  json.shipping_address do
+    json.address_line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
+    json.address_line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
+    json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
+    json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
+    json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country
+    json.postal_code user&.stripe_cards&.physical&.last&.stripe_shipping_address_postal_code
+  end
 end
 json.admin user.admin?
 json.auditor user.auditor?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -580,9 +580,9 @@ Rails.application.routes.draw do
           get :available_icons
         end
 
-        resources :users, only: [ :show ] do
+        resources :users, only: [:show] do
           collection do
-            get "/by_email/:email", to: "users#by_email", as: "by_email", constraints: { email: /[^\/]+/}
+            get "/by_email/:email", to: "users#by_email", as: "by_email", constraints: { email: /[^\/]+/ }
           end
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,7 +564,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v4 do
       defaults format: :json do
-        resource :user do
+        resource :user, only: [] do
+          get "/", to: "users#me", as: "user"
           resources :events, path: "organizations", only: [:index]
           resources :stripe_cards, path: "cards", only: [:index]
           resources :card_grants, only: [:index]
@@ -577,6 +578,12 @@ Rails.application.routes.draw do
 
           get "transactions/missing_receipt", to: "transactions#missing_receipt"
           get :available_icons
+        end
+
+        resources :users, only: [ :show ] do
+          collection do
+            get "/by_email/:email", to: "users#by_email", as: "by_email", constraints: { email: /[^\/]+/}
+          end
         end
 
         resources :events, path: "organizations", only: [:show] do


### PR DESCRIPTION
adds `/api/v4/users/<public_id>` and `/api/v4/users/by_email/<email>` for admins...
also, brings in a restricted scope for `ApiToken`s + `require_oauth2_scope` on v4 controllers:
apps can opt in by taking the "restricted" scope – then, they won't be able to access any actions that `require_oauth2_scope` a scope they don't have or haven't been scoped yet.