### PR TITLE
Exempt salary accounts from card locking

### DIFF
--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -63,7 +63,7 @@ module StripeAuthorizationService
 
         return decline_with_reason!("cash_withdrawals_not_allowed") if cash_withdrawal? && !card.cash_withdrawal_enabled?
 
-        return decline_with_reason!("user_cards_locked") if card.user.cards_locked? && !card.event.plan.is_a?(Event::Plan::SalaryAccount)
+        return decline_with_reason!("user_cards_locked") if card.user.cards_locked? && !event.plan.is_a?(Event::Plan::SalaryAccount)
 
         set_metadata!
 

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -63,7 +63,7 @@ module StripeAuthorizationService
 
         return decline_with_reason!("cash_withdrawals_not_allowed") if cash_withdrawal? && !card.cash_withdrawal_enabled?
 
-        return decline_with_reason!("user_cards_locked") if card.user.cards_locked?
+        return decline_with_reason!("user_cards_locked") if card.user.cards_locked? && !card.event.plan.is_a?(Event::Plan::SalaryAccount)
 
         set_metadata!
 


### PR DESCRIPTION
Context:

<img width="617" height="153" alt="Screenshot 2025-07-20 at 11 32 19 PM" src="https://github.com/user-attachments/assets/8cad4ac3-83c2-422f-865b-7c89f4dfff00" />

This will make approvals for gap years with locked cards but using a salary account slower but it should be within the time we have + is better than declining.