### PR TITLE
Quick fix - `desc` is a symbol not a method

### DIFF
--- a/app/mailboxes/receipt_bin_mailbox.rb
+++ b/app/mailboxes/receipt_bin_mailbox.rb
@@ -44,7 +44,7 @@ class ReceiptBinMailbox < ApplicationMailbox
         MailboxAddress
         .activated
         .where(address: mail.recipients)
-        .order(id: desc)
+        .order(id: :desc)
         .first
         &.user
     end


### PR DESCRIPTION
## Summary of the problem

In https://github.com/hackclub/hcb/pull/11290 I wrote `.order(id: desc)` instead of `.order(id: :desc)` and didn't catch it.

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/891

## Describe your changes

Fix it