### PR TITLE
[My Reimbursements] Hide reports you can't review

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -129,7 +129,10 @@ class MyController < ApplicationController
 
   def reimbursements
     my_reports = current_user.reimbursement_reports
-    reports_to_review = Reimbursement::Report.submitted.where(event: current_user.events, reviewer_id: nil).or(current_user.assigned_reimbursement_reports.submitted)
+    manager_events = current_user.events
+                                 .joins(:organizer_positions)
+                                 .where(organizer_positions: { user_id: current_user.id, role: :manager })
+    reports_to_review = Reimbursement::Report.submitted.where(event: manager_events, reviewer_id: nil).or(current_user.assigned_reimbursement_reports.submitted)
     case params[:filter]
     when "mine"
       @reports = my_reports

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -147,6 +147,7 @@ class MyController < ApplicationController
     @payout_method = current_user.payout_method
   end
 
+  # this doesn't match up to the # of reimbursements on the my/reimbursements page; should it?
   def reimbursements_icon
     @draft_reimbursements_count = current_user.reimbursement_reports.draft.count
     @review_requested_reimbursements_count = current_user.assigned_reimbursement_reports.submitted.count

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -147,7 +147,6 @@ class MyController < ApplicationController
     @payout_method = current_user.payout_method
   end
 
-  # this doesn't match up to the # of reimbursements on the my/reimbursements page; should it?
   def reimbursements_icon
     @draft_reimbursements_count = current_user.reimbursement_reports.draft.count
     @review_requested_reimbursements_count = current_user.assigned_reimbursement_reports.submitted.count


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Before it was showing all pending reports for events you were in that did not have a review assigned.

> [!IMPORTANT]
> The reimbursements icon counter doesn't match up to the number of reimbursements on the my/reimbursements page; should it?

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Now it only checks events you are a manager in becuase you must be a manager to review.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

