### PR TITLE
[Wise] Add a field to track the recipient ID

### DIFF
--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -121,6 +121,7 @@ class WiseTransfersController < ApplicationController
             :address_postal_code,
             :address_state,
             :wise_id,
+            :wise_recipient_id,
             { file: [] }] + WiseTransfer.recipient_information_accessors
 
     keys << :usd_amount if current_user.admin?

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -30,6 +30,7 @@
 #  event_id                         :bigint           not null
 #  user_id                          :bigint           not null
 #  wise_id                          :text
+#  wise_recipient_id                :text
 #
 # Indexes
 #

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -216,6 +216,14 @@ class WiseTransfer < ApplicationRecord
     update!(quoted_usd_amount_cents: estimated_usd_amount_cents) unless quoted_usd_amount_cents.present?
   end
 
+  def wise_url
+    return nil unless wise_id.present?
+
+    "https://wise.com/transactions/activities/by-resource/TRANSFER/#{wise_id}"
+  end
+
+  private
+
   WISE_ID_REGEXPS = [
     /wise\.com\/transactions\/activities\/by-resource\/transfer\/(\d+)/i,
     /wise\.com\/success\/transfer\/(\d+)/i

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -219,13 +219,13 @@ class WiseTransfer < ApplicationRecord
   def wise_url
     return nil unless wise_id.present?
 
-    "https://wise.com/transactions/activities/by-resource/TRANSFER/#{wise_id}"
+    "https://wise.com/transactions/activities/by-resource/TRANSFER/#{CGI.escape(wise_id)}"
   end
 
   def wise_recipient_url
     return nil unless wise_recipient_id.present?
 
-    "https://wise.com/recipients/#{wise_recipient_id}"
+    "https://wise.com/recipients/#{CGI.escape(wise_recipient_id)}"
   end
 
   private

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -222,6 +222,12 @@ class WiseTransfer < ApplicationRecord
     "https://wise.com/transactions/activities/by-resource/TRANSFER/#{wise_id}"
   end
 
+  def wise_recipient_url
+    return nil unless wise_recipient_id.present?
+
+    "https://wise.com/recipients/#{wise_recipient_id}"
+  end
+
   private
 
   WISE_ID_REGEXPS = [

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -77,7 +77,12 @@
   <tbody>
     <tr>
       <td>Sent To:</td>
-      <td><%= @wise_transfer.recipient_name %></td>
+      <td>
+        <%= @wise_transfer.recipient_name %>
+        <% if @wise_transfer.wise_recipient_url %>
+          (<%= link_to("view on Wise", @wise_transfer.wise_recipient_url, target: "_blank") %>)
+        <% end %>
+      </td>
     </tr>
     <tr>
       <td>Email:</td>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -182,6 +182,15 @@
             <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
             <%= form.text_field :wise_id, style: "width: 400px;", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
           </div>
+          <div class="field">
+            <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
+            <%= form.text_field(
+                  :wise_recipient_id,
+                  style: "width: 400px;",
+                  disabled: @wise_transfer.usd_amount_cents.nil?,
+                  placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                ) %>
+          </div>
           <%= form.submit "💸 Mark transfer as sent", disabled: @wise_transfer.usd_amount_cents.nil?, class: "mb-0" %>
         <% end %>
 

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -11,7 +11,7 @@
 
   <div class="flex-grow"></div>
 
-  <%= link_to @wise_transfer.wise_id.present? ? "https://wise.com/transactions/activities/by-resource/TRANSFER/#{@wise_transfer.wise_id}" : "https://wise.com/send", class: "btn btn-small bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank" do %>
+  <%= link_to @wise_transfer.wise_url || "https://wise.com/send", class: "btn btn-small bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank" do %>
     <%= inline_icon "wise" %>
     Open Wise
   <% end %>

--- a/app/views/hcb_codes/_wise_transfer.html.erb
+++ b/app/views/hcb_codes/_wise_transfer.html.erb
@@ -1,6 +1,6 @@
-<% if @hcb_code.wise_transfer.wise_id.present? %>
+<% if @hcb_code.wise_transfer.wise_url %>
   <% admin_tool("mt3") do %>
-    <%= link_to "https://wise.com/transactions/activities/by-resource/TRANSFER/#{@hcb_code.wise_transfer.wise_id}", class: "btn bg-accent", target: "_blank" do %>
+    <%= link_to @hcb_code.wise_transfer.wise_url, class: "btn bg-accent", target: "_blank" do %>
       <%= inline_icon "wise" %>
       View transfer on Wise
     <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -59,7 +59,7 @@
           "type": "controller",
           "class": "StripeCardsController",
           "method": "show",
-          "line": 88,
+          "line": 90,
           "file": "app/controllers/stripe_cards_controller.rb",
           "rendered": {
             "name": "stripe_cards/show",
@@ -196,6 +196,74 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
+      "fingerprint": "6a82c5e649d0b925f7f1d62680a6e2aa12392aa77c32b7018bc053bb8534d820",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/admin/wise_transfer_process.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((WiseTransfer.find(params[:id]).wise_url or \"https://wise.com/send\"), :class => \"btn btn-small bg-[#9FE870] text-[#163300] flex-shrink-0\", :style => \"color: #163300!important; background: #9FE870\", :target => \"_blank\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "AdminController",
+          "method": "wise_transfer_process",
+          "line": 722,
+          "file": "app/controllers/admin_controller.rb",
+          "rendered": {
+            "name": "admin/wise_transfer_process",
+            "file": "app/views/admin/wise_transfer_process.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/wise_transfer_process"
+      },
+      "user_input": "WiseTransfer.find(params[:id]).wise_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "`wise_url` is constructed from validated fields and uses `CGI.escape`"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "87bbf4eaa2f56dae12d31496998c846d8ede1769c79d11856fc01015d3feb757",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/admin/wise_transfer_process.html.erb",
+      "line": 83,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"view on Wise\", WiseTransfer.find(params[:id]).wise_recipient_url, :target => \"_blank\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "AdminController",
+          "method": "wise_transfer_process",
+          "line": 722,
+          "file": "app/controllers/admin_controller.rb",
+          "rendered": {
+            "name": "admin/wise_transfer_process",
+            "file": "app/views/admin/wise_transfer_process.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/wise_transfer_process"
+      },
+      "user_input": "WiseTransfer.find(params[:id]).wise_recipient_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "`wise_recipient_url` is constructed from validated fields and uses `CGI.escape`"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
       "fingerprint": "9b86435f32d34208ef6e6a8465f5374fe7fc9f978e36ef755363d14120b959f8",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
@@ -208,7 +276,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "google_workspace_process",
-          "line": 951,
+          "line": 982,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/google_workspace_process",
@@ -276,7 +344,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "invoice_process",
-          "line": 879,
+          "line": 910,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/invoice_process",
@@ -310,7 +378,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "invoice_process",
-          "line": 879,
+          "line": 910,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/invoice_process",
@@ -378,7 +446,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "google_workspace_process",
-          "line": 951,
+          "line": 982,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/google_workspace_process",
@@ -398,6 +466,6 @@
       "note": "Domain is validated to not have a javascript: url scheme & dns_check_url is injecting that domain in a https url"
     }
   ],
-  "updated": "2025-07-18 14:25:24 +0000",
+  "updated": "2025-08-07 17:03:40 -0400",
   "brakeman_version": "6.2.2"
 }

--- a/db/migrate/20250807184027_add_wise_recipient_id_to_wise_transfers.rb
+++ b/db/migrate/20250807184027_add_wise_recipient_id_to_wise_transfers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWiseRecipientIdToWiseTransfers < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:wise_transfers, :wise_recipient_id, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2025_08_08_033500) do
-
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_07_184027) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2378,6 +2378,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_222150) do
     t.text "return_reason"
     t.integer "quoted_usd_amount_cents"
     t.text "recipient_information_ciphertext"
+    t.text "wise_recipient_id"
     t.index ["event_id"], name: "index_wise_transfers_on_event_id"
     t.index ["user_id"], name: "index_wise_transfers_on_user_id"
   end


### PR DESCRIPTION
## Summary of the problem

We want to keep track of the Wise recipient ID when marking transfers as complete.

## Describe your changes

- Adds a `wise_recipient_id` column to the `wise_transfers` table (nomenclature comes from https://docs.wise.com/api-docs/api-reference/recipient#get)
- Adds validation and normalization for the `wise_recipient_id` field to the `WiseTransfer` model (similar to #11252)
- Adds a new field to the completion form
    <img width="1216" height="858" alt="CleanShot 2025-08-07 at 15 28 00@2x" src="https://github.com/user-attachments/assets/219cb64f-bd8e-4276-9843-ff697217dc22" />
- Adds a link to the recipient page when the ID is populated
    <img width="1066" height="222" alt="CleanShot 2025-08-07 at 15 36 46@2x" src="https://github.com/user-attachments/assets/884b0804-5378-4a39-a993-f070d9db7e3c" />