### PR TITLE
[Announcement] Fix saved scope not including draft announcements

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -58,7 +58,7 @@ class Announcement < ApplicationRecord
   scope :monthly_for, ->(date) { monthly.where("announcements.created_at BETWEEN ? AND ?", date.beginning_of_month, date.end_of_month) }
   validate :content_is_json
 
-  scope :saved, -> { where.not(aasm_state: :template_draft).where.not(content: {}).where.not(template_type: Announcement::Templates::Monthly.name, published_at: nil) }
+  scope :saved, -> { where.not(aasm_state: :template_draft).where.not(content: {}).and(where.not(template_type: Announcement::Templates::Monthly.name, published_at: nil).or(where(template_type: nil))) }
 
   belongs_to :author, class_name: "User"
   belongs_to :event


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Turns out the way SQL works is that comparisons with `null` just return `UNKNOWN` instead of true or false, which meant that #11229 accidentally hid announcements with `template_type = null`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added an explict or to make sure that those announcements are not excluded..

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

