### PR TITLE
[Announcement] Migrate block JSON types to use Ruby identifiers

### DIFF
--- a/app/javascript/controllers/tiptap/nodes/donation_goal_node.js
+++ b/app/javascript/controllers/tiptap/nodes/donation_goal_node.js
@@ -1,7 +1,7 @@
 import { Node } from '@tiptap/core'
 
 export const DonationGoalNode = Node.create({
-  name: 'donationGoal',
+  name: 'Announcement::Block::DonationGoal',
   atom: true,
   group: 'block',
   priority: 2000,

--- a/app/javascript/controllers/tiptap/nodes/donation_summary_node.js
+++ b/app/javascript/controllers/tiptap/nodes/donation_summary_node.js
@@ -1,7 +1,7 @@
 import { Node } from '@tiptap/core'
 
 export const DonationSummaryNode = Node.create({
-  name: 'donationSummary',
+  name: 'Announcement::Block::DonationSummary',
   atom: true,
   group: 'block',
   priority: 2000,

--- a/app/javascript/controllers/tiptap/nodes/hcb_code_node.js
+++ b/app/javascript/controllers/tiptap/nodes/hcb_code_node.js
@@ -1,7 +1,7 @@
 import { Node } from '@tiptap/core'
 
 export const HcbCodeNode = Node.create({
-  name: 'hcbCode',
+  name: 'Announcement::Block::HcbCode',
   atom: true,
   group: 'block',
   priority: 2000,

--- a/app/jobs/one_time_jobs/migrate_block_types.rb
+++ b/app/jobs/one_time_jobs/migrate_block_types.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class MigrateBlockTypes
+    def self.perform
+      Announcement.find_each do |announcement|
+        new_content = ProsemirrorService::Renderer.map_nodes announcement.content do |node|
+          new_type = case node["type"]
+                     when "donationGoal"
+                       "Announcement::Block::DonationGoal"
+                     when "donationSummary"
+                       "Announcement::Block::DonationSummary"
+                     when "hcbCode"
+                       "Announcement::Block::HcbCode"
+                     else
+                       node["type"]
+                     end
+
+          node["type"] = new_type
+        end
+
+        announcement.content = new_content
+
+        announcement.save!
+      end
+
+    end
+
+  end
+end

--- a/app/services/prosemirror_service/donation_goal_node.rb
+++ b/app/services/prosemirror_service/donation_goal_node.rb
@@ -2,9 +2,7 @@
 
 module ProsemirrorService
   class DonationGoalNode < ProsemirrorToHtml::Nodes::Node
-    include ApplicationHelper
-
-    @node_type = "donationGoal"
+    @node_type = "Announcement::Block::DonationGoal"
     @tag_name = "div"
 
     def tag

--- a/app/services/prosemirror_service/donation_summary_node.rb
+++ b/app/services/prosemirror_service/donation_summary_node.rb
@@ -2,7 +2,7 @@
 
 module ProsemirrorService
   class DonationSummaryNode < ProsemirrorToHtml::Nodes::Node
-    @node_type = "donationSummary"
+    @node_type = "Announcement::Block::DonationSummary"
     @tag_name = "div"
 
     def tag

--- a/app/services/prosemirror_service/hcb_code_node.rb
+++ b/app/services/prosemirror_service/hcb_code_node.rb
@@ -2,7 +2,7 @@
 
 module ProsemirrorService
   class HcbCodeNode < ProsemirrorToHtml::Nodes::Node
-    @node_type = "hcbCode"
+    @node_type = "Announcement::Block::HcbCode"
     @tag_name = "div"
 
     def tag


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
We shouldn't have two different types for each block - changing all block types to be the class identifier is clearer.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the types used in the ProseMirror JSON to use Ruby class identifier strings, and added a job to migrate existing content over.

> [!WARNING]
> The job `OneTimeJobs::MigrateBlockTypes` should be run once this is deployed.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

