### PR TITLE
[Command Bar] Show demo mode organizations for auditors

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -35,7 +35,7 @@ class EventsController < ApplicationController
 
         if auditor_signed_in?
           events.concat(
-            Event.not_demo_mode.excluding(@current_user.events).with_attached_logo.map { |e|
+            Event.excluding(@current_user.events).with_attached_logo.map { |e|
               {
                 slug: e.slug,
                 name: e.name,


### PR DESCRIPTION
## Summary of the problem
Auditors can't <kbd>⌘</kbd><kbd>K</kbd> to find organizations that are in demo mode.


## Describe your changes
This PR includes demo mode organizations in the auditor command bar.

Closes #11082