### PR TITLE
[Announcement] Exclude events with disabled monthly announcements in scope

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -418,9 +418,7 @@ class EventsController < ApplicationController
     end
     @announcements = @all_announcements.page(params[:page]).per(10)
 
-    if @event.config.generate_monthly_announcement
-      @monthly_announcement = Announcement.monthly_for(Date.today).where(event: @event).first
-    end
+    @monthly_announcement = Announcement.monthly_for(Date.today).where(event: @event).first
   end
 
   before_action(only: :feed) { request.format = :atom }

--- a/app/jobs/announcement/monthly_job.rb
+++ b/app/jobs/announcement/monthly_job.rb
@@ -5,14 +5,12 @@ class Announcement
     queue_as :default
 
     def perform
-      Event.includes(:config).where(config: { generate_monthly_announcement: true }).find_each do |event|
-        event.announcements.approved_monthly_for(Date.today.prev_month).find_each do |announcement|
-          Rails.error.handle do
-            announcement.mark_published!
-          end
+      Announcement.approved_monthly_for(Date.today.prev_month).find_each do |announcement|
+        Rails.error.handle do
+          announcement.mark_published!
         end
 
-        Announcement::Templates::Monthly.new(event:, author: User.system_user).create
+        Announcement::Templates::Monthly.new(event: announcement.event, author: User.system_user).create
       end
     end
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -54,7 +54,7 @@ class Announcement < ApplicationRecord
     end
   end
 
-  scope :monthly, -> { where(template_type: Announcement::Templates::Monthly.name) }
+  scope :monthly, -> { joins(event: :config).where(:template_type => Announcement::Templates::Monthly.name, "event_configurations.generate_monthly_announcement" => true) }
   scope :monthly_for, ->(date) { monthly.where("announcements.created_at BETWEEN ? AND ?", date.beginning_of_month, date.end_of_month) }
   scope :approved_monthly_for, ->(date) { monthly_for(date).draft }
   validate :content_is_json


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#11299 starte deleting monthly announcements when they were disabled in event configuration and added a check to `monthly_job`, but there were still places where the `monthly` scope was being used without checking if the event had disabled monthly announcements, and there are some monthly announcements in the database for events that have disabled it.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moves the check for disabled monthly announcements to the `monthly` scope, ensuring no monthly announcement is listed for an event that has disabled them. Also removes the now-redundant checks for the configuration.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

