### PR TITLE
Don't generate URLs for unpersisted profile pictures

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -335,14 +335,19 @@ class UsersController < ApplicationController
       set_onboarding
       show_impersonated_sessions = auditor_signed_in? || current_session.impersonated?
       @sessions = show_impersonated_sessions ? @user.user_sessions : @user.user_sessions.not_impersonated
+
       if @user.stripe_cardholder&.errors&.any?
         flash.now[:error] = @user.stripe_cardholder.errors.first.full_message
-        render :edit_address, status: :unprocessable_entity and return
+        render :edit_address, status: :unprocessable_entity
+        return
       end
+
       if @user.payout_method&.errors&.any?
         flash.now[:error] = @user.payout_method.errors.first.full_message
-        render :edit_payout, status: :unprocessable_entity and return
+        render :edit_payout, status: :unprocessable_entity
+        return
       end
+
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,12 +20,14 @@ module UsersHelper
     # so this method shows Gravatars/intials for non-registered and allows showing of uploaded profile pictures for registered users.
     if user.nil?
       default_image
-      Rails.application.routes.url_helpers.url_for(user.profile_picture.variant(
-                                                     thumbnail: "#{size * 2}x#{size * 2}^",
-                                                     gravity: "center",
-                                                     extent: "#{size * 2}x#{size * 2}"
-                                                   ))
     elsif Rails.env.production? && user.is_a?(User) && user.profile_picture&.persisted?
+      Rails.application.routes.url_helpers.url_for(
+        user.profile_picture.variant(
+          thumbnail: "#{size * 2}x#{size * 2}^",
+          gravity: "center",
+          extent: "#{size * 2}x#{size * 2}"
+        )
+      )
     else
       gravatar_url(user.email, user.initials, user.id, size * 2)
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -20,12 +20,12 @@ module UsersHelper
     # so this method shows Gravatars/intials for non-registered and allows showing of uploaded profile pictures for registered users.
     if user.nil?
       default_image
-    elsif Rails.env.production? && user.is_a?(User) && user&.profile_picture&.attached?
       Rails.application.routes.url_helpers.url_for(user.profile_picture.variant(
                                                      thumbnail: "#{size * 2}x#{size * 2}^",
                                                      gravity: "center",
                                                      extent: "#{size * 2}x#{size * 2}"
                                                    ))
+    elsif Rails.env.production? && user.is_a?(User) && user.profile_picture&.persisted?
     else
       gravatar_url(user.email, user.initials, user.id, size * 2)
     end


### PR DESCRIPTION
## Summary of the problem

Fixes https://github.com/hackclub/hcb/issues/11210 (https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/697/samples/timestamp/2025-08-04T15:39:56Z)

When a user submits the edit form with a populated profile picture we end up re-rendering the edit page which also renders their avatar. This fails because at this point the record hasn't been persisted so we can't generate a signed ID.

## Describe your changes

Uses `persisted?` instead of `attached?` (which only checks for presence) to differentiate between these scenarios.

