### PR TITLE
Collect co-signer email when creating subevents

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -825,6 +825,7 @@ class EventsController < ApplicationController
     subevent = ::EventService::Create.new(
       name: params[:name],
       emails: [params[:email]],
+      cosigner_email: params[:cosigner_email],
       is_signee: true,
       country: params[:country],
       point_of_contact_id: @event.point_of_contact_id,

--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -50,6 +50,11 @@
       <%= form.email_field :email, placeholder: "Running this project yourself? Use #{current_user.email}" %>
     </div>
 
+    <div class="field">
+      <%= form.label :cosigner_email, "Co-signer email", class: "bold" %>
+      <%= form.email_field :cosigner_email, placeholder: "Include this if the organizer is under 18" %>
+    </div>
+
     <small class="muted mt-0 mb-4">This project will be created on the <strong><%= @event.plan.label %></strong> plan</small>
 
     <div class="inline-block">


### PR DESCRIPTION
## Summary of the problem
Contracts for minors won't work because we aren't passing a co-signer email into `EventService::Create`


## Describe your changes
Pass a co-signer email into `EventService::Create`