### PR TITLE
[Loops] Clean-up Faraday usage (take 2)

### DIFF
--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -56,30 +56,18 @@ module UserService
 
     def contact_details
       @queue.shift
-      conn = Faraday.new(url: "https://app.loops.so/")
 
-      resp = conn.send(:get) do |req|
-        req.url("api/v1/contacts/find")
-        req.headers["Authorization"] = "Bearer #{Credentials.fetch(:LOOPS)}"
-        req.params[:email] = @user.email
-      end
+      # https://loops.so/docs/api-reference/find-contact
+      resp = loops_client.get("api/v1/contacts/find", { email: @user.email })
 
-      return nil if resp.body.strip == "[]"
-
-      JSON[resp.body][0]
+      resp.body.first
     end
 
     def update(body:)
       @queue.shift
-      conn = Faraday.new(url: "https://app.loops.so/")
 
-      conn.send(:post) do |req|
-        req.url("api/v1/contacts/update")
-        req.body = body.to_json
-        req.headers["Content-Type"] = "application/json"
-        req.headers["Authorization"] = "Bearer #{Credentials.fetch(:LOOPS)}"
-      end
-
+      # https://loops.so/docs/api-reference/update-contact
+      loops_client.post("api/v1/contacts/update", body)
     end
 
     def format_unix(timestamp)
@@ -92,6 +80,15 @@ module UserService
       @contact_details&.[]("addressLine1").present? &&
         @contact_details["addressCity"].present? &&
         @contact_details["addressCountry"].present?
+    end
+
+    def loops_client
+      @loops_client ||= Faraday.new(url: "https://loops.so/") do |c|
+        c.request :authorization, "Bearer", -> { Credentials.fetch(:LOOPS) }
+        c.request :json
+        c.response :json
+        c.response :raise_error
+      end
     end
 
   end

--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -61,6 +61,8 @@ module UserService
       resp = loops_client.get("api/v1/contacts/find", { email: @user.email })
 
       resp.body.first
+    rescue Faraday::ResourceNotFound
+      nil
     end
 
     def update(body:)


### PR DESCRIPTION
## Summary of the problem

1. In https://github.com/hackclub/hcb/pull/11237 I centralized `SyncWithLoops`'s `Faraday` instance and added the `:raise_errors` middleware so we'd get exceptions when things went wrong
2. I subsequently noticed this was causing issues in production so undid my changes in #11291 
3. After digging a bit more I realized that 404s were to be expected from this endpoint and that this was previously handled by `return nil if resp.body.strip == "[]"`
    https://loops.so/docs/api-reference/find-contact
    <img width="992" height="244" alt="CleanShot 2025-08-11 at 11 39 41@2x" src="https://github.com/user-attachments/assets/11d30b1d-47ce-4482-ac2f-6326914ecb71" />

## Describe your changes

Added a `rescue` block for `Faraday::ResourceNotFound` that just returns `nil`