### PR TITLE
[Receipts] Extract currency from textual content

### DIFF
--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -39,6 +39,9 @@ class Receipt < ApplicationRecord
   blind_index :textual_content
   has_encrypted :extracted_card_last4
 
+  monetize :extracted_subtotal_amount_cents, as: "extracted_subtotal_amount", with_model_currency: :extracted_currency, allow_nil: true
+  monetize :extracted_total_amount_cents, as: "extracted_total_amount", with_model_currency: :extracted_currency, allow_nil: true
+
   include StripeAuthorizationsHelper
 
   include PublicIdentifiable

--- a/app/services/receipt_service/extract.rb
+++ b/app/services/receipt_service/extract.rb
@@ -25,6 +25,7 @@ module ReceiptService
 
         subtotal_amount_cents
         total_amount_cents // the amount likely to be charged to a credit card
+        currency // 3-digit ISO 4217 currency code
         card_last_four
         date // in the format of YYYY-MM-DD
         merchant_url // URL for merchant's primary website including https, if available
@@ -77,6 +78,7 @@ module ReceiptService
         suggested_memo: data.transaction_memo,
         extracted_subtotal_amount_cents: data.subtotal_amount_cents&.to_i,
         extracted_total_amount_cents: data.total_amount_cents&.to_i,
+        extracted_currency: data.currency&.upcase,
         extracted_card_last4: data.card_last_four,
         extracted_date: data.date&.to_date,
         extracted_merchant_name: data.merchant_name,

--- a/app/views/receipts/_extracted.html.erb
+++ b/app/views/receipts/_extracted.html.erb
@@ -24,7 +24,7 @@
       <% if receipt.extracted_total_amount_cents %>
         <div class="fs-mask" style="grid-template-columns: 7rem auto;">
           <strong style="font-weight: 600;">Amount</strong>
-          <%= render_money receipt.extracted_total_amount_cents %>
+          <%= receipt.extracted_total_amount.format %>
         </div>
       <% end %>
 

--- a/db/migrate/20250814191925_add_extracted_currency_to_receipt.rb
+++ b/db/migrate/20250814191925_add_extracted_currency_to_receipt.rb
@@ -1,0 +1,5 @@
+class AddExtractedCurrencyToReceipt < ActiveRecord::Migration[7.2]
+  def change
+    add_column :receipts, :extracted_currency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_08_033500) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_14_191925) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1764,6 +1764,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_033500) do
     t.boolean "data_extracted", default: false, null: false
     t.integer "textual_content_source", default: 0
     t.string "textual_content_bidx"
+    t.string "extracted_currency"
     t.index ["receiptable_type", "receiptable_id"], name: "index_receipts_on_receiptable_type_and_receiptable_id"
     t.index ["textual_content_bidx"], name: "index_receipts_on_textual_content_bidx"
     t.index ["user_id"], name: "index_receipts_on_user_id"


### PR DESCRIPTION
## Summary of the problem
HCB doesn't store the currency on uploaded receipts, and we render all extracted amounts as if they're USD.

## Describe your changes
Start extracting the currency on new receipt uploads.

Closes #8207 



