### PR TITLE
[Event Homepage] Fix shift-clicking on homepage chips

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -61,7 +61,7 @@
         <%= inline_icon "attachment", size: 20 %>
         Get reimbursed
       <% end %>
-      <%= link_to event_check_deposits_path(@event), class: "list-badge quick-action" do %>
+      <%= link_to event_check_deposits_path(@event), class: "list-badge quick-action", data: { behavior: "modal_trigger", modal: "deposit_check" }  do %>
         <%= inline_icon "cheque", size: 20 %>
         Deposit a check
       <% end %>
@@ -77,6 +77,11 @@
     <%= render "reimbursement/reports/create_form", modal_id: "create_reimbursement" %>
     <%= render "transfer_modal" %>
     <%= render "invoices/modal" %>
+
+    <section class="modal bg-snow" data-behavior="modal" role="dialog" id="deposit_check">
+      <%= modal_header "Deposit a check" %>
+      <%= render "check_deposits/new", event: @event %>
+    </section>
   <% end %>
 
   <%= render "events/public_message" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -53,11 +53,11 @@
 <div class="flex flex-col gap-[20px]">
   <% if organizer_signed_in?(as: :member) %>
     <div class="flex max-w-full overflow-auto whitespace-nowrap scrollbar-hidden">
-      <%= link_to "#", class: "list-badge quick-action ml-0", data: { behavior: "modal_trigger", modal: "send_transfer" } do %>
+      <%= link_to event_transfers_new_path(@event), class: "list-badge quick-action ml-0", data: { behavior: "modal_trigger", modal: "send_transfer" } do %>
         <%= inline_icon "payment-transfer", size: 20 %>
         Transfer money
       <% end %>
-      <%= link_to "#", class: "list-badge quick-action", data: { behavior: "modal_trigger", modal: "create_reimbursement" } do %>
+      <%= link_to event_reimbursements_path(@event), class: "list-badge quick-action", data: { behavior: "modal_trigger", modal: "create_reimbursement" } do %>
         <%= inline_icon "attachment", size: 20 %>
         Get reimbursed
       <% end %>
@@ -69,7 +69,7 @@
         <%= inline_icon "bank-account", size: 20 %>
         Account numbers
       <% end %>
-      <%= link_to "#", class: "list-badge quick-action", data: { behavior: "modal_trigger", modal: "new_invoice" } do %>
+      <%= link_to new_event_invoice_path(@event), class: "list-badge quick-action", data: { behavior: "modal_trigger", modal: "new_invoice" } do %>
         <%= inline_icon "briefcase", size: 20 %>
         Send an invoice
       <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -78,7 +78,7 @@
     <%= render "transfer_modal" %>
     <%= render "invoices/modal" %>
 
-    <section class="modal bg-snow" data-behavior="modal" role="dialog" id="deposit_check">
+    <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="deposit_check">
       <%= modal_header "Deposit a check" %>
       <%= render "check_deposits/new", event: @event %>
     </section>


### PR DESCRIPTION
This pull request updates several links in the `app/views/events/show.html.erb` file to use more specific paths instead of placeholder `"#"` URLs. These changes improve the maintainability and clarity of the code by directly referencing the appropriate routes.

### Updates to link paths:

* Updated the "Transfer money" link to use the `event_transfers_new_path` helper, ensuring it points to the correct route for initiating a money transfer.
* Updated the "Get reimbursed" link to use the `event_reimbursements_path` helper, linking directly to the reimbursement creation route.
* Updated the "Send an invoice" link to use the `new_event_invoice_path` helper, directing users to the correct route for creating a new invoice.