### PR TITLE
Make sure user-configured check addresses are valid

### DIFF
--- a/app/models/user/payout_method/check.rb
+++ b/app/models/user/payout_method/check.rb
@@ -26,6 +26,14 @@ class User
       validates :address_postal_code, format: { with: /\A\d{5}(?:[-\s]\d{4})?\z/, message: "This isn't a valid ZIP code." }
       attribute :address_country, :text, default: "US"
 
+      validate do
+        combined_length = [address_line1, address_line2].filter(&:present?).sum(&:length)
+
+        if combined_length > 50
+          errors.add(:base, "Address line one and line two's combined length can not exceed 50 characters.")
+        end
+      end
+
       def kind
         "check"
       end

--- a/spec/models/user/payout_method/check_spec.rb
+++ b/spec/models/user/payout_method/check_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User::PayoutMethod::Check do
+  describe "address lines" do
+    it "validates that address lines 1 and 2 don't exceed a combined 50 chars" do
+      instance = described_class.new
+      instance.validate
+      expect(instance.errors[:base]).to be_empty
+
+      instance.address_line1 = "a" * 51
+      instance.validate
+      expect(instance.errors[:base]).to eq(["Address line one and line two's combined length can not exceed 50 characters."])
+
+      instance.address_line1 = "a" * 25
+      instance.address_line2 = "b" * 26
+      instance.validate
+      expect(instance.errors[:base]).to eq(["Address line one and line two's combined length can not exceed 50 characters."])
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

At the moment we don't perform any length validations on `address_line1` and `address_line2` in `User::PayoutMethod::Check`, but when we use these attributes to create a `IncreaseCheck` they cannot exceed a combined 50 characters (this is a Column limitation) https://github.com/hackclub/hcb/blob/9ef293ee61399227d2163cb3c6ed1567f3be0789/app/models/increase_check.rb#L135-L139

This results in downstream failures like https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1897/samples/timestamp/2025-08-11T19:35:15Z which have to be addressed by manually editing addresses rather than putting that responsibility on users (who are much better placed to trim down their address to 50 characters).

https://hackclub.slack.com/archives/C047Y01MHJQ/p1754941540288859

Some additional context in https://github.com/hackclub/hcb/pull/8439.

## Describe your changes

Mirrors the `IncreaseCheck` validation in `User::PayoutMethod::Check`

<img width="1928" height="1858" alt="CleanShot 2025-08-11 at 16 23 12@2x" src="https://github.com/user-attachments/assets/45e08471-df1c-446e-a834-5d8e5704d197" />
