### PR TITLE
Require sudo mode when viewing card details

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class LoginsController < ApplicationController
-  skip_before_action :signed_in_user
+  skip_before_action :signed_in_user, except: [:reauthenticate]
   skip_after_action :verify_authorized
-  before_action :set_login, except: [:new, :create]
-  before_action :set_user, except: [:new, :create]
+  before_action :set_login, except: [:new, :create, :reauthenticate]
+  before_action :set_user, except: [:new, :create, :reauthenticate]
   before_action :set_return_to
 
   layout "login"
@@ -171,6 +171,12 @@ class LoginsController < ApplicationController
         redirect_to choose_login_preference_login_path(@login, return_to: @return_to), status: :temporary_redirect
       end
     end
+  end
+
+  def reauthenticate
+    return unless enforce_sudo_mode
+
+    redirect_to(@return_to || root_path)
   end
 
   private

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -72,6 +72,8 @@ class StripeCardsController < ApplicationController
     authorize @card
 
     if params[:show_details] == "true"
+      return unless enforce_sudo_mode
+
       ahoy.track "Card details shown", stripe_card_id: @card.id
     end
 

--- a/app/controllers/sudo_mode_handler.rb
+++ b/app/controllers/sudo_mode_handler.rb
@@ -138,6 +138,8 @@ class SudoModeHandler
   # Extracts the request parameters as a flat list of key-value pairs (instead
   # of following Rack's nesting conventions) so that we can re-submit them along
   # with the sudo credentials.
+  #
+  # @return [Hash<String, Array<String>>]
   def forwarded_params
     # Mimic the behaviour of `ActionDispatch::Http::Parameters#parameters` to
     # obtain a single hash of both request and query parameters.
@@ -158,16 +160,15 @@ class SudoModeHandler
           name.start_with?("_sudo")
         end
       end
-      .each_with_object([]) do |(name, value_or_values), array|
+      .transform_values do |value_or_values|
         # `Rack::Utils.parse_query` returns a hash of param names to values but
         # returns an array of values for repeated params (as is the convention
-        # params like `tags[]`)
+        # params like `tags[]`). Rather than dealing with both cases we just
+        # make everything an array.
         if value_or_values.is_a?(Array)
-          value_or_values.each do |value|
-            array << [name, value]
-          end
+          value_or_values
         else
-          array << [name, value_or_values]
+          [value_or_values]
         end
       end
   end

--- a/app/controllers/sudo_mode_handler.rb
+++ b/app/controllers/sudo_mode_handler.rb
@@ -189,6 +189,13 @@ class SudoModeHandler
     )
   end
 
+  def form_locals
+    {
+      form_action: request.path,
+      form_method: request.request_method_symbol
+    }
+  end
+
   def render_reauthentication_page(login: find_or_create_login!)
     default_factor, *additional_factors = sorted_factors(login)
 
@@ -215,7 +222,8 @@ class SudoModeHandler
         login:,
         additional_factors:,
         default_factor:,
-        forwarded_params:
+        forwarded_params:,
+        **form_locals,
       },
       status: :unprocessable_entity
     )

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -21,8 +21,8 @@
 <%= user_mention(current_user, class: "badge bg-muted pl-1 m-0 tooltipped") %>
 
 <%= form_tag(
-      request.path,
-      method: request.request_method_symbol,
+      form_action,
+      method: form_method,
       data: {
         controller: ("webauthn-reauth" if default_factor == :webauthn),
         webauthn_reauth_options_url_value: webauthn_auth_options_users_path(email: current_user.email),

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -28,8 +28,10 @@
         webauthn_reauth_options_url_value: webauthn_auth_options_users_path(email: current_user.email),
       }
     ) do %>
-  <% forwarded_params.each do |name, value| %>
-    <%= hidden_field_tag(name, value) %>
+  <% forwarded_params.each do |name, values| %>
+    <% values.each do |value| %>
+      <%= hidden_field_tag(name, value) %>
+    <% end %>
   <% end %>
 
   <%= hidden_field_tag("_sudo[login_id]", login.hashid) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,6 +180,7 @@ Rails.application.routes.draw do
     collection do
       get "login_preference", to: "logins#choose_login_preference", as: :choose_login_preference
       post "complete" # for webauthn
