### PR TITLE
Remove blue shadow from premium promo button

### DIFF
--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -22,7 +22,7 @@
       <% else %>
         <%= link_to "Apply",
           fillout_form("briCUMzx5Sus", { "hcbprojname" => @event.name, "hcburl" => event_url(@event), "name" => current_user.name, "email" => current_user.email }),
-          class: "btn promo-premium-header bg-clip-padding hover:shadow-md hover:shadow-[#94bbe9]",
+          class: "btn promo-premium-header bg-clip-padding",
           target: :_blank %>
       <% end %>
     </div>


### PR DESCRIPTION
Closes https://github.com/hackclub/hcb/issues/11136 - @alexbluo feel free to PR in more design changes, just pushing this so it's fixed in production and now showing to users.