### PR TITLE
Fix incorrect timestamps for money movement

### DIFF
--- a/app/views/events/home/_money_movement.html.erb
+++ b/app/views/events/home/_money_movement.html.erb
@@ -17,7 +17,7 @@
               <% if transaction.is_a?(CanonicalPendingTransaction) %>
                 Pending &bull;
               <% end %>
-              <% subtitle = "#{time_ago_in_words(transaction.date)} ago" %>
+              <% subtitle = transaction.date > 24.hours.ago ? "Earlier today" : "#{time_ago_in_words(transaction.date)} ago" %>
               <% if transaction.try(:raw_stripe_transaction) || transaction.try(:raw_pending_stripe_transaction_id) %>
                 <% subtitle += ", #{transaction.stripe_cardholder.user.name}" %>
               <% end %>
@@ -71,7 +71,7 @@
               <% if transaction.is_a?(CanonicalPendingTransaction) %>
                 Pending &bull;
               <% end %>
-              <% subtitle = "#{time_ago_in_words(transaction.date)} ago" %>
+              <% subtitle = transaction.date > 24.hours.ago ? "Earlier today" : "#{time_ago_in_words(transaction.date)} ago" %>
               <% if transaction.try(:raw_stripe_transaction) || transaction.try(:raw_pending_stripe_transaction_id) %>
                 <% subtitle += ", #{transaction.stripe_cardholder.user.name}" %>
               <% end %>


### PR DESCRIPTION
### Closes #11064

This PR is very similar to #10372 but fixes the timestamps for money movement

<img width="829" height="425" alt="441891878-40e3c9cb-421d-473f-9797-05625057337a" src="https://github.com/user-attachments/assets/1c1c8a96-83c7-498b-8642-ec6dd8586f83" />

---

<img width="1020" height="457" alt="image" src="https://github.com/user-attachments/assets/dae0fb23-1e40-4412-8246-7982fd443928" />
