### PR TITLE
[Transparency Mode] Enforce transparency on children of transparent events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -803,7 +803,7 @@ class Event < ApplicationRecord
   end
 
   def eligible_for_disabling_transparency?
-    !parent.is_public?
+    !parent&.is_public?
   end
 
   def eligible_for_indexing?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -802,6 +802,10 @@ class Event < ApplicationRecord
     !plan.is_a?(Event::Plan::SalaryAccount)
   end
 
+  def eligible_for_disabling_transparency?
+    !parent.is_public?
+  end
+
   def eligible_for_indexing?
     eligible_for_transparency? && !risk_level.in?(%w[moderate high])
   end
@@ -895,6 +899,10 @@ class Event < ApplicationRecord
     unless eligible_for_transparency?
       self.is_public = false
       self.is_indexable = false
+    end
+
+    unless eligible_for_disabling_transparency?
+      self.is_public = true
     end
 
     unless eligible_for_indexing?


### PR DESCRIPTION
## Summary of the problem
Children of transparent events can enable Transparency Mode


## Describe your changes
Disable disabling Transparency Mode on children of transparent events
