### PR TITLE
Fix for `ActiveRecord::PreparedStatementInvalid` when `search` contains placeholders

### DIFF
--- a/spec/services/transaction_grouping_engine/transaction/all_spec.rb
+++ b/spec/services/transaction_grouping_engine/transaction/all_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransactionGroupingEngine::Transaction::All do
+  describe "#run" do
+    it "returns an empty array if there are no transactions" do
+      event = create(:event)
+
+      expect(described_class.new(event_id: event.id).run).to be_empty
+    end
+
+    it "returns transactions for the given event" do
+      events = create_list(:event, 2)
+
+      events.each do |event|
+        ["transaction_1", "transaction_2"].each do |memo|
+          create(
+            :canonical_event_mapping,
+            event: event,
+            canonical_transaction: create(:canonical_transaction, memo:)
+          )
+        end
+      end
+
+      results = described_class.new(event_id: events.first.id).run
+      expect(results.size).to eq(2)
+      expect(results.map(&:event)).to all(eq(events.first))
+      expect(results.map(&:memo)).to contain_exactly("TRANSACTION_1", "TRANSACTION_2")
+    end
+
+    it "allows filtering by memo" do
+      event = create(:event)
+
+      snack = create(
+        :canonical_transaction,
+        memo: "SHELBURNE MARKET",
+        custom_memo: "Snacks at Shelburne Market"
+      )
+      create(:canonical_event_mapping, event: event, canonical_transaction: snack)
+
+      sharks = create(
+        :canonical_transaction,
+        memo: "IKEA 111111111",
+        custom_memo: "A shiver of Blåhaj"
+      )
+      create(:canonical_event_mapping, event: event, canonical_transaction: sharks)
+
+      ["snAck", "mARKet"].each do |search|
+        result = described_class.new(event_id: event.id, search:).all.sole
+        expect(JSON.parse(result.raw_canonical_transaction_ids)).to contain_exactly(snack.id)
+      end
+
+      ["shiver", "IKEA"].each do |search|
+        result = described_class.new(event_id: event.id, search:).all.sole
+        expect(JSON.parse(result.raw_canonical_transaction_ids)).to contain_exactly(sharks.id)
+      end
+    end
+
+    it "escapes the search string" do
+      event = create(:event)
+
+      transaction = create(
+        :canonical_transaction,
+        memo: "; DROP TABLE",
+        custom_memo: "%%%LOL%%%:oops ?"
+      )
+      create(:canonical_event_mapping, event: event, canonical_transaction: transaction)
+
+      [":oops ?", "%%%lol"].each do |search|
+        result = described_class.new(event_id: event.id, search: ":oops ?").all.sole
+        expect(JSON.parse(result.raw_canonical_transaction_ids)).to contain_exactly(transaction.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Internal thread: https://hackclub.slack.com/archives/C047Y01MHJQ/p1754599349421249
Exception: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2117/samples/timestamp/2025-08-07T20:40:51Z

We are hitting a `ActiveRecord::PreparedStatementInvalid` error when `search` contains something that looks like [a placeholder](https://guides.rubyonrails.org/active_record_querying.html#placeholder-conditions) (e.g. `:pdf`).

This is because 
1. The value of `search` is first interpolated into an SQL fragment using `ActiveRecord::Base.sanitize_sql_array` in `search_modifier_for`: https://github.com/hackclub/hcb/blob/37873c40617cf6b30b3c9c621d38cc639d698bcc/app/services/transaction_grouping_engine/transaction/all.rb#L86-L96
2. This SQL fragment is then interpolated into a larger fragment in `canonical_transactions_grouped_sql`: https://github.com/hackclub/hcb/blob/37873c40617cf6b30b3c9c621d38cc639d698bcc/app/services/transaction_grouping_engine/transaction/all.rb#L231 https://github.com/hackclub/hcb/blob/37873c40617cf6b30b3c9c621d38cc639d698bcc/app/services/transaction_grouping_engine/transaction/all.rb#L257
3. (2), along with several other fragments are combined into a single query which is then passed through `ActiveRecord::Base.sanitize_sql_array` to interpolate in `@event_id`: https://github.com/hackclub/hcb/blob/37873c40617cf6b30b3c9c621d38cc639d698bcc/app/services/transaction_grouping_engine/transaction/all.rb#L319

This means that a `:foo` in `@search` is added in (2) but subsequently treated as a placeholder in (3)

Simplified example:
<img width="932" height="760" alt="CleanShot 2025-08-08 at 13 37 26" src="https://github.com/user-attachments/assets/1b7857f3-c513-40ad-a698-bb84ce5cf7ea" />


## Describe your changes

- Adds some really basic test coverage to make sure 
    - the SQL query is at least run
    - the search functionality works
    - escaping is working correctly (or at least enough to solve this issue)
        Test is able to reproduce this failure on the existing code: 
        <img width="1522" height="973" alt="CleanShot 2025-08-08 at 13 20 05" src="https://github.com/user-attachments/assets/e2c1ac65-8016-4a74-bec8-b30c52fdbd32" />

    
- Replaced second call to `sanitize_sql_array` with interpolated calls to `sanitize_sql_for_conditions` for `@event_id`