### PR TITLE
Make sure unsuccessful HTTP calls with Faraday result in exceptions

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1436,6 +1436,15 @@ class AdminController < ApplicationController
     9999 # return something invalidly high to get the ops team to report it
   end
 
+  def pending_identity_vault_verifications_task_size
+    client = Faraday.new do |c|
+      c.response :json
+      c.response :raise_error
+    end
+
+    client.get("https://identity.hackclub.com/api/v1/hcb").body["pending"] || 0
+  end
+
   def hackathons_task_size
     hackathons = Faraday
                  .new(ssl: { verify: false }) { |c| c.response :json }
@@ -1481,7 +1490,7 @@ class AdminController < ApplicationController
       when :pending_you_ship_we_ship_airtable
         airtable_task_size :you_ship_we_ship
       when :pending_identity_vault_verifications
-        Faraday.new { |c| c.response :json }.get("https://identity.hackclub.com/api/v1/hcb").body["pending"] || 0
+        pending_identity_vault_verifications_task_size
       when :emburse_card_requests
         EmburseCardRequest.under_review.size
       when :emburse_transactions

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1422,11 +1422,14 @@ class AdminController < ApplicationController
 
   def airtable_task_size(task_name)
     info = airtable_info[task_name]
-    task = Faraday.new { |c|
-      c.response :json
-      c.authorization :Bearer, Credentials.fetch(:AIRTABLE)
-    }.get("https://api.airtable.com/v0/#{info[:id]}/#{info[:table]}", info[:query]).body["records"]
 
+    client = Faraday.new do |c|
+      c.response :json
+      c.response :raise_error
+      c.authorization :Bearer, Credentials.fetch(:AIRTABLE)
+    end
+
+    task = client.get("https://api.airtable.com/v0/#{info[:id]}/#{info[:table]}", info[:query]).body["records"]
     task.size
   rescue => e
     Rails.error.report(e)

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -96,10 +96,11 @@ class CardGrant
     end
 
     def analyze!
-      conn = Faraday.new url: "https://api.openai.com" do |f|
-        f.request :json
-        f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
-        f.response :json
+      conn = Faraday.new url: "https://api.openai.com" do |c|
+        c.request :json
+        c.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+        c.response :json
+        c.response :raise_error
       end
 
       prompt = <<~PROMPT

--- a/app/models/organizer_position/contract.rb
+++ b/app/models/organizer_position/contract.rb
@@ -211,6 +211,7 @@ class OrganizerPosition
       @docuseal_client || begin
         Faraday.new(url: "https://api.docuseal.co/") do |faraday|
           faraday.response :json
+          faraday.response :raise_error
           faraday.adapter Faraday.default_adapter
           faraday.headers["X-Auth-Token"] = Credentials.fetch(:DOCUSEAL)
           faraday.headers["Content-Type"] = "application/json"

--- a/app/services/hcb_code_service/ai_generate_memo.rb
+++ b/app/services/hcb_code_service/ai_generate_memo.rb
@@ -5,10 +5,11 @@ module HcbCodeService
     def initialize(hcb_code:, conn: nil)
       @hcb_code = hcb_code
 
-      @conn = conn || Faraday.new(headers: { "Authorization" => "Bearer #{Credentials.fetch(:OPENAI_API_KEY)}" }) do |f|
-        f.request :json
-        f.request :retry
-        f.response :json
+      @conn = conn || Faraday.new do |c|
+        c.request :json
+        c.request :retry
+        c.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+        c.response :json
       end
     end
 

--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -56,30 +56,18 @@ module UserService
 
     def contact_details
       @queue.shift
-      conn = Faraday.new(url: "https://app.loops.so/")
 
-      resp = conn.send(:get) do |req|
-        req.url("api/v1/contacts/find")
-        req.headers["Authorization"] = "Bearer #{Credentials.fetch(:LOOPS)}"
-        req.params[:email] = @user.email
-      end
+      # https://loops.so/docs/api-reference/find-contact
+      resp = loops_client.get("api/v1/contacts/find", { email: @user.email })
 
-      return nil if resp.body.strip == "[]"
-
-      JSON[resp.body][0]
+      resp.body.first
     end
 
     def update(body:)
       @queue.shift
-      conn = Faraday.new(url: "https://app.loops.so/")
 
-      conn.send(:post) do |req|
-        req.url("api/v1/contacts/update")
-        req.body = body.to_json
-        req.headers["Content-Type"] = "application/json"
-        req.headers["Authorization"] = "Bearer #{Credentials.fetch(:LOOPS)}"
-      end
-
+      # https://loops.so/docs/api-reference/update-contact
+      loops_client.post("api/v1/contacts/update", body)
     end
 
     def format_unix(timestamp)
@@ -92,6 +80,15 @@ module UserService
       @contact_details&.[]("addressLine1").present? &&
         @contact_details["addressCity"].present? &&
         @contact_details["addressCountry"].present?
+    end
+
+    def loops_client
+      @loops_client ||= Faraday.new(url: "https://loops.so/") do |c|
+        c.request :authorization, "Bearer", -> { Credentials.fetch(:LOOPS) }
+        c.request :json
+        c.response :json
+        c.response :raise_error
+      end
     end
 
   end


### PR DESCRIPTION
## Summary of the problem

In several places throughout the code base we make use of `Faraday` as an HTTP client to make external HTTP calls, but we either
- Fail to check the response code
- Don't configure the `:raise_errors` middleware (https://lostisland.github.io/faraday/#/middleware/included/raising-errors)

## Describe your changes

Audited every call to `Faraday.new` and made sure we were doing one of the above.