### PR TITLE
Move from `logins.initial_login_id` to `logins.is_reauthentication`

### DIFF
--- a/app/controllers/sudo_mode_handler.rb
+++ b/app/controllers/sudo_mode_handler.rb
@@ -183,12 +183,7 @@ class SudoModeHandler
 
     return existing if existing
 
-    raise("Session does not have an initial login") unless current_session.initial_login
-
-    Login.create!(
-      user: current_user,
-      initial_login: current_session.initial_login
-    )
+    Login.create!(user: current_user, is_reauthentication: true)
   end
 
   def form_locals

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -22,8 +22,6 @@
 #  index_logins_on_user_session_id      (user_session_id)
 #
 class Login < ApplicationRecord
-  self.ignored_columns = %w[initial_login_id]
-
   include AASM
   include Hashid::Rails
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -21,10 +21,6 @@
 #  index_logins_on_user_id              (user_id)
 #  index_logins_on_user_session_id      (user_session_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (initial_login_id => logins.id)
-#
 class Login < ApplicationRecord
   self.ignored_columns = %w[initial_login_id]
 

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -8,6 +8,7 @@
 #  aasm_state               :string
 #  authentication_factors   :jsonb
 #  browser_token_ciphertext :text
+#  is_reauthentication      :boolean          default(FALSE), not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  initial_login_id         :bigint

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -87,6 +87,8 @@ class Login < ApplicationRecord
     mark_complete! if may_mark_complete?
   end
 
+  before_create(:sync_is_reauthentication)
+
   def authentication_factors_count
     return 0 if authentication_factors.nil?
 
@@ -147,6 +149,10 @@ class Login < ApplicationRecord
     else
       1
     end
+  end
+
+  def sync_is_reauthentication
+    self.is_reauthentication = reauthentication?
   end
 
 end

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -11,7 +11,6 @@
 #  is_reauthentication      :boolean          default(FALSE), not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  initial_login_id         :bigint
 #  referral_program_id      :bigint
 #  user_id                  :bigint           not null
 #  user_session_id          :bigint
@@ -27,20 +26,16 @@
 #  fk_rails_...  (initial_login_id => logins.id)
 #
 class Login < ApplicationRecord
+  self.ignored_columns = %w[initial_login_id]
+
   include AASM
   include Hashid::Rails
 
   belongs_to :user
   belongs_to :user_session, optional: true
-  belongs_to(
-    :initial_login,
-    optional: true,
-    class_name: "Login",
-    inverse_of: nil
-  )
 
-  scope(:initial, -> { where(initial_login_id: nil) })
-  scope(:reauthentication, -> { where.not(initial_login_id: nil) })
+  scope(:initial, -> { where(is_reauthentication: false) })
+  scope(:reauthentication, -> { where(is_reauthentication: true) })
 
   belongs_to :referral_program, class_name: "Referral::Program", optional: true
 
@@ -87,8 +82,6 @@ class Login < ApplicationRecord
     mark_complete! if may_mark_complete?
   end
 
-  before_create(:sync_is_reauthentication)
-
   def authentication_factors_count
     return 0 if authentication_factors.nil?
 
@@ -133,7 +126,7 @@ class Login < ApplicationRecord
   end
 
   def reauthentication?
-    initial_login_id.present?
+    is_reauthentication?
   end
 
   private
@@ -149,10 +142,6 @@ class Login < ApplicationRecord
     else
       1
     end
-  end
-
-  def sync_is_reauthentication
-    self.is_reauthentication = reauthentication?
   end
 
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -44,12 +44,6 @@ class UserSession < ApplicationRecord
   belongs_to :impersonated_by, class_name: "User", optional: true
   belongs_to :webauthn_credential, optional: true
   has_many(:logins)
-  has_one(
-    :initial_login,
-    -> { initial },
-    class_name: "Login",
-    inverse_of: :user_session,
-  )
 
   include PublicActivity::Model
   tracked owner: proc{ |controller, record| record.impersonated_by || record.user }, recipient: proc { |controller, record| record.impersonated_by || record.user }, only: [:create]

--- a/db/migrate/20250731134844_add_is_reauthentication_to_logins.rb
+++ b/db/migrate/20250731134844_add_is_reauthentication_to_logins.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsReauthenticationToLogins < ActiveRecord::Migration[7.2]
+  def change
+    add_column( :logins, :is_reauthentication, :boolean, default: false, null: false)
+  end
+end

