### PR TITLE
[Categories] Set automatically based on stripe merchant codes

### DIFF
--- a/app/models/raw_pending_stripe_transaction.rb
+++ b/app/models/raw_pending_stripe_transaction.rb
@@ -38,7 +38,7 @@ class RawPendingStripeTransaction < ApplicationRecord
     stripe_transaction.dig("merchant_data", "name")
   end
 
-  def merchant_category_key
+  def merchant_category
     stripe_transaction&.dig("merchant_data", "category")
   end
 

--- a/app/models/raw_pending_stripe_transaction.rb
+++ b/app/models/raw_pending_stripe_transaction.rb
@@ -38,6 +38,10 @@ class RawPendingStripeTransaction < ApplicationRecord
     stripe_transaction.dig("merchant_data", "name")
   end
 
+  def merchant_category_key
+    stripe_transaction&.dig("merchant_data", "category")
+  end
+
   def likely_event_id
     @likely_event_id ||= ::StripeCard.find_by(stripe_id: stripe_card_id)&.event_id
   end

--- a/app/models/raw_stripe_transaction.rb
+++ b/app/models/raw_stripe_transaction.rb
@@ -26,7 +26,7 @@ class RawStripeTransaction < ApplicationRecord
     @memo ||= stripe_transaction.dig("merchant_data", "name")
   end
 
-  def merchant_category_key
+  def merchant_category
     stripe_transaction&.dig("merchant_data", "category")
   end
 

--- a/app/models/raw_stripe_transaction.rb
+++ b/app/models/raw_stripe_transaction.rb
@@ -26,6 +26,10 @@ class RawStripeTransaction < ApplicationRecord
     @memo ||= stripe_transaction.dig("merchant_data", "name")
   end
 
+  def merchant_category_key
+    stripe_transaction&.dig("merchant_data", "category")
+  end
+
   def likely_event_id
     @likely_event_id ||= ::StripeCard.find_by!(stripe_id: stripe_card_id).event_id
   end

--- a/app/models/transaction_category/definition.rb
+++ b/app/models/transaction_category/definition.rb
@@ -19,4 +19,11 @@ class TransactionCategory
 
   Definition::ALL = Definition.load_all
 
+  Definition::BY_STRIPE_MERCHANT_CATEGORY =
+    Definition::ALL.each_with_object({}) do |(_slug, definition), hash|
+      definition.stripe_merchant_categories.each do |stripe_merchant_category|
+        hash[stripe_merchant_category] = definition
+      end
+    end.freeze
+
 end

--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/stripe.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/stripe.rb
@@ -17,6 +17,10 @@ module PendingTransactionEngine
 
           cpt.save!
 
+          TransactionCategoryService
+            .new(model: cpt)
+            .sync_from_stripe!
+
           return cpt
         end
 

--- a/app/services/transaction_category_service.rb
+++ b/app/services/transaction_category_service.rb
@@ -30,9 +30,9 @@ class TransactionCategoryService
 
     # Bail if the model isn't a stripe transaction or for some reason we can't
     # find the category
-    return unless stripe_merchant_category_key.present?
+    return unless stripe_merchant_category.present?
 
-    definition = TransactionCategory::Definition::BY_STRIPE_MERCHANT_CATEGORY[stripe_merchant_category_key]
+    definition = TransactionCategory::Definition::BY_STRIPE_MERCHANT_CATEGORY[stripe_merchant_category]
 
     # We don't have mappings for every stripe category
     return unless definition
@@ -45,17 +45,17 @@ class TransactionCategoryService
 
   attr_reader(:model)
 
-  def stripe_merchant_category_key
+  def stripe_merchant_category
     case model
     when CanonicalPendingTransaction
-      model.raw_pending_stripe_transaction&.merchant_category_key
+      model.raw_pending_stripe_transaction&.merchant_category
     when CanonicalTransaction
