### PR TITLE
Add disabled to receipts form

### DIFF
--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -65,6 +65,7 @@
             <% additional_classes = [].tap do |array|
                  array << "bg-success" if local_assigns[:success]
                  array << "bg-error" if local_assigns[:error]
+                 array << "disabled" if defined?(receiptable) && current_user && !ReceiptablePolicy.new(current_user, receiptable).upload?
                end.join(", ") %>
             <%= form.label :file, class: "btn m1 #{additional_classes}", id: "upload-receipt-button" do %>
               <%= inline_icon "cloud-upload" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We had to remove the disabled because it was breaking the unauthenticated receipts page. This readds it with a check for the presence of `current_user`. See https://github.com/hackclub/hcb/pull/11321#discussion_r2274312989 for more context.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

