### PR TITLE
Require sudo mode for ACH transfers over $500

### DIFF
--- a/app/controllers/ach_transfers_controller.rb
+++ b/app/controllers/ach_transfers_controller.rb
@@ -51,6 +51,10 @@ class AchTransfersController < ApplicationController
 
     authorize @ach_transfer
 
+    if @ach_transfer.amount > 500_00
+      return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
+    end
+
     if @ach_transfer.save
       if ach_transfer_params[:file]
         ::ReceiptService::Create.new(

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -1,5 +1,15 @@
 <% content_for(:container_class, "container--sm py-20") %>
 
+<% content_for(:head) do %>
+  <%#
+    If sudo mode is triggered from within a Turbo frame, the default behaviour
+    would be to render the response within that frame. This meta tag tells Turbo
+    to treat it as a full page navigation.
+    https://turbo.hotwired.dev/handbook/frames#%E2%80%9Cbreaking-out%E2%80%9D-from-a-frame
+  %>
+  <meta name="turbo-visit-control" content="reload">
+<% end %>
+
 <div class="flex">
   <%= render(partial: "application/logo") %>
 </div>

--- a/spec/controllers/ach_transfers_controller_spec.rb
+++ b/spec/controllers/ach_transfers_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe AchTransfersController do
+  include SessionSupport
+
   describe "show" do
     it "redirects to hcb code" do
       event = create(:event)
@@ -36,6 +38,102 @@ describe AchTransfersController do
       get :validate_routing_number, params: { value: "083000137" }
 
       expect(response.body).to eq({ valid: true, hint: "Jpmorgan Chase Bank, Na" }.to_json)
+    end
+  end
+
+  describe "create" do
+    render_views
+
+    def ach_transfer_params
+      {
+        routing_number: "026002532",
+        account_number: "123456789",
+        recipient_email: "orpheus@example.com",
+        bank_name: "The Bank of Nova Scotia",
+        recipient_name: "Orpheus",
+        amount_money: "100",
+        payment_for: "Snacks",
+        send_email_notification: false,
+        invoiced_at: "2025-01-01"
+      }
+    end
+
+    it "creates an ACH transfer" do
+      user = create(:user)
+      event = create(:event, :with_positive_balance)
+      create(:organizer_position, user:, event:)
+
+      sign_in(user)
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          ach_transfer: ach_transfer_params,
+        }
+      )
+
+      expect(response).to redirect_to(event_transfers_path(event))
+
+      ach_transfer = event.ach_transfers.sole
+      expect(ach_transfer).to be_pending
+      expect(ach_transfer.creator).to eq(user)
+      expect(ach_transfer.routing_number).to eq("026002532")
+      expect(ach_transfer.account_number).to eq("123456789")
+      expect(ach_transfer.bank_name).to eq("The Bank of Nova Scotia")
+      expect(ach_transfer.recipient_name).to eq("Orpheus")
+      expect(ach_transfer.recipient_email).to eq("orpheus@example.com")
+      expect(ach_transfer.amount).to eq(100_00)
+      expect(ach_transfer.payment_for).to eq("Snacks")
+      expect(ach_transfer.send_email_notification).to eq(false)
+      expect(ach_transfer.invoiced_at).to eq(Date.new(2025, 1, 1))
+    end
+
+    it "requires sudo mode if the amount is greater than 500" do
+      user = create(:user)
+      Flipper.enable(:sudo_mode_2015_07_21, user)
+      event = create(:event, :with_positive_balance)
+      create(:organizer_position, user:, event:)
+
+      sign_in(user)
+
+      travel(3.hours)
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          ach_transfer: {
+            **ach_transfer_params,
+            amount_money: "500.01",
+          }
+        }
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(event.ach_transfers).to be_empty
+      expect(response.body).to include("Confirm Access")
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          ach_transfer: {
+            **ach_transfer_params,
+            amount_money: "500.01",
+          },
+          _sudo: {
+            submit_method: "email",
+            login_code: user.login_codes.last.code,
+            login_id: user.logins.last.hashid,
+          }
+        }
+      )
+
+      expect(response).to redirect_to(event_transfers_path(event))
+      ach_transfer = event.ach_transfers.sole
+      expect(ach_transfer.payment_for).to eq("Snacks")
+      expect(ach_transfer.amount).to eq(500_01)
     end
   end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -22,5 +22,24 @@ FactoryBot.define do
     trait :card_grant_event do
       association :card_grant_setting
     end
+
+    trait :with_positive_balance do
+      after :create do |event|
+        raw_csv_transaction = RawCsvTransactionService::Create.new(
+          unique_bank_identifier: "FSMAIN",
+          date: 3.days.ago.iso8601(3),
+          memo: "🏦 Test Donation",
+          amount: 1_000
+        ).run
+
+        TransactionEngine::HashedTransactionService::RawCsvTransaction::Import.new.run
+        TransactionEngine::CanonicalTransactionService::Import::All.new.run
+
+        CanonicalEventMapping.create!(
+          canonical_transaction_id: CanonicalTransaction.find_by!(memo: raw_csv_transaction.memo).id,
+          event_id: event.id,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary of the problem

See #6346 

## Describe your changes

- Check for sudo mode in `AchTransfersController#create` when the amount is greater than $500
- Adds a basic test for the green path and the sudo mode case
- (somewhat unrelated) Adds a `turbo-visit-control` meta tag to the reauthentication page so it breaks out of turbo frames