-      model.raw_stripe_transaction&.merchant_category_key
+      model.raw_stripe_transaction&.merchant_category
     else
       raise ArgumentError, "unsupported model type: #{@model.class.name}"
     end
   end
 
-  memo_wise(:stripe_merchant_category_key)
+  memo_wise(:stripe_merchant_category)
 
 end

--- a/app/services/transaction_category_service.rb
+++ b/app/services/transaction_category_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TransactionCategoryService
+  prepend MemoWise
+
   def initialize(model:)
     unless model.is_a?(Categorizable)
       raise ArgumentError, "unsupported model type: #{model.class.name}"
@@ -22,8 +24,38 @@ class TransactionCategoryService
     mapping.save!
   end
 
+  def sync_from_stripe!
+    # If there's already a category assigned, don't reassign it
+    return if @model.category.present?
+
+    # Bail if the model isn't a stripe transaction or for some reason we can't
+    # find the category
+    return unless stripe_merchant_category_key.present?
+
+    definition = TransactionCategory::Definition::BY_STRIPE_MERCHANT_CATEGORY[stripe_merchant_category_key]
+
+    # We don't have mappings for every stripe category
+    return unless definition
+
+    category = TransactionCategory.find_or_create_by!(slug: definition.slug)
+    model.create_category_mapping!(category:, assignment_strategy: "automatic")
+  end
+
   private
 
   attr_reader(:model)
+
+  def stripe_merchant_category_key
+    case model
+    when CanonicalPendingTransaction
+      model.raw_pending_stripe_transaction&.merchant_category_key
+    when CanonicalTransaction
+      model.raw_stripe_transaction&.merchant_category_key
+    else
+      raise ArgumentError, "unsupported model type: #{@model.class.name}"
+    end
+  end
+
+  memo_wise(:stripe_merchant_category_key)
 
 end

--- a/spec/factories/raw_pending_stripe_transaction_factory.rb
+++ b/spec/factories/raw_pending_stripe_transaction_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
           "id": generate(:stripe_card_id)
         },
         "authorization_method": "online",
-        "merchant_data": { "name": "merchant 1" }
+        "merchant_data": { "name": "merchant 1", "category": "bakeries" }
       }
     }
   end

--- a/spec/factories/raw_pending_stripe_transaction_factory.rb
+++ b/spec/factories/raw_pending_stripe_transaction_factory.rb
@@ -8,6 +8,11 @@ FactoryBot.define do
   factory :raw_pending_stripe_transaction do
     amount_cents { Faker::Number.number(digits: 4) }
     sequence(:stripe_transaction_id) { |n| "iauth_#{n}" }
+
+    transient do
+      stripe_merchant_category { "bakeries" }
+    end
+
     stripe_transaction {
       {
         "id": stripe_transaction_id,
@@ -15,7 +20,10 @@ FactoryBot.define do
           "id": generate(:stripe_card_id)
         },
         "authorization_method": "online",
-        "merchant_data": { "name": "merchant 1", "category": "bakeries" }
+        "merchant_data": {
+          "name": "merchant 1",
+          "category": stripe_merchant_category
+        }
       }
     }
   end

--- a/spec/factories/raw_stripe_transaction_factory.rb
+++ b/spec/factories/raw_stripe_transaction_factory.rb
@@ -4,6 +4,24 @@ FactoryBot.define do
   factory :raw_stripe_transaction do
     amount_cents { Faker::Number.number(digits: 4) }
     unique_bank_identifier { "STRIPEISSUING1" }
-    stripe_transaction { { "merchant_data": { "name": Faker::Name.name, "category": "bakeries" } } }
+    transient do
+      sequence(:stripe_transaction_id) { |n| "ipi_#{n}" }
+      stripe_card { create(:stripe_card, :with_stripe_id) }
+      stripe_merchant_category { "bakeries" }
+    end
+
+    stripe_transaction do
+      {
+        "id"            => stripe_transaction_id,
+        "card"          => stripe_card.stripe_id,
+        "type"          => "capture",
+        "amount"        => -amount_cents,
+        "cardholder"    => stripe_card.stripe_cardholder.id,
+        "merchant_data" => {
+          "name"     => Faker::Company.name,
+          "category" => stripe_merchant_category,
+        },
+      }
+    end
   end
 end

