### PR TITLE
Redirect to my cards if nil event during card creation

### DIFF
--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -131,7 +131,11 @@ class StripeCardsController < ApplicationController
   rescue => e
     Rails.error.report(e)
 
-    redirect_to event_cards_new_path(event), flash: { error: e.message }
+    if event.present?
+      redirect_to event_cards_new_path(event), flash: { error: e.message }
+    else
+      redirect_to my_cards_path, flash: { error: e.message }
+    end
   end
 
   def edit


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/660
```
No route matches {action: "new", controller: "stripe_cards", event_id: nil}, possible unmatched constraints: [:event_id]
```

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Confusing - could not reproduce this bug or find a reason why `event_id` would be nil when this form is submitted, but I added a check in case `event` is nil to just redirect to `/my/cards` instead of the event-specific cards page.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

