### PR TITLE
[Announcements] Fix accepted mailer being sent on initial invite

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -143,7 +143,10 @@ class OrganizerPositionInvite < ApplicationRecord
       end
     end
 
-    OrganizerPositionInvitesMailer.with(invite: self).accepted.deliver_later
+    # Don't send mailer if this is the first organizer
+    if self.event.users.size > 1
+      OrganizerPositionInvitesMailer.with(invite: self).accepted.deliver_later
+    end
 
     true
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
When an organization is created and the initial organizer is invited, a template draft announcement was being unnecessarily created as there are no other organizers to send an accepted email to. On database seed, this resulted in 13 announcements being created.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a check to make sure that the mailer is not sent if there is no one else in the organization.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

