### PR TITLE
[DX] Put `Rack::MiniProfiler` on the botton left

### DIFF
--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# https://github.com/MiniProfiler/rack-mini-profiler?tab=readme-ov-file#configuration-options
+Rack::MiniProfiler.config.position = "bottom-left"


### PR DESCRIPTION
## Summary of the problem

It's a bit annoying having `Rack::MiniProfiler` is such a prominent spot (top left).

## Describe your changes

Configure it to be on the bottom left.