### PR TITLE
Remove `ignored_columns` from `Announcement`

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -27,8 +27,6 @@
 #  fk_rails_...  (event_id => events.id)
 #
 class Announcement < ApplicationRecord
-  self.ignored_columns += ["rendered_html", "rendered_email_html"]
-
   include Hashid::Rails
   include AASM
 


### PR DESCRIPTION
## Summary of the problem

Follow-up to #11040 

We no longer need to ignore these columns as they are no longer part of the production schema.

## Describe your changes

Remove the line.