### PR TITLE
Only discard `Receipt::SuggestPairingsJob` on `ActiveJob::DeserializationError` if `cause` is a `ActiveRecord::RecordNotFound`

### DIFF
--- a/app/jobs/receipt/suggest_pairings_job.rb
+++ b/app/jobs/receipt/suggest_pairings_job.rb
@@ -3,11 +3,14 @@
 class Receipt
   class SuggestPairingsJob < ApplicationJob
     queue_as :low
+    discard_on(RTesseract::Error)
+    discard_on(ActiveJob::DeserializationError) do |_job, exception|
+      raise(exception) unless exception.cause.is_a?(ActiveRecord::RecordNotFound)
+    end
+
     def perform(receipt)
       ::ReceiptService::Suggest.new(receipt:).run!
     end
-
-    discard_on ActiveRecord::RecordNotFound, RTesseract::Error
 
   end
 


### PR DESCRIPTION
## Summary of the problem

See https://github.com/hackclub/hcb/pull/11345, https://github.com/hackclub/hcb/pull/11294, and https://hackclub.slack.com/archives/C047Y01MHJQ/p1755531077004089

`ActiveRecord::RecordNotFound` is a bit too broad as it could either come from `ActiveJob`'s deserialization code (in which case we'd want to discard the job) or from the job's logic, which would indicate a bug.

## Describe your changes

- Use `ActiveJob::DeserializationError` instead
- Pass a block to `discard_on` and explicitly re-raise if `cause` isn't `ActiveRecord::RecordNotFound`, as `ActiveJob::DeserializationError` is a bit of a footgun

### Addendum -  Why is `ActiveJob::DeserializationError` a footgun?

See https://github.com/getsentry/sentry-ruby/issues/1071 and https://github.com/rails/rails/issues/40318

https://github.com/rails/rails/blob/9a21e6c3b92eab108c85e2bc9f47ad19a40ad88a/activejob/lib/active_job/arguments.rb#L44-L45

`ActiveJob::DeserializationError` is raised if any `StandardError` (or descendant) gets thrown within the process of deserializing the job's argument. This is problematic as it can make external calls to the database (via https://github.com/rails/globalid/) which can fail for a multitude of reasons (e.g. `ActiveRecord::DatabaseConnectionError`) which don't indicate that the model referenced in the job's parameters does not exist. 