### PR TITLE
Include HCB URL in Help Scout Beacon

### DIFF
--- a/app/views/application/_support_button.html.erb
+++ b/app/views/application/_support_button.html.erb
@@ -20,7 +20,7 @@
       type="button"
       class="support-menu__button fixed bottom-0 right-0 m-5 pop tooltipped tooltipped--w embedded-display-none cursor-pointer"
       style="z-index: 2" aria-label="Get help"
-      onclick="window.Beacon && (window.Beacon('identify', { name: <%= current_user&.name.to_json %>, email: <%= current_user&.email.to_json %>, signature: <%= OpenSSL::HMAC.hexdigest("sha256", Credentials.fetch(:HELPSCOUT, :BEACON_SECRET_KEY) || "", current_user&.email || "").to_json %> }), window.Beacon('session-data', { url: <%= url_params[:url].to_json %>, location: <%= url_params[:location].to_json %>, user_id: <%= url_params[:user_id].to_json %> }), window.Beacon('toggle'))">
+      onclick="window.Beacon && (window.Beacon('identify', { name: <%= current_user&.name.to_json %>, email: <%= current_user&.email.to_json %>, signature: <%= OpenSSL::HMAC.hexdigest("sha256", Credentials.fetch(:HELPSCOUT, :BEACON_SECRET_KEY) || "", current_user&.email || "").to_json %>, 'hcb-url': <%= (current_user && admin_user_path(current_user)).to_json %> }), window.Beacon('session-data', { url: <%= url_params[:url].to_json %>, location: <%= url_params[:location].to_json %>, user_id: <%= url_params[:user_id].to_json %> }), window.Beacon('toggle'))">
       <%= inline_icon "question-mark", size: 18 %>
     </button>
   </div>


### PR DESCRIPTION
## Describe your changes
This PR makes it easier for ops to access user information from live chat conversations in Help Scout. Ops no longer needs to search for a user by email; instead they can just click the URL provided in Help Scout.