### PR TITLE
Switch from outlet to ID for blog widget theme

### DIFF
--- a/app/javascript/controllers/blog_controller.js
+++ b/app/javascript/controllers/blog_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['badge', 'embed']
+  static targets = ['badge']
 
   connect() {
     this.updateBadge()

--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -35,9 +35,9 @@ export default class extends Controller {
   updateBlogEmbed(theme) {
     const resolvedTheme = theme === 'system' ? BK.resolveSystemTheme() : theme
 
-    const blogEmbed = document.getElementById("blog-widget-embed")
+    const blogEmbed = document.getElementById('blog-widget-embed')
     if (blogEmbed) {
       blogEmbed.src = `${blogEmbed.src.split('?')[0]}?theme=${resolvedTheme}`
-    } 
+    }
   }
 }

--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -3,7 +3,6 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['toggle']
-  static outlets = ['blog']
 
   connect() {
     this.updateActiveCheck()
@@ -34,9 +33,11 @@ export default class extends Controller {
   }
 
   updateBlogEmbed(theme) {
-    if (this.hasBlogOutlet) {
-      const resolvedTheme = theme === 'system' ? BK.resolveSystemTheme() : theme
-      this.blogOutlet.embedTarget.src = `${this.blogOutlet.embedTarget.src.split('?')[0]}?theme=${resolvedTheme}`
-    }
+    const resolvedTheme = theme === 'system' ? BK.resolveSystemTheme() : theme
+
+    const blogEmbed = document.getElementById("blog-widget-embed")
+    if (blogEmbed) {
+      blogEmbed.src = `${blogEmbed.src.split('?')[0]}?theme=${resolvedTheme}`
+    } 
   }
 }

--- a/app/views/application/_blog_widget.html.erb
+++ b/app/views/application/_blog_widget.html.erb
@@ -15,7 +15,7 @@
     data-menu-target="content">
     <p class="font-bold text-lg my-0 pb-3 w-full text-center">✨ What's new?</p>
 
-    <iframe loading="lazy" src="<%= "#{Rails.env.development? ? "http://localhost:3001" : "https://blog.hcb.hackclub.com"}/embed?theme=light" %>" class="border-0 w-full min-h-96" style="zoom: 0.9;" data-blog-target="embed"></iframe>
+    <iframe id="blog-widget-embed" loading="lazy" src="<%= "#{Rails.env.development? ? "http://localhost:3001" : "https://blog.hcb.hackclub.com"}/embed?theme=light" %>" class="border-0 w-full min-h-96" style="zoom: 0.9;"></iframe>
 
     <div class="px-5 pt-2 w-full">
       <a href="https://blog.hcb.hackclub.com" target="_blank" class="flex justify-center items-center"><%= inline_icon :external, size: 26 %> See all posts</a>

--- a/app/views/application/_theme_toggle.html.erb
+++ b/app/views/application/_theme_toggle.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (blog_shown: true, top: false) %>
+<%# locals: (top: false) %>
 
 <div data-controller="menu" data-menu-placement-value="<%= top ? "bottom-end" : "bottom-center" %>">
   <button
@@ -11,7 +11,7 @@
     <%= inline_icon "sun", size: home_action_size, class: "dark:hidden" %>
   </button>
 
-  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle" <%= "data-dark-mode-toggle-blog-outlet=#blog-widget" if blog_shown %>>
+  <div data-menu-target="content" class="menu__content menu__content--compact menu__content--2 min-w-32 w-32" data-controller="dark-mode-toggle">
     <a data-dark-mode-toggle-target="toggle" data-value="system">
       System
       <%= inline_icon "check", class: "hidden ml-auto", size: 24, style: "margin-right: -5px" %>

--- a/app/views/events/landing/_header.html.erb
+++ b/app/views/events/landing/_header.html.erb
@@ -2,7 +2,7 @@
 <% page_sm %>
 
 <div class="absolute top-0 right-0 m2">
-  <%= render partial: "application/theme_toggle", locals: { top: true, blog_shown: false } %>
+  <%= render partial: "application/theme_toggle", locals: { top: true } %>
 </div>
 
 <%= content_for(:header) do %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2013 is still happening - while I'm not sure why, it's a lot simpler to just skip using outlets and use `document.findElementById` instead since we just need the iframe element.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Switch from using a Stimulus outlet + target to just the `blog-widget-embed` ID to get the iframe to modify.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

