### PR TITLE
[Announcement] Add Atom feeds!

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -394,6 +394,8 @@ class EventsController < ApplicationController
     raise ActionController::RoutingError.new("Not Found") if !@event.is_public && @all_announcements.empty? && !organizer_signed_in?
   end
 
+  before_action(only: :feed) { request.format = :atom }
+
   def feed
     authorize @event
     @announcements = Announcement.published.where(event: @event).includes(:author).order(published_at: :desc, created_at: :desc)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -394,6 +394,12 @@ class EventsController < ApplicationController
     raise ActionController::RoutingError.new("Not Found") if !@event.is_public && @all_announcements.empty? && !organizer_signed_in?
   end
 
+  def feed
+    authorize @event
+    @announcements = Announcement.published.where(event: @event).includes(:author).order(published_at: :desc, created_at: :desc)
+    @updated_at = @announcements.maximum(:updated_at)
+  end
+
   def card_overview
     @status = %w[active inactive frozen canceled].include?(params[:status]) ? params[:status] : nil
     @type = %w[virtual physical].include?(params[:type]) ? params[:type] : nil

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -103,7 +103,7 @@ module EventsHelper
     end
   end
 
-  def auto_discover_feed_url(event)
+  def auto_discover_feed(event)
     if event.announcements.any?
       content_for :head do
         auto_discovery_link_tag :atom, event_feed_url(event, format: :atom), title: "Announcements for #{event.name}"

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -103,4 +103,11 @@ module EventsHelper
     end
   end
 
+  def auto_discover_feed_url(event)
+    if event.announcements.any?
+      content_for :head do
+        auto_discovery_link_tag :atom, event_feed_url(event, format: :atom), title: "Announcements for #{event.name}"
+      end
+    end
+  end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -85,7 +85,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def feed?
-    is_public
+    announcement_overview?
   end
 
   def emburse_card_overview?

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -84,6 +84,10 @@ class EventPolicy < ApplicationPolicy
     true
   end
 
+  def feed?
+    is_public
+  end
+
   def emburse_card_overview?
     is_public || auditor_or_reader?
   end

--- a/app/views/events/announcement_overview.html.erb
+++ b/app/views/events/announcement_overview.html.erb
@@ -6,6 +6,11 @@
 <h1 class="flex heading items-center">
   <span class="flex-grow flex items-center flex-1">
     Announcements
+    <% if @event_follow.present? || organizer_signed_in?(as: :reader) %>
+      <%= link_to event_feed_path(@event, format: :atom), class: "muted tooltipped tooltipped--e ml-2", "aria-label": "you found an Atom feed!", data: { turbo: false } do %>
+        <%= inline_icon "rss", size: 30 %>
+      <% end %>
+    <% end %>
     <% if organizer_signed_in?(as: :reader) && @event.followers.any? %>
       <%= link_to "#", class: "list-badge quick-action ml-4", data: { behavior: "modal_trigger", modal: "edit_followers" } do %>
         <%= inline_icon "person", size: 20 %>

--- a/app/views/events/announcement_overview.html.erb
+++ b/app/views/events/announcement_overview.html.erb
@@ -1,5 +1,6 @@
 <% title "Announcements for #{@event.name}" %>
 <% page_md %>
+<% auto_discover_feed_url(@event) %>
 <%= render "events/nav", selected: :announcements %>
 <%= render "followers_modal", event_follows: @event.event_follows %>
 

--- a/app/views/events/announcement_overview.html.erb
+++ b/app/views/events/announcement_overview.html.erb
@@ -1,6 +1,6 @@
 <% title "Announcements for #{@event.name}" %>
 <% page_md %>
-<% auto_discover_feed_url(@event) %>
+<% auto_discover_feed(@event) %>
 <%= render "events/nav", selected: :announcements %>
 <%= render "followers_modal", event_follows: @event.event_follows %>
 

