### PR TITLE
Remove announcements flipper flag

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -15,8 +15,7 @@ class FeaturesController < ApplicationController
     totp_2024_06_13: %w[🔒 ⏰],
     event_home_page_redesign_2024_09_21: %w[🏠 📊 📉 💸],
     card_logos_2024_08_27: %w[🌈 💳 📸],
-    donation_tiers_2025_06_24: %w[💖 🥇 🥈 🥉],
-    organization_announcements_tier_1_2025_07_07: %w[📢 📣 🔔 📰 ⚠️ ❗ 🚨 🎉 🥳]
+    donation_tiers_2025_06_24: %w[💖 🥇 🥈 🥉]
   }.freeze
 
   def enable_feature


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The announcements flipper flag has been removed as it is generally available now, so it is no longer needed in `FeaturesController`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removed the announcements entry


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

