### PR TITLE
use .where.missing instead of just .missing

### DIFF
--- a/app/jobs/g_suite/initiate_revocations_job.rb
+++ b/app/jobs/g_suite/initiate_revocations_job.rb
@@ -7,7 +7,7 @@ class GSuite
     def perform
       GSuite.where(immune_to_revocation: false)
             .where("g_suites.created_at < ?", 2.months.ago)
-            .missing(:revocation)
+            .where.missing(:revocation)
             .find_each(batch_size: 100) do |g_suite|
         if g_suite.verification_error? || g_suite.configuring?
           g_suite.build_revocation({ reason: :invalid_dns }).save!


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->

We were only using .missing in the query, which led to this error:

```rb
GSuite.where(immune_to_revocation: false).where("g_suites.created_at < ?", 2.months.ago).missing(:revocation).count
(bank):2:in '<main>': undefined method 'missing' for an instance of ActiveRecord::Relation (NoMethodError)
```

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

We change the line so it's

```rb
GSuite.where(immune_to_revocation: false).where("g_suites.created_at < ?", 2.months.ago).where.missing(:revocation).count
```

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

