### PR TITLE
Don't wait for 2 CTs when settling

### DIFF
--- a/app/services/pending_event_mapping_engine/settle/donation_hcb_code.rb
+++ b/app/services/pending_event_mapping_engine/settle/donation_hcb_code.rb
@@ -6,7 +6,7 @@ module PendingEventMappingEngine
       def run
         unsettled.find_each(batch_size: 100) do |cpt|
           # 1. Wait for 2 canonical transactions (payout and fee reimbursement)
-          if cpt.local_hcb_code.canonical_transactions.length == 2
+          if cpt.local_hcb_code.canonical_transactions.any?
             # 2. identify ct
             ct = cpt.local_hcb_code.canonical_transactions.first
 

--- a/app/services/pending_event_mapping_engine/settle/invoice_hcb_code.rb
+++ b/app/services/pending_event_mapping_engine/settle/invoice_hcb_code.rb
@@ -6,7 +6,7 @@ module PendingEventMappingEngine
       def run
         unsettled.find_each(batch_size: 100) do |cpt|
           # 1. Wait for 2 canonical transactions (payout and fee reimbursement)
-          if cpt.local_hcb_code.canonical_transactions.length == 2
+          if cpt.local_hcb_code.canonical_transactions.any?
             # 2. identify ct
             ct = cpt.local_hcb_code.canonical_transactions.first
 


### PR DESCRIPTION
We no longer have two CTs per invoice / donation. This is because we re-did fee reimbursements. This was preventing these transactions from settling