### PR TITLE
Fix search clearing other filters

### DIFF
--- a/app/views/events/_search.html.erb
+++ b/app/views/events/_search.html.erb
@@ -6,4 +6,7 @@
       <%= inline_icon "view-close", size: 24 %>
     <% end %>
   <% end %>
+  <% params.except(:q, :controller, :action).each do |key, value| %>
+    <%= hidden_field_tag key, value %>
+  <% end %>
 </div>


### PR DESCRIPTION
### Closes https://github.com/hackclub/hcb/pull/10937#pullrequestreview-3025624079


This pull request updates the search form in the `app/views/events/_search.html.erb` file to preserve additional query parameters when submitting the form. 

Key change:

* Added a loop to include hidden fields for all parameters except `:q`, `:controller`, and `:action`, ensuring that these parameters are retained during form submissions. 

