### PR TITLE
Show current active teenager count on promotions page

### DIFF
--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -33,7 +33,7 @@
       to your website for a $500 coupon to spend on custom stickers, cards, marketing materials, and more!
     </p>
     <section class="card__banner card__darker secondary border-top italic">
-      You currently have <%= number_to_human @event.users.count { |user| user.teenager? && user.active? } %> active teenagers in your organization!
+      You currently have <%= number_to_human(@event.users.count { |user| user.teenager? && user.active? }) %> active teenagers in your organization!
     </section>
   </div>
 </div>

--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -9,7 +9,7 @@
 </h1>
 
 <div class="mb3 rounded-xl promo-premium-border">
-  <div class="card" id="jukebox">
+  <div class="card pb0" id="jukebox">
     <div class="card__banner card__banner--top flex justify-between items-center promo-premium-banner">
       <h3 class="h1 py-4 my0 text-transparent promo-premium-header bg-clip-text inline-flex items-center flex-grow">
         <span class="flex-grow">Jukebox</span>
@@ -27,11 +27,14 @@
       <% end %>
     </div>
 
-    <p class="mb0">
+    <p>
       Does your HCB organization have 10 or more active teens? Add a link to
       <%= link_to "Jukebox Print", "https://www.jukeboxprint.com/custom-stickers" %>
       to your website for a $500 coupon to spend on custom stickers, cards, marketing materials, and more!
     </p>
+    <section class="card__banner card__darker secondary border-top italic">
+      You currently have <%= number_to_human @event.users.count { |user| user.teenager? && user.active? } %> active teenagers in your organization!
+    </section>
   </div>
 </div>
 


### PR DESCRIPTION
<img width="761" height="220" alt="Screenshot 2025-07-28 at 10 14 20 PM" src="https://github.com/user-attachments/assets/9bcbce12-a686-40ee-b954-6a1b5e804c57" />

Closes https://github.com/hackclub/hcb/issues/11134.

Put this on the promotions page as I believe that that contextualises it more - let me know if I'm misunderstanding.