### PR TITLE
Fix stripe card defrost policy

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -82,7 +82,7 @@ module Api
             return render json: { error: "Card is canceled." }, status: :unprocessable_entity
           end
 
-          @stripe_card.freeze!
+          @stripe_card.freeze!(frozen_by: current_user)
         elsif params[:status] == "active"
           if @stripe_card.initially_activated?
             return render json: { error: "not_authorized" }, status: :forbidden unless policy(@stripe_card).defrost?

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -24,7 +24,7 @@ class StripeCardsController < ApplicationController
     authorize @card
 
     begin
-      @card.freeze!
+      @card.freeze!(frozen_by: current_user)
       flash[:success] = "Card frozen"
     rescue => e
       flash[:error] = "Card could not be frozen"

--- a/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
+++ b/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module OneTimeJobs
-  class AddLastFrozenByIdToStripeCards
+  class AddLastFrozenByToStripeCards
     def self.perform
       StripeCard.find_each do |sc|
         last_frozen_by_id = sc.versions.where_object_changes_to(stripe_status: "inactive").last&.whodunnit || User.system_user.id

--- a/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
+++ b/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
@@ -4,7 +4,8 @@ module OneTimeJobs
   class AddLastFrozenByIdToStripeCards
     def self.perform
       StripeCard.find_each do |sc|
-        sc.update!(last_frozen_by_id: sc.versions.where_object_changes_to(stripe_status: "inactive").last&.whodunnit)
+        last_frozen_by_id = sc.versions.where_object_changes_to(stripe_status: "inactive").last&.whodunnit || User.system_user.id
+        sc.update!(last_frozen_by_id:)
       end
     end
 

--- a/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
+++ b/app/jobs/one_time_jobs/add_last_frozen_by_to_stripe_cards.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class AddLastFrozenByIdToStripeCards
+    def self.perform
+      StripeCard.find_each do |sc|
+        sc.update!(last_frozen_by_id: sc.versions.where_object_changes_to(stripe_status: "inactive").last&.whodunnit)
+      end
+    end
+
+  end
+end

--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -41,7 +41,7 @@ class Event
           unless event.plan.writeable?
             event.update(financially_frozen: true)
             event.stripe_cards.active.each do |card|
-              card.freeze!
+              card.freeze!(frozen_by: User.system_user)
             end
           end
           if event.plan.hidden?

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -30,6 +30,7 @@
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
 #  event_id                              :bigint           not null
+#  last_frozen_by_id                     :bigint
 #  replacement_for_id                    :bigint
 #  stripe_card_personalization_design_id :integer
 #  stripe_cardholder_id                  :bigint           not null
@@ -39,6 +40,7 @@
 # Indexes
 #
 #  index_stripe_cards_on_event_id              (event_id)
+#  index_stripe_cards_on_last_frozen_by_id     (last_frozen_by_id)
 #  index_stripe_cards_on_replacement_for_id    (replacement_for_id)
 #  index_stripe_cards_on_stripe_cardholder_id  (stripe_cardholder_id)
 #  index_stripe_cards_on_stripe_id             (stripe_id) UNIQUE
@@ -47,6 +49,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (last_frozen_by_id => users.id)
 #  fk_rails_...  (stripe_cardholder_id => stripe_cardholders.id)
 #
 class StripeCard < ApplicationRecord
@@ -79,6 +82,7 @@ class StripeCard < ApplicationRecord
   belongs_to :event
   belongs_to :subledger, optional: true
   belongs_to :stripe_cardholder
+  belongs_to :last_frozen_by, class_name: "User", optional: true
   belongs_to :replacement_for, class_name: "StripeCard", optional: true
   belongs_to :personalization_design, foreign_key: "stripe_card_personalization_design_id", class_name: "StripeCard::PersonalizationDesign", optional: true
   validates_presence_of :stripe_card_personalization_design_id, unless: -> { self.virtual? }
@@ -215,13 +219,6 @@ class StripeCard < ApplicationRecord
 
   def frozen?
     initially_activated? && stripe_status == "inactive"
-  end
-
-  def last_frozen_by
-    user_id = versions.where_object_changes_to(stripe_status: "inactive").last&.whodunnit
-    return nil unless user_id
-
-    User.find_by_id(user_id)
   end
 
   def active?

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -197,9 +197,10 @@ class StripeCard < ApplicationRecord
     status_badge_type
   end
 
-  def freeze!
+  def freeze!(frozen_by: User.system_user)
     StripeService::Issuing::Card.update(self.stripe_id, status: :inactive)
     sync_from_stripe!
