### PR TITLE
Allow users to delete receipts from active card grants

### DIFF
--- a/app/policies/receipt_policy.rb
+++ b/app/policies/receipt_policy.rb
@@ -10,7 +10,8 @@ class ReceiptPolicy < ApplicationPolicy
       # Checking if receiptable is nil prevents unauthorized
       # deletion when user no longer has access to an org
       (record&.receiptable.nil? && record&.user == user) ||
-      (record&.receiptable.instance_of?(Reimbursement::Expense) && record&.user == user && unlocked?)
+      (record&.receiptable.instance_of?(Reimbursement::Expense) && record&.user == user && unlocked?) ||
+      (record&.try(:card_grant)&.user == user && record.card_grant.active?)
   end
 
   def link?

--- a/app/views/receipts/_receipt.html.erb
+++ b/app/views/receipts/_receipt.html.erb
@@ -63,7 +63,7 @@
       <iframe src="<%= file_path %>" style="width: 100%; display: none; height: 100vh; max-height: 100%; border: none; border-radius: 0.75rem; overflow: hidden;"></iframe>
     <% end %>
     <% end %>
-    <% if defined?(delete_on_hover) && delete_on_hover %>
+    <% if defined?(delete_on_hover) && delete_on_hover && policy(receipt).destroy? %>
       <%= pop_icon_to "view-close",
               { controller: "/receipts", action: :destroy, id: receipt.id, popover: local_assigns[:popover] },
               method: :delete,
@@ -92,7 +92,7 @@
             class: "info tooltipped tooltipped--w mr1",
             'aria-label': "Get reimbursed for this" %>
       <% end %>
-      <% if defined?(show_delete_button) %>
+      <% if defined?(show_delete_button) && policy(receipt).destroy?  %>
         <%= pop_icon_to "view-close",
             receipt_path(receipt, { popover: local_assigns[:popover], format: (:html unless local_assigns[:turbo_for_deletion]) }.compact),
             data: {

--- a/app/views/receipts/_receipt.html.erb
+++ b/app/views/receipts/_receipt.html.erb
@@ -92,7 +92,7 @@
             class: "info tooltipped tooltipped--w mr1",
             'aria-label': "Get reimbursed for this" %>
       <% end %>
-      <% if defined?(show_delete_button) && policy(receipt).destroy?  %>
+      <% if defined?(show_delete_button) && policy(receipt).destroy? %>
         <%= pop_icon_to "view-close",
             receipt_path(receipt, { popover: local_assigns[:popover], format: (:html unless local_assigns[:turbo_for_deletion]) }.compact),
             data: {


### PR DESCRIPTION
Plus hide the button if they don't have permission.