### PR TITLE
[Mobile] Exclude user pages from HCB mobile deeplinking

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -35,6 +35,10 @@
             "exclude": true
           },
           {
+            "/": "/my/*",
+            "exclude": true
+          },
+          {
             "/": "/?*",
             "comment": "Organization homepages"
           }


### PR DESCRIPTION
## Summary of the problem
HCB mobile currently deep links user pages (/my/settings, /my/inbox) which do not have full feature parity.


## Describe your changes
Excludes `/my/*`