### PR TITLE
[Bug] Render verification letter in correct documents category

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -24,16 +24,28 @@
   <div class="grid-row text">
     <h3>General documents</h3>
     <div class="grid grid-cols-3 gap-4">
-      <%= render partial: "document", collection: @active_common_documents.general %>
-      <%= link_to event_fiscal_sponsorship_letter_path(event_id: @event.slug, format: "pdf") do %>
-        <li class="card card--hover h-100 w-fit">
-          <div class="overflow-hidden" style="max-height: 250px;">
-            <%= image_tag event_fiscal_sponsorship_letter_url(event_id: @event.slug, format: "png"), width: 330, style: "max-width: 100%;" %>
-          </div>
-          <strong class="h3 block mt1 line-height-2">Fiscal Sponsorship Confirmation</strong>
-          <%= user_mention @event.point_of_contact %>
-        </li>
+      <% if @event.approved? && !@event.demo_mode? %>
+        <%= link_to event_verification_letter_path(event_id: @event.slug, format: "pdf") do %>
+          <li class="card card--hover h-100">
+            <div class="overflow-hidden" style="max-height: 250px;">
+              <%= image_tag event_verification_letter_url(event_id: @event.slug, format: "png"), width: 330, style: "max-width: 100%;" %>
+            </div>
+
+            <strong class="h3 block mt1 line-height-2">Verification Letter</strong>
+            <%= user_mention @event.point_of_contact %>
+          </li>
+        <% end if @event.account_number %>
+        <%= link_to event_fiscal_sponsorship_letter_path(event_id: @event.slug, format: "pdf") do %>
+            <li class="card card--hover h-100 w-fit">
+              <div class="overflow-hidden" style="max-height: 250px;">
+                <%= image_tag event_fiscal_sponsorship_letter_url(event_id: @event.slug, format: "png"), width: 330, style: "max-width: 100%;" %>
+              </div>
+              <strong class="h3 block mt1 line-height-2">Fiscal Sponsorship Confirmation</strong>
+              <%= user_mention @event.point_of_contact %>
+            </li>
+          <% end %>
       <% end %>
+      <%= render partial: "document", collection: @active_common_documents.general %>
     </div>
 
     <h3>Nonprofit status</h3>
@@ -51,19 +63,6 @@
       <%= render partial: "document", collection: @active_common_documents.forms %>
     </div>
   </div>
-
-  <% if @event.approved? && !@event.demo_mode? %>
-    <%= link_to event_verification_letter_path(event_id: @event.slug, format: "pdf") do %>
-      <li class="card card--hover h-100">
-        <div class="overflow-hidden" style="max-height: 250px;">
-          <%= image_tag event_verification_letter_url(event_id: @event.slug, format: "png"), width: 330, style: "max-width: 100%;" %>
-        </div>
-
-        <strong class="h3 block mt1 line-height-2">Verification Letter</strong>
-        <%= user_mention @event.point_of_contact %>
-      </li>
-    <% end if @event.account_number %>
-  <% end %>
 </ul>
 
 <% if @archived_documents.any? || @archived_common_documents.any? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
I forgot to move the code to render the verification letter in the general tab so it creates a huge column and messes up the ui
<img width="927" height="782" alt="image" src="https://github.com/user-attachments/assets/269de84b-2f21-455f-97aa-226478735873" />

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Rending the verification letter in the same place as the contract.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

