### PR TITLE
Revert "Bump strong_migrations from 1.8.0 to 2.4.0 (#10712)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem "loofah" # html email parsing
 gem "namae" # multi-cultural human name parser
 gem "premailer-rails" # css to inline styles for emails
 gem "safely_block"
-gem "strong_migrations", "~> 2" # protects against risky migrations
+gem "strong_migrations", "~> 1" # protects against risky migrations
 # [@garyhtou] ^ We still use Postgres 11 in dev (not in prod). Strong Migrations
 #               2.x is incompatible with Postgres 11.
 gem "xxhash" # fast hashing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,24 +9,6 @@ GIT
   revision: 21ef9d1554eb1fa8f3ecf997fdf165add8df0917
   branch: 7-2-stable
   specs:
-    activemodel (7.2.2.1)
-      activesupport (= 7.2.2.1)
-    activerecord (7.2.2.1)
-      activemodel (= 7.2.2.1)
-      activesupport (= 7.2.2.1)
-      timeout (>= 0.4.0)
-    activesupport (7.2.2.1)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
     rails (7.2.2.1)
       actioncable (= 7.2.2.1)
       actionmailbox (= 7.2.2.1)
@@ -100,12 +82,30 @@ GEM
     activejob (7.2.2.1)
       activesupport (= 7.2.2.1)
       globalid (>= 0.3.6)
+    activemodel (7.2.2.1)
+      activesupport (= 7.2.2.1)
+    activerecord (7.2.2.1)
+      activemodel (= 7.2.2.1)
+      activesupport (= 7.2.2.1)
+      timeout (>= 0.4.0)
     activestorage (7.2.2.1)
       actionpack (= 7.2.2.1)
       activejob (= 7.2.2.1)
       activerecord (= 7.2.2.1)
       activesupport (= 7.2.2.1)
       marcel (~> 1.0)
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     acts_as_paranoid (0.10.3)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
@@ -802,8 +802,8 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.7)
     stripe (11.7.0)
-    strong_migrations (2.4.0)
-      activerecord (>= 7.1)
+    strong_migrations (1.8.0)
+      activerecord (>= 5.2)
     terser (1.2.5)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
@@ -989,7 +989,7 @@ DEPENDENCIES
   stackprof
   statsd-instrument (~> 3.9)
   stripe (= 11.7.0)
-  strong_migrations (~> 2)
+  strong_migrations (~> 1)
   terser (~> 1.2)
   turbo-rails (~> 2.0.13)
   twilio-ruby


### PR DESCRIPTION


## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

Strong Migrations doesn't support Postgres 11, which we unfortunately still use in development. Production is using 15 so we need to make that switch locally very soon.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

This reverts commit 7ba92fe404e486591ae720444637f7d31050b308.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

