### PR TITLE
[Document] Make rails aware that the `category` column will exist later

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -49,6 +49,7 @@ class Document < ApplicationRecord
 
   scope :common, -> { where(event_id: nil) }
 
+  attribute :category, :integer, default: 0
   enum :category, {
     general: 0,
     nonprofit_status: 1,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

migrations from a fresh db fail because the category column does not exist when rails expects it to, since there is a category enum in the model.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

add a line explicitly stating that the category column will exist later.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

