### PR TITLE
Use a toast for admin flash

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -909,6 +909,74 @@ form:has(> #admin-logout-button) {
   margin: 0px;
 }
 
+@keyframes flash-slide-in {
+  from {
+    translate: 0 calc(-100% - var(--flash-offset, 0));
+  }
+
+  to {
+    translate: 0 0;
+  }
+}
+
+#flash-container {
+  position: absolute;
+  top: 0;
+  left: calc(50vw - 25ch);
+  right: calc(50vw - 25ch);
+  display: flex;
+  justify-content: center;
+
+  article.flash {
+    --flash-offset: 1rem;
+    border: 1px solid var(--hcb-bg-2);
+    border-top: 3px solid var(--hcb-link-1);
+    border-radius: 4px;
+    background: white;
+    padding: 1rem;
+    margin: var(--flash-offset) 0 0;
+    overflow: hidden;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    box-shadow: 0 1px 2px hsl(240 3.8% 46.1% / 12%);
+    animation-duration: 0.5s;
+    animation-name: flash-slide-in;
+    z-index: 999;
+
+    &.flash--success {
+      border-top-color: green;
+    }
+
+    &.flash--error {
+      border-top-color: red;
+    }
+
+    &.flash--dismissed {
+      translate: 0 calc(-100% - var(--flash-offset));
+      display: none;
+      transition-property: translate display;
+      transition-duration: 1s;
+      transition-behavior: allow-discrete;
+    }
+
+    .flash--content {
+      flex: 1;
+    }
+  }
+
+  .flash--close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    color: black;
+  }
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -929,10 +929,10 @@ form:has(> #admin-logout-button) {
 
   article.flash {
     --flash-offset: 1rem;
-    border: 1px solid var(--hcb-bg-2);
+    border: 1px solid var(--hcb-bg-3);
     border-top: 3px solid var(--hcb-link-1);
     border-radius: 4px;
-    background: white;
+    background: var(--hcb-bg-1);
     padding: 1rem;
     margin: var(--flash-offset) 0 0;
     overflow: hidden;
@@ -973,7 +973,7 @@ form:has(> #admin-logout-button) {
     background: transparent;
     padding: 0;
     margin: 0;
-    color: black;
+    color: inherit;
   }
 }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -930,7 +930,7 @@ form:has(> #admin-logout-button) {
   article.flash {
     --flash-offset: 1rem;
     border: 1px solid var(--hcb-bg-3);
-    border-top: 3px solid var(--hcb-link-1);
+    border-top: 3px solid var(--hcb-accent);
     border-radius: 4px;
     background: var(--hcb-bg-1);
     padding: 1rem;
@@ -946,11 +946,11 @@ form:has(> #admin-logout-button) {
     z-index: 999;
 
     &.flash--success {
-      border-top-color: green;
+      border-top-color: var(--hcb-accent-active);
     }
 
     &.flash--error {
-      border-top-color: red;
+      border-top-color: var(--hcb-primary);
     }
 
     &.flash--dismissed {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -911,7 +911,7 @@ form:has(> #admin-logout-button) {
 
 @keyframes flash-slide-in {
   from {
-    translate: 0 calc(-100% - var(--flash-offset, 0));
+    translate: 0 calc(100% + var(--flash-offset, 0));
   }
 
   to {
@@ -921,11 +921,12 @@ form:has(> #admin-logout-button) {
 
 #flash-container {
   position: absolute;
-  top: 0;
-  left: calc(50vw - 25ch);
-  right: calc(50vw - 25ch);
+  bottom: 0;
+  right: 0;
+  width: 50ch;
   display: flex;
   justify-content: center;
+  overflow: hidden;
 
   article.flash {
     --flash-offset: 1rem;
@@ -934,12 +935,11 @@ form:has(> #admin-logout-button) {
     border-radius: 4px;
     background: var(--hcb-bg-1);
     padding: 1rem;
-    margin: var(--flash-offset) 0 0;
+    margin: 0 var(--flash-offset) var(--flash-offset) 0;
     overflow: hidden;
     width: 100%;
     display: flex;
     align-items: center;
-    gap: 1rem;
     box-shadow: 0 1px 2px hsl(240 3.8% 46.1% / 12%);
     animation-duration: 0.5s;
     animation-name: flash-slide-in;
@@ -954,10 +954,10 @@ form:has(> #admin-logout-button) {
     }
 
     &.flash--dismissed {
-      translate: 0 calc(-100% - var(--flash-offset));
+      translate: 0 calc(100% + var(--flash-offset));
       display: none;
       transition-property: translate display;
-      transition-duration: 1s;
+      transition-duration: 0.5s;
       transition-behavior: allow-discrete;
     }
 

--- a/app/javascript/controllers/admin_flash_controller.js
+++ b/app/javascript/controllers/admin_flash_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect() {
+    this.dismissTimeout = setTimeout(this.dismiss.bind(this), 5000)
+  }
+
+  disconnect() {
+    clearTimeout(this.dismissTimeout)
+  }
+
+  dismiss() {
+    this.element.classList.add('flash--dismissed')
+  }
+}

--- a/app/views/admin/_flash.html.erb
+++ b/app/views/admin/_flash.html.erb
@@ -1,0 +1,14 @@
+<div id="flash-container">
+  <% flash.to_h.except("imported_transactions", "file").each do |key, value| %>
+    <article
+      role="alertdialog"
+      class="flash flash--<%= key %>"
+      data-controller="admin-flash"
+      data-turbo-temporary>
+      <div class="flash--content"><%= value %></div>
+      <button class="flash--close-button" data-action="click->admin-flash#dismiss:prevent">
+        <%= inline_icon("view-close", size: 20, class: "pointer flash--close") %>
+      </button>
+    </article>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -140,16 +140,8 @@
       </div>
     </nav>
 
-    <% flash.to_h.except("imported_transactions", "file").each do |key, value| %>
-      <% if key == "error" %>
-        <p style="text-align:center;background:red;color:white;"><%= value %></p>
-      <% elsif key == "success" %>
-        <p style="text-align:center;background:green;color:white;"><%= value %></p>
-      <% else %>
-        <p style="text-align:center;background:darkblue;color:white;"><%= value %></p>
-      <% end %>
-      <hr>
-    <% end %>
+    <%= render(partial: "admin/flash") %>
+
     <div id="main" class="overflow-x-auto overflow-y-auto" style="padding: 2rem; margin: 0 auto">
       <%= yield %>
     </div>


### PR DESCRIPTION
## Summary of the problem

The current admin flash is a bit rudimentary and isn't ideal when combined with turbo streams as it shifts the layout and doesn't go away.

This would normally be fine but I'm in the process of introducing several new interactions that would benefit.

## Describe your changes

- Moves the flash logic to a partial (so it can be refreshed from a turbo stream)
- Updates the DOM structure to rely on classes instead of inline styles
- Adds a slide down animation
- Adds a button to dismiss
- Adds a stimulus controller which handles the button clicks and will auto-dismiss after 5 seconds


https://github.com/user-attachments/assets/84019150-4389-4242-aa09-8f916d76215b