### PR TITLE
Fix validation error in `UserService::UpdateCardLocking`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,7 +100,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-
   def user_not_authorized
     flash[:error] = "You are not authorized to perform this action."
     if current_user || !request.get?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -450,6 +450,10 @@ class User < ApplicationRecord
     { role:, access_level: }
   end
 
+  def needs_to_enable_2fa?
+    admin_override_pretend? && !use_two_factor_authentication
+  end
+
   private
 
   def update_stripe_cardholder
@@ -510,7 +514,7 @@ class User < ApplicationRecord
     return unless use_two_factor_authentication_changed?
     return if Rails.env.development?
 
-    if admin_override_pretend? && !use_two_factor_authentication
+    if needs_to_enable_2fa?
       errors.add(:use_two_factor_authentication, "cannot be disabled for admin accounts")
     end
   end

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -20,7 +20,9 @@ module UserService
         TwilioMessageService::Send.new(@user, message).run!
       end
 
-      @user.update!(cards_locked: cards_should_lock)
+      User.with_2fa_requirement_disabled do
+        @user.update!(cards_locked: cards_should_lock)
+      end
     end
 
   end

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -20,9 +20,7 @@ module UserService
         TwilioMessageService::Send.new(@user, message).run!
       end
 
-      User.with_2fa_requirement_disabled do
-        @user.update!(cards_locked: cards_should_lock)
-      end
+      @user.update!(cards_locked: cards_should_lock)
     end
 
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
                duration: 30.minutes,
                learn_more_url: "https://blog.hcb.hackclub.com/posts/7th-may-maintenance" %>
 
-    <% if current_user&.needs_to_enable_2fa? %>
+    <% if current_user&.needs_to_enable_2fa? && !Rails.env.development? %>
       <div class="w-100 px4 !bg-red transparency-banner">
         <p class="h5 medium center mt1 mb1 text-white text-xl">
           ⚠️ Admin users are required to

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,6 +87,14 @@
                duration: 30.minutes,
                learn_more_url: "https://blog.hcb.hackclub.com/posts/7th-may-maintenance" %>
 
+    <% if current_user&.needs_to_enable_2fa? %>
+      <div class="w-100 px4 !bg-red transparency-banner">
+        <p class="h5 medium center mt1 mb1 text-white text-xl">
+          ⚠️ Admin users are required to
+          <%= link_to("enable two-factor authentication", settings_security_path, class: "text-inherit") %>
+        </p>
+      </div>
+    <% end %>
     <% if current_session&.impersonated? %>
       <div class="w-100 px4 bg-white transparency-banner">
         <p class="h5 medium center mt1 mb1">

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -253,26 +253,24 @@ RSpec.describe User, type: :model do
   end
 
   describe "#use_two_factor_authentication" do
-    it "is enforced for admin updates" do
-      user = create(:user, :make_admin)
+    it "cannot be disabled by admins" do
+      user = create(:user, :make_admin, use_two_factor_authentication: true)
 
-      expect(user.update(full_name: "Orpheus the Dinosaur")).to eq(false)
-      expect(user.errors[:access_level]).to contain_exactly("two factor authentication is required for this access level")
+      expect(user.update(use_two_factor_authentication: false)).to eq(false)
+      expect(user.errors[:use_two_factor_authentication]).to contain_exactly("cannot be disabled for admin accounts")
     end
 
-    it "is enforced even if the admin is pretending to be a regular user" do
-      user = create(:user, :make_admin, pretend_is_not_admin: true)
+    it "cannot be disabled by admins pretending not to be admins" do
+      user = create(:user, :make_admin, use_two_factor_authentication: true, pretend_is_not_admin: true)
 
-      expect(user.update(full_name: "Orpheus the Dinosaur")).to eq(false)
-      expect(user.errors[:access_level]).to contain_exactly("two factor authentication is required for this access level")
+      expect(user.update(use_two_factor_authentication: false)).to eq(false)
+      expect(user.errors[:use_two_factor_authentication]).to contain_exactly("cannot be disabled for admin accounts")
     end
 
-    it "can be selectively bypassed" do
-      user = create(:user, :make_admin)
+    it "can be disabled by regular users" do
+      user = create(:user, use_two_factor_authentication: true)
 
-      User.with_2fa_requirement_disabled do
-        expect(user.update(full_name: "Orpheus the Dinosaur")).to eq(true)
-      end
+      expect(user.update(use_two_factor_authentication: false)).to eq(true)
     end
   end
 end


### PR DESCRIPTION
## Summary of the problem

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1940

We have validation in place that prevents updates to users if they don't have 2fa enabled: https://github.com/hackclub/hcb/blob/8f0a8a89ce254306239f00e900bfed6aa0efffa5/app/models/user.rb#L178-L182 (introduced in https://github.com/hackclub/hcb/pull/9432)

This is causing failures in `UserService::UpdateCardLocking` because we get a validation error when trying to update a field on a user record: https://github.com/hackclub/hcb/blob/8f0a8a89ce254306239f00e900bfed6aa0efffa5/app/services/user_service/update_card_locking.rb#L23

## Describe your changes

- Switches the validation mechanism to only take effect when the `use_two_factor_authentication` field is updated.
- Shows a big angry banner if users need to enable 2FA
    <img width="2612" height="2080" alt="CleanShot 2025-08-13 at 16 18 45@2x" src="https://github.com/user-attachments/assets/d4f17996-6e7f-421c-889c-b7b29b3a2ca1" />
