### PR TITLE
Don't render "create tag" action on non-event pages

### DIFF
--- a/app/views/hcb_codes/_create_tag.html.erb
+++ b/app/views/hcb_codes/_create_tag.html.erb
@@ -1,4 +1,4 @@
-<% if OrganizerPosition.role_at_least?(current_user, @event, :member) %>
+<% if @event && OrganizerPosition.role_at_least?(current_user, @event, :member) %>
   <% if button %>
     <%= link_to "#", class: "menu__input #{ "btn mt-3" if defined?(large)}", data: { behavior: "modal_trigger", modal: "create_tag" }, onclick: "document.getElementById('create_tag_hcb_code_id').value = #{button.to_json}" do %>
       <%= inline_icon "plus", size: 15 %>


### PR DESCRIPTION
It doesn't make sense to render these in this context imo.

Closes https://github.com/hackclub/hcb/issues/11099