### PR TITLE
Remove `logins.initial_login_id`

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -21,10 +21,6 @@
 #  index_logins_on_user_id              (user_id)
 #  index_logins_on_user_session_id      (user_session_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (initial_login_id => logins.id)
-#
 class Login < ApplicationRecord
   self.ignored_columns = %w[initial_login_id]
 

--- a/db/migrate/20250731150352_drop_initial_login_id_from_logins.rb
+++ b/db/migrate/20250731150352_drop_initial_login_id_from_logins.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DropInitialLoginIdFromLogins < ActiveRecord::Migration[7.2]
+  def change
+    # The column is ignored and all references have been removed
+    safety_assured do
+      remove_reference(:logins, :initial_login, index: false)
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1377,7 +1377,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "browser_token_ciphertext"
-    t.bigint "initial_login_id"
     t.bigint "referral_program_id"
     t.boolean "is_reauthentication", default: false, null: false
     t.index ["referral_program_id"], name: "index_logins_on_referral_program_id"
@@ -2479,7 +2478,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
   add_foreign_key "invoices", "users", column: "voided_by_id"
   add_foreign_key "lob_addresses", "events"
   add_foreign_key "login_codes", "users"
-  add_foreign_key "logins", "logins", column: "initial_login_id"
   add_foreign_key "mailbox_addresses", "users"
   add_foreign_key "organizer_position_deletion_requests", "organizer_positions"
   add_foreign_key "organizer_position_deletion_requests", "users", column: "closed_by_id"


### PR DESCRIPTION
## Summary of the problem

Extracted from https://github.com/hackclub/hcb/pull/11162

This column is now ignored: https://github.com/hackclub/hcb/blob/a4b1cf68ea7847c7e8c6ed7df12c166c1f866f3c/app/models/login.rb#L29

## Describe your changes

Drops the `initial_login_id` column from the `logins` table.