### PR TITLE
[Categories] Allow category to be set from the pending ledger table and transaction page

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -513,13 +513,17 @@ th {
   padding: 0.5rem;
 }
 
-th {
+thead th {
   background: var(--hcb-bg-2);
 }
 
 tr:nth-child(even) {
   /* Set every other cell slightly darker. Improves readability. */
   background: var(--hcb-bg-2);
+}
+
+table.no-stripes {
+  tr:nth-child(even) { background: inherit; }
 }
 
 table caption {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -523,7 +523,9 @@ tr:nth-child(even) {
 }
 
 table.no-stripes {
-  tr:nth-child(even) { background: inherit; }
+  tr:nth-child(even) {
+    background: inherit;
+  }
 }
 
 table caption {

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -410,6 +410,9 @@ class AdminController < ApplicationController
 
     relation = relation.unsettled if @unsettled
 
+    # Preload transaction categories
+    relation = relation.preload(:category)
+
     @count = relation.count
 
     @canonical_pending_transactions = relation.page(@page).per(@per).order("date desc")

--- a/app/controllers/canonical_pending_transactions_controller.rb
+++ b/app/controllers/canonical_pending_transactions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CanonicalPendingTransactionsController < ApplicationController
+  include TurboStreamFlash
+
   def show
     @canonical_pending_transaction = CanonicalPendingTransaction.find(params[:id])
     authorize @canonical_pending_transaction
@@ -48,13 +50,7 @@ class CanonicalPendingTransactionsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         flash.now[:success] = message
-        partial =
-          if params[:context] == "admin"
-            "admin/flash"
-          else
-            "application/flash"
-          end
-        render(turbo_stream: turbo_stream.replace("flash-container", partial:))
+        update_flash_via_turbo_stream(use_admin_layout: params[:context] == "admin")
       end
       format.html do
         redirect_to(

--- a/app/controllers/canonical_pending_transactions_controller.rb
+++ b/app/controllers/canonical_pending_transactions_controller.rb
@@ -48,7 +48,13 @@ class CanonicalPendingTransactionsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         flash.now[:success] = message
-        render(turbo_stream: turbo_stream.replace("flash-container", partial: "application/flash"))
+        partial =
+          if params[:context] == "admin"
+            "admin/flash"
+          else
+            "application/flash"
+          end
+        render(turbo_stream: turbo_stream.replace("flash-container", partial:))
       end
       format.html do
         redirect_to(

--- a/app/controllers/canonical_transactions_controller.rb
+++ b/app/controllers/canonical_transactions_controller.rb
@@ -3,6 +3,7 @@
 require "csv"
 
 class CanonicalTransactionsController < ApplicationController
+  include TurboStreamFlash
   def show
     @canonical_transaction = CanonicalTransaction.find(params[:id])
 
@@ -49,7 +50,7 @@ class CanonicalTransactionsController < ApplicationController
     respond_to do |format|
       format.turbo_stream do
         flash.now[:success] = message
-        render(turbo_stream: turbo_stream.replace("flash-container", partial: "application/flash"))
+        update_flash_via_turbo_stream(use_admin_layout: params[:context] == "admin")
       end
       format.html do
         redirect_to(

--- a/app/controllers/concerns/turbo_stream_flash.rb
+++ b/app/controllers/concerns/turbo_stream_flash.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TurboStreamFlash
+  private
+
+  # Shows the updated `flash` by rendering a turbo stream which replaces the DOM
+  # element which contains flash messages.
+  #
+  # ⚠️ Because this method renders immediately you should set your message with
+  # `flash.now` before calling it.
+  #
+  # This can be particularly handy if you want to handle simple user
+  # interactions that can occur on multiple pages with a single controller
+  # action (e.g. `CanonicalTransactionsController#set_category`).
+  def update_flash_via_turbo_stream(use_admin_layout: false)
+    partial =
+      if use_admin_layout
+        "admin/flash"
+      else
+        "application/flash"
+      end
+
+    render(turbo_stream: turbo_stream.replace("flash-container", partial:))
+  end
+end

--- a/app/views/admin/pending_ledger.html.erb
+++ b/app/views/admin/pending_ledger.html.erb
@@ -28,6 +28,7 @@
       <th>Amount</th>
       <th>HCB Code</th>
       <th>Event</th>
+      <th>Category</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -49,6 +50,16 @@
         <td><%= cpt.amount %></td>
         <td><%= cpt.hcb_code %></td>
         <td><%= cpt.event.try(:id) %></td>
+        <td>
+          <%= render(
+                partial: "hcb_codes/transaction_category_form",
+                locals: {
+                  model: cpt,
+                  url: set_category_canonical_pending_transaction_path(cpt),
+                  admin_context: true
+                }
+              ) %>
+        </td>
         <td>
           <%#= link_to "Process", transaction_admin_path(cpt) unless cpt.event.present? %>
           <%#= link_to "View", transaction_admin_path(cpt) if cpt.event.present? %>

--- a/app/views/admin/transaction.html.erb
+++ b/app/views/admin/transaction.html.erb
@@ -40,6 +40,19 @@
       <th>MappedBy</th>
       <td><%= @canonical_transaction.canonical_event_mapping.try(:user).try(:email) %></td>
     </tr>
+    <tr>
+      <th>Category</th>
+      <td>
+        <%= render(
+              partial: "hcb_codes/transaction_category_form",
+              locals: {
+                model: @canonical_transaction,
+                url: set_category_canonical_transaction_path(@canonical_transaction),
+                admin_context: true
+              }
+            ) %>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/admin/transaction.html.erb
+++ b/app/views/admin/transaction.html.erb
@@ -2,30 +2,42 @@
 
 <h1>Transaction <%= @canonical_transaction.id %></h1>
 
-<table>
-  <thead>
+<table class="no-stripes <%= "admin-bg-pending" unless @canonical_transaction.canonical_event_mapping %>">
+  <tbody>
     <tr>
       <th>ID</th>
-      <th>Date</th>
-      <th>Memo</th>
-      <th>Bank account</th>
-      <th>FriendlyMemo</th>
-      <th>CustomMemo</th>
-      <th>Amount</th>
-      <th>HCB Code</th>
-      <th>MappedBy</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr class="<%= "admin-bg-pending" unless @canonical_transaction.canonical_event_mapping %>">
       <td><%= link_to @canonical_transaction.id, canonical_transaction_path(@canonical_transaction) %></td>
+    </tr>
+    <tr>
+      <th>Date</th>
       <td><%= @canonical_transaction.date %></td>
+    </tr>
+    <tr>
+      <th>Memo</th>
       <td><%= @canonical_transaction.memo %></td>
+    </tr>
+    <tr>
+      <th>Bank account</th>
       <td><%= @canonical_transaction.bank_account_name %></td>
+    </tr>
+    <tr>
+      <th>FriendlyMemo</th>
       <td><%= @canonical_transaction.friendly_memo %></td>
+    </tr>
+    <tr>
+      <th>CustomMemo</th>
       <td><%= @canonical_transaction.custom_memo %></td>
+    </tr>
+    <tr>
+      <th>Amount</th>
       <td><%= @canonical_transaction.amount.format %></td>
+    </tr>
+    <tr>
+      <th>HCB Code</th>
       <td><%= link_to @canonical_transaction.hcb_code, hcb_code_path(@canonical_transaction.local_hcb_code) %></td>
+    </tr>
+    <tr>
+      <th>MappedBy</th>
       <td><%= @canonical_transaction.canonical_event_mapping.try(:user).try(:email) %></td>
     </tr>
   </tbody>

--- a/app/views/hcb_codes/_transaction_category_form.html.erb
+++ b/app/views/hcb_codes/_transaction_category_form.html.erb
@@ -4,7 +4,8 @@
       model,
       url:,
       method: :post,
-      data: { controller: "form" }
+      data: { controller: "form" },
+      html: { class: "m-0" }
     ) do |f| %>
   <%= select_tag(
         f.field_name(:category_slug),
@@ -13,6 +14,7 @@
           model.category&.slug,
         ),
         include_blank: "None",
-        data: { action: "change->form#submit" }
+        data: { action: "change->form#submit" },
+        class: "m-0"
       ) %>
 <% end %>

--- a/app/views/hcb_codes/_transaction_category_form.html.erb
+++ b/app/views/hcb_codes/_transaction_category_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (model:, url:) %>
+<%# locals: (model:, url:, admin_context: false) %>
 
 <%= form_for(
       model,
@@ -7,6 +7,10 @@
       data: { controller: "form" },
       html: { class: "m-0" }
     ) do |f| %>
+  <% if admin_context %>
+    <%= hidden_field_tag("context", "admin") %>
+  <% end %>
+
   <%= select_tag(
         f.field_name(:category_slug),
         options_for_select(


### PR DESCRIPTION
## Summary of the problem

Adding more places for admins to set transaction categories.

## Describe your changes

- Removed some default margins in the `<form>` and `<select>` in `app/views/hcb_codes/_transaction_category_form.html.erb` so they take up less space
- Reworked the two `set_category` endpoints to leverage the same flash logic and use a `context` param to conditionally render the admin flash
- Rendered the transaction category form on the pending ledger table
- Flipped the transaction details table so there's more room to add additional properties
- Added a new row in the transaction details table for the category

Transaction | Pending ledger
---- | ----
<img width="2494" height="1740" alt="image" src="https://github.com/user-attachments/assets/cb15040a-119a-4b40-aff3-bfe67b1d4efb" /> | <img width="2494" height="1740" alt="image" src="https://github.com/user-attachments/assets/b352b117-1075-4209-a1c2-264316fec401" />

⚠️ This builds upon the work in #11398 which makes the admin flash easier to target from turbo streams and better for these kinds of use cases.