### PR TITLE
Add test coverage for `OrganizerPositionInvitesController#create`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,7 @@ end
 group :test do
   gem "factory_bot_rails" # Test data
   gem "simplecov", require: false # Code coverage
+  gem "webmock"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,9 @@ GEM
       unaccent (~> 0.3)
     country_select (8.0.2)
       countries (~> 5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -420,6 +423,7 @@ GEM
     grape-swagger-entity (0.6.2)
       grape-entity (~> 1)
       grape-swagger (~> 2)
+    hashdiff (1.2.0)
     hashid-rails (1.4.1)
       activerecord (>= 4.0)
       hashids (~> 1.0)
@@ -853,6 +857,10 @@ GEM
       openssl (>= 2.2)
       safety_net_attestation (~> 0.4.0)
       tpm-key_attestation (~> 0.12.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     websocket-driver (0.7.7)
       base64
@@ -999,6 +1007,7 @@ DEPENDENCIES
   validates_zipcode
   web-console (>= 3.3.0)
   webauthn (~> 3.2)
+  webmock
   whitesimilarity
   wicked_pdf
   wkhtmltopdf-binary (= 0.12.6.8)

--- a/app/controllers/organizer_position_invites_controller.rb
+++ b/app/controllers/organizer_position_invites_controller.rb
@@ -113,9 +113,10 @@ class OrganizerPositionInvitesController < ApplicationController
 
   def invite_params
     permitted_params = [:email, :role, :enable_controls, :initial_control_allowance_amount]
-    permitted_params << :cosigner_email if admin_signed_in?
-    permitted_params << :include_videos if admin_signed_in?
-    permitted_params << :is_signee if admin_signed_in?
+
+    if admin_signed_in?
+      permitted_params.push(:cosigner_email, :include_videos, :is_signee)
+    end
     params.require(:organizer_position_invite).permit(permitted_params)
   end
 

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrganizerPositionInvitesController do
+  include SessionSupport
+  render_views
+
+  describe "#create" do
+    it "creates an invitation" do
+      user = create(:user)
+      event = create(:event, organizers: [user])
+
+      sign_in(user)
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          organizer_position_invite: {
+            email: "orpheus@hackclub.com",
+            role: "member",
+            enable_controls: "true",
+            initial_control_allowance_amount: "123.45",
+          }
+        }
+      )
+
+      expect(response).to redirect_to(event_team_path(event))
+      expect(flash[:success]).to eq("Invite successfully sent to orpheus@hackclub.com")
+
+      invite = event.organizer_position_invites.last
+      expect(invite.sender).to eq(user)
+      expect(invite.user.email).to eq("orpheus@hackclub.com")
+      expect(invite.role).to eq("member")
+      expect(invite.initial_control_allowance_amount_cents).to eq(123_45)
+    end
+
+    it "supports additional params for admins" do
+      user = create(:user, :make_admin)
+      event = create(:event, organizers: [user])
+
+      # `OrganizerPosition::Contract` makes external requests to Airtable and
+      # Docuseal which we don't want to perform in this context.
+      expect(ApplicationsTable).to(
+        receive(:all)
+          .with(filter: include(event.id.to_s))
+          .and_return([])
+          .twice
+      )
+      docuseal_request =
+        stub_request(:post, "https://api.docuseal.co/submissions")
+        .to_return(
+          status: 201,
+          body: [{ submission_id: "STUBBED" }].to_json,
+          headers: { content_type: "application/json" }
+        )
+
+      sign_in(user)
+
+      post(
+        :create,
+        params: {
+          event_id: event.friendly_id,
+          organizer_position_invite: {
+            email: "orpheus@hackclub.com",
+            role: "manager",
+            enable_controls: "false",
+            cosigner_email: "cosigner@hackclub.com",
+            include_videos: "true",
+            is_signee: "true",
+          }
+        }
+      )
+
+      expect(docuseal_request).to(have_been_made.once)
+
+      expect(response).to redirect_to(event_team_path(event))
+      expect(flash[:success]).to eq("Invite successfully sent to orpheus@hackclub.com")
+
+      invite = event.organizer_position_invites.last
+      expect(invite.is_signee).to eq(true)
+
+      contract = invite.organizer_position_contracts.sole
+      expect(contract.cosigner_email).to eq("cosigner@hackclub.com")
+      expect(contract.include_videos).to eq(true)
+      expect(contract.external_service).to eq("docuseal")
+      expect(contract.external_id).to eq("STUBBED")
+    end
+  end
+end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -5,10 +5,16 @@ FactoryBot.define do
     name { Faker::Name.unique.name }
     transient do
       plan_type { Event::Plan::FeeWaived }
+      organizers { [] }
     end
 
     after(:create) do |event, context|
       event.plan.update(type: context.plan_type)
+
+      context.organizers.each do |user|
+        create(:organizer_position, event:, user:)
+      end
+
       event.reload
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 
 require "simplecov"
 require "faker"
+require "webmock/rspec"
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -97,4 +98,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  # Allow the test suite to make external web requests
+  WebMock.allow_net_connect!
 end


### PR DESCRIPTION
## Summary of the problem

Related to https://github.com/hackclub/hcb/pull/10543/files#r2243532219

Ideally we'd like both the regular and API endpoints for invitations to share as much code as possible so they don't accidentally diverge. However, doing that kind of refactor is tricky if we don't have a test suite to lean on.

## Describe your changes

- Adds [WebMock](https://github.com/bblimke/webmock)
- Adds test coverage for `OrganizerPositionInvitesController#create`