### PR TITLE
[Announcements] General frontend announcement improvements

### DIFF
--- a/app/views/announcements/_announcement_card.html.erb
+++ b/app/views/announcements/_announcement_card.html.erb
@@ -9,7 +9,7 @@
       <% if announcement.draft? %>
         <span class="text-orange border-orange rounded-full border-solid border-[1px] text-sm p-[6px] mr-1 no-underline">Draft</span>
       <% end %>
-      <%= link_to announcement.title, announcement_path(announcement) %>
+      <%= link_to announcement.title, announcement_path(announcement), class: "font-bold no-underline text-black dark:text-smoke hover:underline" %>
     </h2>
     <% if organizer_signed_in?(as: :member) && !show_event %>
       <div class="flex gap-2">

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -13,7 +13,7 @@
       <div class="flex gap-2 bg-snow dark:bg-darkless p-2 rounded-md rounded-b-none dark:border-b-dark border-b-smoke border-b-[1px] border-solid border-0">
         <%= render partial: "announcements/format_menu" %>
       </div>
-      <div data-tiptap-target="editor" data-action="click->tiptap#focus" class="dark:bg-darkless bg-snow p-2 rounded-md rounded-t-none py-1 min-h-16"></div>
+      <div data-tiptap-target="editor" data-action="click->tiptap#focus" class="dark:bg-darkless bg-snow p-2 rounded-md rounded-t-none py-1 min-h-32"></div>
       <div class="tooltipped absolute right-1 bottom-1 h-8" aria-label="Styling with Markdown is supported">
         <%= inline_icon "markdown", size: 32 %>
       </div>

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -2,14 +2,14 @@
 
 <%= form_with model: @announcement, url: announcement_path(@announcement), data: { controller: "tiptap", "tiptap-target": "form", "tiptap-content-value": content, "tiptap-announcement-id-value": @announcement.id, "tiptap-autosave-value": autosave, "turbo-frame": "_top" }.compact do |form| %>
   <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title, placeholder: "#{@event.name}'s June Update", class: "!max-w-none w-full" %>
+    <%= form.label :title, class: "text-lg" %>
+    <%= form.text_field :title, placeholder: "#{@event.name}'s June Update", class: "!max-w-none w-full mt-1" %>
   </div>
 
   <div class="field">
-    <%= form.label :content %>
+    <%= form.label :content, class: "text-lg" %>
     <%= form.hidden_field :json_content, data: { "tiptap-target": "contentInput" } %>
-    <div class="border-smoke dark:border-0 border-[1px] border-solid rounded-md">
+    <div class="border-smoke dark:border-0 border-[1px] border-solid rounded-md mt-1">
       <div class="flex gap-2 bg-snow dark:bg-darkless p-2 rounded-md rounded-b-none dark:border-b-dark border-b-smoke border-b-[1px] border-solid border-0">
         <%= render partial: "announcements/format_menu" %>
       </div>

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -9,17 +9,15 @@
   <div class="field">
     <%= form.label :content, class: "text-lg" %>
     <%= form.hidden_field :json_content, data: { "tiptap-target": "contentInput" } %>
-    <div class="border-smoke dark:border-0 border-[1px] border-solid rounded-md mt-1">
+    <div class="border-smoke dark:border-0 border-[1px] border-solid rounded-md mt-1 relative">
       <div class="flex gap-2 bg-snow dark:bg-darkless p-2 rounded-md rounded-b-none dark:border-b-dark border-b-smoke border-b-[1px] border-solid border-0">
         <%= render partial: "announcements/format_menu" %>
       </div>
       <div data-tiptap-target="editor" data-action="click->tiptap#focus" class="dark:bg-darkless bg-snow p-2 rounded-md rounded-t-none py-1 min-h-16"></div>
+      <div class="tooltipped absolute right-1 bottom-1 h-8" aria-label="Styling with Markdown is supported">
+        <%= inline_icon "markdown", size: 32 %>
+      </div>
     </div>
-    <p class="h5 muted mt0 mb1">
-      <%= link_to "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#table-of-contents", target: "_blank", class: "flex items-center" do %>
-        <%= inline_icon "markdown", size: 32 %> Styling with Markdown is supported
-      <% end %>
-    </p>
   </div>
 
   <%= form.hidden_field :autosave, data: { "tiptap-target": "autosaveInput" } %>

--- a/app/views/events/_followers_modal.html.erb
+++ b/app/views/events/_followers_modal.html.erb
@@ -2,7 +2,7 @@
 
 <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="edit_followers">
   <%= modal_header "Followers" %>
-  <ul class="grid grid-cols-1 text-left w-full mt-2">
+  <ul class="grid grid-cols-<%= event_follows.size == 1 ? "1" : "2" %> text-left w-full mt-2">
     <% event_follows.each do |event_follow| %>
       <li class="overflow-visible card card--hover flex flex-row justify-between items-center gap-2">
         <span class="w-full flex gap-2 items-center align-middle">

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -126,7 +126,7 @@
       <% end %>
     </div>
     <div class="flex flex-col gap-2 items-start text-left w-full self-stretch">
-      <%= render partial: "announcements/announcement_card", collection: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last(2), as: :announcement %>
+      <%= render partial: "announcements/announcement_card", locals: { announcement: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last } %>
     </div>
 
     <%= render "static_pages/index/explore" %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -125,7 +125,7 @@
         <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
       <% end %>
     </div>
-    <div class="flex flex-col gap-2 items-start text-left w-full self-stretch">
+    <div class="mb-4 text-left w-full self-stretch">
       <%= render partial: "announcements/announcement_card", locals: { announcement: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last } %>
     </div>
 

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -118,7 +118,7 @@
     <%# Latest HCB announcement %>
     <div class="flex flex-row w-full justify-between items-center">
       <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
-        HCB announcements
+        The latest from HCB
       </h2>
       <%= link_to event_announcement_overview_path(Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK)), class: "muted", target: :_blank do %>
         View all announcements


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Addressing some of the feedback Sam left in https://hackclub.slack.com/archives/C047Y01MHJQ/p1753134018964429!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
- Give field labels more padding and make them bigger
- Move MD label to bottom right of editor
- Change followers modal to a 2-column grid
- Make the editor box taller
- Rename announcements header on homepage

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="1162" height="588" alt="image" src="https://github.com/user-attachments/assets/dc6e50b9-badb-40c4-afce-fb63529fbfb5" />

<img width="1066" height="588" alt="image" src="https://github.com/user-attachments/assets/0b04ed05-9ef1-466a-9353-ca4d7392050f" />
