### PR TITLE
[Announcement] Fix prompting when there is no event mission

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -334,7 +334,7 @@ class EventsController < ApplicationController
         end
 
 
-        if @event.description_previously_changed? && !@event.description.empty?
+        if @event.description_previously_changed? && @event.description.present?
           announcement = Announcement::Templates::NewMissionStatement.new(
             event: @event,
             author: current_user

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -334,7 +334,7 @@ class EventsController < ApplicationController
         end
 
 
-        if @event.description_previously_changed?
+        if @event.description_previously_changed? && !@event.description.empty?
           announcement = Announcement::Templates::NewMissionStatement.new(
             event: @event,
             author: current_user


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
Users were being prompted to make an announcement when updating their event for the first time since the description was being changed from `nil` to `""`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a check to make sure the mission is not empty when prompting.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

