### PR TITLE
Fix admin create event flow to create contract for invitee

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -80,7 +80,9 @@ class AdminController < ApplicationController
     ::EventService::Create.new(
       name: params[:name],
       emails:,
-      is_signee: params[:is_signee].to_i == 1,
+      is_signee: params[:is_signee] == "true",
+      cosigner_email: params[:cosigner_email].presence,
+      include_onboarding_videos: params[:include_videos].to_i == 1,
       country: params[:country],
       point_of_contact_id: params[:point_of_contact_id],
       approved: params[:approved].to_i == 1,

--- a/app/controllers/organizer_position_invites_controller.rb
+++ b/app/controllers/organizer_position_invites_controller.rb
@@ -32,7 +32,9 @@ class OrganizerPositionInvitesController < ApplicationController
     authorize @invite
 
     if service.run
-      OrganizerPosition::Contract.create(organizer_position_invite: @invite, cosigner_email: invite_params[:cosigner_email].presence, include_videos: invite_params[:include_videos]) if @invite.is_signee
+      if @invite.is_signee
+        OrganizerPosition::Contract.create(organizer_position_invite: @invite, cosigner_email: invite_params[:cosigner_email].presence, include_videos: invite_params[:include_videos])
+      end
       flash[:success] = "Invite successfully sent to #{user_email}"
       redirect_to event_team_path @invite.event
     else

--- a/app/javascript/controllers/form_hide_field_controller.js
+++ b/app/javascript/controllers/form_hide_field_controller.js
@@ -14,10 +14,6 @@ export default class extends Controller {
   toggle() {
     const selectedValue = this.selectTarget.value
 
-    if (selectedValue === this.conditionValue) {
-      this.fieldTarget.style.display = 'none'
-    } else {
-      this.fieldTarget.style.display = 'block'
-    }
+    this.fieldTarget.hidden = selectedValue === this.conditionValue
   }
 }

--- a/app/javascript/controllers/form_hide_field_controller.js
+++ b/app/javascript/controllers/form_hide_field_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    condition: String,
+  }
+
+  static targets = ['field', 'select']
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    const selectedValue = this.selectTarget.value
+
+    if (selectedValue === this.conditionValue) {
+      this.fieldTarget.style.display = 'none'
+    } else {
+      this.fieldTarget.style.display = 'block'
+    }
+  }
+}

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -2,7 +2,21 @@
 
 module EventService
   class Create
-    def initialize(name:, point_of_contact_id:, emails: [], is_signee: true, country: [], is_public: true, is_indexable: true, approved: false, plan: Event::Plan::Standard, tags: [], can_front_balance: true, demo_mode: false, risk_level: 0)
+    def initialize(name:,
+                   point_of_contact_id:,
+                   cosigner_email:,
+                   include_onboarding_videos:,
+                   emails: [],
+                   is_signee: true,
+                   country: [],
+                   is_public: true,
+                   is_indexable: true,
+                   approved: false,
+                   plan: Event::Plan::Standard,
+                   tags: [],
+                   can_front_balance: true,
+                   demo_mode: false,
+                   risk_level: 0)
       @name = name
       @emails = emails
       @is_signee = is_signee

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -30,6 +30,8 @@ module EventService
       @can_front_balance = can_front_balance
       @demo_mode = demo_mode
       @risk_level = risk_level
+      @cosigner_email = cosigner_email
+      @include_onboarding_videos = include_onboarding_videos
     end
 
     def run
@@ -49,7 +51,12 @@ module EventService
         # event.mark_approved! if @approved
 
         @emails.each do |email|
-          OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: email, is_signee: @is_signee).run!
+          invite_service = OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: email, is_signee: @is_signee)
+          invite_service.run!
+
+          if @is_signee
+            OrganizerPosition::Contract.create(organizer_position_invite: invite_service.model, cosigner_email: @cosigner_email, include_videos: @include_onboarding_videos)
+          end
         end
 
         event

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -17,7 +17,7 @@
       <%= form.email_field :organizer_email, placeholder: "Email Address", value: params[:organizer_email], required: false %>
     </p>
 
-    <%= render "organizer_position_invites/admin_signee_check", form: form %>
+    <%= render "organizer_position_invites/admin_signee_check", form: form, default_selected: true %>
 
     <p>
       <%= form.label :country %>

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Create an organization</h1>
 
-<%= form_with(model: nil, local: true, url: event_create_admin_index_path) do |form| %>
+<%= form_with(local: true, url: event_create_admin_index_path) do |form| %>
   <fieldset>
     <legend>Organization</legend>
     <p>

--- a/app/views/admin/event_new.html.erb
+++ b/app/views/admin/event_new.html.erb
@@ -17,10 +17,7 @@
       <%= form.email_field :organizer_email, placeholder: "Email Address", value: params[:organizer_email], required: false %>
     </p>
 
-    <p>
-      <%= form.check_box :is_signee, { checked: true } %>
-      <%= form.label :is_signee, "Organizer signed contract?" %>
-    </p>
+    <%= render "organizer_position_invites/admin_signee_check", form: form %>
 
     <p>
       <%= form.label :country %>

--- a/app/views/organizer_position_invites/_admin_signee_check.html.erb
+++ b/app/views/organizer_position_invites/_admin_signee_check.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (form:, default_selected: "") %>
+
 <div class="field field--select w-100"
      data-controller="form-hide-field"
      data-form-hide-field-condition-value="false">
