### PR TITLE
[API] Handle cases where cards aren't personalized

### DIFF
--- a/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
@@ -21,7 +21,13 @@ json.user         stripe_card.user,  partial: "api/v4/users/user",   as: :user  
 
 if stripe_card.physical?
   json.personalization do
-    json.color stripe_card.personalization_design.color
-    json.logo_url rails_blob_url(stripe_card.personalization_design.logo)
+    json.color stripe_card.personalization_design&.color
+    json.logo_url(
+      if stripe_card.personalization_design&.logo
+        rails_blob_url(stripe_card.personalization_design.logo)
+      else
+        nil
+      end
+    )
   end
 end


### PR DESCRIPTION
## Summary of the problem

We are currently hitting errors in production that look like

```
ActionView::Template::Error: undefined method 'color' for nil
app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder:24
app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder:23
app/views/api/v4/transactions/_card_charge.json.jbuilder:21
app/helpers/api/v4/application_helper.rb:39 in Api::V4::ApplicationHelper#expand
```

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/570/samples/timestamp/2025-08-01T18:52:17Z

This is likely because the `personalization_design` relation of `StripeCard` is optional https://github.com/hackclub/hcb/blob/b600085ac63c303aa73d62320c9a837a964b133b/app/models/stripe_card.rb#L83 (and not present in the majority of cases).

## Describe your changes

Makes sure the `personalization` object's `color` and `logo_url` properties are `nil` if `personalization_design` doesn't exist.