### PR TITLE
Call `.presence` on `@event.config.subevent_plan`

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -841,7 +841,7 @@ class EventsController < ApplicationController
       point_of_contact_id: @event.point_of_contact_id,
       invited_by: current_user,
       is_public: @event.is_public,
-      plan: @event.config.subevent_plan,
+      plan: @event.config.subevent_plan.presence,
       risk_level: @event.risk_level,
       parent_event: @event
     ).run


### PR DESCRIPTION
Because we may have blank strings in this column.

Closes https://github.com/hackclub/hcb/issues/11088