### PR TITLE
Set revision for AppSignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -18,4 +18,4 @@ default: &defaults
 production:
   <<: *defaults
   active: true
-  revision: "<%= `git rev-parse --short HEAD`.strip %>"
+  revision: "<%= ENV["HATCHBOX_REVISION"] %>"

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -18,3 +18,4 @@ default: &defaults
 production:
   <<: *defaults
   active: true
+  revision: "<%= `git rev-parse --short HEAD`.strip %>"


### PR DESCRIPTION
## Summary of the problem

We aren't currently reporting the code revision to AppSignal which makes historical stats harder to reason about.

## Describe your changes

Added `revision` key to `config/appsignal.yml` as per https://docs.appsignal.com/guides/deploy-markers.html#ruby.