### PR TITLE
Correctly render a plain timed-out method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   rescue_from Rack::Timeout::RequestTimeoutException do
     respond_to do |format|
       format.html { render "errors/timeout" }
-      format.all { render text: "This request timed out, sorry." }
+      format.all { render plain: "This request timed out, sorry." }
     end
   end
 


### PR DESCRIPTION
Fixed https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1688! The root cause of this was that even with a timeout we would still try rendering the template.