### PR TITLE
[Ledger] Allow admins to order transactions by mapped at

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -183,8 +183,7 @@ class EventsController < ApplicationController
 
     set_cacheable
 
-    @order = params[:order_by]
-    @order_by_mapped_at = @order == "mapped_at" && admin_signed_in?
+    @order_by = params[:order_by] || "date"
 
     @pending_transactions = _show_pending_transactions
     @all_transactions = TransactionGroupingEngine::Transaction::All.new(
@@ -199,7 +198,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
-      order_by_mapped_at: @order_by_mapped_at
+      order_by: @order_by.to_sym
     ).run
 
     if (@minimum_amount || @maximum_amount) && !organizer_signed_in?
@@ -1209,7 +1208,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
-      order_by_mapped_at: @order_by_mapped_at
+      order_by: @order_by.to_sym
     ).run
     PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions:, event: @event).run!
     pending_transactions

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -195,7 +195,8 @@ class EventsController < ApplicationController
       user: @user,
       start_date: @start_date,
       end_date: @end_date,
-      missing_receipts: @missing_receipts
+      missing_receipts: @missing_receipts,
+      order_by_mapped_at: true
     ).run
 
     if (@minimum_amount || @maximum_amount) && !organizer_signed_in?
@@ -1204,7 +1205,8 @@ class EventsController < ApplicationController
       user: @user,
       start_date: @start_date,
       end_date: @end_date,
-      missing_receipts: @missing_receipts
+      missing_receipts: @missing_receipts,
+      order_by_mapped_at: true
     ).run
     PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions:, event: @event).run!
     pending_transactions

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -183,7 +183,7 @@ class EventsController < ApplicationController
 
     set_cacheable
 
-    @order_by = params[:order_by] || "date"
+    @order_by = admin_signed_in? && params[:order_by] || "date"
 
     @pending_transactions = _show_pending_transactions
     @all_transactions = TransactionGroupingEngine::Transaction::All.new(

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -183,6 +183,9 @@ class EventsController < ApplicationController
 
     set_cacheable
 
+    @order = params[:order_by]
+    @order_by_mapped_at = @order == "mapped_at" && admin_signed_in?
+
     @pending_transactions = _show_pending_transactions
     @all_transactions = TransactionGroupingEngine::Transaction::All.new(
       event_id: @event.id,
@@ -196,7 +199,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
-      order_by_mapped_at: true
+      order_by_mapped_at: @order_by_mapped_at
     ).run
 
     if (@minimum_amount || @maximum_amount) && !organizer_signed_in?
@@ -1206,7 +1209,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
-      order_by_mapped_at: true
+      order_by_mapped_at: @order_by_mapped_at
     ).run
     PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions:, event: @event).run!
     pending_transactions

--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -3,7 +3,7 @@
 module PendingTransactionEngine
   module PendingTransaction
     class All
-      def initialize(event_id:, search: nil, tag_id: nil, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, revenue: false, expenses: false, user: nil, missing_receipts: false)
+      def initialize(event_id:, search: nil, tag_id: nil, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, revenue: false, expenses: false, user: nil, missing_receipts: false, order_by_mapped_at: false)
         @event_id = event_id
         @search = search
         @tag_id = tag_id&.to_i
@@ -15,6 +15,7 @@ module PendingTransactionEngine
         @expenses = expenses
         @user = user
         @missing_receipts = missing_receipts
+        @order_by_mapped_at = order_by_mapped_at
       end
 
       def run
@@ -36,11 +37,12 @@ module PendingTransactionEngine
           begin
             included_local_hcb_code_associations = [:receipts, :comments, :canonical_transactions, { canonical_pending_transactions: [:canonical_pending_declined_mapping] }]
             included_local_hcb_code_associations << :tags
-            cpts = CanonicalPendingTransaction.includes(:raw_pending_stripe_transaction,
-                                                        local_hcb_code: included_local_hcb_code_associations)
+            cpts = CanonicalPendingTransaction.includes([:raw_pending_stripe_transaction,
+                                                         @order_by_mapped_at ? :canonical_pending_event_mapping : nil,
+                                                         { local_hcb_code: included_local_hcb_code_associations }])
                                               .unsettled
                                               .where(id: canonical_pending_event_mappings.pluck(:canonical_pending_transaction_id))
-                                              .order("canonical_pending_transactions.date desc, canonical_pending_transactions.id desc")
+                                              .order("#{@order_by_mapped_at ? "canonical_pending_event_mappings.created_at" : "canonical_pending_transactions.date"} desc, canonical_pending_transactions.id desc")
 
             if @tag_id
               cpts =

