### PR TITLE
[Announcement] Add validation for unauthorized HCB code block

### DIFF
--- a/app/controllers/announcements/blocks_controller.rb
+++ b/app/controllers/announcements/blocks_controller.rb
@@ -9,10 +9,8 @@ module Announcements
 
       authorize block, policy_class: Announcement::BlockPolicy
 
-      begin
-        block.save!
-      rescue ActiveRecord::RecordInvalid
-        return render json: { errors: block.errors.map { |error| error.full_message } }, status: :bad_request
+      unless block.save
+        return render json: { errors: block.errors.map(&:full_message) }, status: :bad_request
       end
 
       render json: { id: block.id, html: block.rendered_html }

--- a/app/controllers/announcements/blocks_controller.rb
+++ b/app/controllers/announcements/blocks_controller.rb
@@ -12,7 +12,7 @@ module Announcements
       begin
         block.save!
       rescue ActiveRecord::RecordInvalid
-        return render json: { errors: block.errors.map { |error| error.full_message } }
+        return render json: { errors: block.errors.map { |error| error.full_message } }, status: :bad_request
       end
 
       render json: { id: block.id, html: block.rendered_html }

--- a/app/controllers/announcements/blocks_controller.rb
+++ b/app/controllers/announcements/blocks_controller.rb
@@ -9,7 +9,11 @@ module Announcements
 
       authorize block, policy_class: Announcement::BlockPolicy
 
-      block.save!
+      begin
+        block.save!
+      rescue ActiveRecord::RecordInvalid
+        return render json: { errors: block.errors.map { |error| error.full_message } }
+      end
 
       render json: { id: block.id, html: block.rendered_html }
     end

--- a/app/javascript/controllers/tiptap_controller.js
+++ b/app/javascript/controllers/tiptap_controller.js
@@ -212,12 +212,12 @@ export default class extends Controller {
       },
     }).then(r => r.json())
 
-    if ("errors" in res) {
-      const message = `Could not insert block: ${res.errors.join(", ")}`;
+    if ('errors' in res) {
+      const message = `Could not insert block: ${res.errors.join(', ')}`
 
       alert(message)
 
-      return null;
+      return null
     } else {
       return res
     }

--- a/app/javascript/controllers/tiptap_controller.js
+++ b/app/javascript/controllers/tiptap_controller.js
@@ -166,7 +166,10 @@ export default class extends Controller {
 
   async donationGoal() {
     const attrs = await this.createBlock('Announcement::Block::DonationGoal')
-    this.editor.chain().focus().addDonationGoal(attrs).run()
+
+    if (attrs !== null) {
+      this.editor.chain().focus().addDonationGoal(attrs).run()
+    }
   }
 
   async hcbCode() {
@@ -182,12 +185,17 @@ export default class extends Controller {
       hcb_code: hcbCode,
     })
 
-    this.editor.chain().focus().addHcbCode(attrs).run()
+    if (attrs !== null) {
+      this.editor.chain().focus().addHcbCode(attrs).run()
+    }
   }
 
   async donationSummary() {
     const attrs = await this.createBlock('Announcement::Block::DonationSummary')
-    this.editor.chain().focus().addDonationSummary(attrs).run()
+
+    if (attrs !== null) {
+      this.editor.chain().focus().addDonationSummary(attrs).run()
+    }
   }
 
   async createBlock(type, parameters) {
@@ -204,6 +212,14 @@ export default class extends Controller {
       },
     }).then(r => r.json())
 
-    return res
+    if ("errors" in res) {
+      const message = `Could not insert block: ${res.errors.join(", ")}`;
+
+      alert(message)
+
+      return null;
+    } else {
+      return res
+    }
   }
 }

--- a/app/models/announcement/block/hcb_code.rb
+++ b/app/models/announcement/block/hcb_code.rb
@@ -42,7 +42,7 @@ class Announcement
         hcb_code = ::HcbCode.find_by_hashid(parameters["hcb_code"])
 
         if hcb_code.nil? || hcb_code.event != announcement.event
-          errors.add(:base, "You are not authorized to insert this transaction")
+          errors.add(:base, "Transaction can not be found.")
         end
       end
 

--- a/app/models/announcement/block/hcb_code.rb
+++ b/app/models/announcement/block/hcb_code.rb
@@ -41,7 +41,7 @@ class Announcement
       def hcb_code_in_event
         hcb_code = ::HcbCode.find_by_hashid(parameters["hcb_code"])
 
-        unless hcb_code&.event == announcement.event
+        if hcb_code.nil? || hcb_code.event != announcement.event
           errors.add(:base, "You are not authorized to insert this transaction")
         end
       end

--- a/app/models/announcement/block/hcb_code.rb
+++ b/app/models/announcement/block/hcb_code.rb
@@ -42,7 +42,7 @@ class Announcement
         hcb_code = ::HcbCode.find_by_hashid(parameters["hcb_code"])
 
         unless hcb_code&.event == announcement.event
-          errors.add(:parameters, "links a transaction that is not included in this event")
+          errors.add(:base, "You are not authorized to insert this transaction")
         end
       end
 

--- a/app/models/announcement/block/hcb_code.rb
+++ b/app/models/announcement/block/hcb_code.rb
@@ -24,6 +24,8 @@
 class Announcement
   class Block
     class HcbCode < ::Announcement::Block
+      validate :hcb_code_in_event
+
       def render_html(is_email: false)
         hcb_code = ::HcbCode.find_by_hashid(parameters["hcb_code"])
 
@@ -32,6 +34,16 @@ class Announcement
         end
 
         Announcements::BlocksController.renderer.render partial: "announcements/blocks/hcb_code", locals: { hcb_code:, event: announcement.event, is_email:, block: self }
+      end
+
+      private
+
+      def hcb_code_in_event
+        hcb_code = ::HcbCode.find_by_hashid(parameters["hcb_code"])
+
+        unless hcb_code&.event == announcement.event
+          errors.add(:parameters, "links a transaction that is not included in this event")
+        end
       end
 
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
We're not currently doing any validations on when blocks are saved, and leaving checking that any parameters are valid until we render the block. Now that blocks are in the database, we can easily use validations to not save any invalid data in the first place.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a validation to the HCB code block that makes sure that it is in the same event as the announcement the block is a part of, and alerts it to the user with a browser alert (this will be changed to something nicer in a future PR). The existing checks in `render` are not removed since invalid data could still be in the database or be added with a Rails method that does not check validations.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

