### PR TITLE
[Announcement] Validate content is hash

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -55,6 +55,8 @@ class Announcement < ApplicationRecord
     end
   end
 
+  validate :content_is_json
+
   scope :saved, -> { where.not(aasm_state: :template_draft).where.not(content: {}) }
 
   belongs_to :author, class_name: "User"
@@ -83,6 +85,13 @@ class Announcement < ApplicationRecord
       rescue ActiveRecord::RecordNotUnique
         # Do nothing. The user already follows this event.
       end
+    end
+  end
+
+  def content_is_json
+    unless content.is_a?(Hash)
+      Rails.error.unexpected("Announcement #{id}'s content is not a Hash")
+      errors.add(:content, "is invalid")
     end
   end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

We ran into issues where `content` is a string, when it should be a JSON object

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

I added a validation to prevent those from saving— and alert engineers if it isn't

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

