### PR TITLE
Replace `sync_with_loops` with `queue_sync_with_loops_job`

### DIFF
--- a/app/jobs/user/sync_to_loops_job.rb
+++ b/app/jobs/user/sync_to_loops_job.rb
@@ -6,7 +6,7 @@ class User
 
     def perform
       User.all.find_each(batch_size: 100) do |user|
-        user.sync_with_loops
+        User::SyncUserToLoopsJob.perform_later(user_id: user.id)
       end
     end
 

--- a/app/jobs/user/sync_to_loops_job.rb
+++ b/app/jobs/user/sync_to_loops_job.rb
@@ -6,7 +6,7 @@ class User
 
     def perform
       User.all.find_each(batch_size: 100) do |user|
-        User::SyncUserToLoopsJob.perform_later(user_id: user.id)
+        UserService::SyncWithLoops.new(user_id: user.id)
       end
     end
 

--- a/app/jobs/user/sync_to_loops_job.rb
+++ b/app/jobs/user/sync_to_loops_job.rb
@@ -6,7 +6,7 @@ class User
 
     def perform
       User.all.find_each(batch_size: 100) do |user|
-        UserService::SyncWithLoops.new(user_id: user.id)
+        UserService::SyncWithLoops.new(user_id: user.id).run
       end
     end
 

--- a/app/jobs/user/sync_user_to_loops_job.rb
+++ b/app/jobs/user/sync_user_to_loops_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class User
+  class SyncUserToLoopsJob < ApplicationJob
+    queue_as :low
+
+    def perform(user_id:, new_user: false)
+      UserService::SyncWithLoops.new(user_id:, new_user:).run
+    end
+
+  end
+
+end


### PR DESCRIPTION
This will make our requests to update a user faster and not blocking on Loops, see https://hackclub.slack.com/archives/C047Y01MHJQ/p1753735183168919 for context.