### PR TITLE
Fix nil event errors in ct/cpt partials

### DIFF
--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -1,5 +1,7 @@
 <% instance = pt.__id__ %>
+<% event = @event || pt.local_hcb_code.event %>
 <% tagged_with = pt.local_hcb_code.tags.filter { |tag| !@event || tag.event == @event } %>
+
 <tr
   class="transaction muted <%= unless current_user && Flipper.enabled?(:transactions_background_2024_06_05, current_user)
                                  pt.amount.negative? ? "transaction--negative" : pt.amount.positive? ? "transaction--positive" : "transaction--zero"
@@ -64,7 +66,7 @@
             <span title="<%= transaction_memo(pt) %>" style="flex-grow: 1;">
               <% if pt.local_hcb_code.card_grant? && !organizer_signed_in? %>
                 <%= link_to(transaction_memo(pt), spending_card_grant_path(pt.local_hcb_code.disbursement.card_grant), data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "card_grant_details_#{instance}" }) %>
-              <% elsif pt.stripe_card&.subledger.present? &&(@event || pt.local_hcb_code.event).present? && !OrganizerPosition.role_at_least?(current_user, (@event || pt.local_hcb_code.event), :member) %>
+              <% elsif pt.stripe_card&.subledger.present? && event.present? && !OrganizerPosition.role_at_least?(current_user, event, :member) %>
                 <%= link_to url_for(pt.local_hcb_code), data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "transaction_details_#{instance}" } do %>
                   <%= render "hcb_codes/memo", hcb_code: pt.local_hcb_code, location: "ledger", ledger_instance: instance, force_display_details: defined?(force_display_details) %>
                 <% end %>
@@ -77,7 +79,7 @@
           <% end %>
         </div>
 
-        <% if !@event&.demo_mode? && defined?(show_tags) %>
+        <% if !event&.demo_mode? && defined?(show_tags) %>
           <div class="flex flex-wrap pending_transactions_tags tags hcb_code_<%= pt.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: pt.local_hcb_code } %>
           </div>
@@ -93,23 +95,23 @@
             <% end %>
           </div>
         <% end %>
-        <% if policy(pt.local_hcb_code).toggle_tag? %>
+        <% if event.present? && policy(pt.local_hcb_code).toggle_tag? %>
           <div class="overflow-visible relative" style="margin-left: 0.5rem;" data-controller="menu" data-menu-append-to-value="turbo-frame#ledger">
             <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
             <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
-              <% (@event || pt.local_hcb_code.event).tags.each do |tag| %>
+              <% event.tags.each do |tag| %>
                 <div class="flex items-center" data-tag="<%= tag.id %>">
                   <%= button_to toggle_tag_hcb_code_path(id: pt.local_hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(pt.local_hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
                     <%= render partial: "canonical_transactions/tag_icon", locals: { tag: } %>
                     <%= tag.label %>
                     <%= "✓" if tagged_with.include?(tag) %>
                   <% end %>
-                  <%= button_to event_tag_path(@event || pt.local_hcb_code.event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message } do %>
+                  <%= button_to event_tag_path(event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message } do %>
                     <%= inline_icon "delete", size: 18, style: "margin: 0" %>
                   <% end %>
                 </div>
               <% end %>
-              <% if (@event || pt.local_hcb_code.event).tags.any? %>
+              <% if event.tags.any? %>
                 <div class="menu__divider tags__divider"></div>
               <% end %>
               <%= render partial: "hcb_codes/create_tag", locals: { button: pt.local_hcb_code.hashid } %>
@@ -189,8 +191,8 @@
   <% end %>
 </tr>
 
-<% if pt.stripe_card&.subledger&.present? || (Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && (@event || pt.local_hcb_code.event).present?) %>
-  <% pretty_title = pt.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event: @event) %>
+<% if pt.stripe_card&.subledger&.present? || (Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && event.present?) %>
+  <% pretty_title = pt.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event:) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(pt.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(pt.local_hcb_code)) %>
     <%= turbo_frame_tag pt.local_hcb_code.public_id, src: pt.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy, target: "_top" do %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -1,6 +1,8 @@
 <% instance = ct.__id__ %>
+<% event = @event || ct.local_hcb_code.event %>
 <% tagged_with = ct.local_hcb_code.tags.filter { |tag| !@event || tag.event == @event } %>
 <% subscription = local_assigns[:subscription] || nil %>
+
 <tr
   class="transaction <%= unless current_user && Flipper.enabled?(:transactions_background_2024_06_05, current_user)
                            ct.amount.negative? ? "transaction--negative" : ct.amount.positive? ? "transaction--positive" : "transaction--zero"
@@ -62,7 +64,7 @@
             <span title="<%= transaction_memo(ct) %>" style="flex-grow: 1;">
               <% if ct.local_hcb_code.card_grant? && !organizer_signed_in? %>
                 <%= link_to(transaction_memo(ct), spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant), data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "card_grant_details_#{instance}" }) %>