--- a/db/migrate/20250731140146_backfill_is_reauthentication_on_logins.rb
+++ b/db/migrate/20250731140146_backfill_is_reauthentication_on_logins.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillIsReauthenticationOnLogins < ActiveRecord::Migration[7.2]
+  def up
+    # This impacts few enough records in production that a more batched approach
+    # would be overkill.
+    safety_assured do
+      execute <<~SQL
+        UPDATE logins
+        SET is_reauthentication = true
+        WHERE initial_login_id IS NOT NULL
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/db/migrate/20250731150352_drop_initial_login_id_from_logins.rb
+++ b/db/migrate/20250731150352_drop_initial_login_id_from_logins.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DropInitialLoginIdFromLogins < ActiveRecord::Migration[7.2]
+  def change
+    # The column is ignored and all references have been removed
+    safety_assured do
+      remove_reference(:logins, :initial_login, index: false)
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_140146) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_150352) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1373,7 +1373,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_140146) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "browser_token_ciphertext"
-    t.bigint "initial_login_id"
     t.bigint "referral_program_id"
     t.boolean "is_reauthentication", default: false, null: false
     t.index ["referral_program_id"], name: "index_logins_on_referral_program_id"
@@ -2445,7 +2444,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_140146) do
   add_foreign_key "invoices", "users", column: "voided_by_id"
   add_foreign_key "lob_addresses", "events"
   add_foreign_key "login_codes", "users"
-  add_foreign_key "logins", "logins", column: "initial_login_id"
   add_foreign_key "mailbox_addresses", "users"
   add_foreign_key "organizer_position_deletion_requests", "organizer_positions"
   add_foreign_key "organizer_position_deletion_requests", "users", column: "closed_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_134844) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_140146) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_28_132814) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_31_134844) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1377,6 +1375,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_28_132814) do
     t.text "browser_token_ciphertext"
     t.bigint "initial_login_id"
     t.bigint "referral_program_id"
+    t.boolean "is_reauthentication", default: false, null: false
     t.index ["referral_program_id"], name: "index_logins_on_referral_program_id"
     t.index ["user_id"], name: "index_logins_on_user_id"
     t.index ["user_session_id"], name: "index_logins_on_user_session_id"

--- a/spec/controllers/stripe_cards_controller_spec.rb
+++ b/spec/controllers/stripe_cards_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe StripeCardsController do
         :login,
         user:,
         authenticated_with_email: true,
-        initial_login: user_session.initial_login
+        is_reauthentication: true
       )
       login.update!(user_session:)
 

--- a/spec/controllers/sudo_mode_handler_spec.rb
+++ b/spec/controllers/sudo_mode_handler_spec.rb
@@ -26,9 +26,8 @@ RSpec.describe SudoModeHandler do
       Flipper.enable(:sudo_mode_2015_07_21, user) if feature_enabled
 
       user_session = sign_in(user)
-      login = user_session.initial_login
 
-      { user:, user_session:, login: }
+      { user:, user_session: }
     end
   end
 
@@ -238,7 +237,7 @@ RSpec.describe SudoModeHandler do
     end
 
     it "creates a new login" do
-      logged_in_context => { user:, login: initial_login }
+      logged_in_context => { user: }
 
       post(:create)
 
@@ -249,7 +248,7 @@ RSpec.describe SudoModeHandler do
       login = Login.find_by_hashid!(login_id)
 
       expect(login.user).to eq(user)
-      expect(login.initial_login).to eq(initial_login)
+      expect(login.is_reauthentication).to eq(true)
       expect(login).to be_incomplete
     end
   end
@@ -279,8 +278,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "handles email codes" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user:, user_session: }
+      login = create(:login, user:, is_reauthentication: true)
 
       stub_login_service do |instance, service_login|
         expect(instance).to(
@@ -307,8 +306,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "handles sms codes" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user:, user_session: }
+      login = create(:login, user:, is_reauthentication: true)
 
       stub_login_service do |instance, service_login|
         expect(instance).to(
@@ -335,8 +334,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "handles totp codes" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user:, user_session: }
+      login = create(:login, user:, is_reauthentication: true)
 
       stub_login_service do |instance, service_login|
         expect(instance).to(
@@ -363,8 +362,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "handles webauthn" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user:, user_session: }
+      login = create(:login, user:, is_reauthentication: true)
 
       session[:webauthn_challenge] = "WEBAUTHN_CHALLENGE"
 
