### PR TITLE
Remove deprecated usage of passing nil to argument model of form_with

### DIFF
--- a/app/views/admin/ach_start_approval.html.erb
+++ b/app/views/admin/ach_start_approval.html.erb
@@ -27,7 +27,7 @@
 <h3>Actions</h3>
 
 <% if @ach_transfer.pending? %>
-  <%= form_with(model: nil, local: true, url: ach_approve_admin_path(@ach_transfer), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: ach_approve_admin_path(@ach_transfer), method: :post) do |form| %>
     <%= form.submit @ach_transfer.scheduled_on.present? ? "Approve ACH transfer" : "Send ACH transfer", data: { confirm: "Are you sure? Once an ACH transfer is sent, it cannot be un-sent." } %>
     <% if @ach_transfer.scheduled_on.present? %>
       <br>
@@ -36,14 +36,14 @@
   <% end %>
 
   <% unless @ach_transfer.scheduled_on.present? %>
-    <%= form_with(model: nil, local: true, url: ach_send_realtime_admin_path(@ach_transfer), method: :post) do |form| %>
+    <%= form_with(model: false, local: true, url: ach_send_realtime_admin_path(@ach_transfer), method: :post) do |form| %>
       <%= form.submit "⚡ Send in realtime", data: { confirm: "Are you sure? Once a realtime transfer is sent, it cannot be un-sent. Realtime transfers incurr a $1 fee from Column, that will be covered by HCB." } %>
     <% end %>
   <% end %>
 
   <p>or</p>
 
-  <%= form_with(model: nil, local: true, url: ach_reject_admin_path(@ach_transfer), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: ach_reject_admin_path(@ach_transfer), method: :post) do |form| %>
     <div class="field">
       <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
       <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>

--- a/app/views/admin/disbursement_process.html.erb
+++ b/app/views/admin/disbursement_process.html.erb
@@ -70,11 +70,11 @@
       <small>When approved, this disbursement will automatically send on <%= @disbursement.scheduled_on.strftime("%Y-%m-%d") %>.</small>
     <% end %>
 
-    <%= form_with(model: nil, local: true, url: disbursement_approve_admin_path(@disbursement), method: :post) do |form| %>
+    <%= form_with(model: false, local: true, url: disbursement_approve_admin_path(@disbursement), method: :post) do |form| %>
       <%= form.submit "Approve disbursement" %>
     <% end %>
 
-    <%= form_with(model: nil, local: true, url: disbursement_reject_admin_path(@disbursement), method: :post) do |form| %>
+    <%= form_with(model: false, local: true, url: disbursement_reject_admin_path(@disbursement), method: :post) do |form| %>
       <div class="field">
         <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
         <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>

--- a/app/views/admin/employees.html.erb
+++ b/app/views/admin/employees.html.erb
@@ -25,7 +25,7 @@
           <%= link_to "View payments", employee %> <br>
           <%= employee.user.w9s.any? ? ugc_link_to("View latest W9", employee.user.w9s.order(signed_at: :asc).last.url) : "No W9 in HCB" %> <br>
           <% if employee.onboarding? %>
-            <%= form_with model: nil, local: true, url: employee_onboard_path(employee), method: :post do |form| %>
+            <%= form_with model: false, local: true, url: employee_onboard_path(employee), method: :post do |form| %>
               <%= form.text_field :gusto_id, style: "width: 300px;", placeholder: "Gusto ID" %>
               <%= form.submit "Onboard" %>
             <% end %>

--- a/app/views/admin/event_new_from_airtable.html.erb
+++ b/app/views/admin/event_new_from_airtable.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Create an organization from Airtable</h1>
 
-<%= form_with(model: nil, local: true, url: event_create_from_airtable_admin_index_path) do |form| %>
+<%= form_with(model: false, local: true, url: event_create_from_airtable_admin_index_path) do |form| %>
   <p>
     <%= form.label :airtable_record_id, "Airtable Record ID" %>
     <br>

