### PR TITLE
[Logins] Set hidden `sms` param to `true` because we're casting it to a boolean

### DIFF
--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -47,7 +47,7 @@
     <%= hidden_field_tag :timezone %>
     <%= hidden_field_tag :return_to, @return_to if @return_to %>
     <% if @use_sms_auth %>
-      <%= hidden_field_tag :sms %>
+      <%= hidden_field_tag :sms, :true %>
     <% else %>
       <p class="h5 muted"><em>Make sure to check your spam folder</em></p>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
Users are unable to login with SMS because we recently started casting `sms` to a boolean.


## Describe your changes
Sets `sms` to `true` instead of empty.