### PR TITLE
Fix styling on card grant detail tooltips

### DIFF
--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -33,9 +33,9 @@
         <div class="fs-mask">
           <strong class="inline-flex items-center" style="gap: 4px">
             Expiration date
-            <%= link_to "#", class: "text-yellow tooltipped tooltipped--e", "aria-label": "This is what you enter when asked for expiration date at checkout. This is different than your grant's expiration date.", style: "display: flex;", data: { turbo: false } do %>
+            <span class="text-yellow tooltipped tooltipped--e h-[18px]" aria-label="This is what you enter when asked for expiration date at checkout. This is different than your grant's expiration date.">
               <%= inline_icon "important", size: 18, style: "position: unset;" %>
-            <% end %>
+            </span>
           </strong>
           <%= copy_to_clipboard(render_short_exp_date(stripe_card), class: "w-fit", tooltip_direction: "e") { render_exp_date stripe_card } %>
         </div>
@@ -109,9 +109,9 @@
           <div class="fs-mask">
             <strong class="inline-flex items-center" style="gap: 4px">
               Phone number
-              <%= link_to "#", class: "info tooltipped tooltipped--e", "aria-label": "Seem familiar? This is your number! Use this if asked during checkout :)", style: "display: flex;", data: { turbo: false } do %>
+              <span class="info tooltipped tooltipped--e h-[18px]" aria-label="Seem familiar? This is your number! Use this if asked during checkout :)">
                 <%= inline_icon "info", size: 18, style: "position: unset;" %>
-              <% end %>
+              </span>
             </strong>
             <%= copy_to_clipboard(stripe_card.user.pretty_phone_number, class: "w-fit", tooltip_direction: "e") %>
           </div>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -20,7 +20,7 @@
           <p>
             <strong class="inline-flex items-center" style="gap: 4px">
               One time use
-              <span class="info tooltipped tooltipped--e" aria-label="This card will automatically freeze after you make a purchase">
+              <span class="info tooltipped tooltipped--e h-[18px]" aria-label="This card will automatically freeze after you make a purchase">
                 <%= inline_icon "info", size: 18, style: "position: unset;" %>
               </span>
             </strong>

--- a/app/views/card_grants/_grant_details.html.erb
+++ b/app/views/card_grants/_grant_details.html.erb
@@ -9,9 +9,9 @@
         <p>
           <strong class="inline-flex items-center" style="gap: 4px">
             Expiration date
-            <%= link_to "#", class: "text-yellow tooltipped tooltipped--e", "aria-label": "This is when your grant will be returned to #{card_grant.event.name}. Please check the above section if you are looking for your billing information.", style: "display: flex;", data: { turbo: false } do %>
+            <span class="text-yellow tooltipped tooltipped--e h-[18px]" aria-label="This is when your grant will be returned to <%= card_grant.event.name %>. Please check the above section if you are looking for your billing information.">
               <%= inline_icon "important", size: 18, style: "position: unset;" %>
-            <% end %>
+            </span>
           </strong>
           <span><%= format_date card_grant.expires_on %></span>
         </p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some card grant details tooltips were links to `#` when they should have been `span`s, and one `span` tooltip wasn't centered properly.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the `link_to "#"` tooltips to be spans that are properly centered with the text.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="1394" height="948" alt="image" src="https://github.com/user-attachments/assets/e15fea0c-2b3c-4d6b-8f95-bbbed19357d7" />

