### PR TITLE
Fix comment policy

### DIFF
--- a/app/controllers/api/v4/comments_controller.rb
+++ b/app/controllers/api/v4/comments_controller.rb
@@ -12,9 +12,6 @@ module Api
         @hcb_code = HcbCode.find_by_public_id!(params[:transaction_id])
 
         admin_only = params[:admin_only] || false
-        if admin_only && !auditor_signed_in?
-          return render json: { error: "not_authorized", message: "Only administrators can create admin-only comments" }, status: :forbidden
-        end
 
         @comment = @hcb_code.comments.build(
           content: params[:content],

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -17,7 +17,9 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def create?
-    (user.auditor? || users.include?(user)) || (record.admin_only && user.auditor?)
+    return false if record.admin_only && !user.auditor?
+
+    user.auditor? || users.include?(user)
   end
 
   def edit?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -17,7 +17,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def create?
-    user.auditor? || users.include?(user)
+    (user.auditor? || users.include?(user)) || (record.admin_only && user.auditor?)
   end
 
   def edit?


### PR DESCRIPTION
## Summary of the problem
Originally the v4 was checking `auditor_signed_in ` but method is undefined. Also the comment policy doesn't reference anything about checking if you can make an admin only comment. 


## Describe your changes
Moved policy logic to the policy file instead of in controller. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

