### PR TITLE
Fix announcement card when date object is `nil`

### DIFF
--- a/app/views/announcements/_announcement_card.html.erb
+++ b/app/views/announcements/_announcement_card.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </div>
   <p class="italic my-0">
-    <%= announcement.draft? ? "Drafted" : "Published" %> by <%= user_mention announcement.author %> on <%= (announcement.draft? ? announcement.created_at : announcement.published_at).strftime("%B %e, %Y") %>
+    <%= announcement.draft? ? "Drafted" : "Published" %> by <%= user_mention announcement.author %> on <%= (announcement.draft? ? announcement.created_at : announcement.published_at)&.strftime("%B %e, %Y") %>
   </p>
   <hr class="my-1 dark:!border-slate border-smoke">
 


### PR DESCRIPTION
<img width="1552" height="980" alt="image" src="https://github.com/user-attachments/assets/d24ccee2-0fd6-4fa2-b3e1-ab9e40e4f028" />

This pull request includes a minor update to the `app/views/announcements/_announcement_card.html.erb` file. The change ensures that the `strftime` method is only called if the date object is not `nil`, improving code safety.

* [`app/views/announcements/_announcement_card.html.erb`](diffhunk://#diff-5b4ff73e8fc14c2fee0863612408c16cf494ff6e79fd3d91df03b82532ec925dL25-R25): Added safe navigation (`&.`) to the `strftime` method call to handle potential `nil` values for `created_at` or `published_at`.