### PR TITLE
[Sudo mode] Render last authentication in session list

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -39,6 +39,8 @@ class Login < ApplicationRecord
   )
 
   scope(:initial, -> { where(initial_login_id: nil) })
+  scope(:reauthentication, -> { where.not(initial_login_id: nil) })
+
   belongs_to :referral_program, class_name: "Referral::Program", optional: true
 
   has_encrypted :browser_token

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -112,6 +112,10 @@ class UserSession < ApplicationRecord
     )
   end
 
+  def last_reauthenticated_at
+    logins.complete.reauthentication.max_by(&:created_at)&.created_at
+  end
+
   private
 
   def user_is_unlocked

--- a/app/views/users/_user_session.html.erb
+++ b/app/views/users/_user_session.html.erb
@@ -53,6 +53,11 @@
       Expired <%= local_time_ago session.expiration_at %>
     <% else %>
       Logged in <%= local_time_ago session.created_at %>
+      <% if session.last_reauthenticated_at %>
+        <span class="tooltipped tooltipped--n" aria-label="The last time you confirmed access">
+          (last authenticated <%= local_time_ago(session.last_reauthenticated_at) %>)
+        </span>
+      <% end %>
     <% end %>
   </p>
 </div>

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe UserSession, type: :model do
   describe "#last_reauthenticated_at" do
     it "returns nil if there was only an initial login" do
       user_session = create(:user_session)
-      initial_login = create( :login, user: user_session.user, authenticated_with_email: true )
+      initial_login = create(:login, user: user_session.user, authenticated_with_email: true)
       initial_login.update!(user_session:)
 
       expect(user_session.last_reauthenticated_at).to be_nil
@@ -84,7 +84,7 @@ RSpec.describe UserSession, type: :model do
 
     it "returns the latest reauthentication time" do
       user_session = create(:user_session)
-      initial_login = create(:login, user: user_session.user, authenticated_with_email: true )
+      initial_login = create(:login, user: user_session.user, authenticated_with_email: true)
       initial_login.update!(user_session:)
 
       travel(1.hour)

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -72,4 +72,30 @@ RSpec.describe UserSession, type: :model do
       end
     end
   end
+
+  describe "#last_reauthenticated_at" do
+    it "returns nil if there was only an initial login" do
+      user_session = create(:user_session)
+      initial_login = create( :login, user: user_session.user, authenticated_with_email: true )
+      initial_login.update!(user_session:)
+
+      expect(user_session.last_reauthenticated_at).to be_nil
+    end
+
+    it "returns the latest reauthentication time" do
+      user_session = create(:user_session)
+      initial_login = create(:login, user: user_session.user, authenticated_with_email: true )
+      initial_login.update!(user_session:)
+
+      travel(1.hour)
+      reauth1 = create(:login, user: user_session.user, authenticated_with_email: true, initial_login:)
+      reauth1.update!(user_session:)
+
+      travel(1.hour)
+      reauth2 = create(:login, user: user_session.user, authenticated_with_email: true, initial_login:)
+      reauth2.update!(user_session:)
+
+      expect(user_session.last_reauthenticated_at).to eq(reauth2.created_at)
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Users may perform additional authentications when entering sudo mode (#10671). This is useful information to surface.

## Describe your changes

1. Adds `UserSession#last_reauthenticated_at`
2. Renders (1) if present in the list of sessions

Card | Tooltip
---- | ----
<img width="1050" height="1270" alt="CleanShot 2025-07-22 at 12 44 54@2x" src="https://github.com/user-attachments/assets/7bfeaa04-8981-403e-84b2-18cdfaf413ab" /> | <img width="1058" height="244" alt="CleanShot 2025-07-22 at 12 45 40@2x" src="https://github.com/user-attachments/assets/c537ccc9-0373-4924-8eaa-571b7011766f" />
