### PR TITLE
[AI Memo] Upon OpenAI non-200, don't raise error

### DIFF
--- a/app/services/hcb_code_service/ai_generate_memo.rb
+++ b/app/services/hcb_code_service/ai_generate_memo.rb
@@ -27,7 +27,7 @@ module HcbCodeService
       )
 
       unless res.success?
-        Rails.error.unexpected "Failed to contact OpenAI. #{res.status}: #{res.reason_phrase}\n#{res.body&.dig("error", "message")}"
+        Rails.error.report StandardError.new("Failed to contact OpenAI. #{res.status}: #{res.reason_phrase}\n#{res.body&.dig("error", "message")}")
         return nil
       end
 


### PR DESCRIPTION


## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

We recently switched `Airbrake.notify` to `Rails.error.unexpected` which is called when Open AI returns a non-200 status code.

The issue here is `Airbrake.notify` won't raise an error, but `Rails.error.unexpected` will raise an error (but only in non-production).

See docs: https://api.rubyonrails.org/v8.0.2/classes/ActiveSupport/ErrorReporter.html#method-i-unexpected

This changes the behavior of the class from return `nil` to raising an error, which is causing RSpec to fail.

See the spec located at: ./spec/services/hcb_code_service/ai_generate_memo_spec.rb:33

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

To resolve this issue, i'm using `Rails.error.report` instead of `Rails.error.unexpected`; which also means that instead of passing the message as a String, I needed to wrap it some subclass of `Exception`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

