### PR TITLE
More deprecated usage of `form_with(model: nil...`

### DIFF
--- a/app/views/events/_pinned_transactions.html.erb
+++ b/app/views/events/_pinned_transactions.html.erb
@@ -12,7 +12,7 @@
       <% end %>
 
       <%= link_to organizer_signed_in? ? pin.hcb_code : "#", data: @show_popovers ? { turbo_frame: "_top", behavior: "modal_trigger", modal: "transaction_details_#{pin.__id__}" } : {}, class: "pinned__transaction relative card shadow-none border flex flex-col black" do %>
-        <%= form_with url: pin_hcb_code_path(pin.hcb_code, event: @event), model: @hcb_code, data: { turbo_method: :post, turbo_confirm: "This will unpin the transaction for all team members. Continue?" } do |form| %>
+        <%= form_with url: pin_hcb_code_path(pin.hcb_code, event: @event), model: false, data: { turbo_method: :post, turbo_confirm: "This will unpin the transaction for all team members. Continue?" } do |form| %>
           <button type="submit" class="pinned__transaction__pin pointer pop tooltipped tooltipped--w" aria-label="Unpin" style="margin-left: auto" onclick="event.stopPropagation()">
             <%= inline_icon "pin-remove", size: 28 %>
           </button>

--- a/app/views/events/_pinned_transactions.html.erb
+++ b/app/views/events/_pinned_transactions.html.erb
@@ -13,10 +13,21 @@
 
       <%= link_to organizer_signed_in? ? pin.hcb_code : "#", data: @show_popovers ? { turbo_frame: "_top", behavior: "modal_trigger", modal: "transaction_details_#{pin.__id__}" } : {}, class: "pinned__transaction relative card shadow-none border flex flex-col black" do %>
         <% if organizer_signed_in? %>
-          <%= form_with url: pin_hcb_code_path(pin.hcb_code, event: @event), model: false, data: { turbo_method: :post, turbo_confirm: "This will unpin the transaction for all team members. Continue?" } do |form| %>
-            <button type="submit" class="pinned__transaction__pin pointer pop tooltipped tooltipped--w" aria-label="Unpin" style="margin-left: auto" onclick="event.stopPropagation()">
+          <%= form_for(
+                pin.hcb_code,
+                url: pin_hcb_code_path(pin.hcb_code, event: @event),
+                method: :post,
+                data: { turbo_confirm: "This will unpin the transaction for all team members. Continue?" }
+              ) do |form| %>
+            <%= form.button(
+                  type: "submit",
+                  class: "pinned__transaction__pin pointer pop tooltipped tooltipped--w",
+                  aria: { label: "Unpin" },
+                  style: "margin-left: auto",
+                  onclick: "event.stopPropagation()"
+                ) do %>
               <%= inline_icon "pin-remove", size: 28 %>
-            </button>
+            <% end %>
           <% end %>
         <% end %>
 

--- a/app/views/events/_pinned_transactions.html.erb
+++ b/app/views/events/_pinned_transactions.html.erb
@@ -12,11 +12,13 @@
       <% end %>
 
       <%= link_to organizer_signed_in? ? pin.hcb_code : "#", data: @show_popovers ? { turbo_frame: "_top", behavior: "modal_trigger", modal: "transaction_details_#{pin.__id__}" } : {}, class: "pinned__transaction relative card shadow-none border flex flex-col black" do %>
-        <%= form_with url: pin_hcb_code_path(pin.hcb_code, event: @event), model: false, data: { turbo_method: :post, turbo_confirm: "This will unpin the transaction for all team members. Continue?" } do |form| %>
-          <button type="submit" class="pinned__transaction__pin pointer pop tooltipped tooltipped--w" aria-label="Unpin" style="margin-left: auto" onclick="event.stopPropagation()">
-            <%= inline_icon "pin-remove", size: 28 %>
-          </button>
-        <% end if organizer_signed_in? %>
+        <% if organizer_signed_in? %>
+          <%= form_with url: pin_hcb_code_path(pin.hcb_code, event: @event), model: false, data: { turbo_method: :post, turbo_confirm: "This will unpin the transaction for all team members. Continue?" } do |form| %>
+            <button type="submit" class="pinned__transaction__pin pointer pop tooltipped tooltipped--w" aria-label="Unpin" style="margin-left: auto" onclick="event.stopPropagation()">
+              <%= inline_icon "pin-remove", size: 28 %>
+            </button>
+          <% end %>
+        <% end %>
 
         <p class="block font-bold m0 flex items-center g2">
           <%= format_date pin.hcb_code.date %>


### PR DESCRIPTION
## Summary of the problem

See https://github.com/hackclub/hcb/pull/11310 and https://github.com/hackclub/hcb/pull/11322

There was another one: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2140

## Describe your changes

Use `model: false`

cc @albertchae 