--- a/app/services/transaction_grouping_engine/transaction/all.rb
+++ b/app/services/transaction_grouping_engine/transaction/all.rb
@@ -3,7 +3,7 @@
 module TransactionGroupingEngine
   module Transaction
     class All
-      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false, order_by_mapped_at: false)
+      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false, order_by: :date)
         @event_id = event_id
         @search = ActiveRecord::Base.sanitize_sql_like(search || "")
         @tag_id = tag_id&.to_i
@@ -15,7 +15,7 @@ module TransactionGroupingEngine
         @end_date = end_date&.to_datetime
         @user = user
         @missing_receipts = missing_receipts
-        @order_by_mapped_at = order_by_mapped_at
+        @order_by = order_by
       end
 
       def run
@@ -189,6 +189,8 @@ module TransactionGroupingEngine
       end
 
       def canonical_transactions_grouped_sql
+        order_by_mapped_at = @order_by == :mapped_at
+
         pt_group_sql = <<~SQL
           select
             array_agg(pt.id) as pt_ids
@@ -196,10 +198,10 @@ module TransactionGroupingEngine
             ,coalesce(pt.hcb_code, cast(pt.id as text)) as hcb_code
             ,sum(pt.amount_cents) as amount_cents
             ,sum(pt.amount_cents / 100.0)::float as amount
-            #{@order_by_mapped_at ? ",max(cpem.created_at) as mapped_at" : ""}
+            #{order_by_mapped_at ? ",max(cpem.created_at) as mapped_at" : ""}
           from
             canonical_pending_transactions pt
-          #{@order_by_mapped_at ? "left join canonical_pending_event_mappings cpem on cpem.canonical_pending_transaction_id = pt.id" : ""}
+          #{order_by_mapped_at ? "left join canonical_pending_event_mappings cpem on cpem.canonical_pending_transaction_id = pt.id" : ""}
           #{user_joins_for :pt}
           where
             fronted = true -- only included fronted pending transactions
@@ -244,10 +246,10 @@ module TransactionGroupingEngine
             ,coalesce(ct.hcb_code, cast(ct.id as text)) as hcb_code
             ,sum(ct.amount_cents) as amount_cents
             ,sum(ct.amount_cents / 100.0)::float as amount
-            #{@order_by_mapped_at ? ",max(cem.created_at) as mapped_at" : ""}
+            #{order_by_mapped_at ? ",max(cem.created_at) as mapped_at" : ""}
           from
             canonical_transactions ct
