### PR TITLE
Remove n+1 in `EventsController#index`

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,8 +54,6 @@ class EventsController < ApplicationController
           )
         end
 
-        response.content_type = "text/json"
-
         render json: events
       end
       format.html { redirect_to root_path }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,33 +24,23 @@ class EventsController < ApplicationController
     authorize Event
     respond_to do |format|
       format.json do
-        events = @current_user.events.with_attached_logo.reorder("organizer_positions.sort_index ASC", "events.id ASC").map { |x|
-          {
-            name: x.name,
-            slug: x.slug,
-            logo: x.logo.attached? ? Rails.application.routes.url_helpers.url_for(x.logo) : "none",
-            demo_mode: x.demo_mode,
-            member: true,
-            features: {
-              subevents: x.subevents_enabled?
-            }
-          }
-        }
+        events =
+          @current_user
+          .events
+          .with_attached_logo
+          .preload(:config)
+          .reorder("organizer_positions.sort_index ASC", "events.id ASC")
+          .strict_loading
+          .map { |event| serialize_event(event, member: true) }
 
         if auditor_signed_in?
           events.concat(
-            Event.excluding(@current_user.events).with_attached_logo.map { |e|
-              {
-                slug: e.slug,
-                name: e.name,
-                logo: e.logo.attached? ? Rails.application.routes.url_helpers.url_for(e.logo) : "none",
-                demo_mode: e.demo_mode,
-                member: false,
-                features: {
-                  subevents: e.subevents_enabled?
-                }
-              }
-            }
+            Event
+              .excluding(@current_user.events)
+              .with_attached_logo
+              .preload(:config)
+              .strict_loading
+              .map { |event| serialize_event(event, member: false) }
           )
         end
 
@@ -1252,6 +1242,19 @@ class EventsController < ApplicationController
 
   def set_event_follow
     @event_follow = Event::Follow.where({ user_id: current_user.id, event_id: @event.id }).first if current_user
+  end
+
+  def serialize_event(event, member:)
+    {
+      name: event.name,
+      slug: event.slug,
+      logo: event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : "none",
+      demo_mode: event.demo_mode,
+      member:,
+      features: {
+        subevents: event.subevents_enabled?
+      }
+    }
   end
 
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventsController do
+  include SessionSupport
+
+  describe "#index" do
+    it "renders a list of the user's events as json" do
+      user = create(:user)
+
+      event1 = create(:event, name: "Event 1")
+      create(:organizer_position, user:, event: event1, sort_index: 2)
+
+      event2 = create(:event, name: "Event 2", demo_mode: true)
+      create(:organizer_position, user:, event: event2, sort_index: 1)
+      event2.create_config!(subevent_plan: Event::Plan::Standard)
+      logo_path = Rails.root.join("app/assets/images/logo-production.png")
+      event2.logo.attach(io: File.open(logo_path), filename: "logo.png", content_type: "image/png")
+
+      sign_in(user)
+
+      get(:index, format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        [
+          {
+            "name"      => "Event 2",
+            "slug"      => "event-2",
+            "logo"      => Rails.application.routes.url_helpers.url_for(event2.logo),
+            "demo_mode" => true,
+            "member"    => true,
+            "features"  => { "subevents" => true },
+          },
+          {
+            "name"      => "Event 1",
+            "slug"      => "event-1",
+            "logo"      => "none",
+            "demo_mode" => false,
+            "member"    => true,
+            "features"  => { "subevents" => false },
+          }
+        ]
+      )
+    end
+
+    it "includes all events if the user is an admin" do
+      user = create(:user, :make_admin)
+
+      event1 = create(:event, name: "Event 1")
+      create(:organizer_position, user:, event: event1, sort_index: 2)
+
+      event2 = create(:event, name: "Event 2", demo_mode: true)
+      event2.create_config!(subevent_plan: Event::Plan::Standard)
+      logo_path = Rails.root.join("app/assets/images/logo-production.png")
+      event2.logo.attach(io: File.open(logo_path), filename: "logo.png", content_type: "image/png")
+
+      sign_in(user)
+
+      get(:index, format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        [
+          {
+            "name"      => "Event 1",
+            "slug"      => "event-1",
+            "logo"      => "none",
+            "demo_mode" => false,
+            "member"    => true,
+            "features"  => { "subevents" => false },
+          },
+          {
+            "name"      => "Event 2",
+            "slug"      => "event-2",
+            "logo"      => Rails.application.routes.url_helpers.url_for(event2.logo),
+            "demo_mode" => true,
+            "member"    => false,
+            "features"  => { "subevents" => true },
+          },
+        ]
+      )
+    end
+  end
+end

--- a/spec/factories/organizer_position_factory.rb
+++ b/spec/factories/organizer_position_factory.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :organizer_position do
     association :user
     association :event
-    association :organizer_position_invite
+    organizer_position_invite do
+      association(:organizer_position_invite, event:, user:)
+    end
   end
 end


### PR DESCRIPTION
## Summary of the problem

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/performance/incidents/7/samples/6596247683eb67648f30f807-126952945119088104601754329320

This endpoint can be a bit slow when loaded by an admin or auditor.

## Describe your changes

- Adds test coverage
- Improves `:organizer_position` factory so it doesn't create extra users and events
- Refactors `#index` to 
    - remove duplication in the serialization logic
    - preload the `config` relation 
    - add `strict_loading` to the loaded events to help prevent future regressions