### PR TITLE
[DX] Make `/schema` accessible to auditors

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,10 @@ Rails.application.routes.draw do
     mount Audits1984::Engine => "/console"
     mount Sidekiq::Web => "/sidekiq"
     mount Flipper::UI.app(Flipper), at: "flipper", as: "flipper"
-    mount SchemaEndpoint.instance => "/schema"
   end
   constraints AuditorConstraint do
     mount Blazer::Engine, at: "blazer"
+    mount SchemaEndpoint.instance => "/schema"
   end
   get "/sidekiq", to: redirect("users/auth") # fallback if adminconstraint fails, meaning user is not signed in
   if Rails.env.development?


### PR DESCRIPTION
## Summary of the problem

Follow up to #11045, as requested by @Luke-Oldenburg (https://hackclub.slack.com/archives/C047Y01MHJQ/p1753985372569149?thread_ts=1753734366.653599&cid=C047Y01MHJQ)

## Describe your changes

Moves the endpoint from `AdminConstraint` to `AuditorConstraint`