### PR TITLE
[Admin] No longer need contract signee when creating org from Airtable

### DIFF
--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -4,8 +4,8 @@ module EventService
   class Create
     def initialize(name:,
                    point_of_contact_id:,
-                   cosigner_email:,
-                   include_onboarding_videos:,
+                   cosigner_email: nil,
+                   include_onboarding_videos: false,
                    emails: [],
                    is_signee: true,
                    country: [],


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
When creating an organization from Airtable, it says that :cosigner_email and :onboarding_videos are not passed in:
<img width="3024" height="1698" alt="image" src="https://github.com/user-attachments/assets/09c45aef-1c8f-49e3-b46d-8d5e5be653d8" />

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added default values for cosigner_email and onboarding videos to nil and false.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
I can't test this in dev mode.
