### PR TITLE
Fix reimbursement comment policy if `event` is `nil`

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -46,7 +46,7 @@ class CommentPolicy < ApplicationPolicy
     if record.commentable.respond_to?(:events)
       record.commentable.events.collect(&:users).flatten
     elsif record.commentable.is_a?(Reimbursement::Report)
-      [record.commentable.user] + record.commentable.event.users
+      [record.commentable.user] + (record.commentable.event&.users || [])
     elsif record.commentable.is_a?(Event)
       record.commentable.users
     else


### PR DESCRIPTION
## Summary of the problem
https://hackclub.slack.com/archives/CN523HLKW/p1754017799212599
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/551

The comment policy is causing reimbursements to error



## Describe your changes
This change allows `event` to be `nil` by using save navigation and providing a default value