### PR TITLE
[Announcement] Whitelabel mailer

### DIFF
--- a/app/views/layouts/mailer/_header.html.erb
+++ b/app/views/layouts/mailer/_header.html.erb
@@ -5,12 +5,22 @@
   https://github.com/premailer/premailer/pull/244
 %>
 <div class="section" style="text-align: left;">
-  <a
-    href="<%= Rails.application.routes.url_helpers.root_url %>"
-    target="_blank">
-    <img
-      src="<%= Rails.application.routes.url_helpers.root_url %>brand/hcb-icon-icon-original.png"
-      style="width: 2.5rem">
-  </a>
+  <% if @announcement.present? %>
+    <a
+      href="<%= Rails.application.routes.url_helpers.root_url %><%= Rails.application.routes.url_helpers.event_path(@announcement.event) %>"
+      target="_blank">
+      <img
+        src="<%= @announcement.event.logo.present? ? Rails.application.routes.url_helpers.url_for(@announcement.event.logo) : Rails.application.routes.url_helpers.root_url + "brand/hcb-icon-icon-original.png" %>"
+        style="height: 2.5rem; max-width: 80%">
+    </a>
+  <% else %>
+    <a
+      href="<%= Rails.application.routes.url_helpers.root_url %>"
+      target="_blank">
+      <img
+        src="<%= Rails.application.routes.url_helpers.root_url %>brand/hcb-icon-icon-original.png"
+        style="height: 2.5rem">
+    </a>
+  <% end %>
 </div>
 <!-- end text/html -->

--- a/app/views/layouts/mailer/_header.html.erb
+++ b/app/views/layouts/mailer/_header.html.erb
@@ -7,7 +7,7 @@
 <div class="section" style="text-align: left;">
   <% if @announcement.present? %>
     <a
-      href="<%= Rails.application.routes.url_helpers.root_url %><%= Rails.application.routes.url_helpers.event_path(@announcement.event) + "/announcements" %>"
+      href="<%= Rails.application.routes.url_helpers.event_announcement_overview_url(@announcement.event) %>"
       target="_blank">
       <img
         src="<%= @announcement.event.logo.present? ? Rails.application.routes.url_helpers.url_for(@announcement.event.logo) : Rails.application.routes.url_helpers.root_url + "brand/hcb-icon-icon-original.png" %>"

--- a/app/views/layouts/mailer/_header.html.erb
+++ b/app/views/layouts/mailer/_header.html.erb
@@ -7,7 +7,7 @@
 <div class="section" style="text-align: left;">
   <% if @announcement.present? %>
     <a
-      href="<%= Rails.application.routes.url_helpers.root_url %><%= Rails.application.routes.url_helpers.event_path(@announcement.event) %>"
+      href="<%= Rails.application.routes.url_helpers.root_url %><%= Rails.application.routes.url_helpers.event_path(@announcement.event) + "/announcements" %>"
       target="_blank">
       <img
         src="<%= @announcement.event.logo.present? ? Rails.application.routes.url_helpers.url_for(@announcement.event.logo) : Rails.application.routes.url_helpers.root_url + "brand/hcb-icon-icon-original.png" %>"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Mailer wasn't whitelabeled

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

now it shows the org's logo (if it has one) and always links to the org's announcement page

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

<img width="912" height="832" alt="Screenshot 2025-08-20 at 3 26 05 PM" src="https://github.com/user-attachments/assets/c48950fc-6894-47a9-8f3f-3b3a0a0a208d" />