--- a/app/views/admin/event_process.html.erb
+++ b/app/views/admin/event_process.html.erb
@@ -3,12 +3,12 @@
 <% if @event.approved? %>
   <p>Although this event was <strong>approved</strong>, you may still reject it or bring it back to pending.</p>
 
-  <%= form_with(model: nil, local: true, url: event_toggle_approved_admin_path(@event), method: :put) do |form| %>
+  <%= form_with(model: false, local: true, url: event_toggle_approved_admin_path(@event), method: :put) do |form| %>
     <%= form.submit "Mark as pending",
       data: { confirm: "This event was previously approved. Are you sure you want to undo that and mark it as pending?" } %>
   <% end %>
 
-  <%= form_with(model: nil, local: true, url: event_reject_admin_path(@event), method: :put) do |form| %>
+  <%= form_with(model: false, local: true, url: event_reject_admin_path(@event), method: :put) do |form| %>
     <%= form.submit "Reject event",
       data: { confirm: "Are you sure you want to reject this event? This can not be undone." } %>
   <% end %>
@@ -16,11 +16,11 @@
 <% elsif !@event.rejected? %>
   <p>This event is currently <strong>pending</strong> your review.</p>
 
-  <%= form_with(model: nil, local: true, url: event_toggle_approved_admin_path(@event), method: :put) do |form| %>
+  <%= form_with(model: false, local: true, url: event_toggle_approved_admin_path(@event), method: :put) do |form| %>
     <%= form.submit "Approve event" %>
   <% end %>
 
-  <%= form_with(model: nil, local: true, url: event_reject_admin_path(@event), method: :put) do |form| %>
+  <%= form_with(model: false, local: true, url: event_reject_admin_path(@event), method: :put) do |form| %>
     <%= form.submit "Reject event",
       data: { confirm: "Are you sure you want to reject this event? This can not be undone." } %>
   <% end %>

--- a/app/views/admin/google_workspace_process.html.erb
+++ b/app/views/admin/google_workspace_process.html.erb
@@ -69,7 +69,7 @@
       <li>Click 'Submit' below</li>
     </ol>
   <% end %>
-  <%= form_with(model: nil, local: true, url: google_workspace_approve_admin_path(@g_suite), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: google_workspace_approve_admin_path(@g_suite), method: :post) do |form| %>
     <%= form.submit "Approve" %>
   <% end %>
 <% end %>
@@ -81,7 +81,7 @@
 <% if @g_suite.verifying? %>
   <p>HCB is now trying to automatically verify if the user has configured their domain correctly with the TXT record. This happens once every hour.</p>
   <p>If you would like to manually attempt to verify this domain:</p>
-  <%= form_with(model: nil, local: true, url: google_workspace_verify_admin_path(@g_suite), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: google_workspace_verify_admin_path(@g_suite), method: :post) do |form| %>
     <%= form.submit "Click Here" %>
   <% end %>
   <p>You can additionally verify that the TXT record they have matches the verification key we have on file:</p>
@@ -89,7 +89,7 @@
   <p><%= link_to "DNS Check", @g_suite.dns_check_url, target: "_blank" %></p>
   <p>If it does not match or is missing, make sure to notify the event owner and have them set it up on their DNS provider.</p>
   <p>Has it still been stuck on verifying after a few days? Try updating the verification key.</p>
-  <%= form_with(model: nil, local: true, url: google_workspace_approve_admin_path(@g_suite), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: google_workspace_approve_admin_path(@g_suite), method: :post) do |form| %>
     <%= form.submit "Update verification key" %>
   <% end %>
   <% if false %>
@@ -132,7 +132,7 @@
     <li>Once the DKIM key has been added to the domain's DNS by the organizer, go back to the Google Admin page above, select the domain, and click "Start Authentication"</li>
   </ul>
 </div>
