### PR TITLE
Discard `Receipt::SuggestPairingsJob` on `ActiveJob::DeserializationError`

### DIFF
--- a/app/jobs/receipt/suggest_pairings_job.rb
+++ b/app/jobs/receipt/suggest_pairings_job.rb
@@ -3,6 +3,9 @@
 class Receipt
   class SuggestPairingsJob < ApplicationJob
     queue_as :low
+
+    discard_on ActiveJob::DeserializationError
+
     def perform(receipt)
       ::ReceiptService::Suggest.new(receipt:).run!
     end


### PR DESCRIPTION
## Summary of the problem

We have a number of `Receipt::SuggestPairingsJob` instances that end up retrying in a loop because the underlying record has been deleted: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1717

## Describe your changes

Discard these jobs if they hit `ActiveJob::DeserializationError`