### PR TITLE
[Categories] Add one-time jobs to backfill transaction categories

### DIFF
--- a/app/jobs/one_time_jobs/backfill_canonical_pending_transaction_categories.rb
+++ b/app/jobs/one_time_jobs/backfill_canonical_pending_transaction_categories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillCanonicalPendingTransactionCategories
+    include Sidekiq::IterableJob
+
+    sidekiq_options(queue: :low, retry: false)
+
+    def build_enumerator(cursor:)
+      active_record_records_enumerator(CanonicalPendingTransaction, cursor:)
+    end
+
+    def each_iteration(canonical_pending_transaction)
+      TransactionCategoryService.new(model: canonical_pending_transaction).sync_from_stripe!
+    end
+
+  end
+end

--- a/app/jobs/one_time_jobs/backfill_canonical_transaction_categories.rb
+++ b/app/jobs/one_time_jobs/backfill_canonical_transaction_categories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillCanonicalTransactionCategories
+    include Sidekiq::IterableJob
+
+    sidekiq_options(queue: :low, retry: false)
+
+    def build_enumerator(cursor:)
+      active_record_records_enumerator(CanonicalTransaction, cursor:)
+    end
+
+    def each_iteration(canonical_transaction)
+      TransactionCategoryService.new(model: canonical_transaction).sync_from_stripe!
+    end
+
+  end
+end

--- a/spec/jobs/one_time_jobs/backfill_canonical_pending_transaction_categories_spec.rb
+++ b/spec/jobs/one_time_jobs/backfill_canonical_pending_transaction_categories_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OneTimeJobs::BackfillCanonicalPendingTransactionCategories do
+  it "sets canonical pending transaction categories based on stripe transactions" do
+    cpt = create(
+      :canonical_pending_transaction,
+      raw_pending_stripe_transaction: create(
+        :raw_pending_stripe_transaction,
+        stripe_merchant_category: "bakeries",
+      )
+    )
+
+    Sidekiq::Testing.inline! do
+      described_class.perform_async
+    end
+
+    cpt.reload
+    expect(cpt.category.slug).to eq("food-fun")
+    expect(cpt.category_mapping.assignment_strategy).to eq("automatic")
+  end
+end

--- a/spec/jobs/one_time_jobs/backfill_canonical_transaction_categories_spec.rb
+++ b/spec/jobs/one_time_jobs/backfill_canonical_transaction_categories_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OneTimeJobs::BackfillCanonicalTransactionCategories do
+  it "sets canonical transaction categories based on stripe transactions" do
+    ct = create(
+      :canonical_transaction,
+      transaction_source: create(
+        :raw_stripe_transaction,
+        stripe_merchant_category: "bakeries",
+      )
+    )
+
+    Sidekiq::Testing.inline! do
+      described_class.perform_async
+    end
+
+    ct.reload
+    expect(ct.category.slug).to eq("food-fun")
+    expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+  end
+end


### PR DESCRIPTION
## Summary of the problem

In https://github.com/hackclub/hcb/pull/11386 we started automatically assigning transaction categories based on stripe merchant codes, but that only applies to newly-created records.

## Describe your changes

Adds two iterable jobs that loop through the `canonical_pending_transactions` and `canonical_transactions` tables and run `TransactionCategoryService#sync_from_stripe!` on each record.