### PR TITLE
[DX] Add a `/schema` endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     mount Audits1984::Engine => "/console"
     mount Sidekiq::Web => "/sidekiq"
     mount Flipper::UI.app(Flipper), at: "flipper", as: "flipper"
+    mount SchemaEndpoint.instance => "/schema"
   end
   constraints AuditorConstraint do
     mount Blazer::Engine, at: "blazer"

--- a/lib/schema_endpoint.rb
+++ b/lib/schema_endpoint.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# A very simple Rack app that outputs the current database schema in the same
+# format as `db/schema.rb` so we can resolve differences between development
+# and production environments.
+class SchemaEndpoint
+  include Singleton
+
+  STREAM_SCHEMA = ->(io) {
+    begin
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, io)
+    ensure
+      io.close
+    end
+  }
+
+  RESPONSE_HEADERS = {
+    "Content-Type" => "text/plain; charset=utf-8",
+  }.freeze
+
+  def call(env)
+    request = Rack::Request.new(env)
+
+    unless request.get?
+      return [404, {}, ["Not found"]]
+    end
+
+    # Stream the response if the server supports it
+    # https://github.com/rack/rack/blob/main/SPEC.rdoc#hijacking-
+    if env["rack.hijack?"]
+      [200, RESPONSE_HEADERS.merge("rack.hijack" => STREAM_SCHEMA), []]
+    else
+      schema = StringIO.new
+      STREAM_SCHEMA.call(schema)
+      [200, RESPONSE_HEADERS, [schema.string]]
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary of the problem

Issues like https://github.com/hackclub/hcb/pull/11044 are annoying to diagnose as they require us to use Blazer to query the state of the production schema and compare it to the `db/schema.rb` format.

## Describe your changes

Adds a `/schema` endpoint which effectively does `rails db:schema:dump`, letting us copy and paste the production state and immediately see a local diff.