### PR TITLE
Refactor mailer set_emails into an event method

### DIFF
--- a/app/mailers/account_number_mailer.rb
+++ b/app/mailers/account_number_mailer.rb
@@ -2,7 +2,7 @@
 
 class AccountNumberMailer < ApplicationMailer
   before_action :set_event_memo_and_amount_cents
-  default to: -> { @event.users.map(&:email_address_with_name) }
+  default to: -> { @event.organizer_contact_emails }
 
   def insufficent_balance
     mail subject: "A direct debit for #{@event.name} was reversed due to an insufficent balance"

--- a/app/mailers/donation_mailer.rb
+++ b/app/mailers/donation_mailer.rb
@@ -33,8 +33,7 @@ class DonationMailer < ApplicationMailer
   end
 
   def set_emails
-    @emails = @donation.event.users.map(&:email_address_with_name)
-    @emails << @donation.event.config.contact_email if @donation.event.config.contact_email.present?
+    @emails = @donation.event.organizer_contact_emails
   end
 
 end

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -2,7 +2,7 @@
 
 class EventMailer < ApplicationMailer
   before_action { @event = params[:event] }
-  before_action :set_emails
+  before_action { @emails = @event.organizer_contact_emails }
 
   def monthly_donation_summary
     @donations = @event.donations.where(aasm_state: [:in_transit, :deposited], created_at: Time.now.last_month.beginning_of_month..).order(:created_at)
@@ -39,13 +39,6 @@ class EventMailer < ApplicationMailer
     ).create
 
     mail to: @emails, subject: "#{@event.name} has reached its donation goal!"
-  end
-
-  private
-
-  def set_emails
-    @emails = @event.users.map(&:email_address_with_name)
-    @emails << @event.config.contact_email if @event.config.contact_email.present?
   end
 
 end

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -11,8 +11,7 @@ class InvoiceMailer < ApplicationMailer
 
   def notify_organizers_paid
     @invoice = params[:invoice]
-    @emails = @invoice.sponsor.event.users.map(&:email_address_with_name)
-    @emails << @invoice.sponsor.event.config.contact_email if @invoice.sponsor.event.config.contact_email.present?
+    @emails = @invoice.sponsor.event.organizer_contact_emails
     @emails = @emails.length > 10 ? [@invoice.creator.email_address_with_name] : @emails
 
     if @invoice.sponsor.event.can_front_balance?

--- a/app/mailers/stripe_card/personalization_design_mailer.rb
+++ b/app/mailers/stripe_card/personalization_design_mailer.rb
@@ -8,7 +8,7 @@ class StripeCard
 
       return unless @event
 
-      mail to: @event.users.map(&:email_address_with_name), subject: "Your card logo was rejected by our card issuer"
+      mail to: @event.organizer_contact_emails, subject: "Your card logo was rejected by our card issuer"
     end
 
     private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -770,6 +770,13 @@ class Event < ApplicationRecord
     organizer_positions.joins(:user).count { |op| op.user.teenager? && op.user.active? }
   end
 
+  def organizer_contact_emails
+    emails = users.map(&:email_address_with_name)
+    emails << config.contact_email if config.contact_email.present?
+
+    emails
+  end
+
   private
 
   def point_of_contact_is_admin


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The code to get a list of emails of all users in an event is replicated across several mailers, and some don't take into account the team contact email if it is set.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a method on `Event` that gets a list of all event users along with the team contact email, and used it everywhere mailers need it.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

