### PR TITLE
Decline cash withdrawals over $500

### DIFF
--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -61,7 +61,15 @@ module StripeAuthorizationService
 
         return decline_with_reason!("inadequate_balance") if card_balance_available < amount_cents
 
-        return decline_with_reason!("cash_withdrawals_not_allowed") if cash_withdrawal? && !card.cash_withdrawal_enabled?
+        if cash_withdrawal?
+          unless card.cash_withdrawal_enabled?
+            return decline_with_reason!("cash_withdrawals_not_allowed")
+          end
+
+          if amount_cents > 500_00
+            return decline_with_reason!("exceeds_approval_amount_limit")
+          end
+        end
 
         return decline_with_reason!("user_cards_locked") if card.user.cards_locked? && event.plan.card_lockable?
 

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :stripe_authorization do
+    amount { 0 }
+    approved { true }
+    merchant_data do
+      {
+        category: "grocery_stores_supermarkets",
+        network_id: "1234567890",
+        name: "HCB-TEST"
+      }
+    end
+    pending_request do
+      {
+        amount: 1000,
+      }
+    end
+  end
+end

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     merchant_data do
       {
         category: "grocery_stores_supermarkets",
+        category_code: "5411",
         network_id: "1234567890",
         name: "HCB-TEST"
       }
@@ -15,6 +16,17 @@ FactoryBot.define do
       {
         amount: 1000,
       }
+    end
+
+    trait :cash_withdrawal do
+      merchant_data do
+        {
+          category: "automated_cash_disburse",
+          category_code: "6011",
+          network_id: "1234567890",
+          name: "HCB-ATM-TEST"
+        }
+      end
     end
   end
 end

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -14,8 +14,12 @@ FactoryBot.define do
     end
     pending_request do
       {
-        amount: 1000,
+        amount: pending_amount,
       }
+    end
+
+    transient do
+      pending_amount { 10_00 }
     end
 
     trait :cash_withdrawal do

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
         card_grant = create(:card_grant, event:, amount_cents: 1000, merchant_lock: ["W9JEIROWXKO5PEO"], category_lock: ["wrecking_and_salvage_yards"])
         service = create_service(amount: 1000, stripe_card: card_grant.stripe_card)
         expect(service.run).to be(false)
+        expect(service.declined_reason).to eq("merchant_not_allowed")
       end
     end
 

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -2,25 +2,6 @@
 
 require "rails_helper"
 
-FactoryBot.define do
-  factory :stripe_authorization do
-    amount { 0 }
-    approved { true }
-    merchant_data do
-      {
-        category: "grocery_stores_supermarkets",
-        network_id: "1234567890",
-        name: "HCB-TEST"
-      }
-    end
-    pending_request do
-      {
-        amount: 1000,
-      }
-    end
-  end
-end
-
 RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest, type: :model do
   let(:event) { create(:event) }
   let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:) }


### PR DESCRIPTION
## Summary of the problem

https://hackclub.slack.com/archives/C026RKHLPNJ/p1754325378783549

We are currently relying on the limit enforced by Stripe, which can change. As a precautionary measure we're doing to cap cash withdrawals to $500 (on cards that allow them) for now and introduce a more granular setting at a later date.

## Describe your changes

- Moves the `:stripe_authorization` factory to `spec/factories`, adds a `:cash_withdrawal` trait, and makes `pending_amount` configurable
- Adds test coverage for the current withdrawal behaviour (there wasn't any before)
- Updates the logic to cap the amount to $500