--- a/spec/factories/raw_stripe_transaction_factory.rb
+++ b/spec/factories/raw_stripe_transaction_factory.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :raw_stripe_transaction do
     amount_cents { Faker::Number.number(digits: 4) }
     unique_bank_identifier { "STRIPEISSUING1" }
-    stripe_transaction { { "merchant_data": { "name": Faker::Name.name } } }
+    stripe_transaction { { "merchant_data": { "name": Faker::Name.name, "category": "bakeries" } } }
   end
 end

--- a/spec/models/raw_pending_stripe_transaction_spec.rb
+++ b/spec/models/raw_pending_stripe_transaction_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe RawPendingStripeTransaction, type: :model do
       expect(raw_pending_stripe_transaction.authorization_method).to eql("online")
     end
   end
+
+  describe "#merchant_category_key" do
+    it "returns the merchant category key from the JSON data" do
+      expect(raw_pending_stripe_transaction.merchant_category_key).to eq("bakeries")
+    end
+
+    it "returns nil by default" do
+      expect(described_class.new.merchant_category_key).to be_nil
+    end
+  end
 end

--- a/spec/models/raw_pending_stripe_transaction_spec.rb
+++ b/spec/models/raw_pending_stripe_transaction_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe RawPendingStripeTransaction, type: :model do
     end
   end
 
-  describe "#merchant_category_key" do
-    it "returns the merchant category key from the JSON data" do
-      expect(raw_pending_stripe_transaction.merchant_category_key).to eq("bakeries")
+  describe "#merchant_category" do
+    it "returns the merchant category from the JSON data" do
+      expect(raw_pending_stripe_transaction.merchant_category).to eq("bakeries")
     end
 
     it "returns nil by default" do
-      expect(described_class.new.merchant_category_key).to be_nil
+      expect(described_class.new.merchant_category).to be_nil
     end
   end
 end

--- a/spec/models/raw_stripe_transaction_spec.rb
+++ b/spec/models/raw_stripe_transaction_spec.rb
@@ -3,8 +3,19 @@
 require "rails_helper"
 
 RSpec.describe RawStripeTransaction, type: :model do
+  let(:raw_stripe_transaction) { create(:raw_stripe_transaction) }
+
   it "is valid" do
-    raw_stripe_transaction = create(:raw_stripe_transaction)
     expect(raw_stripe_transaction).to be_valid
+  end
+
+  describe "#merchant_category_key" do
+    it "returns the merchant category key from the JSON data" do
+      expect(raw_stripe_transaction.merchant_category_key).to eq("bakeries")
+    end
+
+    it "returns nil by default" do
+      expect(described_class.new.merchant_category_key).to be_nil
+    end
   end
 end

--- a/spec/models/raw_stripe_transaction_spec.rb
+++ b/spec/models/raw_stripe_transaction_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe RawStripeTransaction, type: :model do
     expect(raw_stripe_transaction).to be_valid
   end
 
-  describe "#merchant_category_key" do
-    it "returns the merchant category key from the JSON data" do
-      expect(raw_stripe_transaction.merchant_category_key).to eq("bakeries")
+  describe "#merchant_category" do
+    it "returns the merchant category from the JSON data" do
+      expect(raw_stripe_transaction.merchant_category).to eq("bakeries")
     end
 
     it "returns nil by default" do
-      expect(described_class.new.merchant_category_key).to be_nil
+      expect(described_class.new.merchant_category).to be_nil
     end
   end
 end

