### PR TITLE
[AppSignal] Ignore `ActionController::RoutingError`

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -4,15 +4,15 @@ default: &defaults
   push_api_key: <%= Credentials.fetch(:APPSIGNAL) %>
 
   ignore_errors:
+    - ActionController::BadRequest
+    - ActionController::InvalidAuthenticityToken
+    - ActionController::InvalidCrossOriginRequest
+    - ActionController::MethodNotAllowed
+    - ActionController::ParameterMissing
+    - ActionController::UnknownFormat
+    - ActionController::UnknownHttpMethod
     - ActionDispatch::Http::MimeNegotiation::InvalidType
     - ActionDispatch::Http::Parameters::ParseError
-    - ActionController::BadRequest
-    - ActionController::UnknownHttpMethod
-    - ActionController::MethodNotAllowed
-    - ActionController::UnknownFormat
-    - ActionController::ParameterMissing
-    - ActionController::InvalidCrossOriginRequest
-    - ActionController::InvalidAuthenticityToken
     - ActiveRecord::RecordNotFound
 
 production:

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -9,6 +9,7 @@ default: &defaults
     - ActionController::InvalidCrossOriginRequest
     - ActionController::MethodNotAllowed
     - ActionController::ParameterMissing
+    - ActionController::RoutingError
     - ActionController::UnknownFormat
     - ActionController::UnknownHttpMethod
     - ActionDispatch::Http::MimeNegotiation::InvalidType

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
## Summary of the problem

We are getting alerted for 404s: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/296

These exceptions are automatically handled by Rails: https://github.com/rails/rails/blob/cfc9b90f70d64a83b0aadec72bd858b197e2d733/guides/source/configuring.md?plain=1#L2205

## Describe your changes

Add `ActionController::RoutingError` to AppSignal's `ignore_errors` config.