### PR TITLE
Hide unpublished monthly announcements

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -58,7 +58,7 @@ class Announcement < ApplicationRecord
   scope :monthly_for, ->(date) { monthly.where("announcements.created_at BETWEEN ? AND ?", date.beginning_of_month, date.end_of_month) }
   validate :content_is_json
 
-  scope :saved, -> { where.not(aasm_state: :template_draft).where.not(content: {}) }
+  scope :saved, -> { where.not(aasm_state: :template_draft).where.not(content: {}).where.not(template_type: Announcement::Templates::Monthly.name, published_at: nil) }
 
   belongs_to :author, class_name: "User"
   belongs_to :event


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, after editing a monthly announcement, it will appear in the announcement list. We don't want this to happen because it should only be linked from the callout at the top of the page until it is published.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove announcements from the saved scope if their template type is monthly and their published at is nil.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

