### PR TITLE
[Announcement] Confirm publishing an announcement from the create form

### DIFF
--- a/app/javascript/controllers/tiptap_controller.js
+++ b/app/javascript/controllers/tiptap_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
     announcementId: Number,
     autosave: Boolean,
     followers: Number,
-    published: Boolean
+    published: Boolean,
   }
 
   editor = null
@@ -86,12 +86,14 @@ export default class extends Controller {
   submit(autosave) {
     if (autosave !== true && !this.publishedValue) {
       const data = new FormData(this.formTarget)
-      const draft = data.get("announcement[draft]")
+      const draft = data.get('announcement[draft]')
 
-      if (draft === "false") {
-        let confirmed = confirm(`Are you sure you would like to publish this announcement and notify ${this.followersValue} follower${this.followersValue === 1 ? "" : "s"}?`)
-      
-        if (!confirmed) return;
+      if (draft === 'false') {
+        let confirmed = confirm(
+          `Are you sure you would like to publish this announcement and notify ${this.followersValue} follower${this.followersValue === 1 ? '' : 's'}?`
+        )
+
+        if (!confirmed) return
       }
     }
 

--- a/app/javascript/controllers/tiptap_controller.js
+++ b/app/javascript/controllers/tiptap_controller.js
@@ -18,6 +18,8 @@ export default class extends Controller {
     content: String,
     announcementId: Number,
     autosave: Boolean,
+    followers: Number,
+    published: Boolean
   }
 
   editor = null
@@ -82,6 +84,17 @@ export default class extends Controller {
   }
 
   submit(autosave) {
+    if (autosave !== true && !this.publishedValue) {
+      const data = new FormData(this.formTarget)
+      const draft = data.get("announcement[draft]")
+
+      if (draft === "false") {
+        let confirmed = confirm(`Are you sure you would like to publish this announcement and notify ${this.followersValue} follower${this.followersValue === 1 ? "" : "s"}?`)
+      
+        if (!confirmed) return;
+      }
+    }
+
     this.autosaveInputTarget.value = autosave === true ? 'true' : 'false'
     this.contentInputTarget.value = JSON.stringify(this.editor.getJSON())
     this.formTarget.requestSubmit()

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (content: nil, autosave: true) %>
 
-<%= form_with model: @announcement, url: announcement_path(@announcement), data: { controller: "tiptap", "tiptap-target": "form", "tiptap-content-value": content, "tiptap-announcement-id-value": @announcement.id, "tiptap-autosave-value": autosave, "turbo-frame": "_top" }.compact do |form| %>
+<%= form_with model: @announcement, url: announcement_path(@announcement), data: { controller: "tiptap", "tiptap-target": "form", "tiptap-content-value": content, "tiptap-announcement-id-value": @announcement.id, "tiptap-autosave-value": autosave, "tiptap-followers-value": @event.followers.size, "tiptap-published-value": @announcement.published?, "turbo-frame": "_top" }.compact do |form| %>
   <div class="field">
     <%= form.label :title, class: "text-lg" %>
     <%= form.text_field :title, placeholder: "#{@event.name}'s June Update", class: "!max-w-none w-full mt-1" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently we have `turbo_confirm` on publishing draft announcements, but there's no confirmation when publishing an announcement straight from the creation form!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a confirmation dialog to the creation form when publishing an announcement for the first time.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

