### PR TITLE
Add job and cron to delete old template draft announcements

### DIFF
--- a/app/jobs/delete_old_template_drafts_job.rb
+++ b/app/jobs/delete_old_template_drafts_job.rb
@@ -5,7 +5,7 @@ class DeleteOldTemplateDraftsJob < ApplicationJob
 
   def perform
     old_template_drafts = Announcement.template_draft.where("created_at < ?", 1.month.ago)
-    old_template_drafts.destroy_all
+    old_template_drafts.delete_all!
   end
 
 end

--- a/app/jobs/delete_old_template_drafts_job.rb
+++ b/app/jobs/delete_old_template_drafts_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DeleteOldTemplateDraftsJob < ApplicationJob
+  queue_as :low
+
+  def perform
+    old_template_drafts = Announcement.template_draft.where("created_at < ?", 1.month.ago)
+    old_template_drafts.destroy_all
+  end
+
+end

--- a/app/jobs/delete_old_template_drafts_job.rb
+++ b/app/jobs/delete_old_template_drafts_job.rb
@@ -4,7 +4,7 @@ class DeleteOldTemplateDraftsJob < ApplicationJob
   queue_as :low
 
   def perform
-    old_template_drafts = Announcement.template_draft.where("created_at < ?", 1.month.ago)
+    old_template_drafts = Announcement.template_draft.where("created_at < ?", 2.months.ago)
     old_template_drafts.delete_all!
   end
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -216,3 +216,7 @@ weekly_ysws_event_summary_job:
 monthly_follower_summary_job:
   cron: "0 0 1 * *" # run first day of each month
   class: "MonthlyFollowerSummaryJob"
+
+delete_old_template_drafts_job:
+  cron: "0 0 1 * *" # run first day of each month
+  class: "DeleteOldTemplateDraftsJob"


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
A lot of database records are being created with #10945 merged, many of which will not be used if the user does not click on the link to edit it (which will convert it from a template draft into a draft).

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Every month, delete template draft announcements that are over a month old.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

