### PR TITLE
[DX] Dependency clean-up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,8 +128,6 @@ gem "validates_zipcode" # validation for event's zip codes
 
 gem "rqrcode" # QR code generation
 
-gem "brakeman" # static security vulnerability scanner
-
 gem "awesome_print" # pretty print objects in console
 gem "byebug", platforms: [:windows]
 
@@ -159,6 +157,7 @@ group :development, :test do
   gem "rubocop"
   gem "rubocop-rails", "~> 2.30"
   gem "relaxed-rubocop"
+  gem "brakeman" # static security vulnerability scanner
 
   gem "rspec-rails", "~> 7.1.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -137,15 +137,6 @@ gem "appsignal" # error tracking + performance monitoring
 gem "lograge" # Log formatting
 gem "statsd-instrument", "~> 3.9" # For reporting to HC Grafana
 
-group :production do
-
-  # gem "heroku-deflater" # compression
-
-  # Heroku language runtime metrics
-  # https://devcenter.heroku.com/articles/language-runtime-metrics-ruby#add-the-barnes-gem-to-your-application
-  gem "barnes"
-end
-
 group :test do
   gem "factory_bot_rails" # Test data
   gem "simplecov", require: false # Code coverage

--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,6 @@ gem "brakeman" # static security vulnerability scanner
 
 gem "awesome_print" # pretty print objects in console
 gem "byebug", platforms: [:windows]
-gem "dry-validation"
 
 gem "bootsnap", ">= 1.4.4", require: false # reduces boot times through caching; required in config/boot.rb
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem "faraday" # web requests
 gem "stripe", "11.7.0"
 gem "plaid", "~> 34.0"
 gem "yellow_pages", github: "hackclub/yellow_pages"
-gem "recursive-open-struct" # for stubbing stripe api objects
 
 gem "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -649,8 +649,6 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
-    recursive-open-struct (2.0.0)
-      ostruct
     red-colors (0.4.0)
       json
       matrix
@@ -956,7 +954,6 @@ DEPENDENCIES
   rack-timeout
   rails!
   react-rails
-  recursive-open-struct
   redcarpet
   redis (~> 5.4)
   relaxed-rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,27 +263,15 @@ GEM
       dotenv (= 3.1.7)
       railties (>= 6.1)
     drb (2.2.3)
-    dry-configurable (1.3.0)
-      dry-core (~> 1.1)
-      zeitwerk (~> 2.6)
     dry-core (1.1.0)
       concurrent-ruby (~> 1.0)
       logger
       zeitwerk (~> 2.6)
     dry-inflector (1.2.0)
-    dry-initializer (3.2.0)
     dry-logic (1.6.0)
       bigdecimal
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
-      zeitwerk (~> 2.6)
-    dry-schema (1.14.1)
-      concurrent-ruby (~> 1.0)
-      dry-configurable (~> 1.0, >= 1.0.1)
-      dry-core (~> 1.1)
-      dry-initializer (~> 3.2)
-      dry-logic (~> 1.5)
-      dry-types (~> 1.8)
       zeitwerk (~> 2.6)
     dry-types (1.8.3)
       bigdecimal (~> 3.0)
@@ -291,12 +279,6 @@ GEM
       dry-core (~> 1.0)
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
-      zeitwerk (~> 2.6)
-    dry-validation (1.11.1)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 1.1)
-      dry-initializer (~> 3.2)
-      dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
     email_reply_parser (0.5.11)
     erb (5.0.1)
@@ -916,7 +898,6 @@ DEPENDENCIES
   diffy
   doorkeeper (~> 5.8)
   dotenv-rails
-  dry-validation
   email_reply_parser
   erb_lint
   eu_central_bank

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,9 +169,6 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     backport (1.2.0)
-    barnes (0.0.9)
-      multi_json (~> 1)
-      statsd-ruby (~> 1.1)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
@@ -790,7 +787,6 @@ GEM
       sprockets (>= 3.0.0)
     stackprof (0.2.27)
     statsd-instrument (3.9.9)
-    statsd-ruby (1.5.0)
     stringio (3.1.7)
     stripe (11.7.0)
     strong_migrations (1.8.0)
@@ -879,7 +875,6 @@ DEPENDENCIES
   audits1984
   awesome_print
   aws-sdk-s3
-  barnes
   bcrypt (~> 3.1.7)
   blazer
   blind_index

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -245,7 +245,17 @@ class StripeCard < ApplicationRecord
   def stripe_obj
     @stripe_obj ||= ::Stripe::Issuing::Card.retrieve(id: stripe_id)
   rescue => e
-    RecursiveOpenStruct.new({ number: "XXXX", cvc: "XXX", created: Time.now.utc.to_i, shipping: { status: "delivered", carrier: "USPS", eta: 2.weeks.ago, tracking_number: "12345678s9" } })
+    OpenStruct.new(
+      number: "XXXX",
+      cvc: "XXX",
+      created: Time.now.utc.to_i,
+      shipping: OpenStruct.new(
+        status: "delivered",
+        carrier: "USPS",
+        eta: 2.weeks.ago,
+        tracking_number: "12345678s9"
+      )
+    )
   end
 
   def secret_details

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -46,11 +46,3 @@ plugin :tmp_restart
 
 # Report stats to AppSignal
 plugin :appsignal
-
-# Heroku Barnes config for Puma
-# https://github.com/heroku/barnes
-require "barnes"
-before_fork do
-  # worker configuration
-  Barnes.start
-end


### PR DESCRIPTION
## Summary of the problem

Did a quick pass through our `Gemfile` and did some housekeeping.

## Describe your changes

- I can't find any references to `dry-validation`
- We don't need `brakeman` in the default group (i.e. we only run it in development and CI, it isn't require to run the app)
- `barnes` seems to require a local StatsD server which AFAIK we do not have
- `recursive-open-struct` was used in one place and was trivially replaced by just passing an `OpenStruct` for the necessary property instead of a `Hash`.