### PR TITLE
Check destroy policy in followers modal

### DIFF
--- a/app/views/events/_followers_modal.html.erb
+++ b/app/views/events/_followers_modal.html.erb
@@ -8,14 +8,16 @@
         <span class="w-full flex gap-2 items-center align-middle">
           <%= user_mention event_follow.user %>
           <div class="flex-grow"></div>
-          <%= pop_icon_to "member-remove",
-                          follow_path(event_follow),
-                          class: "error",
-                          data: {
-                            turbo_frame: "_top",
-                            turbo_method: :delete,
-                            turbo_confirm: "Are you sure you want to remove this follower?",
-                          } %>
+          <% if policy(event_follow).destroy? %>
+            <%= pop_icon_to "member-remove",
+                            follow_path(event_follow),
+                            class: "error",
+                            data: {
+                              turbo_frame: "_top",
+                              turbo_method: :delete,
+                              turbo_confirm: "Are you sure you want to remove this follower?",
+                            } %>
+          <% end %>
         </span>
       </li>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The remove button currently shows up for all members of an organization even though only managers and the follower themselves can remove the follow.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check the destroy policy to render the remove button in followers modal.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