+      post "reauthenticate"
     end
     member do
       get "/", to: "logins#choose_login_preference", as: :choose_login_preference

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -395,22 +395,23 @@ describe LoginsController do
         expect(current_session!).to eq(login.user_session)
       end
     end
+
+    it "redirects to the user's settings page if they don't have a name or phone number" do
+      user = create(:user, full_name: nil, phone_number: nil)
+      login = create(:login, user:)
+      login_code = create(:login_code, user:)
+
+      post(
+        :complete,
+        params: {
+          id: login.hashid,
+          method: "login_code",
+          login_code: login_code.code
+        }
+      )
+
+      expect(response).to redirect_to(edit_user_path(user.slug))
+    end
   end
 
-  it "redirects to the user's settings page if they don't have a name or phone number" do
-    user = create(:user, full_name: nil, phone_number: nil)
-    login = create(:login, user:)
-    login_code = create(:login_code, user:)
-
-    post(
-      :complete,
-      params: {
-        id: login.hashid,
-        method: "login_code",
-        login_code: login_code.code
-      }
-    )
-
-    expect(response).to redirect_to(edit_user_path(user.slug))
-  end
 end

--- a/spec/controllers/stripe_cards_controller_spec.rb
+++ b/spec/controllers/stripe_cards_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StripeCardsController do
+  include SessionSupport
+  render_views
+
+  describe "#show" do
+    it "renders a stripe card" do
+      user = create(:user, phone_number: "+18556254225")
+      event = create(:event)
+      create(:organizer_position, user:, event:)
+      card = create(
+        :stripe_card,
+        :with_stripe_id,
+        event:,
+        stripe_cardholder: create(:stripe_cardholder, user:),
+        initially_activated: true,
+        card_type: "virtual",
+      )
+
+      sign_in(user)
+
+      get(:show, params: { id: card.id })
+
+      expect(response).to have_http_status(:ok)
+
+      details =
+        response
+        .parsed_body
+        .css("article.card section.details > *")
+        .map { |el| el.text.gsub(/\s+/, " ").strip }
+
+      expect(details).to eq(
+        [
+          "Activation status Active",
+          "Card number •••• •••• •••• 9876",
+          "Expiration date 02/2030",
+          "CVC •••",
+          "Address 8605 Santa Monica Blvd #86294",
+          "City West Hollywood",
+          "State CA",
+          "ZIP/Postal code 90069",
+          "Phone number (855) 625-4225",
+          "Type Virtual",
+          "Network Visa"
+        ]
+      )
+    end
+  end
+end

--- a/spec/controllers/stripe_cards_controller_spec.rb
+++ b/spec/controllers/stripe_cards_controller_spec.rb
@@ -6,38 +6,103 @@ RSpec.describe StripeCardsController do
   include SessionSupport
   render_views
 
+  def setup_context
+    user = create(:user, phone_number: "+18556254225")
+    event = create(:event)
+    create(:organizer_position, user:, event:)
+    card = create(
+      :stripe_card,
+      :with_stripe_id,
+      event:,
+      stripe_cardholder: create(:stripe_cardholder, user:),
+      initially_activated: true,
+      card_type: "virtual",
+    )
+
+    { user:, event:, card: }
+  end
+
+  def details_snapshot(response)
+    response
+      .parsed_body
+      .css("article.card section.details > *")
+      .map { |el| el.text.gsub(/\s+/, " ").strip }
+  end
+
   describe "#show" do
     it "renders a stripe card" do
-      user = create(:user, phone_number: "+18556254225")
-      event = create(:event)
-      create(:organizer_position, user:, event:)
-      card = create(
-        :stripe_card,
-        :with_stripe_id,
-        event:,
-        stripe_cardholder: create(:stripe_cardholder, user:),
-        initially_activated: true,
-        card_type: "virtual",
-      )
-
+      setup_context => { card:, user: }
       sign_in(user)
 
       get(:show, params: { id: card.id })
 
       expect(response).to have_http_status(:ok)
 
