### PR TITLE
[Announcement] Create and destroy monthly announcements when config is changed

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -360,8 +360,12 @@ class EventsController < ApplicationController
           @event.plan.mark_inactive!(plan_param) # deactivate old plan and replace it
         end
 
-        if @event.config.generate_monthly_announcement_previously_changed? && !@event.config.generate_monthly_announcement
-          @event.announcements.monthly_for(Date.today).first&.destroy!
+        if @event.config.generate_monthly_announcement_previously_changed?
+          if @event.config.generate_monthly_announcement
+            Announcement::Templates::Monthly.new(event: @event, author: User.system_user).create
+          else
+            @event.announcements.monthly_for(Date.today).first&.destroy!
+          end
         end
 
         if @event.description_previously_changed? && @event.description.present?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -360,6 +360,9 @@ class EventsController < ApplicationController
           @event.plan.mark_inactive!(plan_param) # deactivate old plan and replace it
         end
 
+        if @event.config.generate_monthly_announcement_previously_changed? && !@event.config.generate_monthly_announcement
+          @event.announcements.monthly_for(Date.today).first&.destroy!
+        end
 
         if @event.description_previously_changed? && @event.description.present?
           announcement = Announcement::Templates::NewMissionStatement.new(

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -360,14 +360,6 @@ class EventsController < ApplicationController
           @event.plan.mark_inactive!(plan_param) # deactivate old plan and replace it
         end
 
-        if @event.config.generate_monthly_announcement_previously_changed?
-          if @event.config.generate_monthly_announcement
-            Announcement::Templates::Monthly.new(event: @event, author: User.system_user).create
-          else
-            @event.announcements.monthly_for(Date.today).first&.destroy!
-          end
-        end
-
         if @event.description_previously_changed? && @event.description.present?
           announcement = Announcement::Templates::NewMissionStatement.new(
             event: @event,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -360,6 +360,7 @@ class EventsController < ApplicationController
           @event.plan.mark_inactive!(plan_param) # deactivate old plan and replace it
         end
 
+
         if @event.description_previously_changed? && @event.description.present?
           announcement = Announcement::Templates::NewMissionStatement.new(
             event: @event,

--- a/app/jobs/announcement/monthly_job.rb
+++ b/app/jobs/announcement/monthly_job.rb
@@ -5,13 +5,13 @@ class Announcement
     queue_as :default
 
     def perform
-      Announcement.monthly_for(Date.today.prev_month).find_each do |announcement|
-        Rails.error.handle do
-          announcement.mark_published!
-        end
-      end
-
       Event.includes(:config).where(config: { generate_monthly_announcement: true }).find_each do |event|
+        event.announcements.monthly_for(Date.today.prev_month).find_each do |announcement|
+          Rails.error.handle do
+            announcement.mark_published!
+          end
+        end
+
         Announcement::Templates::Monthly.new(event:, author: User.system_user).create
       end
     end

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -30,11 +30,22 @@ class Event
     validates :subevent_plan, inclusion: { in: -> { Event::Plan.available_plans.map(&:name) } }, allow_blank: true
 
     after_create :set_defaults
+    after_save :create_or_destroy_monthly_announcement
 
     private
 
     def set_defaults
       self.generate_monthly_announcement = event.is_public unless self.generate_monthly_announcement.present?
+    end
+
+    def create_or_destroy_monthly_announcement
+      if self.generate_monthly_announcement_previously_changed?
+        if self.generate_monthly_announcement
+          Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create
+        else
+          self.event.announcements.monthly_for(Date.today).first&.destroy!
+        end
+      end
     end
 
   end

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -41,7 +41,7 @@ class Event
     def create_or_destroy_monthly_announcement
       if self.generate_monthly_announcement_previously_changed?
         if self.generate_monthly_announcement
-          Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create
+          Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create if self.event.announcements.monthly_for(Date.today).empty?
         else
           self.event.announcements.monthly_for(Date.today).first&.destroy!
         end

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -176,6 +176,9 @@
     </div>
     <p class="h5 muted mt0 mb1">
       Use this to enable auto-scheduled monthly announcements.
+      <% if @event.config.generate_monthly_announcement %>
+        If disabled, the current monthly announcement draft will be discarded.
+      <% end %>
     </p>
     <%= form.submit "Update", disabled: %>
   </div>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe EventsController do
   include SessionSupport
 
   describe "#index" do
+    before do
+      # This is required since creating event configs creates a monthly announcement for the event authored by the system user
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+    end
+
     it "renders a list of the user's events as json" do
       user = create(:user)
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
When a manager either enables or disables generating monthly announcements in event settings, nothing happens right now. When it is enabled, it should create a new monthly announcement, and when disabled, discard the current monthly draft.

Also, if an event had already disabled monthly announcements, the announcement is still in the database, so it currently would get sent out at the end of the month.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Added a save hook on `Event::Configuration` to create and destroy monthly announcements, a check in the monthly announcement job, and a warning on the event settings page about disabling generating monthly announcements.