### PR TITLE
Switch `user_sessions.user_id` to `NOT NULL`

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -20,7 +20,7 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  impersonated_by_id       :bigint
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #  webauthn_credential_id   :bigint
 #
 # Indexes

--- a/db/migrate/20250721124159_add_null_check_constraint_to_user_sessions_user_id.rb
+++ b/db/migrate/20250721124159_add_null_check_constraint_to_user_sessions_user_id.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddNullCheckConstraintToUserSessionsUserId < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint(
+      :user_sessions,
+      "user_id IS NOT NULL",
+      name: "user_sessions_user_id_not_null",
+      validate: false
+    )
+  end
+end

--- a/db/migrate/20250721124328_validate_null_check_constraint_on_user_sessions_user_id.rb
+++ b/db/migrate/20250721124328_validate_null_check_constraint_on_user_sessions_user_id.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNullCheckConstraintOnUserSessionsUserId < ActiveRecord::Migration[7.2]
+  def up
+    validate_check_constraint(:user_sessions, name: "user_sessions_user_id_not_null")
+    change_column_null(:user_sessions, :user_id, false)
+    remove_check_constraint(:user_sessions, name: "user_sessions_user_id_not_null")
+  end
+
+  def down
+    add_check_constraint(
+      :user_sessions,
+      "user_id IS NOT NULL",
+      name: "user_sessions_user_id_not_null",
+      validate: false
+    )
+    change_column_null(:user_sessions, :user_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_17_152952) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_21_124328) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2198,7 +2198,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_17_152952) do
   end
 
   create_table "user_sessions", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "fingerprint"


### PR DESCRIPTION
## Summary of the problem

We don't currently enforce that `UserSession` has a `user_id` despite the fact that every entry in production has one

<img width="780" height="359" alt="CleanShot 2025-07-21 at 14 48 10@2x" src="https://github.com/user-attachments/assets/aff0fb22-36ae-4ee2-892c-3e163e382ecf" />

and it wouldn't make much sense to have a session without an associated user.

## Describe your changes

- Adds a presence validation on `user_id`
- As per https://github.com/ankane/strong_migrations?tab=readme-ov-file#setting-not-null-on-an-existing-column,
  1. Adds a migration to add a non-validated check constraint on the column
  2. Adds a subsequent migration to validate (i) and add a NOT NULL
