### PR TITLE
[Receipt Bin] Use `Mail#recipients` instead of `.to.first`

### DIFF
--- a/app/mailboxes/receipt_bin_mailbox.rb
+++ b/app/mailboxes/receipt_bin_mailbox.rb
@@ -34,11 +34,19 @@ class ReceiptBinMailbox < ApplicationMailbox
 
   private
 
+  RECEIPTS_ADDRESSES = ["receipts@hackclub.com", "receipts@hcb.gg"].freeze
+
   def set_user
-    if mail.to.first.start_with?("receipts@")
+    if mail.recipients.any? { |addr| RECEIPTS_ADDRESSES.include?(addr) }
       @user = User.find_by(email: mail.from[0])
     else
-      @user = MailboxAddress.activated.find_by(address: mail.to.first)&.user
+      @user =
+        MailboxAddress
+        .activated
+        .where(address: mail.recipients)
+        .order(id: desc)
+        .first
+        &.user
     end
   end
 


### PR DESCRIPTION
## Summary of the problem

- https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/539/samples/timestamp/2025-08-08T19:06:02Z
- https://hackclub.slack.com/archives/C096P73LEMT/p1754679998405029

`mail.to.first` isn't always present (e.g. when we are BCCed) which can cause errors in production.

## Describe your changes

Use `Mail#recipients` (https://api.rubyonrails.org/classes/Mail/Message.html#method-i-recipients) to handle more scenarios