--- a/app/views/events/feed.atom.builder
+++ b/app/views/events/feed.atom.builder
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: "1.0"
+
+xml.feed xmlns: "http://www.w3.org/2005/Atom" do
+  xml.title "#{@event.name} – Announcements"
+  xml.updated @updated_at.xmlschema
+  xml.link rel: "self", href: event_feed_url(@event)
+  xml.link rel: "alternate", href: event_announcement_overview_url(@event)
+  xml.id "urn:hcb:announcements_feed_#{@event.public_id}"
+  # ^ what can ya do
+  xml.generator "HCB", uri: "https://github.com/hackclub/hcb", version: Build.commit_name
+  xml.icon rails_blob_url(@event.logo) if @event.logo.present?
+  xml.logo rails_blob_url(@event.background_image) if @event.background_image.present?
+  # ^ per RFC 4287, "logo" is supposed to refer to something wide?
+  @announcements.each do |announcement|
+    xml.entry do
+      xml.title announcement.title
+      xml.id announcement_url(announcement)
+      xml.updated announcement.updated_at.xmlschema
+      xml.published announcement.published_at.xmlschema
+      xml.link rel: "alternate", href: announcement_url(announcement)
+      xml.author do
+        xml.name announcement.author.initial_name
+      end
+      xml.content announcement.render_email, type: "html"
+    end
+  end
+end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,10 +6,10 @@
 
 <% title @event.name %>
 <% page_md %>
-<% auto_discover_feed_url(@event) %>
 <%= render "nav", selected: :home %>
 
 <% if @event&.is_public %>
+  <% auto_discover_feed_url(@event) %>
   <% content_for :head do %>
     <% img = "https://hcb-og.hackclub.com/api/embeds/#{@event.slug}" %>
     <meta property="og:type" content="website">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,6 +6,7 @@
 
 <% title @event.name %>
 <% page_md %>
+<% auto_discover_feed_url(@event) %>
 <%= render "nav", selected: :home %>
 
 <% if @event&.is_public %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,7 +9,7 @@
 <%= render "nav", selected: :home %>
 
 <% if @event&.is_public %>
-  <% auto_discover_feed_url(@event) %>
+  <% auto_discover_feed(@event) %>
   <% content_for :head do %>
     <% img = "https://hcb-og.hackclub.com/api/embeds/#{@event.slug}" %>
     <meta property="og:type" content="website">

--- a/app/views/events/transactions.html.erb
+++ b/app/views/events/transactions.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if @event&.is_public %>
-  <% auto_discover_feed_url(@event) %>
+  <% auto_discover_feed(@event) %>
   <% content_for :head do %>
     <% img = "https://hcb-og.hackclub.com/api/embeds/#{@event.slug}" %>
     <meta property="og:type" content="website">

--- a/app/views/events/transactions.html.erb
+++ b/app/views/events/transactions.html.erb
@@ -5,6 +5,7 @@
 <% end %>
 
 <% if @event&.is_public %>
+  <% auto_discover_feed_url(@event) %>
   <% content_for :head do %>
     <% img = "https://hcb-og.hackclub.com/api/embeds/#{@event.slug}" %>
     <meta property="og:type" content="website">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -747,6 +747,7 @@ Rails.application.routes.draw do
     get "cards/new", to: "stripe_cards#new"
     get "announcements", to: "events#announcement_overview", as: :announcement_overview
     get "announcements/new", to: "announcements#new"
+    get "feed.atom", to: "events#feed", as: :feed, format: "atom"
     get "stripe_cards/shipping", to: "stripe_cards#shipping", as: :stripe_cards_shipping
 
     resources :follows, only: [:create], controller: "event/follows"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -747,7 +747,7 @@ Rails.application.routes.draw do
     get "cards/new", to: "stripe_cards#new"
     get "announcements", to: "events#announcement_overview", as: :announcement_overview
     get "announcements/new", to: "announcements#new"
-    get "feed.atom", to: "events#feed", as: :feed, format: "atom"
+    get "feed", to: "events#feed", as: :feed
     get "stripe_cards/shipping", to: "stripe_cards#shipping", as: :stripe_cards_shipping
 
     resources :follows, only: [:create], controller: "event/follows"


### PR DESCRIPTION
hokay so:
we got atom xml:
<img width="200" src="https://github.com/user-attachments/assets/408a6288-6fa8-4e02-a8c6-69a50ddf58f9" />
it validates:
<img width="300" src="https://github.com/user-attachments/assets/142afc7f-acfc-46ba-bcdf-6bc07be72940" />
if you follow/organize the event you get this little guy:
<img width="400" src="https://github.com/user-attachments/assets/5743ab6b-bdee-4d67-bb4d-22a641bc4f81" />
it renders beautifully in your feed reader of choice:
<img width="403" src="https://github.com/user-attachments/assets/e4fe138f-4a90-4783-aef2-dbaa792e9799" />
what more could you want?