-      details =
-        response
-        .parsed_body
-        .css("article.card section.details > *")
-        .map { |el| el.text.gsub(/\s+/, " ").strip }
-
-      expect(details).to eq(
+      expect(details_snapshot(response)).to eq(
         [
           "Activation status Active",
           "Card number •••• •••• •••• 9876",
           "Expiration date 02/2030",
           "CVC •••",
+          "Address 8605 Santa Monica Blvd #86294",
+          "City West Hollywood",
+          "State CA",
+          "ZIP/Postal code 90069",
+          "Phone number (855) 625-4225",
+          "Type Virtual",
+          "Network Visa"
+        ]
+      )
+    end
+
+    it "requires sudo mode to view the details" do
+      setup_context => { card:, user: }
+      Flipper.enable(:sudo_mode_2015_07_21, user)
+
+      user_session = sign_in(user)
+
+      travel(3.hours)
+
+      get(:show, params: { id: card.id, show_details: true })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Confirm Access")
+
+      # Simulate a reauthentication (this would happen in
+      # `LoginsController#reauthenticate` and result in a redirect back to this
+      # page)
+      login = create(
+        :login,
+        user:,
+        authenticated_with_email: true,
+        initial_login: user_session.initial_login
+      )
+      login.update!(user_session:)
+
+      expect(Stripe::Issuing::Card).to(
+        receive(:retrieve)
+          .with(id: card.stripe_id, expand: ["cvc", "number"])
+          .and_return(
+            Stripe::Card.construct_from(
+              {
+                id: card.stripe_id,
+                cvc: "123",
+                number: "4242424242424242"
+              }
+            )
+          )
+      )
+
+      get(:show, params: { id: card.id, show_details: true })
+
+      expect(response).to have_http_status(:ok)
+
+      expect(details_snapshot(response)).to eq(
+        [
+          "Activation status Active",
+          "Card number 4242 4242 4242 4242",
+          "Expiration date 02/2030",
+          "CVC 123",
           "Address 8605 Santa Monica Blvd #86294",
           "City West Hollywood",
           "State CA",

--- a/spec/controllers/sudo_mode_handler_spec.rb
+++ b/spec/controllers/sudo_mode_handler_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe SudoModeHandler do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("Confirm Access")
+
+      form = response.parsed_body.css("form").sole
+      expect(form.attr("action")).to eq("/anonymous")
+      expect(form.attr("method")).to eq("post")
     end
 
     it "allows the request to proceed if the user does not have the feature enabled" do

--- a/spec/controllers/sudo_mode_handler_spec.rb
+++ b/spec/controllers/sudo_mode_handler_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe SudoModeHandler do
   render_views(true)
 
   controller(ApplicationController) do
+    skip_after_action :verify_authorized
+    before_action :enforce_sudo_mode
+
+    def index
+      render(status: :ok, plain: "Index")
+    end
+
     def create
-      skip_authorization
-
-      unless enforce_sudo_mode
-        return
-      end
-
       render(status: :created, plain: "Created")
     end
   end
@@ -206,6 +207,32 @@ RSpec.describe SudoModeHandler do
           ["users[1][tags][]", "hack clubber"],
           ["users[2][name]", "Blåhaj"],
           ["users[2][settings][emoji]", "🦈"],
+        ]
+      )
+    end
+
+    it "intercepts GET requests via a different endpoint" do
+      logged_in_context
+
+      get(:index, params: { q: "dinosaurs", sort_by: "name", sort_direction: "asc" })
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Confirm Access")
+
+      form = response.parsed_body.css("form").sole
+      expect(form.attr("action")).to eq(reauthenticate_logins_path)
+      expect(form.attr("method")).to eq("post")
+
+      form_params =
+        response
+        .parsed_body
+        .css("form [name]")
+        .map { |el| [el.attr("name"), el.attr("value")] }
+        .reject { |(name, _)| name.start_with?("_sudo") }
+
+      expect(form_params).to eq(
+        [
+          ["return_to", "/anonymous?q=dinosaurs&sort_by=name&sort_direction=asc"]
         ]
       )
     end


### PR DESCRIPTION
## Summary of the problem

See https://github.com/hackclub/hcb/issues/6346

Internal discussion: https://hackclub.slack.com/archives/C047Y01MHJQ/p1753889368598189

## Describe your changes

- Add `GET` request support to `SudoModeHandler` by submitting a `POST` request to `LoginsController#reauthenticate` and redirecting back
- Require sudo mode in `StripeCardsController#show`
- Basic testing of `StripeCardsController#show`