-          #{@order_by_mapped_at ? "left join canonical_event_mappings cem on cem.canonical_transaction_id = ct.id" : ""}
+          #{order_by_mapped_at ? "left join canonical_event_mappings cem on cem.canonical_transaction_id = ct.id" : ""}
           #{user_joins_for :ct}
           where
             ct.id in (
@@ -308,7 +310,7 @@ module TransactionGroupingEngine
             ,q1.hcb_code
             ,q1.amount_cents
             ,q1.amount::float
-            #{@order_by_mapped_at ? ",q1.mapped_at" : ""}
+            #{order_by_mapped_at ? ",q1.mapped_at" : ""}
             ,(#{date_select}) as date
             ,(#{canonical_pending_transaction_ids_select}) as canonical_pending_transaction_ids
             ,(#{canonical_pending_transactions_select}) as canonical_pending_transactions
@@ -319,7 +321,7 @@ module TransactionGroupingEngine
             #{ct_group_sql}
           ) q1
           #{modifiers}
-          order by #{@order_by_mapped_at ? "mapped_at" : "date"} desc, pt_ids[1] desc, ct_ids[1] desc
+          order by #{order_by_mapped_at ? "mapped_at" : "date"} desc, pt_ids[1] desc, ct_ids[1] desc
         SQL
 
         ActiveRecord::Base.sanitize_sql_array([q, { event_id: @event_id }])

--- a/app/services/transaction_grouping_engine/transaction/all.rb
+++ b/app/services/transaction_grouping_engine/transaction/all.rb
@@ -3,7 +3,7 @@
 module TransactionGroupingEngine
   module Transaction
     class All
-      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false)
+      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false, order_by_mapped_at: false)
         @event_id = event_id
         @search = ActiveRecord::Base.sanitize_sql_like(search || "")
         @tag_id = tag_id&.to_i
@@ -15,6 +15,7 @@ module TransactionGroupingEngine
         @end_date = end_date&.to_datetime
         @user = user
         @missing_receipts = missing_receipts
+        @order_by_mapped_at = order_by_mapped_at
       end
 
       def run
@@ -195,8 +196,10 @@ module TransactionGroupingEngine
             ,coalesce(pt.hcb_code, cast(pt.id as text)) as hcb_code
             ,sum(pt.amount_cents) as amount_cents
             ,sum(pt.amount_cents / 100.0)::float as amount
+            #{@order_by_mapped_at ? ",max(cpem.created_at) as mapped_at" : ""}
           from
             canonical_pending_transactions pt
+          #{@order_by_mapped_at ? "left join canonical_pending_event_mappings cpem on cpem.canonical_pending_transaction_id = pt.id" : ""}
           #{user_joins_for :pt}
           where
             fronted = true -- only included fronted pending transactions
@@ -241,8 +244,10 @@ module TransactionGroupingEngine
             ,coalesce(ct.hcb_code, cast(ct.id as text)) as hcb_code
             ,sum(ct.amount_cents) as amount_cents
             ,sum(ct.amount_cents / 100.0)::float as amount
+            #{@order_by_mapped_at ? ",max(cem.created_at) as mapped_at" : ""}
           from
             canonical_transactions ct
+          #{@order_by_mapped_at ? "left join canonical_event_mappings cem on cem.canonical_transaction_id = ct.id" : ""}
           #{user_joins_for :ct}
           where
             ct.id in (
@@ -303,6 +308,7 @@ module TransactionGroupingEngine
             ,q1.hcb_code
             ,q1.amount_cents
             ,q1.amount::float
+            #{@order_by_mapped_at ? ",q1.mapped_at" : ""}
             ,(#{date_select}) as date
             ,(#{canonical_pending_transaction_ids_select}) as canonical_pending_transaction_ids
             ,(#{canonical_pending_transactions_select}) as canonical_pending_transactions
@@ -313,7 +319,7 @@ module TransactionGroupingEngine
             #{ct_group_sql}
           ) q1
           #{modifiers}
-          order by date desc, pt_ids[1] desc, ct_ids[1] desc
+          order by #{@order_by_mapped_at ? "mapped_at" : "date"} desc, pt_ids[1] desc, ct_ids[1] desc
         SQL
 
         ActiveRecord::Base.sanitize_sql_array([q, { event_id: @event_id }])

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -29,6 +29,27 @@
     </div>
   <% end %>
 
+  <% admin_tool "overflow-hidden" do %>
+    <div data-controller="menu" data-menu-placement-value="bottom-end">
+      <button
+        type="button"
+        class="pop menu__toggle menu__toggle--arrowless overflow-visible"
+        data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown"
+        data-menu-target="toggle">
+        <%= inline_icon "list", size: 28 %>
+      </button>
+      <div class="menu__content menu__content--2 menu__content--compact h5" data-menu-target="content">
+        <% ["date", "mapped_at"].each do |order| %>
+          <div class="flex items-center">
+            <%= link_to(upsert_query_params(order_by: order), class: "flex-auto menu__action #{"menu__action--active" if @order == order}", data: { turbo_prefetch: "false" }) do %>
+              <%= order.humanize %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <% if organizer_signed_in? && @event.tags.size > 0 %>
     <div
       data-controller="menu"

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -39,10 +39,10 @@
         <%= inline_icon "list", size: 28 %>
       </button>
       <div class="menu__content menu__content--2 menu__content--compact h5" data-menu-target="content">
-        <% ["date", "mapped_at"].each do |order| %>
+        <% ["date", "mapped_at"].each do |order_by| %>
           <div class="flex items-center">
-            <%= link_to(upsert_query_params(order_by: order), class: "flex-auto menu__action #{"menu__action--active" if @order == order}", data: { turbo_prefetch: "false" }) do %>
-              <%= order.humanize %>
+            <%= link_to(upsert_query_params(order_by:), class: "flex-auto menu__action #{"menu__action--active" if @order_by == order_by}", data: { turbo_prefetch: "false" }) do %>
+              <%= order_by.humanize %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It'd be useful for admins to be able to order transactions by the date they were mapped at instead of the transaction date.

Closes #9118 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Modified `TransactionGroupingEngine::Transaction::All` and `PendingTransactionEngine::PendingTransaction::All` to take in an `order_by` parameter that orders transactions by the date they were mapped when `order_by == :mapped_at`, and adds a new admin tool to the ledger filter bar that allows admins to change the order method used.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="1914" height="1042" alt="image" src="https://github.com/user-attachments/assets/26d249ac-a1c1-4476-b391-c8d711e21fcf" />

