### PR TITLE
Only show published HCB announcements on home page

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -126,7 +126,7 @@
       <% end %>
     </div>
     <div class="flex flex-col gap-2 items-start text-left w-full self-stretch">
-      <%= render partial: "announcements/announcement_card", collection: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.order(published_at: :desc).last(2), as: :announcement %>
+      <%= render partial: "announcements/announcement_card", collection: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last(2), as: :announcement %>
     </div>
 
     <%= render "static_pages/index/explore" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Drafts on the HCB ops org were showing on the home page to people who had access (org members, auditors+)


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Only show published HCB announcements on home page


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

