### PR TITLE
Remove `initial_login_id` from `ignored_columns` on `Login`

### DIFF
--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -26,8 +26,6 @@
 #  fk_rails_...  (initial_login_id => logins.id)
 #
 class Login < ApplicationRecord
-  self.ignored_columns = %w[initial_login_id]
-
   include AASM
   include Hashid::Rails
 


### PR DESCRIPTION
## Summary of the problem

Extracted from https://github.com/hackclub/hcb/pull/11162

## Describe your changes

Once https://github.com/hackclub/hcb/pull/11248 ships we will no longer need to ignore the column.