### PR TITLE
[Announcement] Fix bugs in monthly announcement job

### DIFF
--- a/app/jobs/announcement/monthly_job.rb
+++ b/app/jobs/announcement/monthly_job.rb
@@ -7,7 +7,7 @@ class Announcement
     def perform
       Announcement.monthly_for(Date.today.prev_month).find_each do |announcement|
         Rails.error.handle do
-          announcement.publish!
+          announcement.mark_published!
         end
       end
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -42,7 +42,7 @@ class Announcement < ApplicationRecord
     state :published
 
     event :mark_published do
-      transitions from: :draft, to: :published
+      transitions from: [:template_draft, :draft], to: :published
 
       after do
         Announcement::PublishedJob.perform_later(announcement: self)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
`Announcement::MonthlyJob` had a couple bugs:
1. it was using `publish!` instead of `mark_published!`
2. If a monthly announcement was not edited, it would still be a template draft when the job ran, which was not a valid transition

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
1. Change the job to use `mark_published!`
2. Allow template drafts to be published in the AASM configuration for `Announcement`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