-<%= form_with(model: nil, local: true, url: google_workspace_update_admin_path(@g_suite), method: :post) do |dkim_key_form| %>
+<%= form_with(model: false, local: true, url: google_workspace_update_admin_path(@g_suite), method: :post) do |dkim_key_form| %>
   <%= dkim_key_form.label :dkim_key do %>
     <%= dkim_key_form.text_field :dkim_key, value: @g_suite.dkim_key %>
   <% end %>
@@ -141,7 +141,7 @@
 <hr>
 <h3>Google Workspace Revocation Immunity</h3>
 <p>This Google Workspace is<%= @g_suite.immune_to_revocation? ? nil : " not" %> immune to revocation.<%= !@g_suite.immune_to_revocation? && @g_suite.revocation.present? ? " Turning this on will immediately cancel the current revocation for this Google Workspace." : nil %> </p>
-<%= form_with(model: nil, local: true, url: google_workspace_toggle_revocation_immunity_admin_path(@g_suite), method: :post) do |form| %>
+<%= form_with(model: false, local: true, url: google_workspace_toggle_revocation_immunity_admin_path(@g_suite), method: :post) do |form| %>
   <%= form.submit "Toggle" %>
 <% end %>
 <hr>

--- a/app/views/admin/google_workspaces.html.erb
+++ b/app/views/admin/google_workspaces.html.erb
@@ -28,7 +28,7 @@
   <%= form.submit "Search" %>
 <% end %>
 
-<%= form_with(model: nil, local: true, url: google_workspaces_verify_all_admin_index_path, method: :post) do |form| %>
+<%= form_with(model: false, local: true, url: google_workspaces_verify_all_admin_index_path, method: :post) do |form| %>
   <%= form.submit "Attempt to verify all currently verifying domains" %>
 <% end %>
 

--- a/app/views/admin/increase_check_process.html.erb
+++ b/app/views/admin/increase_check_process.html.erb
@@ -67,7 +67,7 @@
 
 <% if @check.pending? %>
   <%= button_to "💸 Approve and send check", approve_increase_check_path(@check), method: :post, data: { confirm: "Are you sure you want to send this check?" } %>
-  <%= form_with(model: nil, local: true, url: reject_increase_check_path(@check), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: reject_increase_check_path(@check), method: :post) do |form| %>
     <div class="field">
       <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
       <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>

--- a/app/views/admin/invoice_process.html.erb
+++ b/app/views/admin/invoice_process.html.erb
@@ -56,7 +56,7 @@
     ⚠️ Warning: this action is permanent and irreversable. If you do this in error, a new invoice will have to be created for the sponsor, which will send them another email. Please exercise caution. Your account will be associated with this action.
   </p>
 
-  <%= form_with(model: nil, local: true, url: invoice_mark_paid_admin_path(@invoice.id), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: invoice_mark_paid_admin_path(@invoice.id), method: :post) do |form| %>
     <fieldset>
       <legend>Manually Mark Paid</legend>
       <p>

--- a/app/views/admin/paypal_transfer_process.html.erb
+++ b/app/views/admin/paypal_transfer_process.html.erb
@@ -66,7 +66,7 @@
 <% end %>
 
 <% if @paypal_transfer.may_mark_rejected? %>
-  <%= form_with(model: nil, local: true, url: reject_paypal_transfer_path(@paypal_transfer), method: :post) do |form| %>
+  <%= form_with(model: false, local: true, url: reject_paypal_transfer_path(@paypal_transfer), method: :post) do |form| %>
     <div class="field">
       <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
       <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>

--- a/app/views/admin/raw_transaction_new.html.erb
+++ b/app/views/admin/raw_transaction_new.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Add a Raw Transaction By Hand</h1>
 
-<%= form_with(model: nil, local: true, url: raw_transaction_create_admin_index_path) do |form| %>
+<%= form_with(model: false, local: true, url: raw_transaction_create_admin_index_path) do |form| %>
   <fieldset>
     <legend>Raw Transaction</legend>
     <p>

