### PR TITLE
Fix dark mode blog widget error

### DIFF
--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -34,7 +34,9 @@ export default class extends Controller {
   }
 
   updateBlogEmbed(theme) {
-    const resolvedTheme = theme === 'system' ? BK.resolveSystemTheme() : theme
-    this.blogOutlet.embedTarget.src = `${this.blogOutlet.embedTarget.src.split('?')[0]}?theme=${resolvedTheme}`
+    if (this.hasBlogOutlet) {
+      const resolvedTheme = theme === 'system' ? BK.resolveSystemTheme() : theme
+      this.blogOutlet.embedTarget.src = `${this.blogOutlet.embedTarget.src.split('?')[0]}?theme=${resolvedTheme}`
+    }
   }
 }

--- a/app/views/application/_blog_widget.html.erb
+++ b/app/views/application/_blog_widget.html.erb
@@ -8,9 +8,7 @@
     data-menu-target="toggle"
     data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">
     <%= inline_icon "rep", size: home_action_size %>
-    <% if Flipper.enabled?(:changelog_widget_2025_04_24, current_user) %>
-      <span class="badge !bg-red !text-white hidden absolute top-[-15px] right-[-4px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
-    <% end %>
+    <span class="badge !bg-red !text-white hidden absolute top-[-15px] right-[-4px] block m-0 py-[2px] px-1" data-blog-target="badge"></span>
   </a>
   <div
     class="absolute top-10 card py-3 px-0 w-80 z-10 flex flex-col items-center justify-start leading-normal hidden"

--- a/app/views/application/_docs_header.html.erb
+++ b/app/views/application/_docs_header.html.erb
@@ -7,9 +7,7 @@
       <div style="height: 28px;">
         <%= render partial: "application/theme_toggle" %>
       </div>
-      <% if signed_in? %>
-        <%= render partial: "application/blog_widget" %>
-      <% end %>
+      <%= render partial: "application/blog_widget" %>
 
       <% if signed_in? %>
         <%= button_to logout_users_path,

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -3,11 +3,9 @@
     <% unless request.path.include?("auth") || request.path.include?("logins") %>
       <%= render partial: "application/theme_toggle" %>
     <% end %>
-    <% if signed_in? %>
-      <div class="ml2">
-        <%= render partial: "application/blog_widget" %>
-      </div>
-    <% end %>
+    <div class="ml2">
+      <%= render partial: "application/blog_widget" %>
+    </div>
   </div>
 
   <%= render partial: "application/logo" %>

--- a/app/views/application/_theme_toggle.html.erb
+++ b/app/views/application/_theme_toggle.html.erb
@@ -1,15 +1,17 @@
-<div data-controller="menu" data-menu-placement-value="<%= defined?(top) ? "bottom-end" : "bottom-center" %>">
+<%# locals: (blog_shown: true, top: false) %>
+
+<div data-controller="menu" data-menu-placement-value="<%= top ? "bottom-end" : "bottom-center" %>">
   <button
     data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown"
     data-menu-target="toggle"
-    class="muted <%= "bg-transparent border-0 p-0" if defined?(top) %>"
+    class="muted <%= "bg-transparent border-0 p-0" if top %>"
     type="button"
     data-action="class#toggle focus#focus">
     <%= inline_icon "moon", size: home_action_size, class: "hidden dark:block" %>
     <%= inline_icon "sun", size: home_action_size, class: "dark:hidden" %>
   </button>
 
-  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle" data-dark-mode-toggle-blog-outlet="#blog-widget">
+  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle" <%= 'data-dark-mode-toggle-blog-outlet=#blog-widget' if blog_shown %>>
     <a data-dark-mode-toggle-target="toggle" data-value="system">
       System
       <%= inline_icon "check", class: "hidden ml-auto", size: 24, style: "margin-right: -5px" %>

--- a/app/views/application/_theme_toggle.html.erb
+++ b/app/views/application/_theme_toggle.html.erb
@@ -11,7 +11,7 @@
     <%= inline_icon "sun", size: home_action_size, class: "dark:hidden" %>
   </button>
 
-  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle" <%= 'data-dark-mode-toggle-blog-outlet=#blog-widget' if blog_shown %>>
+  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle" <%= "data-dark-mode-toggle-blog-outlet=#blog-widget" if blog_shown %>>
     <a data-dark-mode-toggle-target="toggle" data-value="system">
       System
       <%= inline_icon "check", class: "hidden ml-auto", size: 24, style: "margin-right: -5px" %>

--- a/app/views/events/landing/_header.html.erb
+++ b/app/views/events/landing/_header.html.erb
@@ -2,7 +2,7 @@
 <% page_sm %>
 
 <div class="absolute top-0 right-0 m2">
-  <%= render partial: "application/theme_toggle", locals: { top: true, tooltip_location: "w" } %>
+  <%= render partial: "application/theme_toggle", locals: { top: true, blog_shown: false } %>
 </div>
 
 <%= content_for(:header) do %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2013/samples/timestamp/2025-07-16T18:55:27Z

```
Error: Missing outlet element "blog" for host controller "dark-mode-toggle". Stimulus couldn't find a matching outlet element using selector "#blog-widget".
```

This was caused by places where the theme toggle is rendered without the blog widget

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added checks to make sure the dark mode toggle controller doesn't try to update the blog widget when it is not present. Also removed the Flipper flag on the blog widget and removed the need to be signed in to see the blog widget.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

