### PR TITLE
Handle locked accounts gracefully

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -171,6 +171,8 @@ class LoginsController < ApplicationController
         redirect_to choose_login_preference_login_path(@login, return_to: @return_to), status: :temporary_redirect
       end
     end
+  rescue SessionsHelper::AccountLockedError => e
+    redirect_to(auth_users_path, flash: { error: e.message })
   end
 
   def reauthenticate

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -14,6 +14,8 @@ module SessionsHelper
   # sessions
   IMPERSONATED_SESSION_DURATION = SESSION_DURATION_OPTIONS.fetch("1 hour")
 
+  class AccountLockedError < StandardError; end
+
   def impersonate_user(user)
     sign_out
     sign_in(user:, impersonate: true)
@@ -50,6 +52,8 @@ module SessionsHelper
 
     if impersonate
       user_session.impersonated_by = current_user
+    else
+      raise(AccountLockedError, "Your HCB account has been locked.") if user.locked?
     end
 
     user_session.save!

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -423,6 +423,25 @@ RSpec.describe LoginsController do
 
       expect(response).to redirect_to(edit_user_path(user.slug))
     end
+
+    it "redirects to the auth page with a flash message if the user's account is locked" do
+      user = create(:user)
+      user.lock!
+      login = create(:login, user:)
+      login_code = create(:login_code, user:)
+
+      post(
+        :complete,
+        params: {
+          id: login.hashid,
+          method: "login_code",
+          login_code: login_code.code
+        }
+      )
+
+      expect(flash[:error]).to eq("Your HCB account has been locked.")
+      expect(response).to redirect_to(auth_users_path)
+    end
   end
 
   describe "#reauthenticate" do


### PR DESCRIPTION
## Summary of the problem

When we try to create a session for a locked user https://github.com/hackclub/hcb/blob/21ec8d158f5d4ba52f4e7d780124dd01a26e611b/app/helpers/sessions_helper.rb#L55 we end up hitting a validation error https://github.com/hackclub/hcb/blob/a4b1cf68ea7847c7e8c6ed7df12c166c1f866f3c/app/models/user_session.rb#L115-L119 which goes unhandled (https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2036)

## Describe your changes

- Checks whether the user is locked in `SessionsHelper#sign_in` and throws `AccountLockedError`
- Adds handling for `AccountLockedError` in `LoginsController#complete`
- Adds tests to make sure
  - We correctly redirect users
  - We still allow admins to impersonate locked users