### PR TITLE
Remove Venmo references from account numbers page

### DIFF
--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -63,7 +63,7 @@
       selected: local_assigns[:selected] == :invoices if policy(@event).invoices? %>
     <%= dock_item "Account numbers",
       account_number_event_path(@event),
-      tooltip: "Receive payouts from GoFundMe, Shopify, Venmo, and more",
+      tooltip: "Receive payouts from GoFundMe, Shopify, and more",
       icon: "bank-account",
       selected: local_assigns[:selected] == :account_number if policy(@event).account_number? && !Flipper.enabled?(:event_home_page_redesign_2024_09_21, @event) %>
     <%= dock_item "Check deposits",

--- a/app/views/events/account_number.html.erb
+++ b/app/views/events/account_number.html.erb
@@ -8,7 +8,7 @@
       <span class="flex items-center flex-grow">
         Account & routing number
       </span>
-      <h4 class="mt1 mb1 muted medium center">Connect your HCB account to GoFundMe, Shopify, Venmo, and more.</h4>
+      <h4 class="mt1 mb1 muted medium center">Connect your HCB account to GoFundMe, Shopify, and more.</h4>
     </div>
     <a href="#" data-behavior="modal_trigger" data-modal="ach_form" class="btn">
       <%= inline_icon "bank-account" %>
@@ -47,7 +47,7 @@
 <% else %>
   <h1 class="heading block center border-none">Account <span class="xs-hide">& routing</span> number</h1>
 
-  <h4 class="mt0 muted medium center mb3">Connect your HCB account to GoFundMe, Shopify, Venmo, and more.</h4>
+  <h4 class="mt0 muted medium center mb3">Connect your HCB account to GoFundMe, Shopify, and more.</h4>
 
   <hr>
 <% end %>
@@ -109,7 +109,7 @@
 
           <section class="card__banner card__darker border-top overflow-hidden info flex items-start" style="border-radius: 0 0 0.5rem 0.5rem">
             <%= inline_icon "info", class: "mr1", size: 24 %>
-            <p class="m0 left-align">You may need to tap "Verify bank manually" or similar when linking your account to apps like Venmo.</p>
+            <p class="m0 left-align">You may need to tap "Verify bank manually" or similar when linking your account to apps like Shopify.</p>
           </section>
         </div>
       <% else %>


### PR DESCRIPTION
## Summary of the problem

Our mentioning of Venmo is causing a lot of confusion as HCB accounts can't be used as payment method.

## Describe your changes

Remove references to Venmo (as requested by @leowilkin)