### PR TITLE
Revert "Flipper for card grant popovers"

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,6 +1,6 @@
 <% title "Home" %>
 <% page_md %>
-<% @show_card_popovers = Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) %>
+
 <%= render "users/nav", selected: :home if signed_in? %>
 
 <h1 class="heading items-center sm:items-start justify-center sm:justify-between center sm:text-left w-auto m-0">


### PR DESCRIPTION
Reverts hackclub/hcb#10649

Card grants don't work in popovers for regular users because they can't render the stripe card view. It appears as fine to admins though.