### PR TITLE
Switch `users.email` to `NOT NULL`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@
 #  charge_notifications          :integer          default("email_and_sms"), not null
 #  comment_notifications         :integer          default("all_threads"), not null
 #  creation_method               :integer
-#  email                         :text
+#  email                         :text             not null
 #  full_name                     :string
 #  locked_at                     :datetime
 #  payout_method_type            :string

--- a/db/migrate/20250728132738_add_null_check_constraint_to_users_email.rb
+++ b/db/migrate/20250728132738_add_null_check_constraint_to_users_email.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+#
+class AddNullCheckConstraintToUsersEmail < ActiveRecord::Migration[7.2]
+    def change
+      add_check_constraint(
+        :users,
+        "email IS NOT NULL",
+        name: "users_email_not_null",
+        validate: false
+      )
+    end
+end

--- a/db/migrate/20250728132814_validate_null_check_constraint_on_users_email.rb
+++ b/db/migrate/20250728132814_validate_null_check_constraint_on_users_email.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNullCheckConstraintOnUsersEmail < ActiveRecord::Migration[7.2]
+  def up
+    validate_check_constraint(:users, name: "users_email_not_null")
+    change_column_null(:users, :email, false)
+    remove_check_constraint(:users, name: "users_email_not_null")
+  end
+
+  def down
+    add_check_constraint(
+      :users,
+      "email IS NOT NULL",
+      name: "users_email_not_null",
+      validate: false
+    )
+    change_column_null(:users, :email, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_21_195537) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_28_132814) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2242,7 +2242,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_195537) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.text "email"
+    t.text "email", null: false
     t.string "full_name"
     t.text "phone_number"
     t.string "slug"


### PR DESCRIPTION
## Summary of the problem

- We have a presence validation on `User#email`: https://github.com/hackclub/hcb/blob/1d41ad3bdc0c994cb879baca93d61df785320899/app/models/user.rb#L165
- We don't have any `NULL` or blank values in the database
    <img width="782" height="360" alt="CleanShot 2025-07-28 at 09 33 30" src="https://github.com/user-attachments/assets/332b7f5c-9476-4e27-9761-498b345e0051" />
- Yet `users.email` is a nullable column: https://github.com/hackclub/hcb/blob/fefb74bc9a399bd5d9ea2129f703a76fa76b7a4f/db/schema.rb#L2245

## Describe your changes

As per the strong migrations guidelines for changing a column's nullability:
1. Adds a non-validated check constraint
2. Validates (1), switches the column to `NOT NULL`, drops (1)

See #11015 for a similar change.