### PR TITLE
Fallback to 0 events when sorting plans by popularity

### DIFF
--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -79,7 +79,7 @@ class Event
     end
 
     def self.available_plans_by_popularity
-      available_plans.sort_by { |p| plan_popularities[p] }.reverse!
+      available_plans.sort_by { |p| plan_popularities[p].presence || 0 }.reverse!
     end
 
     def self.plan_popularities


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
PR #11093 added a new method `available_plans_by_popularity` on `Event::Plan`, but this method relied on a query that did not include plans that were not being used. In seed data, only the Standard plan is used, causing the sort to throw an error when comparing `nil` and `Integer`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Fallback to 0 if there are no events associated with the plan being sorted.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

