### PR TITLE
[DX] Fix email display in Flipper

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -38,7 +38,7 @@ Flipper::UI.configure do |config|
       case model
       when "User"
         User.where(id: mapping.keys).pluck(:id, :email, :full_name).each do |(id, email, full_name)|
-          actor_names[mapping.fetch(id)] = ActionMailer::Base.email_address_with_name(email, full_name)
+          actor_names[mapping.fetch(id)] = CGI.escape_html(ActionMailer::Base.email_address_with_name(email, full_name))
         end
       when "Event"
         Event.where(id: mapping.keys).pluck(:id, :name).each do |(id, name)|

--- a/spec/misc/flipper_spec.rb
+++ b/spec/misc/flipper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("Flipper configuration") do
 
       actor_names = Flipper::UI.configuration.actor_names_source.call([user.flipper_id])
 
-      expect(actor_names).to eq({ user.flipper_id => "Orpheus the Dinosaur <orpheus@hackclub.com>" })
+      expect(actor_names).to eq({ user.flipper_id => "Orpheus the Dinosaur &lt;orpheus@hackclub.com&gt;" })
     end
 
     it "handles users without names" do


### PR DESCRIPTION
## Summary of the problem

- In #10962 I configured `actor_names_source` to show the name and email of flipper actors https://github.com/hackclub/hcb/blob/fefb74bc9a399bd5d9ea2129f703a76fa76b7a4f/spec/misc/flipper_spec.rb#L20
- When testing I noticed we weren't displaying the email address 
    <img width="1250" height="448" alt="image" src="https://github.com/user-attachments/assets/d9b71685-1871-44a0-8b3c-cc4eece0997e" />


After some quick digging I found out Flipper assumes the output of `actor_names_source` is HTML so it performs additional sanitization before rendering: https://github.com/flippercloud/flipper/blob/fcb554ca5c5c9e324f81d52b186c111313504b39/lib/flipper/ui/views/feature.erb#L77-L78. This meant the email part of the output which is wrapped in `<` and `>` gets stripped out.

## Describe your changes

- Runs `ActionMailer::Base.email_address_with_name` through `CGI.escape_html`
- Updates the spec

which fixes the issue:

<img width="617" height="229" alt="CleanShot 2025-07-28 at 10 20 10" src="https://github.com/user-attachments/assets/03d8d1c3-a924-4489-8d67-4ee3f1993445" />
