### PR TITLE
[Disbursements] Fix issue where pressing enter would change org selection

### DIFF
--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -18,7 +18,7 @@
                     <% disabled_message = "Insufficient balance" if sending && !admin_signed_in? && event.balance_available <= 0 %>
                     <% disabled_message = "HCB transfers disabled" if sending && !policy(event).create_transfer? %>
                     <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
-                        <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150">
+                        <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
                             <div class="text-left"><%= event.name %></div>
                             <div class="text-muted pl-2">
                                 <% if admin_signed_in? %>


### PR DESCRIPTION
## Summary of the problem
Pressing enter would automatically select the first organization


## Describe your changes
Set `type="button"` to prevent this