### PR TITLE
[DX] Switch `config.flipper.strict` to `false`

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
 
   # Setting to `true` or `:raise` will raise error when a feature doesn't exist.
   # Use `:warn` to log a warning instead.
-  config.flipper.strict = :warn
+  config.flipper.strict = false
 
   # Don't limit to 100 actors per feature
   config.flipper.actor_limit = false


### PR DESCRIPTION
## Summary of the problem

See https://github.com/hackclub/hcb/pull/10835#discussion_r2190728256

While in theory being alerted when referencing unknown feature flags would be a good thing, in practice we don't have the machinery in place to make sure we call `Flipper.add` on all known features.

## Describe your changes

Switch `config.flipper.strict` to `false so we don't have noise like this in our logs

<img width="857" height="727" alt="CleanShot 2025-07-29 at 14 32 11" src="https://github.com/user-attachments/assets/fc1f7543-9a72-4c13-b21c-7492394a1368" />
