### PR TITLE
[Categories] Automatically set invoices and donations to `donations`

### DIFF
--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/donation.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/donation.rb
@@ -18,7 +18,11 @@ module PendingTransactionEngine
             raw_pending_donation_transaction_id: @raw_pending_donation_transaction.id,
             fronted: true
           }
-          ::CanonicalPendingTransaction.create!(attrs)
+          cpt = ::CanonicalPendingTransaction.create!(attrs)
+
+          TransactionCategoryService.new(model: cpt).set!(slug: "donations", assignment_strategy: "automatic")
+
+          cpt
         end
 
         private

--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/invoice.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/invoice.rb
@@ -19,7 +19,11 @@ module PendingTransactionEngine
             fronted: true,
             fee_waived: fee_waived?
           }
-          ::CanonicalPendingTransaction.create!(attrs)
+          cpt = ::CanonicalPendingTransaction.create!(attrs)
+
+          TransactionCategoryService.new(model: cpt).set!(slug: "donations", assignment_strategy: "automatic")
+
+          cpt
         end
 
         private

--- a/db/data/transaction_categories.json
+++ b/db/data/transaction_categories.json
@@ -5,6 +5,9 @@
   "benefits": {
     "label": "Benefits"
   },
+  "donations": {
+    "label": "Donations"
+  },
   "events-projects": {
     "label": "Events / Projects"
   },

--- a/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/donation_spec.rb
+++ b/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/donation_spec.rb
@@ -6,9 +6,6 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
 
   context "when passing a raw pending donation transaction that is not yet processed" do
     it "processes into a CanonicalPendingTransaction" do
-      expect(RawPendingDonationTransaction.count).to eq(0)
-
-
       raw_pending_donation_transaction = create(:raw_pending_donation_transaction, date_posted: Date.current)
 
       expect do
@@ -39,7 +36,7 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
     end
 
     context "when processed" do
-      it "copies the attributes and sets fronted to true" do
+      it "copies the attributes, sets fronted to true, and sets the category to 'donations'" do
         expect do
           described_class.new(raw_pending_donation_transaction:).run
         end.to change { CanonicalPendingTransaction.count }.by(1)
@@ -49,6 +46,8 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
         expect(canonical_pending_transaction.memo).to eq(raw_pending_donation_transaction.memo)
         expect(canonical_pending_transaction.amount_cents).to eq(raw_pending_donation_transaction.amount_cents)
         expect(canonical_pending_transaction.fronted).to eq(true)
+        expect(canonical_pending_transaction.category.slug).to eq("donations")
+        expect(canonical_pending_transaction.category_mapping.assignment_strategy).to eq("automatic")
       end
     end
   end

--- a/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/invoice_spec.rb
+++ b/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/invoice_spec.rb
@@ -6,9 +6,6 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
 
   context "when passing a raw pending invoice transaction that is not yet processed" do
     it "processes into a CanonicalPendingTransaction" do
-      expect(RawPendingInvoiceTransaction.count).to eq(0)
-
-
       raw_pending_invoice_transaction = create(:raw_pending_invoice_transaction, date_posted: Date.current)
 
       expect do
@@ -49,6 +46,8 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
         expect(canonical_pending_transaction.memo).to eq(raw_pending_invoice_transaction.memo)
         expect(canonical_pending_transaction.amount_cents).to eq(raw_pending_invoice_transaction.amount_cents)
         expect(canonical_pending_transaction.fronted).to eq(true)
+        expect(canonical_pending_transaction.category.slug).to eq("donations")
+        expect(canonical_pending_transaction.category_mapping.assignment_strategy).to eq("automatic")
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem

In a similar manner to #11386 we want to automatically categorize invoices and donations as `donations`.

## Describe your changes

- Adds `donations` to `db/data/transaction_categories.json`
- Updates `PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::Donation` and `...::Invoice` to apply the `donations` category to the created `CanonicalPendingTransaction`