### PR TITLE
Correctly handle validation errors for card grants

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -16,8 +16,7 @@ class CardGrantsController < ApplicationController
 
     @prefill_email = params[:email]
 
-    @event.create_card_grant_setting unless @event.card_grant_setting.present?
-
+    @event.create_card_grant_setting! unless @event.card_grant_setting.present?
 
     @card_grant.amount_cents = params[:amount_cents] if params[:amount_cents]
   end

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -18,7 +18,6 @@ class CardGrantsController < ApplicationController
 
     @event.create_card_grant_setting unless @event.card_grant_setting.present?
 
-    last_card_grant = @event.card_grants.order(created_at: :desc).first
 
     @card_grant.amount_cents = params[:amount_cents] if params[:amount_cents]
   end

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -10,11 +10,9 @@ class CardGrantsController < ApplicationController
   before_action :set_card_grant, except: %i[new create]
 
   def new
-    @card_grant = @event.card_grants.build
+    @card_grant = @event.card_grants.build(email: params[:email])
 
     authorize @card_grant
-
-    @prefill_email = params[:email]
 
     @event.create_card_grant_setting! unless @event.card_grant_setting.present?
 

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -25,14 +25,13 @@ class CardGrantsController < ApplicationController
 
     authorize @card_grant
 
-    @card_grant.save!
+    unless @card_grant.save
+      flash[:error] = @card_grant.errors.full_messages.to_sentence
+      render(:new, status: :unprocessable_entity)
+      return
+    end
 
     flash[:success] = "Successfully sent a grant to #{@card_grant.email}!"
-
-  rescue => e
-    flash[:error] = "Something went wrong. #{e.message}"
-    Rails.error.report(e)
-  ensure
     redirect_to event_transfers_path(@event)
   end
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -86,7 +86,9 @@ class CardGrant < ApplicationRecord
 
   validates_presence_of :amount_cents, :email
   validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }
-  validates :purpose, length: { maximum: 30 }
+
+  MAXIMUM_PURPOSE_LENGTH = 30
+  validates :purpose, length: { maximum: MAXIMUM_PURPOSE_LENGTH }
 
   scope :not_activated, -> { active.where(stripe_card_id: nil) }
   scope :activated, -> { active.where.not(stripe_card_id: nil) }

--- a/app/views/card_grants/_create_form.html.erb
+++ b/app/views/card_grants/_create_form.html.erb
@@ -20,7 +20,7 @@
 
   <div class="field">
     <%= form.label :purpose, "Purpose (optional, shown to recipient)" %>
-    <%= form.text_field :purpose, placeholder: "Pizza for a club meeting", disabled: %>
+    <%= form.text_field :purpose, placeholder: "Pizza for a club meeting", disabled:, maxlength: CardGrant::MAXIMUM_PURPOSE_LENGTH %>
   </div>
 
   <div class="field">

--- a/app/views/card_grants/_create_form.html.erb
+++ b/app/views/card_grants/_create_form.html.erb
@@ -7,7 +7,7 @@
 <%= form_with model: [@event, card_grant], data: { turbo_frame: "_top" } do |form| %>
   <div class="field">
     <%= form.label :email %>
-    <%= form.email_field :email, value: @prefill_email, placeholder: "fiona@hackclub.com", autofocus: true, required: true, disabled: %>
+    <%= form.email_field :email, value: card_grant.email, placeholder: "fiona@hackclub.com", autofocus: true, required: true, disabled: %>
   </div>
 
   <div class="field">

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -21,4 +21,39 @@ RSpec.describe CardGrantsController do
       expect(event.reload.card_grant_setting).to be_present
     end
   end
+
+  describe "#create" do
+    it "creates a card grant" do
+      user = create(:user)
+      event = create(:event, :with_positive_balance, plan_type: Event::Plan::HackClubAffiliate)
+      create(:organizer_position, user:, event:)
+      sign_in(user)
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          card_grant: {
+            amount_cents: "123.45",
+            email: "recipient@example.com",
+            keyword_lock: "some keywords",
+            purpose: "Raffle prize",
+            one_time_use: "true",
+            pre_authorization_required: "true",
+            instructions: "Here's a card grant for your raffle prize"
+          }
+        }
+      )
+
+      expect(response).to redirect_to(event_transfers_path(event))
+      card_grant = event.card_grants.sole
+      expect(card_grant.amount_cents).to eq(123_45)
+      expect(card_grant.email).to eq("recipient@example.com")
+      expect(card_grant.keyword_lock).to eq("some keywords")
+      expect(card_grant.purpose).to eq("Raffle prize")
+      expect(card_grant.one_time_use).to eq(true)
+      expect(card_grant.pre_authorization_required).to eq(true)
+      expect(card_grant.instructions).to eq("Here's a card grant for your raffle prize")
+    end
+  end
 end

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe CardGrantsController do
       expect(response).to have_http_status(:ok)
       expect(event.reload.card_grant_setting).to be_present
     end
+
+    it "uses the email param to pre-fill the email field" do
+      user = create(:user)
+      event = create(:event)
+      create(:organizer_position, user:, event:)
+      sign_in(user)
+
+      expect(event.card_grant_setting).to be_nil
+
+      get(:new, params: { event_id: event.friendly_id, email: "orpheus@hackclub.com" })
+
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.card_grant_setting).to be_present
+      input = response.parsed_body.css("[name='card_grant[email]']").sole
+      expect(input.get_attribute("value")).to eq("orpheus@hackclub.com")
+    end
   end
 
   describe "#create" do

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CardGrantsController do
+  include SessionSupport
+  render_views
+
+  describe "#new" do
+    it "renders successfully" do
+      user = create(:user)
+      event = create(:event)
+      create(:organizer_position, user:, event:)
+      sign_in(user)
+
+      expect(event.card_grant_setting).to be_nil
+
+      get(:new, params: { event_id: event.friendly_id })
+
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.card_grant_setting).to be_present
+    end
+  end
+end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -3,10 +3,13 @@
 FactoryBot.define do
   factory :event do
     name { Faker::Name.unique.name }
+    transient do
+      plan_type { Event::Plan::FeeWaived }
+    end
 
-    after(:create) do |e|
-      e.plan.update(type: Event::Plan::FeeWaived)
-      e.reload
+    after(:create) do |event, context|
+      event.plan.update(type: context.plan_type)
+      event.reload
     end
 
     factory :event_with_organizer_positions do


### PR DESCRIPTION
## Summary of the problem

- https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1486/samples/timestamp/2025-08-04T14:08:26Z
- https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1502/samples/last

When validation fails for a card grant we
- Fire an AppSignal error regardless of what the error was
- Lose the form state by redirecting back to the transfers page instead of letting the user fix their errors

## Describe your changes

See individual commits