### PR TITLE
Fix the amount and date filters on the transactions page

### DIFF
--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -101,7 +101,7 @@
           <%= avatar_for @user, size: 18 %>
           <%= @user.name %>
 
-          <%= link_to event_ledger_url(@event, upsert_query_params(user: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(user: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>
@@ -109,7 +109,7 @@
       <% if @type %>
         <div class="badge badge-large bg-muted">
           <%= @type.humanize.gsub("Ach", "ACH").gsub("Paypal", "PayPal").gsub("Hcb", "HCB") %>
-          <%= link_to event_ledger_url(@event, upsert_query_params(type: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(type: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>
@@ -117,7 +117,7 @@
       <% if @direction %>
         <div class="badge badge-large bg-muted">
           <%= @direction.humanize.gsub("In", "Incoming").gsub("Out", "Outgoing") %>
-          <%= link_to event_ledger_url(@event, upsert_query_params(direction: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(direction: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>
@@ -129,7 +129,7 @@
           <%= @end_date && @start_date ? " and " : "" %>
           <%= @end_date&.to_datetime&.strftime("%m/%d/%Y") || "" %>
 
-          <%= link_to event_ledger_url(@event, upsert_query_params(start: nil, end: nil, commit: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(start: nil, end: nil, commit: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>
@@ -141,7 +141,7 @@
           <%= @minimum_amount && @maximum_amount ? " and " : "" %>
           <%= render_money @maximum_amount if @maximum_amount %>
 
-          <%= link_to event_ledger_url(@event, upsert_query_params(minimum_amount: nil, maximum_amount: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(minimum_amount: nil, maximum_amount: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>
@@ -149,7 +149,7 @@
       <% if @missing_receipts %>
         <div class="badge badge-large bg-muted">
           Missing receipts
-          <%= link_to event_ledger_url(@event, upsert_query_params(missing_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(missing_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -67,7 +67,7 @@
       <div class="menu__content menu__content--2 menu__content--compact h5" data-menu-target="content">
         <% [10, 25, 50, 100, 200].each do |amount| %>
           <div class="flex items-center">
-            <%= link_to(upsert_query_params(per: amount), class: "flex-auto menu__action", data: { turbo_prefetch: "false" }) do %>
+            <%= link_to(event_ledger_path(@event, upsert_query_params(per: amount)), class: "flex-auto menu__action", data: { turbo_prefetch: "false" }) do %>
               <%= amount %> Transactions Per Page
             <% end %>
           </div>
@@ -81,7 +81,7 @@
   <div class="flex items-center filter-menu">
     <%= render partial: "filter_menu" %>
 
-    <%= link_to nil, class: "-ml-2 pop muted tooltipped tooltipped--s", aria: { label: "Clear filters" }, data: { turbo_prefetch: "false" } do %>
+    <%= link_to event_ledger_path(@event), class: "-ml-2 pop muted tooltipped tooltipped--s", aria: { label: "Clear filters" }, data: { turbo_prefetch: "false" } do %>
       <%= inline_icon "view-close", size: 28 %>
     <% end %>
 
@@ -91,7 +91,7 @@
           <%= render partial: "canonical_transactions/tag_icon", locals: { tag: @tag } %>
           <%= @tag.label %>
 
-          <%= link_to event_ledger_url(@event, upsert_query_params(tag: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+          <%= link_to event_ledger_path(@event, upsert_query_params(tag: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -116,7 +116,7 @@
           <%= link_to("Missing receipts", event_ledger_path(@event, upsert_query_params(missing_receipts: true)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
         </div>
         <div>
-          <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params("missing_receipts" => nil)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params(missing_receipts: nil)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
         </div>
       </div>
     </div>

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -1,4 +1,6 @@
-<div data-controller="menu" data-menu-append-to-value="turbo-frame#ledger" data-menu-placement-value="bottom-start">
+<% ledger_turbo_frame_id = "#{dom_id(@event)}_ledger" %>
+
+<div data-controller="menu" data-menu-append-to-value="turbo-frame#<%= ledger_turbo_frame_id %>" data-menu-placement-value="bottom-start">
   <button
     type="button"
     aria-label="Add filter..."

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -24,7 +24,7 @@
         <div data-tabs-target="tab" id="tags">
           <% @event.tags.order(label: :asc).each do |tag| %>
             <div class="flex items-center" data-tag="<%= tag.id %>">
-              <%= link_to(upsert_query_params(tag: tag.label), class: "flex-auto menu__action #{"menu__action--active" if @tag == tag}", data: { turbo_prefetch: "false" }) do %>
+              <%= link_to(event_ledger_path(@event, upsert_query_params(tag: tag.label)), class: "flex-auto menu__action #{"menu__action--active" if @tag == tag}", data: { turbo_prefetch: "false" }) do %>
                 <%= render partial: "canonical_transactions/tag_icon", locals: { tag: } %>
                 <%= tag.label %>
               <% end %>
@@ -35,7 +35,7 @@
       <div data-tabs-target="tab" id="user">
         <% @organizers.each do |position| %>
           <div class="flex items-center">
-            <%= link_to(upsert_query_params(user: position.user.friendly_id), class: "flex-auto flex items-center menu__action #{"menu__action--active" if @user&.friendly_id == position.user.friendly_id}", data: { turbo_prefetch: "false" }) do %>
+            <%= link_to(event_ledger_path(@event, upsert_query_params(user: position.user.friendly_id)), class: "flex-auto flex items-center menu__action #{"menu__action--active" if @user&.friendly_id == position.user.friendly_id}", data: { turbo_prefetch: "false" }) do %>
               <div class="avatar-grow line-height-0 mr1">
                 <%= avatar_for position.user, size: 18 %>
               </div>
@@ -47,7 +47,7 @@
       <div data-tabs-target="tab" id="type">
         <% ["ach_transfer", "card_charge", "check_deposit", "donation", "fiscal_sponsorship_fee", "hcb_transfer", "invoice", "mailed_check", "paypal_transfer", "refund", "reimbursement", "wire"].each do |type| %>
           <div class="flex items-center">
-            <%= link_to(upsert_query_params(type:), class: "flex-auto menu__action #{"menu__action--active" if @type == type}", data: { turbo_prefetch: "false" }) do %>
+            <%= link_to(event_ledger_path(@event, upsert_query_params(type:)), class: "flex-auto menu__action #{"menu__action--active" if @type == type}", data: { turbo_prefetch: "false" }) do %>
               <%= type.humanize.gsub("Ach", "ACH").gsub("Paypal", "PayPal").gsub("Hcb", "HCB") %>
             <% end %>
           </div>
@@ -99,13 +99,13 @@
           </div>
           <% ["expenses", "revenue"].each do |direction| %>
             <div class="flex items-center">
-              <%= link_to(upsert_query_params(direction:), class: "flex-auto menu__action #{"menu__action--active" if @direction == direction}", data: { turbo_prefetch: "false" }) do %>
+              <%= link_to(event_ledger_path(@event, upsert_query_params(direction:)), class: "flex-auto menu__action #{"menu__action--active" if @direction == direction}", data: { turbo_prefetch: "false" }) do %>
                 <%= direction.humanize %>
               <% end %>
             </div>
           <% end %>
           <div class="flex items-center">
-            <%= link_to(upsert_query_params(direction: nil), class: "flex-auto menu__action #{"menu__action--active" unless @direction}", data: { turbo_prefetch: "false" }) do %>
+            <%= link_to(event_ledger_path(@event, upsert_query_params(direction: nil)), class: "flex-auto menu__action #{"menu__action--active" unless @direction}", data: { turbo_prefetch: "false" }) do %>
              Both
             <% end %>
           </div>
@@ -113,10 +113,10 @@
       </div>
       <div data-tabs-target="tab" id="receipts">
         <div class="flex items-center">
-          <%= link_to("Missing receipts", upsert_query_params(missing_receipts: true), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          <%= link_to("Missing receipts", event_ledger_path(@event, upsert_query_params(missing_receipts: true)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
         </div>
         <div>
-          <%= link_to("All transactions", upsert_query_params("missing_receipts" => nil), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params("missing_receipts" => nil)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
         </div>
       </div>
     </div>

--- a/app/views/events/transactions.html.erb
+++ b/app/views/events/transactions.html.erb
@@ -141,7 +141,7 @@
 
   <%= render "pinned_transactions" %>
 
-  <%= turbo_frame_tag [dom_id(@event), :ledger], src: event_ledger_path(@event, **params.to_unsafe_h) do %>
+  <%= turbo_frame_tag [dom_id(@event), :ledger], src: event_ledger_path(@event, request.query_parameters) do %>
     <%= render partial: "filter" %>
 
     <%= render "application/loading_container", klass: "mt-8" %>


### PR DESCRIPTION
Fixes https://github.com/hackclub/hcb/issues/11263

## Summary of the problem

### Context

- The transaction page uses a turbo frame to lazy load the ledger: https://github.com/hackclub/hcb/blob/bf8c2791596a5d502be1b8d12046490445f3c110/app/views/events/transactions.html.erb#L144-L148
- The contents of the turbo frame are rendered by the `.../ledger` endpoint (note that these contain the filters as well): https://github.com/hackclub/hcb/blob/6e1deab06a36ee580aedc5b5abd8b4ed4a64b7b7/app/views/events/ledger.html.erb#L2-L3
- The filters are a mix of links https://github.com/hackclub/hcb/blob/2abe39a5cde4869372dc8d4edbc302019753c6e5/app/views/events/_filter_menu.html.erb#L50-L52 and forms https://github.com/hackclub/hcb/blob/2abe39a5cde4869372dc8d4edbc302019753c6e5/app/views/events/_filter_menu.html.erb#L57-L61
- When the user clicks on the filter icon, these filter options are rendered inside of a menu https://github.com/hackclub/hcb/blob/d84dbbac2d29d75362b7172df841cb4458e763bc/app/views/events/_filter_menu.html.erb#L1

### Where this went wrong

1. Our menu component supports a `data-menu-append-to-value` attribute which determines where the DOM for the menu is rendered. This was configured in this case but pointed to an ID that did not exist (`turbo-frame#ledger`), which meant the menu was being appended outside of the `<turbo-frame>` element.
2. This meant that when one of the filter forms was submitted, turbo treated this as a full page visit to the `.../ledger` endpoint, and when the response didn't include the full page structure it bailed and issued a full page reload of that URL (likely because of the behaviour described in https://turbo.hotwired.dev/handbook/drive#reloading-when-assets-change)

## Describe your changes

- Fixes the `data-menu-append-to-value` attribute.
- Scopes the params passed to the ledger turbo frame to just `request.query_parameters` instead of all of `params` as that led to `action` and `controller` being set which caused havoc with all the `link_to(upsert_query_params...` calls we had
- Uses explicit paths in all `link_to`s 