### PR TITLE
[Announcement] Add event creation as updated default in atom feed

### DIFF
--- a/app/views/events/feed.atom.builder
+++ b/app/views/events/feed.atom.builder
@@ -4,7 +4,7 @@ xml.instruct! :xml, version: "1.0"
 
 xml.feed xmlns: "http://www.w3.org/2005/Atom" do
   xml.title "#{@event.name} – Announcements"
-  xml.updated @updated_at.xmlschema
+  xml.updated @updated_at.present? ? @updated_at.xmlschema : @event.created_at.xmlschema
   xml.link rel: "self", href: event_feed_url(@event)
   xml.link rel: "alternate", href: event_announcement_overview_url(@event)
   xml.id "urn:hcb:announcements_feed_#{@event.public_id}"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
feed.atom currently throws an error if there are no announcements!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds `event.created_at` as the default `updated` field in the announcements atom feed

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

