### PR TITLE
Include local amount on HCB code partial

### DIFF
--- a/app/models/raw_stripe_transaction.rb
+++ b/app/models/raw_stripe_transaction.rb
@@ -24,7 +24,7 @@ class RawStripeTransaction < ApplicationRecord
 
   include ActiveSupport::NumberHelper
 
-  ZERO_DECIMAL_CURRENCIES = %w[BIF CLP DJF GNF JPY KMF KRW MGA PYG RWF UGX VND VUV XAF XOF XPF]
+  ZERO_DECIMAL_CURRENCIES = %w[BIF CLP DJF GNF JPY KMF KRW MGA PYG RWF UGX VND VUV XAF XOF XPF].freeze
 
   def memo
     @memo ||= stripe_transaction.dig("merchant_data", "name")

--- a/app/views/hcb_codes/_stripe_card.html.erb
+++ b/app/views/hcb_codes/_stripe_card.html.erb
@@ -187,6 +187,16 @@
         <span><strong>Sign in to view</strong></span>
       <% end %>
     </div>
+    <% if @hcb_code.raw_stripe_transaction.local_amount %>
+      <div>
+        <strong>Local amount</strong>
+        <% if organizer_signed_in? %>
+          <span><%= @hcb_code.raw_stripe_transaction.local_amount %></span>
+        <% else %>
+          <span><strong>Sign in to view</strong></span>
+        <% end %>
+      </div>
+    <% end %>
     <% if @hcb_code.pt.present? %>
       <div>
         <span style="height: 100%;">


### PR DESCRIPTION
## Summary of the problem
Right now, it's hard to see how much a card transaction is for in the local currency. We show the merchant currency, but not the amount. This can make it hard to pair receipts or understand finances in a local context.


## Describe your changes
This PR adds a line to the Stripe card partial on HCB codes to include the local currency, if applicable. It references a new method on the Raw Stripe Transaction. This makes it easier for users to see how much a transaction was for in the original currency before it was converted to USD by Visa.

cc @leowilkin 