### PR TITLE
Update Nokogiri to address CVEs in libxml2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     observer (0.1.2)


### PR DESCRIPTION


## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Nokogiri 1.18.9 resolves multiple CVEs found in libxml2:
- https://github.com/advisories/GHSA-32vr-5hxf-x93f
- https://github.com/advisories/GHSA-6qrf-r65h-2r77
- https://github.com/advisories/GHSA-qg4c-8pj4-qgw2
- https://github.com/advisories/GHSA-gg7j-w83p-fxr9
- https://github.com/advisories/GHSA-83xx-9f6p-vwfj


For more info, see https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-353f-x4gh-cqq8


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Ran `bundle update nokogiri`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

