### PR TITLE
Backfill `logins.is_reauthentication` and keep it in sync with `initial_login_id` on creation

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -87,6 +87,8 @@ class Login < ApplicationRecord
     mark_complete! if may_mark_complete?
   end
 
+  before_create(:sync_is_reauthentication)
+
   def authentication_factors_count
     return 0 if authentication_factors.nil?
 
@@ -147,6 +149,10 @@ class Login < ApplicationRecord
     else
       1
     end
+  end
+
+  def sync_is_reauthentication
+    self.is_reauthentication = reauthentication?
   end
 
 end

--- a/db/migrate/20250731140146_backfill_is_reauthentication_on_logins.rb
+++ b/db/migrate/20250731140146_backfill_is_reauthentication_on_logins.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillIsReauthenticationOnLogins < ActiveRecord::Migration[7.2]
+  def up
+    # This impacts few enough records in production that a more batched approach
+    # would be overkill.
+    safety_assured do
+      execute <<~SQL
+        UPDATE logins
+        SET is_reauthentication = true
+        WHERE initial_login_id IS NOT NULL
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe Login do
       expect(login).to be_reauthentication
     end
   end
+
+  it "sets is_reauthentication automatically on creation" do
+    initial_login = create(:login)
+    reauthentication = create(:login, initial_login:, user: initial_login.user)
+
+    expect(initial_login.is_reauthentication).to eq(false)
+    expect(reauthentication.is_reauthentication).to eq(true)
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Extracted from https://github.com/hackclub/hcb/pull/11162 and builds on top of https://github.com/hackclub/hcb/pull/11190.

## Describe your changes

- Adds a migration to backfill `is_reauthentication`
- Adds a `before_create` on `Login` to set `is_reauthentication` for new records