-              <% elsif ct.local_hcb_code.stripe_card&.subledger.present? && (@event || ct.local_hcb_code.event).present? && !OrganizerPosition.role_at_least?(current_user, (@event || ct.local_hcb_code.event), :member) %>
+              <% elsif ct.local_hcb_code.stripe_card&.subledger.present? && event.present? && !OrganizerPosition.role_at_least?(current_user, event, :member) %>
                 <%= link_to url_for(ct.local_hcb_code), data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "transaction_details_#{instance}" } do %>
                   <%= render "hcb_codes/memo", hcb_code: ct.local_hcb_code, location: "ledger", ledger_instance: instance, force_display_details: defined?(force_display_details) %>
                 <% end %>
@@ -75,7 +77,7 @@
           <% end %>
         </div>
 
-        <% if !@event&.demo_mode? && defined?(show_tags) %>
+        <% if !event&.demo_mode? && defined?(show_tags) %>
           <div class="flex flex-wrap tags hcb_code_<%= ct.local_hcb_code.hashid %>_tags" style="gap: 0.25rem">
             <%= render partial: "canonical_transactions/tag", collection: tagged_with, locals: { hcb_code: ct.local_hcb_code } %>
           </div>
@@ -92,23 +94,23 @@
           </div>
         <% end %>
 
-        <% if policy(ct.local_hcb_code).toggle_tag? %>
+        <% if event.present? && policy(ct.local_hcb_code).toggle_tag? %>
           <div class="overflow-visible relative" style="margin-left: 0.5rem;" data-controller="menu" data-menu-append-to-value="turbo-frame#ledger">
             <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
             <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
-              <% (@event || ct.local_hcb_code.event).tags.each do |tag| %>
+              <% event.tags.each do |tag| %>
                 <div class="flex items-center" data-tag="<%= tag.id %>">
                   <%= button_to toggle_tag_hcb_code_path(id: ct.local_hcb_code.hashid, tag_id: tag.id), class: "menu__action #{tag_dom_id(ct.local_hcb_code, tag, "_toggle")}", form_class: "flex-auto", form: { "data-turbo" => "true" } do %>
                     <%= render partial: "canonical_transactions/tag_icon", locals: { tag: } %>
                     <%= tag.label %>
                     <%= "✓" if tagged_with.include?(tag) %>
                   <% end %>
-                  <%= button_to event_tag_path(@event || ct.local_hcb_code.event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message } do %>
+                  <%= button_to event_tag_path(event, tag), class: "menu__action", method: :delete, title: "Delete this tag", form: { "data-turbo" => "true", "data-turbo-confirm" => tag.removal_confirmation_message } do %>
                     <%= inline_icon "delete", size: 18, style: "margin: 0" %>
                   <% end %>
                 </div>
               <% end %>
-              <% if (@event || ct.local_hcb_code.event).tags.any? %>
+              <% if event.tags.any? %>
                 <div class="menu__divider tags__divider"></div>
               <% end %>
               <%= render partial: "hcb_codes/create_tag", locals: { button: ct.local_hcb_code.hashid } %>
@@ -196,9 +198,8 @@
   <% end %>
 </tr>
 
-<% event = @event || ct.local_hcb_code.event %>
 <% if ct.local_hcb_code.stripe_card&.subledger.present? || (Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) && event.present? && !show_mock_data?(event)) %>
-  <% pretty_title = ct.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event: @event) %>
+  <% pretty_title = ct.local_hcb_code.pretty_title(show_event_name: defined?(show_event_name), show_amount: defined?(show_amount), event:) %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="transaction_details_<%= instance %>" data-state-url="<%= hcb_code_path(ct.local_hcb_code) %>" data-state-title="<%= pretty_title %>">
     <%= modal_header(pretty_title, external_link: url_for(ct.local_hcb_code)) %>
     <%= turbo_frame_tag ct.local_hcb_code.public_id, src: ct.local_hcb_code.popover_path(transaction_show_receipt_button: local_assigns[:receipt_upload_button], transaction_show_author_img: local_assigns[:show_author_column]), loading: :lazy, target: "_top" do %>
@@ -267,7 +268,7 @@
 
 <% if (Flipper.enabled?(:hcb_code_popovers_2023_06_16, current_user) || !organizer_signed_in?) && ct.local_hcb_code.card_grant? %>
   <section class="modal modal--scroll modal--popover bg-snow" data-behavior="modal" role="dialog" id="card_grant_details_<%= instance %>" data-state-url="<%= spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant) %>" data-state-title="<%= transaction_memo(ct) %>">
-    <%= modal_header(ct.local_hcb_code.pretty_title(show_event_name: false, show_amount: true, event: @event), external_link: spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant)) %>
+    <%= modal_header(ct.local_hcb_code.pretty_title(show_event_name: false, show_amount: true, event:), external_link: spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant)) %>
     <%= turbo_frame_tag "spending_#{ct.local_hcb_code.disbursement.card_grant.public_id}", src: spending_card_grant_path(ct.local_hcb_code.disbursement.card_grant, params: { frame: true }), loading: :lazy do %>
       <strong>Loading...</strong>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1687/samples/timestamp/2025-08-20T15:06:42Z

Sometimes `@event` is not set and the canonical (pending) transaction being rendered is not yet mapped to an event - this needs to be handled in the canonical (pending) transaction partials.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Refactored the default event in both partials to a variable and does not render the create tag menu if there is no event set.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

