### PR TITLE
Improve format for monthly announcement date in callout

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -11,11 +11,11 @@ class AnnouncementMailer < ApplicationMailer
   end
 
   def seven_day_warning
-    mail to: @emails, subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{@scheduled_for.strftime("%b %-d")}"
+    mail to: @emails, subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{@scheduled_for.strftime("%B #{@scheduled_for.day.ordinalize}")}"
   end
 
   def two_day_warning
-    mail to: @emails, subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{@scheduled_for.strftime("%b %-d")}"
+    mail to: @emails, subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{@scheduled_for.strftime("%B #{@scheduled_for.day.ordinalize}")}"
   end
 
   def set_warning_variables

--- a/app/views/events/announcement_overview.html.erb
+++ b/app/views/events/announcement_overview.html.erb
@@ -30,12 +30,13 @@
 </h1>
 
 <% if @monthly_announcement.present? && organizer_signed_in?(as: :reader) %>
-  <% scheduled_for = Date.today.next_month.beginning_of_month.strftime("%b %-d") %>
-  <%= render "callout", type: "warning", title: "You have a scheduled monthly announcement that will be delivered on #{scheduled_for}", footer: :questions do %>
+  <% scheduled_for = Date.today.next_month.beginning_of_month %>
+  <% scheduled_for_string = scheduled_for.strftime("%B #{scheduled_for.day.ordinalize}") %>
+  <%= render "callout", type: "warning", title: "You have a scheduled monthly announcement that will be delivered on #{scheduled_for_string}", footer: :questions do %>
     <ul>
-      <li>You can <%= link_to "view and edit this announcement", announcement_path(@monthly_announcement) %> any time before <%= scheduled_for %>.</li>
+      <li>You can <%= link_to "view and edit this announcement", announcement_path(@monthly_announcement) %> any time before <%= scheduled_for_string %>.</li>
       <li>If you would like to disable sending monthly announcements, you may do so in your <%= link_to "organization settings", edit_event_path(@event) %>.</li>
-      <li>This announcement will be sent out to everyone following you on <%= scheduled_for %>.</li>
+      <li>This announcement will be sent out to everyone following you on <%= scheduled_for_string %>.</li>
     </ul>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
"Sep 1" was a weird format for the date in the callout - "September 1st" makes more sense.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the date formatting in the warning callout and warning emails to show the full month name and ordinalized day.

<img width="921" height="227" alt="image" src="https://github.com/user-attachments/assets/8129ea71-16ea-4c66-876f-4843a3ff6773" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

