### PR TITLE
[Card Grants] Fix `new` page

### DIFF
--- a/app/views/card_grants/new.html.erb
+++ b/app/views/card_grants/new.html.erb
@@ -1,4 +1,4 @@
 <% page_sm %>
 <%= render "events/nav", selected: :transfers %>
 
-<% render "create_form", locals: { card_grant: @card_grant } %>
+<% render "create_form", card_grant: @card_grant %>


### PR DESCRIPTION
## Summary of the problem
The `new` page is broken because we're passing locals into a render call that isn't a partial.


## Describe your changes
Drops `locals` and passes arguments directly