### PR TITLE
Use one previewer for all LibreOffice previews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -231,5 +231,3 @@ gem "pstore"
 gem "bcrypt", "~> 3.1.7"
 
 gem "prosemirror_to_html"
-
-gem "activestorage-office-previewer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,8 +94,6 @@ GEM
       activerecord (= 7.2.2.1)
       activesupport (= 7.2.2.1)
       marcel (~> 1.0)
-    activestorage-office-previewer (0.1.2)
-      activestorage (>= 6.0.0)
     activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
@@ -875,7 +873,6 @@ PLATFORMS
 DEPENDENCIES
   aasm
   active_storage_validations (= 2.0.2)
-  activestorage-office-previewer
   acts_as_paranoid (~> 0.10.3)
   actual_db_schema
   ahoy_email (~> 2.4)

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require_relative "boot"
 
 require "rails/all"
 require_relative "../app/lib/credentials"
-require_relative "../lib/active_storage/previewer/csv_previewer"
+require_relative "../lib/active_storage/previewer/document_previewer"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -95,7 +95,7 @@ module Bank
     config.active_record.encryption.key_derivation_salt = Credentials.fetch(:ACTIVE_RECORD, :ENCRYPTION, :KEY_DERIVATION_SALT)
 
     # CSV previews
-    config.active_storage.previewers << ActiveStorage::Previewer::CsvPreviewer
+    config.active_storage.previewers << ActiveStorage::Previewer::DocumentPreviewer
 
   end
 end

--- a/lib/active_storage/previewer/document_previewer.rb
+++ b/lib/active_storage/previewer/document_previewer.rb
@@ -16,7 +16,7 @@ module ActiveStorage
         "application/vnd.openxmlformats-officedocument.presentationml.presentation", # .pptx
 
         "application/vnd.ms-excel", # .xls
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" # .xlsx
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", # .xlsx
         "text/csv", # .csv
       ].freeze
 

--- a/lib/active_storage/previewer/document_previewer.rb
+++ b/lib/active_storage/previewer/document_previewer.rb
@@ -4,8 +4,16 @@ require "active_storage/previewer"
 
 module ActiveStorage
   class Previewer
-    class CsvPreviewer < ActiveStorage::Previewer
+    class DocumentPreviewer < ActiveStorage::Previewer
       ACCEPTABLE_CONTENT_TYPES = [
+        "application/msword", # .doc
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # .docx
+
+        "application/vnd.ms-powerpoint", # .ppt
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation", # .pptx
+
+        "application/vnd.ms-excel", # .xls
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" # .xlsx
         "text/csv", # .csv
       ].freeze
 

--- a/lib/active_storage/previewer/document_previewer.rb
+++ b/lib/active_storage/previewer/document_previewer.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# this is a custom version of https://github.com/basecamp/activestorage-office-previewer
+# that also supports CSV files.
+
 require "active_storage/previewer"
 
 module ActiveStorage


### PR DESCRIPTION
Will remove the gem added for `.docx` previews as we now have a custom version of this gem that supports `.csv` files.