### PR TITLE
[v4/OAuth] show individual authorizations, allow making ApiTokens last forever

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -94,6 +94,18 @@ class UsersController < ApplicationController
     redirect_back_or_to security_user_path(current_user)
   end
 
+  def make_oauth_authorization_eternal
+    token = ApiToken.find(params[:id])
+    authorize token, :make_eternal?
+
+    if token.update(expires_in: nil)
+      flash[:success] = "Authorization made eternal."
+    else
+      flash[:error] = "Failed to make authorization eternal."
+    end
+    redirect_back_or_to security_user_path(token.user)
+  end
+
   def receipt_report
     ReceiptReport::SendJob.perform_later(current_user.id, force_send: true)
     flash[:success] = "Receipt report generating. Check #{current_user.email}"
@@ -138,12 +150,21 @@ class UsersController < ApplicationController
     show_impersonated_sessions = auditor_signed_in? || current_session.impersonated?
     @sessions = show_impersonated_sessions ? @user.user_sessions : @user.user_sessions.not_impersonated
     @sessions = @sessions.not_expired
-    @oauth_authorizations = @user.api_tokens
-                                 .where.not(application_id: nil)
-                                 .select("application_id, MAX(api_tokens.created_at) AS created_at, MIN(api_tokens.created_at) AS first_authorized_at, COUNT(*) AS authorization_count")
-                                 .accessible
-                                 .group(:application_id)
-                                 .includes(:application)
+    @oauth_tokens_by_app = @user.api_tokens
+                                .where.not(application_id: nil)
+                                .accessible
+                                .includes(:application)
+                                .order(created_at: :desc)
+                                .group_by(&:application)
+    @oauth_authorizations = @oauth_tokens_by_app.map do |app, tokens|
+      OpenStruct.new(
+        application: app,
+        created_at: tokens.max_by(&:created_at).created_at,
+        first_authorized_at: tokens.min_by(&:created_at).created_at,
+        authorization_count: tokens.size,
+        tokens: tokens,
+      )
+    end
     @all_sessions = (@sessions + @oauth_authorizations).sort_by { |s| s.created_at }.reverse!
 
     @expired_sessions = @user

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -51,4 +51,6 @@ class ApiToken < ApplicationRecord
     PREFIX + SecureRandom.urlsafe_base64(token_size)
   end
 
+  def abbreviated = "#{token[..7]}...#{token[-3..]}"
+
 end

--- a/app/policies/api_token_policy.rb
+++ b/app/policies/api_token_policy.rb
@@ -1,0 +1,6 @@
+class ApiTokenPolicy < ApplicationPolicy
+  def make_eternal?
+    user&.admin?
+  end
+
+end

--- a/app/policies/api_token_policy.rb
+++ b/app/policies/api_token_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApiTokenPolicy < ApplicationPolicy
   def make_eternal?
     user&.admin?

--- a/app/views/users/_oauth_authorization.erb
+++ b/app/views/users/_oauth_authorization.erb
@@ -7,7 +7,47 @@
       <%= inline_icon "door-leave", size: home_action_size %>
     <% end %>
   </span>
-
+  <% admin_tool do %>
+    <p class="mt-2 mb-1 bold">Individual authorizations (<%= authorization.authorization_count %>):</p>
+    <table class="table table--small text-sm">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Token</th>
+          <th>Authorized At</th>
+          <th>Scopes</th>
+          <th>Expires</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% authorization.tokens.each do |token| %>
+          <tr>
+            <td><%= token.id %></td>
+            <td><code><%= token.abbreviated %></code></td>
+            <td><%= local_time_ago token.created_at %></td>
+            <td><%= token.scopes %></td>
+            <td>
+              <% if token.expires_in %>
+                <%= time_ago_in_words(token.created_at + token.expires_in.seconds) %> from now
+              <% else %>
+                Never
+              <% end %>
+            </td>
+            <td>
+              <% if token.expires_in %>
+                <%= link_to make_authorization_eternal_users_path(id: token.id), method: :post,
+                            class: "btn bg-success py1 px2 h4" do %>
+                  <%= inline_icon "clock", size: home_action_size %>
+                  make eternal
+                <% end %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
   <p class="regular italic muted text-sm m-0 mt-1">
     <%= authorization.authorization_count == 1 ? "Authorized" : "Last authorized" %> <%= local_time_ago authorization.created_at %>
   </p>

--- a/app/views/users/edit_security.html.erb
+++ b/app/views/users/edit_security.html.erb
@@ -137,7 +137,7 @@
     <% @all_sessions.each do |session| %>
       <% if session.is_a? UserSession %>
         <%= render "user_session", session: %>
-      <% elsif session.is_a? ApiToken %>
+      <% elsif session.respond_to? :authorization_count %>
         <%= render "oauth_authorization", authorization: session %>
       <% end %>
     <% end %>
@@ -152,7 +152,7 @@
       <% @expired_sessions.each do |session| %>
         <% if session.is_a? UserSession %>
           <%= render "user_session", session: %>
-        <% elsif session.is_a? ApiToken %>
+        <% elsif session.respond_to? :authorization_count %>
           <%= render "oauth_authorization", authorization: session %>
         <% end %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
       delete "logout", to: "users#logout"
       delete "logout_session", to: "users#logout_session"
       delete "revoke/:id", to: "users#revoke_oauth_application", as: "revoke_oauth_application"
+      post "make_oauth_authorization_eternal/:id", to: "users#make_oauth_authorization_eternal", as: "make_authorization_eternal"
 
       # sometimes users refresh the login code page and get 404'd
       get "exchange_login_code", to: redirect("/users/auth", status: 301)


### PR DESCRIPTION
adds this to OAuth authorizations on the security edit page for admins:

<img width="300"  src="https://github.com/user-attachments/assets/791d5b13-eeea-4305-aaf5-7a8df32e5427" />
<img width="300" src="https://github.com/user-attachments/assets/0f003b27-ec53-48f0-be2e-d86d3f50bb51" />


this PR is friend to #10944, they will live a very happy life together if and when they land...