### PR TITLE
[Announcement::Block::DonationSummary] Add end date and fallbacks to donation summary block

### DIFF
--- a/app/models/announcement/block.rb
+++ b/app/models/announcement/block.rb
@@ -26,10 +26,10 @@ class Announcement
     belongs_to :announcement
     has_one :event, through: :announcement
 
+    before_save { self.parameters ||= {} }
     after_create :refresh!
 
     def refresh!
-      self.parameters ||= {}
       self.rendered_html = render
       self.rendered_email_html = render(is_email: true)
 

--- a/app/models/announcement/block/donation_summary.rb
+++ b/app/models/announcement/block/donation_summary.rb
@@ -24,12 +24,30 @@
 class Announcement
   class Block
     class DonationSummary < ::Announcement::Block
+      before_create do
+        start_date_param
+        end_date_param
+
+        self
+      end
+
       def render_html(is_email: false)
-        start_date = parameters["start_date"].present? ? Date.parse(parameters["start_date"]) : 1.month.ago
-        donations = announcement.event.donations.where(aasm_state: [:in_transit, :deposited], created_at: start_date..).order(:created_at)
+        start_date = start_date_param
+        end_date = end_date_param
+        donations = announcement.event.donations.where(aasm_state: [:in_transit, :deposited], created_at: start_date..end_date).order(:created_at)
         total = donations.sum(:amount)
 
-        Announcements::BlocksController.renderer.render partial: "announcements/blocks/donation_summary", locals: { donations:, total:, start_date:, is_email:, block: self }
+        Announcements::BlocksController.renderer.render partial: "announcements/blocks/donation_summary", locals: { donations:, total:, start_date:, end_date:, is_email:, block: self }
+      end
+
+      private
+
+      def start_date_param
+        self.parameters["start_date"] ||= 1.month.ago
+      end
+
+      def end_date_param
+        self.parameters["end_date"] ||= Time.now
       end
 
     end

--- a/app/models/announcement/block/donation_summary.rb
+++ b/app/models/announcement/block/donation_summary.rb
@@ -24,12 +24,8 @@
 class Announcement
   class Block
     class DonationSummary < ::Announcement::Block
-      before_create do
-        start_date_param
-        end_date_param
-
-        self
-      end
+      before_create :start_date_param
+      before_create :end_date_param
 
       def render_html(is_email: false)
         start_date = start_date_param
@@ -43,19 +39,15 @@ class Announcement
       private
 
       def start_date_param
-        if self.parameters["start_date"].present?
-          Date.parse(self.parameters["start_date"])
-        else
-          self.parameters["start_date"] = 1.month.ago
-        end
+        self.parameters["start_date"] ||= 1.month.ago.to_s
+
+        Date.parse(self.parameters["start_date"])
       end
 
       def end_date_param
-        if self.parameters["end_date"].present?
-          Date.parse(self.parameters["end_date"])
-        else
-          self.parameters["end_date"] = Time.now
-        end
+        self.parameters["end_date"] ||= Time.now.to_s
+
+        Date.parse(self.parameters["end_date"])
       end
 
     end

--- a/app/models/announcement/block/donation_summary.rb
+++ b/app/models/announcement/block/donation_summary.rb
@@ -43,11 +43,19 @@ class Announcement
       private
 
       def start_date_param
-        self.parameters["start_date"] ||= 1.month.ago
+        if self.parameters["start_date"].present?
+          Date.parse(self.parameters["start_date"])
+        else
+          self.parameters["start_date"] = 1.month.ago
+        end
       end
 
       def end_date_param
-        self.parameters["end_date"] ||= Time.now
+        if self.parameters["end_date"].present?
+          Date.parse(self.parameters["end_date"])
+        else
+          self.parameters["end_date"] = Time.now
+        end
       end
 
     end

--- a/app/models/announcement/templates/monthly.rb
+++ b/app/models/announcement/templates/monthly.rb
@@ -52,7 +52,7 @@ class Announcement
 
       def create
         announcement = Announcement.create!(event: @event, title:, content: {}, aasm_state: :template_draft, author: @author, template_type: self.class.name)
-        block = Announcement::Block::DonationSummary.create!(announcement:, parameters: { start_date: Date.current.beginning_of_month })
+        block = Announcement::Block::DonationSummary.create!(announcement:, parameters: { start_date: Date.current.beginning_of_month, end_date: Date.current.end_of_month })
         announcement.update!(content: json_content(block))
       end
 

--- a/app/views/announcements/blocks/_donation_summary.html.erb
+++ b/app/views/announcements/blocks/_donation_summary.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (donations: nil, total: 0, start_date:, is_email: false, block: nil) %>
+<%# locals: (donations: nil, total: 0, start_date:, end_date:, is_email: false, block: nil) %>
 
 <%= render "announcements/blocks/block_shell", block:, type: "donationSummary", is_email: do %>
   <%= render partial: "announcements/blocks/block_actions", locals: { block:, is_email: } %>
-  <p><strong>Donation summary for <%= start_date.strftime("%B %e, %Y") %> - <%= Time.now.strftime("%B %e, %Y") %></strong></p>
+  <p><strong>Donation summary for <%= start_date.strftime("%B %e, %Y") %> - <%= end_date.strftime("%B %e, %Y") %></strong></p>
   <ul>
     <% donations.each do |donation| %>
       <li>


### PR DESCRIPTION
## Summary of the problem
<!-- Why these changes are being made? What problem does it solve? Link any related issues to provide more details. -->
End dates for donation summaries are needed to properly support monthly announcements and prevent it from updating on an accidental refresh.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add the end date parameter to the donation summary block, and refactor a bit to be better about default values for block parameters.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

