### PR TITLE
Allow admins to bypass OrganizerPosition.role_at_least?

### DIFF
--- a/app/models/organizer_position.rb
+++ b/app/models/organizer_position.rb
@@ -55,6 +55,9 @@ class OrganizerPosition < ApplicationRecord
   end
 
   def self.role_at_least?(user, event, role)
+    return false unless event.present? && role.present?
+    return true if user&.admin?
+
     if role.to_s == "reader"
       return event.ancestor_organizer_positions.reader_access.where(user:).exists?
     end


### PR DESCRIPTION
## Summary of the problem
Admins are currently failing `OrganizerPosition.role_at_least?` checks due to a recent change in #9739 


## Describe your changes
This PR adds back two lines that prevented admins from bypassing `OrganizerPosition.role_at_least?` checks.