--- a/spec/services/transaction_category_service_spec.rb
+++ b/spec/services/transaction_category_service_spec.rb
@@ -72,4 +72,118 @@ RSpec.describe TransactionCategoryService do
       end
     end
   end
+
+  describe "sync_from_stripe!" do
+    context "for canonical transactions" do
+      it "sets the category based on our mapping" do
+        ct = create(
+          :canonical_transaction,
+          transaction_source: create(
+            :raw_stripe_transaction,
+            stripe_merchant_category: "bakeries",
+          )
+        )
+
+        described_class.new(model: ct).sync_from_stripe!
+
+        ct.reload
+        expect(ct.category.slug).to eq("food-fun")
+        expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+      end
+
+      it "leaves the current category intact if one exists" do
+        ct = create(
+          :canonical_transaction,
+          category_slug: "rent",
+          transaction_source: create(
+            :raw_stripe_transaction,
+            stripe_merchant_category: "bakeries",
+          )
+        )
+
+        described_class.new(model: ct).sync_from_stripe!
+
+        ct.reload
+        expect(ct.category.slug).to eq("rent")
+      end
+
+      it "ignores non-stripe transactions" do
+        ct = create(:canonical_transaction)
+
+        described_class.new(model: ct).sync_from_stripe!
+
+        expect(ct.reload.category).to be_nil
+      end
+
+      it "ignores unmapped categories" do
+        ct = create(
+          :canonical_transaction,
+          transaction_source: create(
+            :raw_stripe_transaction,
+            stripe_merchant_category: "definitely-not-a-thing",
+          )
+        )
+
+        described_class.new(model: ct).sync_from_stripe!
+
+        expect(ct.reload.category).to be_nil
+      end
+    end
+
+    context "for canonical pending transactions" do
+      it "sets the category based on our mapping" do
+        cpt = create(
+          :canonical_pending_transaction,
+          raw_pending_stripe_transaction: create(
+            :raw_pending_stripe_transaction,
+            stripe_merchant_category: "bakeries",
+          )
+        )
+
+        described_class.new(model: cpt).sync_from_stripe!
+
+        cpt.reload
+        expect(cpt.category.slug).to eq("food-fun")
+        expect(cpt.category_mapping.assignment_strategy).to eq("automatic")
+      end
+
+      it "leaves the current category intact if one exists" do
+        cpt = create(
+          :canonical_pending_transaction,
+          category_slug: "rent",
+          raw_pending_stripe_transaction: create(
+            :raw_pending_stripe_transaction,
+            stripe_merchant_category: "bakeries",
+          )
+        )
+
+        described_class.new(model: cpt).sync_from_stripe!
+
+        cpt.reload
+        expect(cpt.category.slug).to eq("rent")
+      end
+
+      it "ignores non-stripe transactions" do
+        cpt = create(:canonical_pending_transaction)
+
+        described_class.new(model: cpt).sync_from_stripe!
+
+        expect(cpt.reload.category).to be_nil
+      end
+
+      it "ignores unmapped categories" do
+        cpt = create(
+          :canonical_pending_transaction,
+          raw_pending_stripe_transaction: create(
+            :raw_pending_stripe_transaction,
+            stripe_merchant_category: "definitely-not-a-thing",
+          )
+        )
+
+        described_class.new(model: cpt).sync_from_stripe!
+
+        expect(cpt.reload.category).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

In #11298 and #11371 we added a mechanism to associate transactions to categories. We would like to do that automatically for Stripe transactions.

## Describe your changes

1. Adds a `merchant_category` method to both the raw stripe transaction models
2. Adds `TransactionCategoryService#sync_from_stripe!` to handle the syncing logic
3. Runs (2) when `CanonicalPendingTransaction`s are created for `RawPendingStripeTransaction`s

I _think_ this is sufficient given the updated logic in `CanonicalPendingTransactionService::Settle` but I'm not sure if that's the only way Stripe transactions are created.