### PR TITLE
Add missing annotation for `receipts.extracted_currency`

### DIFF
--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -7,6 +7,7 @@
 #  id                              :bigint           not null, primary key
 #  data_extracted                  :boolean          default(FALSE), not null
 #  extracted_card_last4_ciphertext :text
+#  extracted_currency              :string
 #  extracted_date                  :datetime
 #  extracted_merchant_name         :string
 #  extracted_merchant_url          :string


### PR DESCRIPTION
## Summary of the problem

https://github.com/hackclub/hcb/pull/11327 added a new column but not the annotations

From https://hcb.hackclub.com/schema:

<img width="1826" height="812" alt="CleanShot 2025-08-18 at 14 01 45@2x" src="https://github.com/user-attachments/assets/da83c612-a4c8-4d29-9544-34cebf729d9d" />

## Describe your changes

Commits the annotation