### PR TITLE
[Announcement::Block] Associate to Event

### DIFF
--- a/app/models/announcement/block.rb
+++ b/app/models/announcement/block.rb
@@ -24,6 +24,7 @@
 class Announcement
   class Block < ApplicationRecord
     belongs_to :announcement
+    has_one :event, through: :announcement
 
     after_create :refresh!
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Our pundit check does `record.event`, but that's not defined. It should be `record.announcement.event`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

i added a 
```
    has_one :event, through: :announcement
```
to Announcement::Block

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

