### PR TITLE
Show sender available balance in org picker to admins

### DIFF
--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -20,7 +20,7 @@
                     <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
                         <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
                             <div class="text-left <%= "tooltipped tooltipped--e" if admin_signed_in? %>" aria-label="<%= "ID: #{event.id}" if admin_signed_in? %>"><%= event.name %></div>
-                            
+
                             <div class="text-muted pl-2">
                               <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
                                   <strong>-</strong>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -19,7 +19,7 @@
                     <% disabled_message = "HCB transfers disabled" if sending && !policy(event).create_transfer? %>
                     <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
                         <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
-                            <div class="text-left"><%= event.name %></div>
+                            <div class="text-left tooltipped tooltipped--e" aria-label="ID: <%= event.id %>"><%= event.name %></div>
                             <div class="text-muted pl-2">
                               <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
                                   <strong>-</strong>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -19,7 +19,8 @@
                     <% disabled_message = "HCB transfers disabled" if sending && !policy(event).create_transfer? %>
                     <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
                         <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
-                            <div class="text-left tooltipped tooltipped--e" aria-label="ID: <%= event.id %>"><%= event.name %></div>
+                            <div class="text-left <%= "tooltipped tooltipped--e" if admin_signed_in? %>" aria-label="<%= "ID: #{event.id}" if admin_signed_in? %>"><%= event.name %></div>
+                            
                             <div class="text-muted pl-2">
                               <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
                                   <strong>-</strong>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -21,13 +21,9 @@
                         <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
                             <div class="text-left"><%= event.name %></div>
                             <div class="text-muted pl-2">
-                                <% if admin_signed_in? %>
-                                    <%= event.id %>
-                                <% else %>
-                                    <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
-                                        <strong>-</strong>
-                                    <% end %>
-                                <% end %>
+                              <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
+                                  <strong>-</strong>
+                              <% end %>
                             </div>
                         </button>
                         <hr class="my-0">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Supersedes #10938 

> @leowilkin requested to be able to see sender event balance when created a disbursement, which is currently hidden when an admin is signed in.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Org balance is now shown in the org picker in place of the ID, and the ID has been moved to a tooltip on the organization's name.

<img width="1328" height="987" alt="image" src="https://github.com/user-attachments/assets/f775313a-d93d-43ce-8069-5050be9bea56" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

