### PR TITLE
[Announcement::Block::DonationGoal] Save event donation goal on block create

### DIFF
--- a/app/models/announcement/block.rb
+++ b/app/models/announcement/block.rb
@@ -30,7 +30,6 @@ class Announcement
     after_create :refresh!
 
     def refresh!
-      self.parameters ||= {}
       self.rendered_html = render
       self.rendered_email_html = render(is_email: true)
 

--- a/app/models/announcement/block.rb
+++ b/app/models/announcement/block.rb
@@ -26,6 +26,7 @@ class Announcement
     belongs_to :announcement
     has_one :event, through: :announcement
 
+    before_save { self.parameters ||= {} }
     after_create :refresh!
 
     def refresh!

--- a/app/models/announcement/block/donation_goal.rb
+++ b/app/models/announcement/block/donation_goal.rb
@@ -25,9 +25,7 @@ class Announcement
   class Block
     class DonationGoal < ::Announcement::Block
       before_create do
-        if self.parameters["goal"].nil?
-          self.parameters["goal"] = announcement.event.donation_goal.id
-        end
+        goal_param
 
         self
       end
@@ -35,7 +33,7 @@ class Announcement
       def render_html(is_email: false)
         goal = nil
         begin
-          goal = Donation::Goal.find(parameters["goal"])
+          goal = Donation::Goal.find(goal_param)
         rescue ActiveRecord::RecordNotFound
           goal = announcement.event.donation_goal
         end
@@ -43,6 +41,12 @@ class Announcement
         percentage = (goal.progress_amount_cents.to_f / goal.amount_cents) if goal.present?
 
         Announcements::BlocksController.renderer.render partial: "announcements/blocks/donation_goal", locals: { goal:, percentage:, is_email:, block: self }
+      end
+
+      private
+
+      def goal_param
+        self.parameters["goal"] || announcement.event.donation_goal.id
       end
 
     end

--- a/app/models/announcement/block/donation_goal.rb
+++ b/app/models/announcement/block/donation_goal.rb
@@ -24,19 +24,11 @@
 class Announcement
   class Block
     class DonationGoal < ::Announcement::Block
-      before_create do
-        goal_param
-
-        self
-      end
+      before_create :goal_param
 
       def render_html(is_email: false)
-        goal = nil
-        begin
-          goal = Donation::Goal.find(goal_param)
-        rescue ActiveRecord::RecordNotFound
-          goal = announcement.event.donation_goal
-        end
+        goal = Donation::Goal.find_by(id: goal_param)
+        goal ||= announcement.event.donation_goal
 
         percentage = (goal.progress_amount_cents.to_f / goal.amount_cents) if goal.present?
 
@@ -46,7 +38,7 @@ class Announcement
       private
 
       def goal_param
-        self.parameters["goal"] || announcement.event.donation_goal.id
+        self.parameters["goal"] ||= announcement.event.donation_goal.id
       end
 
     end

--- a/app/models/announcement/block/donation_goal.rb
+++ b/app/models/announcement/block/donation_goal.rb
@@ -27,7 +27,7 @@ class Announcement
       before_create :goal_param
 
       def render_html(is_email: false)
-        goal = Donation::Goal.find_by(id: goal_param)
+        goal = Donation::Goal.find_by(event: announcement.event, id: goal_param)
         goal ||= announcement.event.donation_goal
 
         percentage = (goal.progress_amount_cents.to_f / goal.amount_cents) if goal.present?


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
The donation goal block for announcements was not saving the ID of the donation goal is was referencing, so if it was refreshed after a new donation goal had been created, it would update to a different goal.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Saves the ID of the current donation goal in the parameters on save, and references it if it exists.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

