### PR TITLE
[Reimbursement::Expense] Remove expense approval on update

### DIFF
--- a/app/models/reimbursement/expense.rb
+++ b/app/models/reimbursement/expense.rb
@@ -117,6 +117,13 @@ module Reimbursement
       end
     end
 
+    before_update do
+      if approved? && (memo_changed? || amount_cents_changed? || category_changed? || description_changed?)
+        mark_pending!
+        self.approved_by = nil
+      end
+    end
+
     def receipt_required?
       true
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, someone can issue a reimbursement report with an expense for $2, get it approved by a manager, but if the entire report is not yet approved they can still convert it to a draft and modify the $2 expense to have different details, such as for $4 instead of $2. When submitted back for review, it looks like the expense was approved, even though it could be entirely different.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added a callback to `Reimbursement::Expense` that will mark the expense as pending if is updated with new details (memo/amount/category/description), so that it must be reviewed again before the report is paid out.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

