### PR TITLE
Add `is_reauthentication` to `logins`

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -8,6 +8,7 @@
 #  aasm_state               :string
 #  authentication_factors   :jsonb
 #  browser_token_ciphertext :text
+#  is_reauthentication      :boolean          default(FALSE), not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  initial_login_id         :bigint

--- a/db/migrate/20250731134844_add_is_reauthentication_to_logins.rb
+++ b/db/migrate/20250731134844_add_is_reauthentication_to_logins.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsReauthenticationToLogins < ActiveRecord::Migration[7.2]
+  def change
+    add_column( :logins, :is_reauthentication, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -1377,6 +1375,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_174149) do
     t.text "browser_token_ciphertext"
     t.bigint "initial_login_id"
     t.bigint "referral_program_id"
+    t.boolean "is_reauthentication", default: false, null: false
     t.index ["referral_program_id"], name: "index_logins_on_referral_program_id"
     t.index ["user_id"], name: "index_logins_on_user_id"
     t.index ["user_session_id"], name: "index_logins_on_user_session_id"


### PR DESCRIPTION
## Summary of the problem

Extracted from https://github.com/hackclub/hcb/pull/11162.

## Describe your changes

Adds a new `is_reauthentication` column which will eventually replace our use of `initial_login_id`.