### PR TITLE
[Sudo mode] Add client-side support for WebAuthn

### DIFF
--- a/app/javascript/controllers/webauthn_reauth_controller.js
+++ b/app/javascript/controllers/webauthn_reauth_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from '@hotwired/stimulus'
+import { get } from '@github/webauthn-json'
+import { appsignal } from '../appsignal'
+
+class UserVisibleError extends Error {}
+
+export default class extends Controller {
+  static targets = ['responseInput', 'continueButton', 'errorCard']
+
+  static values = {
+    optionsUrl: String,
+  }
+
+  async connect() {
+    this.continueButtonTarget.disabled = true
+
+    try {
+      const options = await this.fetchOptions()
+      const credential = await this.retrieveCredential(options)
+
+      this.responseInputTarget.value = JSON.stringify(credential)
+      this.continueButtonTarget.disabled = false
+      this.continueButtonTarget.form.requestSubmit(this.continueButtonTarget)
+    } catch (error) {
+      let message = 'Unexpected error'
+
+      if (error instanceof UserVisibleError) {
+        message = error.message
+      } else {
+        appsignal.sendError(error)
+      }
+
+      this.errorCardTarget.innerText = message
+      this.errorCardTarget.classList.remove('hidden')
+    }
+  }
+
+  async fetchOptions() {
+    const optionsResponse = await fetch(this.optionsUrlValue)
+
+    if (optionsResponse.status == 404) {
+      throw new UserVisibleError(
+        'No security keys found. Please use a different method.'
+      )
+    } else if (!optionsResponse.ok) {
+      throw new UserVisibleError('Unexpected server error')
+    }
+
+    return optionsResponse.json()
+  }
+
+  async retrieveCredential(options) {
+    try {
+      return await get({ publicKey: options })
+    } catch {
+      throw new UserVisibleError(
+        'Failed to verify security key. Please use a different method.'
+      )
+    }
+  }
+}

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -10,7 +10,14 @@
 
 <%= user_mention(current_user, class: "badge bg-muted pl-1 m-0 tooltipped") %>
 
-<%= form_tag(request.path, method: request.request_method_symbol) do %>
+<%= form_tag(
+      request.path,
+      method: request.request_method_symbol,
+      data: {
+        controller: ("webauthn-reauth" if default_factor == :webauthn),
+        webauthn_reauth_options_url_value: webauthn_auth_options_users_path(email: current_user.email),
+      }
+    ) do %>
   <% forwarded_params.each do |name, value| %>
     <%= hidden_field_tag(name, value) %>
   <% end %>
@@ -54,7 +61,13 @@
       For additional security, please authenticate with your security key.
     </p>
 
-    <%= hidden_field_tag("_sudo[webauthn_response]", nil) %>
+    <div class="error-card hidden" data-webauthn-reauth-target="errorCard"></div>
+
+    <%= hidden_field_tag(
+          "_sudo[webauthn_response]",
+          nil,
+          data: { webauthn_reauth_target: "responseInput" }
+        ) %>
   <% end %>
 
   <%= button_tag(
@@ -62,7 +75,8 @@
         type: "submit",
         name: "_sudo[submit_method]",
         value: default_factor,
-        class: "btn mt-4"
+        class: "btn mt-4",
+        data: { webauthn_reauth_target: "continueButton" }
       ) %>
 
   <% if additional_factors.present? %>


### PR DESCRIPTION
## Summary of the problem

In #10671 I added server-side support for WebAuthn but intentionally omitted the client-side logic so I could address it in a follow-up.

## Describe your changes

Introduces a new stimulus controller that is bound when using the WebAuthn reauthentication method