@@ -8,7 +10,7 @@
         ["❌ Won't sign the contract", "false"],
       ],
       { include_blank: "Select a contract signee status",
-        selected: "true"
+        selected: default_selected
       },
       { required: true, style: "width: 100%",
         data: {

--- a/app/views/organizer_position_invites/_admin_signee_check.html.erb
+++ b/app/views/organizer_position_invites/_admin_signee_check.html.erb
@@ -8,6 +8,7 @@
         ["❌ Won't sign the contract", "false"],
       ],
       { include_blank: "Select a contract signee status",
+        selected: "true"
       },
       { required: true, style: "width: 100%",
         data: {

--- a/app/views/organizer_position_invites/_admin_signee_check.html.erb
+++ b/app/views/organizer_position_invites/_admin_signee_check.html.erb
@@ -1,0 +1,26 @@
+<div class="field field--select w-100"
+     data-controller="form-hide-field"
+     data-form-hide-field-condition-value="false">
+  <h3 class="mb2 mt1">Contracts</h3>
+  <%= form.select :is_signee,
+      [
+        ["📃 Contract Signee", "true"],
+        ["❌ Won't sign the contract", "false"],
+      ],
+      { include_blank: "Select a contract signee status",
+      },
+      { required: true, style: "width: 100%",
+        data: {
+          form_hide_field_target: "select",
+          action: "form-hide-field#toggle",
+        }
+      } %>
+
+  <div data-form-hide-field-target="field">
+    <%= form.email_field :cosigner_email, placeholder: "Cosignee email (required if under 18)", class: "w-100 mt1" %>
+  </div>
+  <div class="field field--checkbox">
+    <%= form.check_box :include_videos %>
+    <%= form.label :include_videos, "Would you like us to include the onboarding videos?" %>
+  </div>
+</div>

--- a/app/views/organizer_position_invites/_form.html.erb
+++ b/app/views/organizer_position_invites/_form.html.erb
@@ -66,17 +66,27 @@
   <% end %>
 
   <% admin_tool("mt2 mb2 flex g1") do %>
-    <div class="field field--select w-100">
+    <div class="field field--select w-100"
+         data-controller="form-hide-field"
+         data-form-hide-field-condition-value="false">
       <h3 class="mb2 mt1">Contracts</h3>
       <%= form.select :is_signee,
           [
             ["📃 Contract Signee", "true"],
             ["❌ Won't sign the contract", "false"],
           ],
-          { include_blank: "Select a contract signee status" },
-          { required: true, style: "width: 100%" } %>
+          { include_blank: "Select a contract signee status",
+          },
+          { required: true, style: "width: 100%",
+            data: {
+              form_hide_field_target: "select",
+              action: "form-hide-field#toggle",
+            }
+          } %>
 
-      <%= form.email_field :cosigner_email, placeholder: "Cosignee email (required if under 18)", class: "w-100 mt1" %>
+      <div data-form-hide-field-target="field">
+        <%= form.email_field :cosigner_email, placeholder: "Cosignee email (required if under 18)", class: "w-100 mt1" %>
+      </div>
       <div class="field field--checkbox">
         <%= form.check_box :include_videos %>
         <%= form.label :include_videos, "Would you like us to include the onboarding videos?" %>

--- a/app/views/organizer_position_invites/_form.html.erb
+++ b/app/views/organizer_position_invites/_form.html.erb
@@ -66,32 +66,7 @@
   <% end %>
 
   <% admin_tool("mt2 mb2 flex g1") do %>
-    <div class="field field--select w-100"
-         data-controller="form-hide-field"
-         data-form-hide-field-condition-value="false">
-      <h3 class="mb2 mt1">Contracts</h3>
-      <%= form.select :is_signee,
-          [
-            ["📃 Contract Signee", "true"],
-            ["❌ Won't sign the contract", "false"],
-          ],
-          { include_blank: "Select a contract signee status",
-          },
-          { required: true, style: "width: 100%",
-            data: {
-              form_hide_field_target: "select",
-              action: "form-hide-field#toggle",
-            }
-          } %>
-
-      <div data-form-hide-field-target="field">
-        <%= form.email_field :cosigner_email, placeholder: "Cosignee email (required if under 18)", class: "w-100 mt1" %>
-      </div>
-      <div class="field field--checkbox">
-        <%= form.check_box :include_videos %>
-        <%= form.label :include_videos, "Would you like us to include the onboarding videos?" %>
-      </div>
-    </div>
+    <%= render "organizer_position_invites/admin_signee_check", form: form %>
   <% end %>
 
   <%= form.submit "Submit" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Fixes https://github.com/hackclub/hcb/issues/10738

When creating a new event in the admin flow, invited users would not have an associated contract created. This PR fixes that.

## Describe your changes

**Best reviewed by commits**

- extract a partial to ask for signee + cosigner + onboarding videos from regular invite flow and share it with admin flow
- currently this has is_signee default to true since that was the existing behavior for admins, we should revisit if that's what we want for regular invites too. It's slightly awkward to set the default due to the partial being shared now.

small QOL improvement to hide the cosigner field if the user is not going to be a signee, as it's not relevant. This will still get sent to the backend if a user filled it out but then flipped the `is_signee` flag off, but the backend correctly ignores it.

We might want to fold in contract creation into the OrganizerPositionInvite service somehow since they seem related.
