### PR TITLE
Only show two columns on card grants with Stripe cards

### DIFF
--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -36,7 +36,7 @@
     <% end %>
   <%# Grantee has accepted invite %>
   <% elsif @card_grant.user.admin? || organizer_signed_in? || @card_grant.user == current_user %>
-    <div class="justify-center grid grid-cols-1 md:grid-cols-2">
+    <div class="justify-center grid grid-cols-1 <%= "md:grid-cols-2" if @card_grant.stripe_card.present? %>">
       <% if @card_grant.stripe_card %>
         <div>
           <%= render @card_grant.stripe_card, headless: true %>


### PR DESCRIPTION
Fixes:

<img width="893" height="277" alt="Screenshot 2025-07-25 at 9 43 40 PM" src="https://github.com/user-attachments/assets/304e343c-b26a-4eb7-91bc-4e4096b3c0c2" />


With:

<img width="863" height="302" alt="Screenshot 2025-07-25 at 9 43 35 PM" src="https://github.com/user-attachments/assets/da7094ee-e986-46cb-8958-f8b54cb6415f" />
