### PR TITLE
[Ledger] Fix ledger sorting showing unstyled page

### DIFF
--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <% admin_tool "overflow-hidden" do %>
-    <div data-controller="menu" data-menu-placement-value="bottom-end">
+    <div data-controller="menu" data-menu-placement-value="bottom-end" data-menu-append-to-value="turbo-frame#<%= dom_id(@event) %>_ledger">
       <button
         type="button"
         class="pop menu__toggle menu__toggle--arrowless overflow-visible"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The ledger sorting buttons were showing an unstyled page since they were not in a turbo frame, causing the entire page content to be replaced by the ledger.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Puts the ledger sort menu in the ledger turbo frame so that it captures the links.

