### PR TITLE
Show whether a grant is one time use in grant details partial

### DIFF
--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -20,9 +20,9 @@
           <p>
             <strong class="inline-flex items-center" style="gap: 4px">
               One time use
-              <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": card_grant.one_time_use ? "This card will automatically freeze after you make a purchase" : "There is no limit on the number of purchases you can make using this grant", style: "display: flex;", data: { turbo: false } do %>
+              <span class="info tooltipped tooltipped--e" aria-label="This card will automatically freeze after you make a purchase"> 
                 <%= inline_icon "info", size: 18, style: "position: unset;" %>
-              <% end %>
+              </span>
             </strong>
             <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
           </p>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -17,6 +17,16 @@
         </p>
 
         <p>
+          <strong class="inline-flex items-center" style="gap: 4px">
+            One time use
+            <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": card_grant.one_time_use ? "This card will automatically freeze after you make a purchase" : "There is no limit on the number of purchases you can make using this grant", style: "display: flex;", data: { turbo: false } do %>
+              <%= inline_icon "info", size: 18, style: "position: unset;" %>
+            <% end %>
+          </strong>
+          <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
+        </p>
+
+        <p>
           <strong>Allowed merchants</strong>
           <% if card_grant.allowed_merchants.any? %>
             <span><%= card_grant.allowed_merchant_names.join(", ") %><br>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -18,7 +18,7 @@
 
         <p>
           <strong class="inline-flex items-center" style="gap: 4px">
-            One time use
+            One time use?
             <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": card_grant.one_time_use ? "This card will automatically freeze after you make a purchase" : "There is no limit on the number of purchases you can make using this grant", style: "display: flex;", data: { turbo: false } do %>
               <%= inline_icon "info", size: 18, style: "position: unset;" %>
             <% end %>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -20,7 +20,7 @@
           <p>
             <strong class="inline-flex items-center" style="gap: 4px">
               One time use
-              <span class="info tooltipped tooltipped--e" aria-label="This card will automatically freeze after you make a purchase"> 
+              <span class="info tooltipped tooltipped--e" aria-label="This card will automatically freeze after you make a purchase">
                 <%= inline_icon "info", size: 18, style: "position: unset;" %>
               </span>
             </strong>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -16,15 +16,17 @@
           <span><%= format_date card_grant.expires_on %></span>
         </p>
 
-        <p>
-          <strong class="inline-flex items-center" style="gap: 4px">
-            One time use?
-            <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": card_grant.one_time_use ? "This card will automatically freeze after you make a purchase" : "There is no limit on the number of purchases you can make using this grant", style: "display: flex;", data: { turbo: false } do %>
-              <%= inline_icon "info", size: 18, style: "position: unset;" %>
-            <% end %>
-          </strong>
-          <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
-        </p>
+        <% if card_grant.one_time_use %>
+          <p>
+            <strong class="inline-flex items-center" style="gap: 4px">
+              One time use
+              <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": card_grant.one_time_use ? "This card will automatically freeze after you make a purchase" : "There is no limit on the number of purchases you can make using this grant", style: "display: flex;", data: { turbo: false } do %>
+                <%= inline_icon "info", size: 18, style: "position: unset;" %>
+              <% end %>
+            </strong>
+            <span><%= card_grant.one_time_use ? "Yes" : "No" %></span>
+          </p>
+        <% end %>
 
         <p>
           <strong>Allowed merchants</strong>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Users given a grant should be able to see if their grant is one time use - currently this is only shown to organizers in the manage grant overview.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added one time use with a tooltip explaining it to the grant details partial

<img width="506" height="210" alt="image" src="https://github.com/user-attachments/assets/a236cc0f-4ddc-4a9a-b615-5b75eb2a9831" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

