### PR TITLE
[Announcement] Ensure nil is not included in the monthly template

### DIFF
--- a/app/models/announcement/templates/monthly.rb
+++ b/app/models/announcement/templates/monthly.rb
@@ -101,7 +101,7 @@ class Announcement
                 { type: "text", text: "The #{@event.name} team" },
               ],
             },
-          ].filter(&:present?),
+          ].compact,
         }
       end
 

--- a/app/models/announcement/templates/monthly.rb
+++ b/app/models/announcement/templates/monthly.rb
@@ -101,7 +101,7 @@ class Announcement
                 { type: "text", text: "The #{@event.name} team" },
               ],
             },
-          ],
+          ].filter(&:present?),
         }
       end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
New monthly announcements generated for non-transparent organizations currently have a bug where nil is included as a ProseMirror block, which caused the ProseMirror renderer to throw an error.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a filter to make sure that nil is not included as a block in the monthly template

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