@@ -396,8 +395,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "rejects invalid methods" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user:, user_session: }
+      login = create(:login, user:, is_reauthentication: true)
 
       expect do
         post(
@@ -417,8 +416,8 @@ RSpec.describe SudoModeHandler do
     end
 
     it "handles login failures" do
-      logged_in_context => { user:, login: initial_login, user_session: }
-      login = create(:login, user:, initial_login:)
+      logged_in_context => { user: }
+      login = create(:login, user:, is_reauthentication: true)
 
       stub_login_service do |instance, _service_login|
         expect(instance).to(

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -34,37 +34,12 @@ RSpec.describe Login do
 
     it "is true when the login is a reauthentication and one factor was used regardless of 2fa" do
       user = create(:user, use_two_factor_authentication: true)
-      initial_login = create(:login, user:)
-      login = create(:login, user:, initial_login:)
+      login = create(:login, user:, is_reauthentication: true)
 
       login.update!(authenticated_with_email: true)
 
       expect(login).to be_reauthentication
       expect(login).to be_complete
     end
-  end
-
-  describe "#reauthentication?" do
-    it "is false by default" do
-      login = create(:login)
-
-      expect(login).not_to be_reauthentication
-    end
-
-    it "is true when there is an initial login" do
-      user = create(:user)
-      initial_login = create(:login, user:)
-      login = create(:login, user:, initial_login:)
-
-      expect(login).to be_reauthentication
-    end
-  end
-
-  it "sets is_reauthentication automatically on creation" do
-    initial_login = create(:login)
-    reauthentication = create(:login, initial_login:, user: initial_login.user)
-
-    expect(initial_login.is_reauthentication).to eq(false)
-    expect(reauthentication.is_reauthentication).to eq(true)
   end
 end

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe Login do
       expect(login).to be_reauthentication
     end
   end
+
+  it "sets is_reauthentication automatically on creation" do
+    initial_login = create(:login)
+    reauthentication = create(:login, initial_login:, user: initial_login.user)
+
+    expect(initial_login.is_reauthentication).to eq(false)
+    expect(reauthentication.is_reauthentication).to eq(true)
+  end
 end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe UserSession, type: :model do
         user = create(:user)
         Flipper.enable(:sudo_mode_2015_07_21, user)
         user_session = create(:user_session, user:)
-        initial_login = create(
+        _initial_login = create(
           :login,
           user:,
           user_session:,
@@ -60,7 +60,7 @@ RSpec.describe UserSession, type: :model do
 
         _login = create(
           :login,
-          initial_login:,
+          is_reauthentication: true,
           user:,
           user_session:,
           aasm_state: "complete",
@@ -88,11 +88,11 @@ RSpec.describe UserSession, type: :model do
       initial_login.update!(user_session:)
 
       travel(1.hour)
-      reauth1 = create(:login, user: user_session.user, authenticated_with_email: true, initial_login:)
+      reauth1 = create(:login, user: user_session.user, authenticated_with_email: true, is_reauthentication: true)
       reauth1.update!(user_session:)
 
       travel(1.hour)
-      reauth2 = create(:login, user: user_session.user, authenticated_with_email: true, initial_login:)
+      reauth2 = create(:login, user: user_session.user, authenticated_with_email: true, is_reauthentication: true)
       reauth2.update!(user_session:)
 
       expect(user_session.last_reauthenticated_at).to eq(reauth2.created_at)


### PR DESCRIPTION
## Summary of the problem

One of the underlying assumptions behind the design of sudo mode is that `UserSession` would always have at least one `Login` (referred to as the initial login), which could be referenced by subsequent logins (referred to as reauthentications) in their `initial_login_id`.

This is outlined here: https://github.com/hackclub/hcb/pull/10903

However, I recently realized that this assumption does not hold as we have a mechanism for admins to impersonate and unimpersonate users which creates `UserSession` records without any associated `Login`s whatsoever. This means
- This assertion fails in production: https://github.com/hackclub/hcb/blob/c772fdf8a2456e76e79d4f42c6735fb4058c0489/app/controllers/sudo_mode_handler.rb#L186
- We don't have a way to model reauthentications in that context as we don't have an `initial_login_id` to reference

https://github.com/hackclub/hcb/blob/21ec8d158f5d4ba52f4e7d780124dd01a26e611b/app/helpers/sessions_helper.rb#L17-L26

Internal discussions:
- https://hackclub.slack.com/archives/C047Y01MHJQ/p1753895603368189
- https://hackclub.slack.com/archives/C096P73LEMT/p1753889138870219

## Describe your changes

> [!WARNING]
> The commits in this PR are not intended to be shipped all at once. I included the complete set of changes here to make it easier for reviewers to reason about the big picture, but once approved I will extract them into separate PRs (as indicated by the numbers in the commit messages).
>
> **As such, I _highly_ recommend reviewing this commit by commit as there is necessary code that is added and later removed that will not appear in the combined diff**

**Stage 1**: https://github.com/hackclub/hcb/pull/11190
- Add `is_reauthentication` column to the `logins` table

**Stage 2**: https://github.com/hackclub/hcb/pull/11191
- Automatically populate `is_reauthentication` when logins are created
- Backfill `is_reauthentication` for existing logins

**Stage 3**: https://github.com/hackclub/hcb/pull/11192
- Switch application logic to use `is_reauthentication` and ignore `initial_login_id`

**Stage 4**: https://github.com/hackclub/hcb/pull/11248
- Drop the `initial_login_id` column from the `logins` table

**Stage 5**: https://github.com/hackclub/hcb/pull/11249
- Remove `initial_login_id` from `ignored_columns`