### PR TITLE
Restore "Decline Stripe card authorizations for specific merchant categories"

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -89,4 +89,15 @@ class AdminMailer < ApplicationMailer
     )
   end
 
+  def blocked_authorization
+    @stripe_card = params.fetch(:stripe_card)
+    @event = @stripe_card.event
+    @merchant_category = params.fetch(:merchant_category)
+
+    mail(
+      to: OPERATIONS_EMAIL,
+      subject: "#{@event.name}: Stripe card authorization blocked"
+    )
+  end
+
 end

--- a/app/services/stripe_authorization_service.rb
+++ b/app/services/stripe_authorization_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module StripeAuthorizationService
+  FORBIDDEN_MERCHANT_CATEGORIES =
+    Set.new(
+      [
+        "betting_casino_gambling",
+        # This looks like a typo but matches Stripe's documentation
+        # https://docs.stripe.com/issuing/categories
+        "government_licensed_online_casions_online_gambling_us_region_only",
+        "government_licensed_horse_dog_racing_us_region_only",
+        "government_owned_lotteries_non_us_region",
+        "government_owned_lotteries_us_region_only",
+      ]
+    ).freeze
+end

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -57,6 +57,15 @@ module StripeAuthorizationService
       def approve?
         return decline_with_reason!("event_frozen") if event.financially_frozen?
 
+        if forbidden_merchant_category?
+          AdminMailer
+            .with(stripe_card: card, merchant_category:)
+            .blocked_authorization
+            .deliver_later
+
+          return decline_with_reason!("merchant_not_allowed")
+        end
+
         return decline_with_reason!("merchant_not_allowed") unless merchant_allowed?
 
         return decline_with_reason!("inadequate_balance") if card_balance_available < amount_cents
@@ -91,11 +100,19 @@ module StripeAuthorizationService
         )
       end
 
+      def merchant_category
+        auth.dig(:merchant_data, :category)
+      end
+
+      def forbidden_merchant_category?
+        StripeAuthorizationService::FORBIDDEN_MERCHANT_CATEGORIES.include?(merchant_category)
+      end
+
       def merchant_allowed?
         disallowed_categories = card&.card_grant&.disallowed_categories
         disallowed_merchants = card&.card_grant&.disallowed_merchants
 
-        return false if disallowed_categories&.include?(auth[:merchant_data][:category])
+        return false if disallowed_categories&.include?(merchant_category)
         return false if disallowed_merchants&.include?(auth[:merchant_data][:network_id])
 
         allowed_categories = card&.card_grant&.allowed_categories
@@ -105,7 +122,7 @@ module StripeAuthorizationService
         has_restrictions = allowed_categories.present? || allowed_merchants.present? || keyword_lock.present?
         return true unless has_restrictions
 
-        return true if allowed_categories&.include?(auth[:merchant_data][:category])
+        return true if allowed_categories&.include?(merchant_category)
         return true if allowed_merchants&.include?(auth[:merchant_data][:network_id])
         return true if keyword_lock.present? && Regexp.new(keyword_lock).match?(auth[:merchant_data][:name])
 

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -101,7 +101,7 @@ module StripeAuthorizationService
       end
 
       def merchant_category
-        auth.dig(:merchant_data, :category)
+        auth[:merchant_data][:category]
       end
 
       def forbidden_merchant_category?

--- a/app/views/admin_mailer/blocked_authorization.html.erb
+++ b/app/views/admin_mailer/blocked_authorization.html.erb
@@ -1,0 +1,24 @@
+<p>
+  A Stripe card authorization for a <code><%= @merchant_category %></code> merchant was blocked.
+</p>
+
+<ul>
+  <li>
+    <%= link_to("Event: #{@event.name}", event_url(@event)) %>
+  </li>
+  <li>
+    <%= link_to("Stripe Card", stripe_card_url(@stripe_card)) %>
+    <ul>
+      <% if @stripe_card.name.present? %>
+        <li><strong>Card name:</strong> <%= @stripe_card.name %></li>
+      <% end %>
+      <li>
+        <strong>Cardholder:</strong>
+        <%= link_to(admin_user_url(@stripe_card.user)) do %>
+          <%= @stripe_card.user.full_name %>
+          (<%= @stripe_card.user.email %>)
+        <% end %>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -32,5 +32,16 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :gambling do
+      merchant_data do
+        {
+          category: "betting_casino_gambling",
+          category_code: "7995",
+          network_id: "1234567890",
+          name: "CASINO"
+        }
+      end
+    end
   end
 end

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :stripe_authorization do
+  factory(:stripe_authorization, class: "Stripe::Issuing::Authorization") do
+    skip_create
+    initialize_with { Stripe::Issuing::Authorization.construct_from(attributes) }
+
     amount { 0 }
     approved { true }
     merchant_data do

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -8,4 +8,18 @@ class AdminMailerPreview < ActionMailer::Preview
     AdminMailer.with(events: @events).weekly_ysws_event_summary
   end
 
