### PR TITLE
Fix sub-organizations not showing for auditors

### DIFF
--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -157,7 +157,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def sub_organizations?
-    admin_or_reader? && (record.subevents_enabled? || record.subevents.any?)
+    auditor_or_reader? && (record.subevents_enabled? || record.subevents.any?)
   end
 
   def create_sub_organization?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The policy is checking `admin_or_reader?` instead of `auditor_or_reader?`


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

