### PR TITLE
[Card Grants] Fix bug where organizers couldn't update merchant locks

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -71,7 +71,7 @@ class CardGrantsController < ApplicationController
   def update
     authorize @card_grant
 
-    if @card_grant.update(params.require(:card_grant).permit(:purpose))
+    if @card_grant.update(params.require(:card_grant).permit(:purpose, :merchant_lock, :category_lock, :keyword_lock))
       flash[:success] = "Grant's purpose has been successfully updated!"
     else
       flash[:error] = @card_grant.errors.full_messages.to_sentence


### PR DESCRIPTION
## Summary of the problem
Organizers currently can't update merchant locks in the new "Manage grant" menu because of a bug where the parameters aren't permitted.


## Describe your changes
This PR adds the parameters as permitted in the `CardGrantsController`