+  def blocked_authorization
+    AdminMailer
+      .with(
+        stripe_card: StripeCard.new(
+          id: 1,
+          name: "AWS Billing",
+          event: Event.first,
+          user: User.first,
+        ).tap(&:readonly!),
+        merchant_category: StripeAuthorizationService::FORBIDDEN_MERCHANT_CATEGORIES.first
+      )
+      .blocked_authorization
+  end
+
 end

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest, type: :model do
+  include ActionMailer::TestHelper
+
   let(:event) { create(:event) }
   let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:) }
   let(:stripe_authorization) { attributes_for(:stripe_authorization, card: { id: stripe_card.stripe_id }) }
@@ -26,6 +28,31 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
   it "approves when sufficient funds" do
     create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
     expect(service.run).to be(true)
+  end
+
+  context "forbidden merchants" do
+    let(:stripe_authorization) do
+      attributes_for(
+        :stripe_authorization,
+        :gambling,
+        card: { id: stripe_card.stripe_id }
+      )
+    end
+
+    it "declines and notifies ops" do
+      sent_emails = capture_emails do
+        expect(service.run).to be(false)
+      end
+
+      expect(service.declined_reason).to eq("merchant_not_allowed")
+
+      ops_email =
+        sent_emails
+        .filter { |mail| mail.recipients.include?(ApplicationMailer::OPERATIONS_EMAIL) }
+        .sole
+
+      expect(ops_email.subject).to eq("#{event.name}: Stripe card authorization blocked")
+    end
   end
 
   context "card grants" do

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
 
   let(:event) { create(:event) }
   let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:) }
-  let(:stripe_authorization) { attributes_for(:stripe_authorization, card: { id: stripe_card.stripe_id }) }
+  let(:stripe_authorization) { build(:stripe_authorization, card: { id: stripe_card.stripe_id }) }
   let(:service) do
     StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(
       stripe_event: { data: { object: stripe_authorization, } }
@@ -32,7 +32,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
 
   context "forbidden merchants" do
     let(:stripe_authorization) do
-      attributes_for(
+      build(
         :stripe_authorization,
         :gambling,
         card: { id: stripe_card.stripe_id }
@@ -60,7 +60,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
     before(:example) { create(:canonical_pending_transaction, amount_cents: 10000, event:, fronted: true ) }
 
     def create_service(stripe_card: card_grant.stripe_card, amount: 1000)
-      StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(stripe_event: { data: { object: attributes_for(:stripe_authorization, card: { id: stripe_card.stripe_id }, pending_request: { amount: }) } })
+      StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRequest.new(stripe_event: { data: { object: build(:stripe_authorization, card: { id: stripe_card.stripe_id }, pending_request: { amount: }) } })
     end
 
     it "approves" do
@@ -197,7 +197,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
 
   context "withdrawals" do
     let(:stripe_authorization) do
-      attributes_for(
+      build(
         :stripe_authorization,
         :cash_withdrawal,
         card: { id: stripe_card.stripe_id }
@@ -220,7 +220,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
 
     context "with amount > $500" do
       let(:stripe_authorization) do
-        attributes_for(
+        build(
           :stripe_authorization,
           :cash_withdrawal,
           card: { id: stripe_card.stripe_id },

--- a/spec/services/stripe_authorization_service_spec.rb
+++ b/spec/services/stripe_authorization_service_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StripeAuthorizationService do
+  describe "FORBIDDEN_MERCHANT_CATEGORIES" do
+    it "contains a list of valid merchant categories" do
+      described_class::FORBIDDEN_MERCHANT_CATEGORIES.each do |merchant_category|
+        expect(YellowPages::Category.categories_by_key.fetch(merchant_category)).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

1. #11405 added some logic to the Stripe Issuing webhook endpoint to ban gambling merchants
2. This inadvertently caused an issue (https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2226) as in test scenarios, `auth` is a `Hash` whereas in production `auth` is a `Stripe::Issuing::Authorization` object which doesn't have a `dig` method
3. #11430 reverted (1) to avoid causing more issues while the issue was fixed

## Describe your changes

1. Restores #11405
2. Updates the `:stripe_authorization` factory to construct a `Stripe::Issuing::Authorization` object
3. Updates usage of (2) to use `build` instead of `attributes_for`
4. Updates the `merchant_category` method to avoid `dig`