### PR TITLE
Properly center "Welcome to" on small screens

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -180,7 +180,7 @@
 
             <div class="welcome__content">
               <div class="center">
-                <h3 class="h3 caps secondary block m0">Welcome to</h3>
+                <h3 class="h3 caps secondary block my-0">Welcome to</h3>
                 <h1 class="primary mt0 border-none"><%= @organizer_position&.initial? ? "HCB" : @event.name %></h1>
               </div>
 

--- a/app/views/layouts/docs.html.erb
+++ b/app/views/layouts/docs.html.erb
@@ -129,7 +129,7 @@
 
             <div class="welcome__content">
               <div class="center">
-                <h3 class="h3 caps secondary block m0">Welcome to</h3>
+                <h3 class="h3 caps secondary block my-0">Welcome to</h3>
                 <h1 class="primary mt0 border-none"><%= @organizer_position&.initial? ? "HCB" : @event.name %></h1>
               </div>
 


### PR DESCRIPTION
Before | After
---- | ----
<img width="750" height="1334" alt="CleanShot 2025-07-30 at 13 33 16@2x" src="https://github.com/user-attachments/assets/cbaffdba-bb2d-4384-8733-609493f9b329" /> | <img width="752" height="1334" alt="CleanShot 2025-07-30 at 13 32 52@2x" src="https://github.com/user-attachments/assets/7d69dd49-bd84-4885-a844-9861a41381f6" /> 


## Summary of the problem

https://hackclub.slack.com/archives/C068U0JMV19/p1753892044644149

We have CSS that gives headings a bit more space on smaller screens https://github.com/hackclub/hcb/blob/272c735e134d77810e5bde25c4de8a150e44f18a/app/assets/stylesheets/application.scss#L406-L419 by stretching them out horizontally by 1rem. However the `<h3>` element with "Welcome to" has a `m0` class on it which zeroes out all the margin https://github.com/hackclub/hcb/blob/300969e63f9c63176e4c68da02e7f4a923756223/app/assets/stylesheets/space.css#L1-L3 and has a higher precedence. This results in the `<h3>` being rendered off-center as it is larger than its container.

<img width="832" height="589" alt="CleanShot 2025-07-30 at 13 41 28@2x" src="https://github.com/user-attachments/assets/0b6c15d5-a77e-4678-a22c-6b6cfbd925c3" />

## Describe your changes

Instead of using `m0`, use Tailwind's `my-0` which only zeroes out `margin-top` and `margin-bottom`.