### PR TITLE
[Card Grants] Verify organization balance before creation or topup of card grant

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -153,9 +153,12 @@ class CardGrantsController < ApplicationController
   def topup
     authorize @card_grant
 
-    @card_grant.topup!(amount_cents: Monetize.parse(params[:amount]).cents, topped_up_by: current_user)
-
-    redirect_to @card_grant, flash: { success: "Successfully topped up grant." }
+    begin
+      @card_grant.topup!(amount_cents: Monetize.parse(params[:amount]).cents, topped_up_by: current_user)
+      redirect_to @card_grant, flash: { success: "Successfully topped up grant." }
+    rescue ArgumentError => e
+      redirect_to @card_grant, flash: { error: e.message }
+    end
   end
 
   def withdraw


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This solves an issue that allowed users to create or topup card grants without verifying the organization's balance. That allowed the organization to go into debt.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Implement a check to ensure the organization has sufficient balance before allowing a topup or grant creation. .


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

