### PR TITLE
Fix `accordion` Stimulus controller usage

### DIFF
--- a/app/views/events/settings/_card_grants.html.erb
+++ b/app/views/events/settings/_card_grants.html.erb
@@ -39,7 +39,7 @@
           <div class="field--checkbox--switch" style="flex-shrink:0">
             <%= card_grant_setting_fields.label :reimbursement_conversions_enabled do %>
               <%= card_grant_setting_fields.check_box :reimbursement_conversions_enabled,
-                data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
+                data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
                 switch: true %>
               <span class="slider"></span>
             <% end %>
@@ -56,7 +56,7 @@
           <div class="field--checkbox--switch" style="flex-shrink:0">
             <%= card_grant_setting_fields.label :pre_authorization_required do %>
               <%= card_grant_setting_fields.check_box :pre_authorization_required,
-                data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
+                data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
                 switch: true %>
               <span class="slider"></span>
             <% end %>

--- a/app/views/events/settings/_card_grants.html.erb
+++ b/app/views/events/settings/_card_grants.html.erb
@@ -6,7 +6,7 @@
 
     <%= form.fields_for :card_grant_setting, event.card_grant_setting do |card_grant_setting_fields| %>
       <h3 class="mb1" id="transparency_mode_heading">Grant settings</h3>
-      <div class="card" data-controller="accordion">
+      <div class="card">
 
         <%= card_grant_setting_fields.hidden_field :id, value: event.card_grant_setting.id %>
 
@@ -39,7 +39,6 @@
           <div class="field--checkbox--switch" style="flex-shrink:0">
             <%= card_grant_setting_fields.label :reimbursement_conversions_enabled do %>
               <%= card_grant_setting_fields.check_box :reimbursement_conversions_enabled,
-                data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
                 switch: true %>
               <span class="slider"></span>
             <% end %>
@@ -56,7 +55,6 @@
           <div class="field--checkbox--switch" style="flex-shrink:0">
             <%= card_grant_setting_fields.label :pre_authorization_required do %>
               <%= card_grant_setting_fields.check_box :pre_authorization_required,
-                data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
                 switch: true %>
               <span class="slider"></span>
             <% end %>
@@ -68,7 +66,7 @@
       </div>
 
       <h3 class="mb1" id="transparency_mode_heading">Spending restrictions</h3>
-      <div class="card mb-4" data-controller="accordion">
+      <div class="card mb-4">
         <div class="flex flex-col md:flex-row gap-4">
           <div class="w-full flex-grow">
 

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -102,7 +102,7 @@
       <span style="font-weight: 700">Make <%= possessive(@event.name) %> finances transparent</span>
       <div class="field--checkbox--switch ml-auto">
         <%= form.label :is_public do %>
-          <%= form.check_box :is_public, data: { action: "change->accordion#toggle", target: "accordion.checkbox" }, disabled:, switch: true %>
+          <%= form.check_box :is_public, data: { action: "change->accordion#toggle", accordion_target: "checkbox" }, disabled:, switch: true %>
           <span class="slider"></span>
         <% end %>
       </div>
@@ -168,7 +168,7 @@
       <div class="field--checkbox--switch ml-auto">
         <%= form.fields_for :config do |config| %>
           <%= config.label :generate_monthly_announcement do %>
-            <%= config.check_box :generate_monthly_announcement, data: { action: "change->accordion#toggle", target: "accordion.checkbox" }, disabled:, switch: true %>
+            <%= config.check_box :generate_monthly_announcement, data: { action: "change->accordion#toggle", accordion_target: "checkbox" }, disabled:, switch: true %>
             <span class="slider"></span>
           <% end %>
         <% end %>

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -162,13 +162,13 @@
   </div>
 
   <h3 class="mb1" id="announcements_heading">Announcements</h3>
-  <div class="card mb3" data-controller="accordion">
+  <div class="card mb3">
     <div class="field field--checkbox">
       <span style="font-weight: 700">Generate monthly announcements</span>
       <div class="field--checkbox--switch ml-auto">
         <%= form.fields_for :config do |config| %>
           <%= config.label :generate_monthly_announcement do %>
-            <%= config.check_box :generate_monthly_announcement, data: { action: "change->accordion#toggle", accordion_target: "checkbox" }, disabled:, switch: true %>
+            <%= config.check_box :generate_monthly_announcement, disabled:, switch: true %>
             <span class="slider"></span>
           <% end %>
         <% end %>

--- a/app/views/events/settings/_donation_tiers.html.erb
+++ b/app/views/events/settings/_donation_tiers.html.erb
@@ -13,7 +13,7 @@
       <%= form_with(model: event, local: true) do |form| %>
         <%= form.label :donation_tiers_enabled do %>
           <%= form.check_box :donation_tiers_enabled,
-            data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
+            data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
             disabled:,
             checked: @event.donation_tiers_enabled,
             onchange: "this.closest('form').requestSubmit();",

--- a/app/views/events/settings/_donations.html.erb
+++ b/app/views/events/settings/_donations.html.erb
@@ -12,7 +12,7 @@
           <div class="field--checkbox--switch ml-auto" style="flex-shrink:0">
             <%= form.label :donation_page_enabled do %>
               <%= form.check_box :donation_page_enabled,
-                data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
+                data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
                 disabled:,
                 switch: true %>
               <span class="slider"></span>
@@ -63,7 +63,7 @@
         <div class="field--checkbox--switch ml-auto" style="flex-shrink:0">
           <%= form.label :donation_goal_enabled do %>
             <%= form.check_box :donation_goal_enabled,
-              data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
+              data: { action: "change->accordion#toggle", accordion_target: "checkbox" },
               disabled:,
               checked: @event.donation_goal.present?,
               onchange: @event.donation_goal && "!this.checked && (!confirm('Remove donation goal?') ? (this.checked = true) : this.closest('form').requestSubmit())",


### PR DESCRIPTION
## Summary of the problem

We're getting a couple of recurring errors in production:
1. The `content` target is sometimes missing (https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2025/samples/timestamp/2025-08-01T18:19:46Z)
    ```
    Missing target element "content" for "accordion" controller
    ```
2. We get console warnings about the target syntax
    ```
    Please replace data-target="accordion.checkbox" with data-accordion-target="checkbox". The data-target attribute is deprecated and will be removed in a future version of Stimulus.
    ```
    This was deprecated in https://github.com/hotwired/stimulus/releases/tag/v2.0.0.

## Describe your changes

I audited the code base for places where we were using the `accordion` controller and
- Updated `data-target` to `data-accordion-target`
- Removed references to the controller that didn't have a corresponding `target` content (which is pretty essential to its functionality)

