### PR TITLE
Fix template error in `public_activity/user_session/_create.html.erb`

### DIFF
--- a/app/views/public_activity/user_session/_create.html.erb
+++ b/app/views/public_activity/user_session/_create.html.erb
@@ -1,7 +1,7 @@
 <% current_user ||= local_assigns[:p][:current_user] %>
 
 <% if activity&.trackable&.impersonated? %>
-  <% if auditor_signed_in? %>
+  <% if current_user.auditor? %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user: } do %>
       impersonated <%= activity.trackable.user.name %> on HCB
     <% end %>


### PR DESCRIPTION
## Summary of the problem

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/752/samples/6596247683eb67648f30f807-15411492911189529520175433250012?activeFilter=timeline&selectedTime=2025-07-11T00%3A00%3A00.000Z

We are running to the following error:

```
undefined method 'generate_key' for nil
```

which is happening because we call `auditor_signed_in` from within a `PublicActivity` template

https://github.com/hackclub/hcb/blob/b676a855b8f0b6e9ccde562ee62e37fa74d4067d/app/views/public_activity/user_session/_create.html.erb#L4

which calls `auditor_signed_in?`

https://github.com/hackclub/hcb/blob/21ec8d158f5d4ba52f4e7d780124dd01a26e611b/app/helpers/sessions_helper.rb#L65-L67

which eventually tries to read an encrypted cookie (which does not exist in this context)

https://github.com/hackclub/hcb/blob/21ec8d158f5d4ba52f4e7d780124dd01a26e611b/app/helpers/sessions_helper.rb#L121

The errors started around July 10th which coincides with https://github.com/hackclub/hcb/pull/10914/files#diff-393ea2d38d8dc67fd12998ed0e44d33d793c5c4553987a5fe1c2d69281c982be being rolled out.

## Describe your changes

- Add a test to hopefully prevent future regressions
- Revert back to using `current_user.auditor?`