### PR TITLE
Report `deprecation.rails` ActiveSupport::Notifications to AppSignal

### DIFF
--- a/config/initializers/deprecation_warnings.rb
+++ b/config/initializers/deprecation_warnings.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-ActiveSupport::Notifications.subscribe('deprecation.rails') do |_name, _start, _finish, _id, payload|
+ActiveSupport::Notifications.subscribe("deprecation.rails") do |_name, _start, _finish, _id, payload|
   message = payload[:message]
   callstack = payload[:callstack]
   deprecation_horizon = payload[:deprecation_horizon]
-  gem_name = payload[:gem_name] || 'rails'
+  gem_name = payload[:gem_name] || "rails"
 
-  # there doesn't seem to be a great way to get controller#action here without some more ceremony
-  # so hopefully just the controller and stacktrace will be enough for us to narrow down any issues.
-  class_name = "#{Thread.current[:public_activity_controller]&.class}"
+  execution_context = ActiveSupport::ExecutionContext.to_h
+  appsignal_action = (execution_context[:controller] || execution_context[:job]).class.to_s
+  if execution_context[:controller]
+    appsignal_action += "##{execution_context[:controller].action_name}"
+  end
 
   Appsignal.report_error(ActiveSupport::DeprecationException.new(message)) do
     Appsignal.set_namespace("deprecation.rails")
-    Appsignal.set_action(class_name)
+    Appsignal.set_action(appsignal_action)
     Appsignal.add_tags(
       deprecation: true,
       gem: gem_name,

--- a/config/initializers/deprecation_warnings.rb
+++ b/config/initializers/deprecation_warnings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+ActiveSupport::Notifications.subscribe('deprecation.rails') do |_name, _start, _finish, _id, payload|
+  message = payload[:message]
+  callstack = payload[:callstack]
+  deprecation_horizon = payload[:deprecation_horizon]
+  gem_name = payload[:gem_name] || 'rails'
+
+  # there doesn't seem to be a great way to get controller#action here without some more ceremony
+  # so hopefully just the controller and stacktrace will be enough for us to narrow down any issues.
+  class_name = "#{Thread.current[:public_activity_controller]&.class}"
+
+  Appsignal.report_error(ActiveSupport::DeprecationException.new(message)) do
+    Appsignal.set_namespace("deprecation.rails")
+    Appsignal.set_action(class_name)
+    Appsignal.add_tags(
+      deprecation: true,
+      gem: gem_name,
+      horizon: deprecation_horizon
+    )
+    Appsignal.add_custom_data(
+      deprecation_message: message,
+      callstack: callstack
+    )
+  end
+end


### PR DESCRIPTION
## Summary of the problem

We don't have much visibility into Rails deprecations in prod or a test suite

## Describe your changes

HCB's setting for deprecations in production is notify
https://github.com/hackclub/hcb/blob/fd60bc13b0fe081f7e1da8cd4d0fa98ee2f21990/config/environments/production.rb#L115-L116

We can listen for these notifications and report them to AppSignal for
visibility. See https://www.fastruby.io/blog/rails/upgrades/deprecation-warnings-rails-guide.html for more details.

I think we should merge this soon so we can start collecting Rails 8
deprecations, then merge more of https://github.com/hackclub/hcb/pull/10836 piecemeal to see if the deprecations resolve.

To test locally, I changed the configuration to `:notify`, set a real AppSignal credential and ran this in a rails console
```
ActiveRecord::Base.connection_pool.connection
```
This reported the following warning to AppSignal

```
DEPRECATION WARNING: ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
and will be removed in Rails 8.0. Use #lease_connection instead.
```

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2122
