### PR TITLE
Always show tags section in hcb code show for members

### DIFF
--- a/app/views/hcb_codes/_tags.html.erb
+++ b/app/views/hcb_codes/_tags.html.erb
@@ -1,4 +1,4 @@
-<% if hcb_code.tags.any? || organizer_signed_in?(as: :member) %>
+<% if hcb_code.tags.any? || TagPolicy.new(current_user, @event).create? %>
   <div>
     <strong>Tags</strong>
     <div class="flex items-center flex-wrap" style="gap: 0.25rem">

--- a/app/views/hcb_codes/_tags.html.erb
+++ b/app/views/hcb_codes/_tags.html.erb
@@ -1,4 +1,4 @@
-<% if hcb_code.tags.any? %>
+<% if hcb_code.tags.any? || organizer_signed_in?(as: :member) %>
   <div>
     <strong>Tags</strong>
     <div class="flex items-center flex-wrap" style="gap: 0.25rem">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
While it doesn't make sense for readers or transparent viewers to see the tags section if there's nothing there, anyone able to add a tag should be able to see the section if there are no tags already.

Fixes #11090

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a check for `organizer_signed_in?(as: :member)`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

