### PR TITLE
[DX] Only run `suggest_lint_changes` for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   suggest_lint_changes:
     name: 'Suggest lint changes'
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,7 +47,6 @@ jobs:
         run: bin/lint -c
       - name: Comment suggested changes
         uses: parkerbxyz/suggest-changes@v2.0.0
-        if: ${{ github.event.pull_request }}
   erblint:
     name: 'ERB Lint'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of the problem

- We are currently using `if: ${{ github.event.pull_request }}` to conditionally run `parkerbxyz/suggest-changes` but I can't find any evidence that `github.event.pull_request` is still supported
- Our `if` is on the very last step of the job so we still run all the previous steps before bailing

## Describe your changes

- Move the `if` to the job definition
- Use the documented `github.event_name == 'pull_request'` (https://docs.github.com/en/actions/reference/contexts-reference#example-usage-of-the-github-context)

