### PR TITLE
Only show the latest announcement from HCB if one exists

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -26,6 +26,8 @@ class StaticPagesController < ApplicationController
         event&.is_public? && event.is_indexable?
       end.sample(6)
 
+      @latest_hcb_announcement = Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last
+
       @organizer_positions = @service.organizer_positions.not_hidden
       @invites = @service.invites
 

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -116,18 +116,20 @@
     <%= render "static_pages/index/teen_raffle" %>
 
     <%# Latest HCB announcement %>
-    <div class="flex flex-row w-full justify-between items-center">
-      <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
-        The latest from HCB
-      </h2>
-      <%= link_to event_announcement_overview_path(Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK)), class: "muted", target: :_blank do %>
-        View all announcements
-        <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
-      <% end %>
-    </div>
-    <div class="mb-4 text-left w-full self-stretch">
-      <%= render partial: "announcements/announcement_card", locals: { announcement: Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK).announcements.published.order(published_at: :desc).last } %>
-    </div>
+    <% if @latest_hcb_announcement %>
+      <div class="flex flex-row w-full justify-between items-center">
+        <h2 class="heading h2 line-height-4 my-2 mr-auto py-2 px-4 ml-0 pl-0 border-none">
+          The latest from HCB
+        </h2>
+        <%= link_to event_announcement_overview_path(Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK)), class: "muted", target: :_blank do %>
+          View all announcements
+          <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
+        <% end %>
+      </div>
+      <div class="mb-4 text-left w-full self-stretch">
+        <%= render partial: "announcements/announcement_card", locals: { announcement: @latest_hcb_announcement } %>
+      </div>
+    <% end %>
 
     <%= render "static_pages/index/explore" %>
 


### PR DESCRIPTION
## Summary of the problem

On a fresh database we run into an exception because the HCB org doesn't have any announcements.

<img width="1143" height="908" alt="image" src="https://github.com/user-attachments/assets/f49add8d-c368-4081-ab10-c99e4b5a7db4" />

## Describe your changes

- Moves the announcement selection logic to the controller
- Hides the entire section depending on whether an announcement exists