### PR TITLE
Fix crashes on Stripe card personalization designs & tags

### DIFF
--- a/app/views/hcb_codes/_tags.html.erb
+++ b/app/views/hcb_codes/_tags.html.erb
@@ -7,7 +7,7 @@
       </div>
 
       <div data-controller="menu">
-        <% if policy(Tag.new).create? %>
+        <% if TagPolicy.new(current_user, @event).create? %>
           <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless h-full" style="height: 1.6rem" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
         <% end %>
         <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">

--- a/app/views/stripe_cards/_stripe_card.html.erb
+++ b/app/views/stripe_cards/_stripe_card.html.erb
@@ -29,7 +29,7 @@
     <% end %>
     <p class="stripe-card__number fs-mask">
       <% if stripe_card.user != current_user %>
-        <% if OrganizerPosition.role_at_least?(current_user, @event, :reader) %>
+        <% if OrganizerPosition.role_at_least?(current_user, stripe_card.event, :reader) %>
           <%= stripe_card.hidden_card_number_with_last_four %>
         <% else %>
           <%= stripe_card.hidden_card_number %>


### PR DESCRIPTION
## Summary of the problem
Stripe card personalization designs and tags are both having issues in prod right now. This PR fixes both of them.

