### PR TITLE
Improve card details

### DIFF
--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -61,7 +61,12 @@
         <% end %>
 
         <div class="fs-mask">
-          <strong>Expiration date</strong>
+          <strong class="inline-flex items-center" style="gap: 4px">
+            Expiration date
+            <%= link_to "#", class: "text-yellow tooltipped tooltipped--e", "aria-label": "This is what you enter when asked for expiration date at checkout. This is different than your grant's expiration date.", style: "display: flex;", data: { turbo: false } do %>
+              <%= inline_icon "important", size: 18, style: "position: unset;" %>
+            <% end %>
+          </strong>
           <%= copy_to_clipboard(render_short_exp_date(stripe_card), class: "w-fit", tooltip_direction: "e") { render_exp_date stripe_card } %>
         </div>
 
@@ -99,6 +104,18 @@
           <strong>ZIP/Postal code</strong>
           <%= copy_to_clipboard(stripe_card.stripe_cardholder.address_postal_code, class: "w-fit", tooltip_direction: "e") %>
         </div>
+
+        <% if stripe_card.user.phone_number %>
+          <div class="fs-mask">
+            <strong class="inline-flex items-center" style="gap: 4px">
+              Phone number
+              <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": "Seem familiar? This is your number! Use this if asked during checkout :)", style: "display: flex;", data: { turbo: false } do %>
+                <%= inline_icon "info", size: 18, style: "position: unset;" %>
+              <% end %>
+            </strong>
+            <%= copy_to_clipboard(stripe_card.user.pretty_phone_number, class: "w-fit", tooltip_direction: "e") %>
+          </div>
+        <% end %>
 
         <div>
           <strong>Type</strong>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -2,10 +2,17 @@
 
 <% if (stripe_card = card_grant.stripe_card).present? %>
   <div>
-    <div class="card container--md">
+    <div class="card container--md pt-0">
+      <p>This is information about your grant:</p>
+
       <section class="details">
         <p>
-          <strong>Expiration date</strong>
+          <strong class="inline-flex items-center" style="gap: 4px">
+            Expiration date
+            <%= link_to "#", class: "text-yellow tooltipped tooltipped--e", "aria-label": "This is when your grant will be returned to #{card_grant.event.name}. Please check the above section if you are looking for your billing information.", style: "display: flex;", data: { turbo: false } do %>
+              <%= inline_icon "important", size: 18, style: "position: unset;" %>
+            <% end %>
+          </strong>
           <span><%= format_date card_grant.expires_on %></span>
         </p>
 

--- a/app/views/stripe_cards/_details.html.erb
+++ b/app/views/stripe_cards/_details.html.erb
@@ -135,6 +135,18 @@
       <%= copy_to_clipboard(stripe_card.stripe_cardholder.address_postal_code, class: "w-fit", tooltip_direction: "e") %>
     </div>
 
+    <% if stripe_card.user.phone_number %>
+      <div class="fs-mask">
+        <strong class="inline-flex items-center" style="gap: 4px">
+          Phone number
+          <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": "Seem familiar? This is your number! Use this if asked during checkout :)", style: "display: flex;", data: { turbo: false } do %>
+            <%= inline_icon "info", size: 18, style: "position: unset;" %>
+          <% end %>
+        </strong>
+        <%= copy_to_clipboard(stripe_card.user.pretty_phone_number, class: "w-fit", tooltip_direction: "e") %>
+      </div>
+    <% end %>
+
     <div>
       <strong>Type</strong>
       <%= stripe_card.virtual? ? "Virtual" : "Physical" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
People keep getting confused over what is the expiration date on card grants and what to use as their phone number during checkout.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
This PR adds the users own phone number to the card details section on both card grants and regular stripe cards. It also adds tooltips to the expiration dates on card grants to guide users towards the correct one to use.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

