### PR TITLE
Improve error handling in `Api::V4::CardGrantsController#create`

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -38,11 +38,7 @@ class CardGrantsController < ApplicationController
         raise e unless e.record.is_a?(CardGrant)
 
         flash[:error] = @card_grant.errors.full_messages.to_sentence
-      when ArgumentError
-        # `DisbursementService::Create` will raise `ArgumentError` if there are
-        # insufficient funds.
-        raise e unless e.message.start_with?("You don't have enough money")
-
+      when DisbursementService::Create::UserError
         flash[:error] = e.message
       else
         raise e

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::CardGrantsController do
+  render_views
+
+  describe "#create" do
+    def card_grant_params
+      {
+        amount_cents: "123_45",
+        email: "recipient@example.com",
+        keyword_lock: "some keywords",
+        purpose: "Raffle prize",
+        one_time_use: "true",
+        pre_authorization_required: "true",
+        instructions: "Here's a card grant for your raffle prize"
+      }
+    end
+
+    it "creates a card grant" do
+      user = create(:user, full_name: "Orpheus the Dinosaur", email: "orpheus@hackclub.com")
+      event = create(:event, :with_positive_balance, name: "Test Event", plan_type: Event::Plan::HackClubAffiliate)
+      create(:organizer_position, user:, event:)
+
+      token = create(:api_token, user:)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+
+      # `UsersHelper#profile_picture_for` uses `gravatar_url` if the user
+      # hasn't uploaded an image. The background colour for the Gravatar
+      # fallback image is determined by the user's ID, which makes the
+      # response value unpredictable.
+      allow_any_instance_of(UsersHelper).to receive(:gravatar_url).and_return("https://gravatar.com/avatar/stubbed")
+
+      post(:create, params: { event_id: event.friendly_id, **card_grant_params }, as: :json)
+
+      expect(response).to have_http_status(:created)
+      card_grant = event.card_grants.sole
+      disbursement = card_grant.disbursement
+      recipient = card_grant.user
+
+      serialized_event = {
+        "id"                                => event.public_id,
+        "name"                              => "Test Event",
+        "slug"                              => "test-event",
+        "background_image"                  => nil,
+        "country"                           => nil,
+        "created_at"                        => event.created_at.iso8601(3),
+        "fee_percentage"                    => 0.0,
+        "icon"                              => nil,
+        "playground_mode"                   => false,
+        "playground_mode_meeting_requested" => false,
+        "transparent"                       => true
+      }
+
+      expect(response.parsed_body).to eq(
+        {
+          "id"                         => card_grant.public_id,
+          "amount_cents"               => 123_45,
+          "card_id"                    => nil,
+          "one_time_use"               => true,
+          "pre_authorization_required" => true,
+          "status"                     => "active",
+          "allowed_categories"         => [],
+          "allowed_merchants"          => [],
+          "category_lock"              => [],
+          "merchant_lock"              => [],
+          "keyword_lock"               => "some keywords",
+          "disbursements"              => [
+            {
+              "id"             => disbursement.public_id,
+              "memo"           => "Grant to recipient",
+              "status"         => "completed",
+              "transaction_id" => disbursement.local_hcb_code.public_id,
+              "amount_cents"   => 123_45,
+              "card_grant_id"  => card_grant.public_id,
+              "from"           => serialized_event,
+              "to"             => serialized_event,
+              "sender"         => {
+                "id"       => user.public_id,
+                "name"     => "Orpheus D",
+                "email"    => "orpheus@hackclub.com",
+                "admin"    => false,
+                "auditor"  => false,
+                "avatar"   => "https://gravatar.com/avatar/stubbed",
+                "birthday" => nil,
+              },
+            }
+          ],
+          "organization"               => serialized_event,
+          "user"                       => {
+            "id"      => recipient.public_id,
+            "name"    => "recipient",
+            "admin"   => false,
+            "auditor" => false,
+            "avatar"  => "https://gravatar.com/avatar/stubbed",
+          },
+        }
+      )
+    end
+  end
+end

--- a/spec/factories/api_token_factory.rb
+++ b/spec/factories/api_token_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:api_token) do
+    association(:user)
+    token { ApiToken.generate }
+    expires_in { 5.minutes }
+  end
+end


### PR DESCRIPTION
Internal thread: https://hackclub.slack.com/archives/C047Y01MHJQ/p1754407379830219

## Summary of the problem

The API endpoint to create card grants has many of the same issues that were addressed in https://github.com/hackclub/hcb/pull/11211 for the non-API version (e.g. https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1651/samples/last).

## Describe your changes

- Use `DisbursementService::Create::UserError` instead of a plain `ArgumentError` for exceptions that require specific handling
- Return an error response for validation and  `DisbursementService::Create` errors
- Return a `201 Created` response with a `Location` header
- Add tests

----

Internal thread making sure these changes are safe to roll out: https://hackclub.slack.com/archives/GBXBFEED9/p1754417640438699