### PR TITLE
Set turbo frame target to top on HCB code popovers

### DIFF
--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -185,7 +185,7 @@
   <% pretty_title = pt.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event: @event) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(pt.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(pt.local_hcb_code)) %>
-    <%= turbo_frame_tag pt.local_hcb_code.public_id, src: pt.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy do %>
+    <%= turbo_frame_tag pt.local_hcb_code.public_id, src: pt.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy, target: "_top" do %>
       <div class="shimmer mb1 mt3">
         <div class="shimmer__border"></div>
         <div class="shimmer__main">

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -192,7 +192,7 @@
   <% pretty_title = ct.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event: @event) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(ct.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(ct.local_hcb_code)) %>
-    <%= turbo_frame_tag ct.local_hcb_code.public_id, src: ct.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy do %>
+    <%= turbo_frame_tag ct.local_hcb_code.public_id, src: ct.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy, target: "_top" do %>
       <div class="shimmer mb1 mt3">
         <div class="shimmer__border"></div>
         <div class="shimmer__main">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C068U0JMV19/p1753204464687409

Clicking on links inside HCB code popovers would be captured by the turbo frame instead of navigating the page, resulting in either an infinite loading state or "Content missing"

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added `target="_top"` to the turbo frame to disable capturing links.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

