### PR TITLE
Add announcements permissions to roles page

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -117,6 +117,13 @@ class StaticPagesController < ApplicationController
         "View reimbursement reports": :reader,
         "Review, approve, and reject reports": :manager,
       },
+      Announcements: {
+        "Create or delete an announcement": :manager,
+        "Publish an announcement": :manager,
+        "View announcements": :reader,
+        "View followers": :reader,
+        "Remove followers": :manager
+      },
       "Google Workspace": {
         "Create an account": :manager,
         "Suspend an account": :manager,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Clarify who can do what with announcements!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a hash with the announcements permissions list to the roles controller method:
<img width="983" height="271" alt="image" src="https://github.com/user-attachments/assets/b29e07ac-e544-46ab-9067-4cfe9928c667" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