+    self.last_frozen_by = frozen_by
     save!
   end
 

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -6,7 +6,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def shipping?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def freeze?
@@ -14,8 +14,8 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def defrost?
-    return false if record&.event&.financially_frozen?
-    return false if record&.last_frozen_by.present? && record&.last_frozen_by != user && !admin_or_manager?
+    return false if record.event&.financially_frozen?
+    return false if record.last_frozen_by.present? && record.last_frozen_by != user && !admin_or_manager?
 
     freeze?
   end
@@ -25,11 +25,11 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def activate?
-    (user&.admin? || member_and_cardholder?) && !record&.canceled? && !record&.event&.financially_frozen?
+    (user&.admin? || member_and_cardholder?) && !record.canceled? && !record.event&.financially_frozen?
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || grantee?
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || grantee?
   end
 
   def edit?
@@ -41,7 +41,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def transactions?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader) || cardholder?
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || cardholder?
   end
 
   def ephemeral_keys?
@@ -59,19 +59,19 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def member?
-    OrganizerPosition.role_at_least?(user, record&.event, :member)
+    OrganizerPosition.role_at_least?(user, record.event, :member)
   end
 
   def cardholder?
-    record&.user == user
+    record.user == user
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record&.event)&.manager?
+    user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
   end
 
   def grantee?
-    cardholder? && record&.card_grant
+    cardholder? && record.card_grant
   end
 
 end

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -14,7 +14,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def defrost?
-    return false if record&.event.financially_frozen?
+    return false if record&.event&.financially_frozen?
     return false if record&.last_frozen_by.present? && record&.last_frozen_by != user && !admin_or_manager?
 
     freeze?
@@ -25,7 +25,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def activate?
-    (user&.admin? || member_and_cardholder?) && !record&.canceled? && !record&.event.financially_frozen?
+    (user&.admin? || member_and_cardholder?) && !record&.canceled? && !record&.event&.financially_frozen?
   end
 
   def show?

--- a/app/services/stripe_authorization_service/create_from_webhook.rb
+++ b/app/services/stripe_authorization_service/create_from_webhook.rb
@@ -51,7 +51,7 @@ module StripeAuthorizationService
 
           if cpt&.stripe_card&.card_grant&.one_time_use
             PaperTrail.request(whodunnit: User.system_user.id) do
-              cpt.stripe_card.freeze!
+              cpt.stripe_card.freeze!(frozen_by: User.system_user)
             end
           end
         else

--- a/db/migrate/20250807185341_add_last_frozen_by_id_to_stripe_cards.rb
+++ b/db/migrate/20250807185341_add_last_frozen_by_id_to_stripe_cards.rb
@@ -1,0 +1,9 @@
+class AddLastFrozenByIdToStripeCards < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :stripe_cards, :last_frozen_by_id, :bigint
+    add_index :stripe_cards, :last_frozen_by_id, algorithm: :concurrently
+    add_foreign_key :stripe_cards, :users, column: :last_frozen_by_id, validate: false
+  end
+end

--- a/db/migrate/20250807185606_validate_add_last_frozen_by_id_to_stripe_cards.rb
+++ b/db/migrate/20250807185606_validate_add_last_frozen_by_id_to_stripe_cards.rb
@@ -1,0 +1,5 @@
+class ValidateAddLastFrozenByIdToStripeCards < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :stripe_cards, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_07_185606) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1987,7 +1987,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
     t.boolean "initially_activated", default: false, null: false
     t.boolean "cash_withdrawal_enabled", default: false
     t.datetime "canceled_at"
+    t.bigint "last_frozen_by_id"
     t.index ["event_id"], name: "index_stripe_cards_on_event_id"
+    t.index ["last_frozen_by_id"], name: "index_stripe_cards_on_last_frozen_by_id"
     t.index ["replacement_for_id"], name: "index_stripe_cards_on_replacement_for_id"
     t.index ["stripe_cardholder_id"], name: "index_stripe_cards_on_stripe_cardholder_id"
     t.index ["stripe_id"], name: "index_stripe_cards_on_stripe_id", unique: true
@@ -2515,6 +2517,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
   add_foreign_key "stripe_cardholders", "users"
   add_foreign_key "stripe_cards", "events"
   add_foreign_key "stripe_cards", "stripe_cardholders"
+  add_foreign_key "stripe_cards", "users", column: "last_frozen_by_id"
   add_foreign_key "subledgers", "events"
   add_foreign_key "transactions", "ach_transfers"
   add_foreign_key "transactions", "bank_accounts"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Cards that didn't have a papertrail set were not able to be unfrozen by the cardholder before.
Closes #10682 #10749


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check for a presence of a papertrail.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

