### PR TITLE
Fix fee reimbursement memo date

### DIFF
--- a/app/models/hcb_code/memo.rb
+++ b/app/models/hcb_code/memo.rb
@@ -91,7 +91,7 @@ class HcbCode
       end
 
       def outgoing_fee_reimbursement_memo
-        "🗂️ Stripe fee reimbursements for #{ct.date.beginning_of_week.strftime("%-m/%-d")} to #{ct2.date.beginning_of_week.strftime("%-m/%-d")}"
+        "🗂️ Stripe fee reimbursements for week of #{ct.date.beginning_of_week.strftime("%-m/%-d")}"
       end
 
       def reimbursement_payout_holding_memo


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fee reimbursement memos were saying the same date twice in a range, like "🗂️ Stripe fee reimbursements for 8/11 to 8/11".

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Reverted it back to just say "week of [date]"

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

