### PR TITLE
V3 API improvements

### DIFF
--- a/app/api/api/entities/ach_transfer.rb
+++ b/app/api/api/entities/ach_transfer.rb
@@ -19,6 +19,11 @@ module Api
         expose :beneficiary do
           expose :recipient_name, as: :name
         end
+
+        expose_associated User do |ach_transfer, options|
+          ach_transfer.creator
+        end
+
       end
 
       def self.entity_name

--- a/app/api/api/entities/activity.rb
+++ b/app/api/api/entities/activity.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       expose_associated User do |activity, options|
-        activity.user
+        activity.owner&.is_a?(User) ? activity.owner : activity.user
       end
 
       expose_associated Transaction do |activity, options|

--- a/app/api/api/entities/activity.rb
+++ b/app/api/api/entities/activity.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       expose_associated User do |activity, options|
-        activity.owner&.is_a?(User) ? activity.owner : activity.user
+        activity.owner.is_a?(User) ? activity.owner : activity.user
       end
 
       expose_associated Transaction do |activity, options|

--- a/app/api/api/entities/activity.rb
+++ b/app/api/api/entities/activity.rb
@@ -22,6 +22,8 @@ module Api
           return activity.trackable.try(:hcb_code)
         elsif activity.trackable.try(:hcb_code)
           HcbCode.find_by_hcb_code(activity.trackable.try(:hcb_code))
+        elsif (cpt_hcb_code = activity.trackable.try(:canonical_pending_transaction)&.try(:local_hcb_code))
+          cpt_hcb_code
         end
       end
 


### PR DESCRIPTION
changes the V3 transparency API to:
expose the creator of `AchTransfer`s as a `User`
expose the actual `owner` of PublicActivity activities rather than only trying `#user`
and.....drumroll please:
correctly expose the linked HCB code on RawPendingStripeTransaction.create activities
(previously they were unlinked because rpst doesn't directly have a `local_hcb_code`, it's on the associated cpt)