--- a/app/views/admin/stripe_card_personalization_design_new.html.erb
+++ b/app/views/admin/stripe_card_personalization_design_new.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Create a new card design</h1>
 
-<%= form_with(model: nil, local: true, url: stripe_card_personalization_design_create_admin_index_path, data: {
+<%= form_with(model: false, local: true, url: stripe_card_personalization_design_create_admin_index_path, data: {
                 turbo: "false",
               }) do |form| %>
   <fieldset>

--- a/app/views/admin/transaction.html.erb
+++ b/app/views/admin/transaction.html.erb
@@ -42,7 +42,7 @@
 
     <p>Sent at <%= format_datetime @suggested_wise_mapping.sent_at %></p>
 
-    <%= form_with model: nil, local: true, url: set_wise_transfer_path(@canonical_transaction), class: "mb-0", method: :post do |form| %>
+    <%= form_with model: false, local: true, url: set_wise_transfer_path(@canonical_transaction), class: "mb-0", method: :post do |form| %>
       <%= form.hidden_field :wise_transfer_id, value: @suggested_wise_mapping.id %>
       <%= form.submit "Map to Wise transfer ##{@suggested_wise_mapping.id}", data: { "turbo-confirm": "Are you sure you want to map this transaction to Wise transfer ##{@suggested_wise_mapping.id}?" }, class: "!mb-0 mt-3" %>
       <%= link_to "View Wise transfer ##{@suggested_wise_mapping.id}", wise_transfer_process_admin_path(@suggested_wise_mapping), class: "ml-2", target: "_blank" %>
@@ -62,7 +62,7 @@
     <tr class="<%= "admin-bg-pending" unless @canonical_transaction.canonical_event_mapping %>">
       <td>
         <div class="flex flex-row gap-2">
-          <%= form_with model: nil, local: true, url: set_event_path(@canonical_transaction), method: :post do |form| %>
+          <%= form_with model: false, local: true, url: set_event_path(@canonical_transaction), method: :post do |form| %>
             <%= form.collection_select(:event_id, Event.reorder(Event::CUSTOM_SORT).not_demo_mode, :id, :admin_dropdown_description, { include_blank: true, selected: @canonical_transaction.event.try(:id) }, { style: "width: 300px;" }) %>
             <%= form.submit "Set", data: { "turbo-confirm": @mapping_confirm_msg } %>
           <% end %>
@@ -73,13 +73,13 @@
         <% end %>
       </td>
       <td>
-        <%= form_with model: nil, local: true, url: set_wire_path(@canonical_transaction), method: :post do |form| %>
+        <%= form_with model: false, local: true, url: set_wire_path(@canonical_transaction), method: :post do |form| %>
           <%= form.collection_select(:wire_id, Wire.approved + [@canonical_transaction.wire].compact, :id, :admin_dropdown_description, { include_blank: true, selected: @canonical_transaction.wire&.id }, { style: "width: 300px;" }) %>
           <%= form.submit "Set", data: { "turbo-confirm": @mapping_confirm_msg } %>
         <% end %>
       </td>
       <td>
-        <%= form_with model: nil, local: true, url: set_wise_transfer_path(@canonical_transaction), method: :post do |form| %>
+        <%= form_with model: false, local: true, url: set_wise_transfer_path(@canonical_transaction), method: :post do |form| %>
           <%= form.collection_select(:wise_transfer_id, WiseTransfer.sent + [@canonical_transaction.wise_transfer].compact, :id, :admin_dropdown_description, { include_blank: true, selected: @canonical_transaction.wise_transfer&.id }, { style: "width: 300px;" }) %>
           <%= form.submit "Set", data: { "turbo-confirm": @mapping_confirm_msg } %>
         <% end %>

--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -102,7 +102,7 @@
   <%= button_to "💸 Approve and automatically send transfer", send_wire_path(@wire), method: :post, data: { confirm: "This will automatically send the wire. You don't need to send it manually!" } %>
   <%= button_to "💸 Approve and manually send transfer", approve_wire_path(@wire), method: :post, data: { confirm: "Have you manually sent this wire? This option requires you send this wire." } %>
   <%= button_to "✏️ Edit wire", edit_wire_path(@wire), method: :get %>
-  <%= form_with(model: nil, local: true, url: reject_wire_path(@wire), method: :post) do |form| %>
+  <%= form_with(mode: false, local: true, url: reject_wire_path(@wire), method: :post) do |form| %>
     <div class="field">
       <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
       <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>

--- a/app/views/card_grant/pre_authorizations/_screenshot_form.html.erb
+++ b/app/views/card_grant/pre_authorizations/_screenshot_form.html.erb
@@ -1,6 +1,6 @@
 <div id="screenshot_upload_form" class="flex-shrink-0 h-[200px]">
   <div class="<%= "mb3" if defined?(include_spacing) %> h-100" style="position: relative;">
-    <%= form_with model: nil, url: card_grant_pre_authorizations_path, method: :patch, remote: true, class: "flex flex-col justify-center h-100", data: {
+    <%= form_with model: false, url: card_grant_pre_authorizations_path, method: :patch, remote: true, class: "flex flex-col justify-center h-100", data: {
           turbo: defined?(turbo) ? turbo : "false",
           controller: "file-drop form",
           action: defined?(disabled) && disabled ? "" : "

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -1,7 +1,7 @@
 <% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @direction %>
 
 <div class="filterbar flex flex-row justify-between items-center width-100" style="gap: 16px">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-auto") do |form| %>
       <%= render "search", form: %>
     <% if @tag %>
       <%= form.hidden_field :tag, value: @tag.label %>

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -52,7 +52,7 @@
         <% end %>
       </div>
       <div data-tabs-target="tab" id="date">
-        <%= form_with(model: nil, local: true, method: :get, class: "flex-auto p1") do |form| %>
+        <%= form_with(model: false, local: true, method: :get, class: "flex-auto p1") do |form| %>
           <p class="bold mb0 mt0">Transactions after...</p>
           <%= form.date_field :start, class: "border mb1", value: @start_date %>
           <p class="bold mb0 mt0">Transactions before...</p>
@@ -68,7 +68,7 @@
         <% end %>
       </div>
       <div data-tabs-target="tab" id="amount">
-        <%= form_with(model: nil, local: true, method: :get, class: "flex-auto") do |form| %>
+        <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
           <div class="m-2">
             <p class="bold mb-0 mt-2">Transactions more than...</p>
             <div class="flex mb1">

--- a/app/views/events/donation_overview.html.erb
+++ b/app/views/events/donation_overview.html.erb
@@ -220,7 +220,7 @@
 </h2>
 
 <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb2">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "search", form: %>
   <% end %>
   <div>

--- a/app/views/events/employees.html.erb
+++ b/app/views/events/employees.html.erb
@@ -52,7 +52,7 @@
 <% end %>
 
 <div class="flex items-center gap-4 flex-col-reverse sm:flex-row">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 my-3 w-full sm:w-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-1 my-3 w-full sm:w-auto") do |form| %>
     <%= render "search", form: %>
   <% end %>
   <div style="text-align: center;">

--- a/app/views/events/filters/_menu.html.erb
+++ b/app/views/events/filters/_menu.html.erb
@@ -46,7 +46,7 @@
             <% end %>
 
           <% when "date_range" %>
-            <%= form_with(model: nil, local: true, method: :get, class: "flex-auto p1") do |form| %>
+            <%= form_with(model: false, local: true, method: :get, class: "flex-auto p1") do |form| %>
               <% ["after", "before"].each do |suffix| %>
                 <label class="bold"><%= suffix.humanize %>...</label>
                 <%= form.date_field "#{filter[:key_base]}_#{suffix}", class: "border mb1", value: params["#{filter[:key_base]}_#{suffix}"] %>
@@ -60,7 +60,7 @@
             <% end %>
 
           <% when "amount_range" %>
-            <%= form_with(model: nil, local: true, method: :get, class: "flex-auto p1") do |form| %>
+            <%= form_with(model: false, local: true, method: :get, class: "flex-auto p1") do |form| %>
                 <% ["less_than", "greater_than"].each do |suffix| %>
                   <label class="bold"><%= suffix.humanize %>...</label>
                   <div class="input p-0 mb-2 flex border border-gray-200 dark:bg-darkless dark:border-0 rounded-lg px-3 items-center">

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -47,7 +47,7 @@
 </div>
 
 <div class="flex items-center gap-6 sm:gap-4 flex-col-reverse sm:flex-row mb2">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "search", form: %>
   <% end %>
   <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>

--- a/app/views/events/team.html.erb
+++ b/app/views/events/team.html.erb
@@ -51,7 +51,7 @@
 <% end %>
 
 <div class="filterbar flex flex-row justify-between items-center width-100" style="gap: 16px">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-auto md-mr2") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-auto md-mr2") do |form| %>
     <%= render "search", form: %>
     <%= form.hidden_field :filter, value: params[:filter] if params[:filter] %>
     <%= form.hidden_field :view, value: @view if @view %>

--- a/app/views/events/transfers.html.erb
+++ b/app/views/events/transfers.html.erb
@@ -33,7 +33,7 @@
 </div>
 
 <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb2">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "search", form: %>
   <% end %>
   <div>

--- a/app/views/exports/collect_email.html.erb
+++ b/app/views/exports/collect_email.html.erb
@@ -4,7 +4,7 @@
   <h3 class="mt2 md-mt0">
     This export is too big, so we'll send you an email when it's ready.
   </h3>
-  <%= form_with(model: nil, local: true, method: :get, url: transactions_exports_path(event: @event_slug, format: @file_extension)) do |form| %>
+  <%= form_with(model: false, local: true, method: :get, url: transactions_exports_path(event: @event_slug, format: @file_extension)) do |form| %>
     <%= form.text_field :event, style: "display: none", value: @event_slug %>
     <%= form.text_field :email, class: "w-100 fit my2", placeholder: "fiona@hackclub.com", required: true, type: "email" %>
     <p>

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -42,7 +42,7 @@
 </div>
 
 <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb2">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
+  <%= form_with(mode: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "events/search", form: %>
   <% end %>
 

--- a/app/views/my/reimbursements.html.erb
+++ b/app/views/my/reimbursements.html.erb
@@ -72,7 +72,7 @@
 <h3 class="mb0">Reports</h3>
 
 <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb2 mt1">
-  <%= form_with(model: nil, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
+  <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "events/search", form: %>
   <% end %>
   <div>

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -1,7 +1,7 @@
 <% instance = local_assigns.__id__ %>
 <div id="receipt_upload_form">
   <div class="<%= "mb3" if defined?(include_spacing) %>" style="position: relative;">
-    <%= form_with model: nil, url: receipts_path, method: :post, remote: true, class: "flex flex-col justify-center#{" my-inbox-dropzone" if defined?(restricted_dropzone)}", data: {
+    <%= form_with model: false, url: receipts_path, method: :post, remote: true, class: "flex flex-col justify-center#{" my-inbox-dropzone" if defined?(restricted_dropzone)}", data: {
           turbo: defined?(turbo) ? turbo : "false",
           controller: "file-drop form",
           action: "


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

`form_with(model: nil)` is being deprecated in Rails 8

https://github.com/rails/rails/commit/0c150bacaaca7772121300ca124e3ed5392f6ab9

This is the most prominent deprecation warning we are seeing after adding https://github.com/hackclub/hcb/pull/11289

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

@KiKoS0 already had a commit addressing most of these in https://github.com/hackclub/hcb/pull/10836 so I pulled it out into a separate PR and rebased it off main to fix merge conflicts 

It looks like we can either omit the `model:` argument entirely or explicitly set `model: false`
