### PR TITLE
[V4 API] Add expense payout transaction type

### DIFF
--- a/app/views/api/v4/transactions/_expense_payout.json.jbuilder
+++ b/app/views/api/v4/transactions/_expense_payout.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.report_id expense_payout.expense.report.public_id

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -30,14 +30,15 @@ if current_user&.auditor?
 end
 
 if policy(hcb_code).show?
-  json.card_charge   { json.partial! "api/v4/transactions/card_charge",   hcb_code:                               } if hcb_code.stripe_card? || hcb_code.stripe_force_capture?
-  json.donation      { json.partial! "api/v4/transactions/donation",      donation:     hcb_code.donation         } if hcb_code.donation?
-  json.invoice       { json.partial! "api/v4/transactions/invoice",       invoice:      hcb_code.invoice          } if hcb_code.invoice?
-  json.check         { json.partial! "api/v4/transactions/check",         check:        hcb_code.check            } if hcb_code.check?
-  json.check         { json.partial! "api/v4/transactions/check",         check:        hcb_code.increase_check   } if hcb_code.increase_check?
-  json.transfer      { json.partial! "api/v4/transactions/disbursement",  disbursement: hcb_code.disbursement     } if hcb_code.disbursement?
-  json.ach_transfer  { json.partial! "api/v4/transactions/ach_transfer",  ach_transfer: hcb_code.ach_transfer     } if hcb_code.ach_transfer?
-  json.check_deposit { json.partial! "api/v4/transactions/check_deposit", check_deposit: hcb_code.check_deposit   } if hcb_code.check_deposit?
+  json.card_charge    { json.partial! "api/v4/transactions/card_charge",    hcb_code:                                             } if hcb_code.stripe_card? || hcb_code.stripe_force_capture?
+  json.donation       { json.partial! "api/v4/transactions/donation",       donation:       hcb_code.donation                     } if hcb_code.donation?
+  json.expense_payout { json.partial! "api/v4/transactions/expense_payout", expense_payout: hcb_code.reimbursement_expense_payout } if hcb_code.reimbursement_expense_payout?
+  json.invoice        { json.partial! "api/v4/transactions/invoice",        invoice:        hcb_code.invoice                      } if hcb_code.invoice?
+  json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.check                        } if hcb_code.check?
+  json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.increase_check               } if hcb_code.increase_check?
+  json.transfer       { json.partial! "api/v4/transactions/disbursement",   disbursement:   hcb_code.disbursement                 } if hcb_code.disbursement?
+  json.ach_transfer   { json.partial! "api/v4/transactions/ach_transfer",   ach_transfer:   hcb_code.ach_transfer                 } if hcb_code.ach_transfer?
+  json.check_deposit  { json.partial! "api/v4/transactions/check_deposit",  check_deposit:  hcb_code.check_deposit                } if hcb_code.check_deposit?
 end
 
 json.organization hcb_code.event, partial: "api/v4/events/event", as: :event if expand?(:organization)


### PR DESCRIPTION
This adds the expense payout transaction type so we can link to the associated report from the mobile app.

> [!IMPORTANT]  
> Should we add other expense fields to the expense payout view created here or should we wait until there is a thorough reimbursement API and just return those fields from that?