### PR TITLE
[Card Grants] Fix card grant settings page for non-admins

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1073,8 +1073,11 @@ class EventsController < ApplicationController
         :category_lock,
         :keyword_lock,
         :invite_message,
+        :banned_merchants,
+        :banned_categories,
         :expiration_preference,
-        :reimbursement_conversions_enabled
+        :reimbursement_conversions_enabled,
+        :pre_authorization_required
       ],
       config_attributes: [
         :id,


### PR DESCRIPTION
## Summary of the problem
Certain attributes (blocked merchants, pre-authorization required) aren't permitted for non-admins.


## Describe your changes
This PR permits those parameters even for regular users.