### PR TITLE
Handle `DisbursementService` errors in `CardGrantsController#topup`

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -168,6 +168,8 @@ class CardGrantsController < ApplicationController
     @card_grant.topup!(amount_cents: Monetize.parse(params[:amount]).cents, topped_up_by: current_user)
 
     redirect_to @card_grant, flash: { success: "Successfully topped up grant." }
+  rescue DisbursementService::Create::UserError => e
+    redirect_to @card_grant, flash: { error: e.message }
   end
 
   def withdraw


### PR DESCRIPTION
## Summary of the problem

We're having the same issue as https://github.com/hackclub/hcb/pull/11211 but on a different endpoint

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2128

## Describe your changes

Adds explicit handling of `DisbursementService::Create::UserError` so we can report the error back to the user.