### PR TITLE
Add test coverage for `ReceiptBinMailbox`

### DIFF
--- a/spec/mailboxes/receipt_bin_mailbox_spec.rb
+++ b/spec/mailboxes/receipt_bin_mailbox_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReceiptBinMailbox do
+  include ActionMailbox::TestHelper
+  include ActionMailer::TestHelper
+
+  def receive_email(to:, from:, cc: nil)
+    receive_inbound_email_from_mail(
+      to:,
+      from:,
+      cc:,
+      subject: "Receipt",
+      body: <<~BODY,
+        Receipt attached
+      BODY
+      attachments: {
+        "logo.png" => File.read(Rails.root.join("public/logo.png"))
+      }
+    )
+  end
+
+  context "with generic addresses" do
+    it "finds the user based on the from address" do
+      user = create(:user, email: "test@example.com")
+
+      sent_emails = capture_emails do
+        receive_email(to: "receipts@hackclub.com", from: user.email)
+      end
+
+      expect(user.receipts.count).to eq(1)
+
+      confirmation_email = sent_emails.sole
+      expect(confirmation_email.to).to contain_exactly(user.email)
+      expect(confirmation_email.text_part.body.to_s).to include("We got your receipt")
+    end
+
+    it "supports CCs" do
+      user = create(:user, email: "test@example.com")
+
+      sent_emails = capture_emails do
+        receive_email(
+          to: "hack-clubber@example.com",
+          cc: "receipts@hcb.gg",
+          from: user.email
+        )
+      end
+
+      expect(user.receipts.count).to eq(1)
+
+      confirmation_email = sent_emails.sole
+      expect(confirmation_email.to).to contain_exactly(user.email)
+      expect(confirmation_email.text_part.body.to_s).to include("We got your receipt")
+    end
+  end
+
+  context "with a mailbox address" do
+    it "finds the user based on the mailbox address" do
+      user = create(:user, email: "test@example.com")
+      mailbox_address = user.mailbox_addresses.create!
+      mailbox_address.mark_activated!
+
+      sent_emails = capture_emails do
+        receive_email(to: mailbox_address.address, from: "not-user@example.com")
+      end
+
+      expect(user.receipts.count).to eq(1)
+
+      confirmation_email = sent_emails.sole
+      expect(confirmation_email.to).to contain_exactly("not-user@example.com")
+      expect(confirmation_email.text_part.body.to_s).to include("We got your receipt")
+    end
+
+    it "supports CCs" do
+      user = create(:user, email: "test@example.com")
+      mailbox_address = user.mailbox_addresses.create!
+      mailbox_address.mark_activated!
+
+      sent_emails = capture_emails do
+        receive_email(
+          to: "hack-clubber@example.com",
+          cc: mailbox_address.address,
+          from: "not-user@example.com"
+        )
+      end
+
+      expect(user.receipts.count).to eq(1)
+
+      confirmation_email = sent_emails.sole
+      expect(confirmation_email.to).to contain_exactly("not-user@example.com")
+      expect(confirmation_email.text_part.body.to_s).to include("We got your receipt")
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

I changed some logic in this class in https://github.com/hackclub/hcb/pull/11290 but because of a hard-to-spot typo it threw errors in production https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/891 so I had to make a quick fix https://github.com/hackclub/hcb/pull/11307.

## Describe your changes

Adds basic test coverage for this class.