### PR TITLE
Integrate web mocking library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,7 @@ end
 group :test do
   gem "factory_bot_rails" # Test data
   gem "simplecov", require: false # Code coverage
+  gem "webmock", "~> 3.25"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,9 @@ GEM
       unaccent (~> 0.3)
     country_select (8.0.2)
       countries (~> 5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -420,6 +423,7 @@ GEM
     grape-swagger-entity (0.6.2)
       grape-entity (~> 1)
       grape-swagger (~> 2)
+    hashdiff (1.2.0)
     hashid-rails (1.4.1)
       activerecord (>= 4.0)
       hashids (~> 1.0)
@@ -851,6 +855,10 @@ GEM
       openssl (>= 2.2)
       safety_net_attestation (~> 0.4.0)
       tpm-key_attestation (~> 0.12.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     websocket-driver (0.7.7)
       base64
@@ -997,6 +1005,7 @@ DEPENDENCIES
   validates_zipcode
   web-console (>= 3.3.0)
   webauthn (~> 3.2)
+  webmock (~> 3.25)
   whitesimilarity
   wicked_pdf
   wkhtmltopdf-binary (= 0.12.6.8)

--- a/spec/controllers/ach_transfers_controller_spec.rb
+++ b/spec/controllers/ach_transfers_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe AchTransfersController do
+  include SessionSupport
+
   describe "show" do
     it "redirects to hcb code" do
       event = create(:event)
@@ -15,27 +17,72 @@ describe AchTransfersController do
 
   describe "validate_routing_number" do
     before do
-      # janky way of signing in for tests, we basically override the call in sessions_helper that checks for current_user to return this test user
       user = create(:user)
-      allow(controller).to receive(:current_user).and_return(user)
+      sign_in(user)
     end
 
-    it "doesn't perform a lookup when routing number is invalid" do
-      expect(ColumnService).not_to receive(:get)
+    context "when value param is empty" do
+      it "doesn't perform a lookup and is valid" do
+        get :validate_routing_number, params: { value: "" }
 
-      get :validate_routing_number, params: { value: "not a routing number" }
+        body = JSON.parse(response.body)
+        expect(ColumnService).not_to receive(:get)
+        expect(body["valid"]).to be_truthy
+      end
     end
 
-    it "handles unknown routing numbers" do
-      get :validate_routing_number, params: { value: "123456789" }
+    context "when value param is in invalid format" do
+      it "is invalid" do
+        get :validate_routing_number, params: { value: "INVALID_FORMAT" }
 
-      expect(response.body).to match(/"valid":false/)
+        body = JSON.parse(response.body)
+
+        expect(ColumnService).not_to receive(:get)
+        expect(body["valid"]).to be_falsy
+        expect(body["hint"]).to eq "Bank not found for this routing number."
+      end
     end
 
-    it "returns bank name" do
-      get :validate_routing_number, params: { value: "083000137" }
+    context "when using ColumnService to get instructions" do
+      let(:param_value) { "123456789" }
+      context "when routing number type is different than aba" do
+        it "is invalid" do
+          stub_request(:get, "https://api.column.com/institutions/#{param_value}")
+            .to_return_json(status: 200, body: { routing_number_type: "not_aba" })
 
-      expect(response.body).to eq({ valid: true, hint: "Jpmorgan Chase Bank, Na" }.to_json)
+          get :validate_routing_number, params: { value: param_value }
+          body = JSON.parse(response.body)
+
+          expect(body["valid"]).to be_falsy
+          expect(body["hint"]).to eq "Please enter an ABA routing number."
+        end
+      end
+
+      context "when ach_eligible is false and routing_number_type is 'aba'" do
+        it "is invalid" do
+          stub_request(:get, "https://api.column.com/institutions/#{param_value}")
+            .to_return_json(status: 200, body: { ach_eligible: false, routing_number_type: "aba" })
+
+          get :validate_routing_number, params: { value: param_value }
+          body = JSON.parse(response.body)
+
+          expect(body["valid"]).to be_falsy
+          expect(body["hint"]).to eq "This routing number cannot accept ACH transfers."
+        end
+      end
+
+      context "when ach_eligible is true and routing_number_type is 'aba'" do
+        it "is invalid" do
+          stub_request(:get, "https://api.column.com/institutions/#{param_value}")
+            .to_return_json(status: 200, body: { ach_eligible: true, routing_number_type: "aba", full_name: "full name" })
+
+          get :validate_routing_number, params: { value: param_value }
+          body = JSON.parse(response.body)
+
+          expect(body["valid"]).to be_truthy
+          expect(body["hint"]).to eq "Full Name"
+        end
+      end
     end
   end
 end

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -70,6 +70,11 @@ describe LoginsController do
       user = create(:user, phone_number: "+18556254225")
       # This can't be done through the factory because we have validation logic
       # that clears out `phone_number_verified` when the phone number changes.
+      stub_request(:get, "https://app.loops.so/api/v1/contacts/find").
+        with(query: { email: user.email }).
+        to_return(status: 200, body: "[]", headers: {})
+
+      stub_request(:post, "https://app.loops.so/api/v1/contacts/update")
       user.update!(use_sms_auth: true, phone_number_verified: true)
       login = create(:login, user:)
 
@@ -90,6 +95,11 @@ describe LoginsController do
     context "webauthn" do
       it "signs the user in and redirects" do
         user = create(:user, phone_number: "+18556254225")
+        stub_request(:get, "https://app.loops.so/api/v1/contacts/find").
+          with(query: { email: user.email }).
+          to_return(status: 200, body: "[]", headers: {})
+        stub_request(:post, "https://app.loops.so/api/v1/contacts/update")
+
         login = create(:login, user:)
         webauthn_credential = create_webauthn_credential(user:)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,9 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 require "public_activity/testing"
 PublicActivity.enabled = false
 
+# Mocking web requests
+require "webmock/rspec"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
# WIP

Fixes #10755 Closes #10829 

## Summary of the problem

Summary from the issue #10755

> There are several tests in our test suite making real API calls to Stripe and other services. We should consider stubbing these out with a gem like https://rubygems.org/gems/vcr or https://rubygems.org/gems/webmock so they're easier to run.
> 
> This might also let us reduce the number of credentials needed (or completely eliminate them) so anyone outside of HCB can run things.
> 

## Describe your changes
`webmock` integration as library used in test group that mocks web requests.

integration of the library involves fixing the existing web requests called in the specs. Otherwise, specs that make real web requests fail with `webmock` exception.
Following is all the spec files that need fixing:
- [x] spec/controllers/ach_transfers_controller_spec.rb
- [x] UserService::SyncWithLoops
- [ ] others tba
