### PR TITLE
Fix renaming transactions lag

### DIFF
--- a/app/views/hcb_codes/edit.html.erb
+++ b/app/views/hcb_codes/edit.html.erb
@@ -8,10 +8,13 @@
 
 <% if @frame %>
   <%= turbo_frame_tag @hcb_code do %>
-    <%= form_with model: @hcb_code, data: { turbo: true, controller: "form" }, html: { style: "flex-grow: 1" } do |form| %>
+    <%= form_with model: @hcb_code,
+                    data: { turbo: true, controller: "form" },
+                    html: { style: "flex-grow: 1", onsubmit: "$('#checkIcon').hide(); $('#loadingIcon').removeClass('hidden');" } do |form| %>
       <div class="flex items-center">
         <button class="pop border-none cursor-pointer mr2 <%= "ai" if @ai_memo %> tooltipped tooltipped--e" aria-label="Save">
-          <%= inline_icon "check", size: 28 %>
+          <%= inline_icon "check", size: 28, id: "checkIcon" %>
+          <%= inline_icon "loading", size: 20, id: "loadingIcon", class: "hidden" %>
         </button>
 
         <%= form.text_field :memo,

--- a/app/views/hcb_codes/edit.html.erb
+++ b/app/views/hcb_codes/edit.html.erb
@@ -9,8 +9,8 @@
 <% if @frame %>
   <%= turbo_frame_tag @hcb_code do %>
     <%= form_with model: @hcb_code,
-                    data: { turbo: true, controller: "form" },
-                    html: { style: "flex-grow: 1", onsubmit: "$('#checkIcon').hide(); $('#loadingIcon').removeClass('hidden');" } do |form| %>
+                  data: { turbo: true, controller: "form" },
+                  html: { style: "flex-grow: 1", onsubmit: "$('#checkIcon').hide(); $('#loadingIcon').removeClass('hidden');" } do |form| %>
       <div class="flex items-center">
         <button class="pop border-none cursor-pointer mr2 <%= "ai" if @ai_memo %> tooltipped tooltipped--e" aria-label="Save">
           <%= inline_icon "check", size: 28, id: "checkIcon" %>


### PR DESCRIPTION
Currently, when a user finishes renaming a transaction, the UI appears laggy. This PR adds a loading indicator to give show visual feedback to the user 


https://github.com/user-attachments/assets/cec753e4-cf3e-44cb-814a-d4a1c64e53cf

Resolves #11205

