### PR TITLE
Automatically assign categories for Stripe fees, Stripe fee reimbursements, and bank fees

### DIFF
--- a/app/models/transaction_category/definition.rb
+++ b/app/models/transaction_category/definition.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class TransactionCategory
-  Definition = Struct.new(:slug, :label, :stripe_merchant_categories, keyword_init: true) do
+  Definition = Struct.new(
+    :slug,
+    :label,
+    :stripe_merchant_categories,
+    :hq_only,
+    keyword_init: true
+  ) do
     def self.load_all
       path = Rails.root.join("db/data/transaction_categories.json")
       JSON.parse(File.read(path)).to_h do |slug, attributes|
@@ -11,10 +17,13 @@ class TransactionCategory
             slug:,
             label: attributes.fetch("label"),
             stripe_merchant_categories: attributes.fetch("stripe_merchant_categories", []),
+            hq_only: attributes.fetch("hq_only", false),
           ).freeze
         ]
       end.freeze
     end
+
+    alias_method(:hq_only?, :hq_only)
   end
 
   Definition::ALL = Definition.load_all

--- a/app/services/event_mapping_engine/map/hcb_codes/short.rb
+++ b/app/services/event_mapping_engine/map/hcb_codes/short.rb
@@ -20,6 +20,8 @@ module EventMappingEngine
             ActiveRecord::Base.transaction do
               ct.update_column(:hcb_code, hcb_code.hcb_code)
 
+              assign_transaction_category!(hcb_code:, canonical_transaction: ct)
+
               attrs = {
                 canonical_transaction_id: ct.id,
                 event_id: guess_event_id(hcb_code, ct),
@@ -60,6 +62,23 @@ module EventMappingEngine
           end
 
           return hcb_code.ct&.canonical_event_mapping&.subledger_id if hcb_code.events.length == 1
+        end
+
+        def assign_transaction_category!(hcb_code:, canonical_transaction:)
+          category_slug =
+            if hcb_code.bank_fee?
+              "bank-fees"
+            elsif hcb_code.stripe_service_fee?
+              "other-fees"
+            elsif hcb_code.outgoing_fee_reimbursement?
+              "other-fees"
+            end
+
+          return unless category_slug
+
+          TransactionCategoryService
+            .new(model: canonical_transaction)
+            .set!(slug: category_slug, assignment_strategy: "automatic")
         end
 
       end

--- a/app/services/event_mapping_engine/map/hcb_codes/short.rb
+++ b/app/services/event_mapping_engine/map/hcb_codes/short.rb
@@ -67,11 +67,13 @@ module EventMappingEngine
         def assign_transaction_category!(hcb_code:, canonical_transaction:)
           category_slug =
             if hcb_code.bank_fee?
-              "other-fees"
+              "fiscal-sponsorship-fees"
+            elsif hcb_code.fee_revenue?
+              "hcb-revenue"
             elsif hcb_code.stripe_service_fee?
-              "bank-fees"
+              "stripe-service-fees"
             elsif hcb_code.outgoing_fee_reimbursement?
-              "other-fees"
+              "stripe-fee-reimbursements"
             end
 
           return unless category_slug

--- a/app/services/event_mapping_engine/map/hcb_codes/short.rb
+++ b/app/services/event_mapping_engine/map/hcb_codes/short.rb
@@ -67,9 +67,9 @@ module EventMappingEngine
         def assign_transaction_category!(hcb_code:, canonical_transaction:)
           category_slug =
             if hcb_code.bank_fee?
-              "bank-fees"
-            elsif hcb_code.stripe_service_fee?
               "other-fees"
+            elsif hcb_code.stripe_service_fee?
+              "bank-fees"
             elsif hcb_code.outgoing_fee_reimbursement?
               "other-fees"
             end

--- a/db/data/transaction_categories.json
+++ b/db/data/transaction_categories.json
@@ -16,6 +16,9 @@
       "financial_institutions"
     ]
   },
+  "fiscal-sponsorship-fees": {
+    "label": "Fiscal sponsorship fees"
+  },
   "food-fun": {
     "label": "Food / fun",
     "stripe_merchant_categories": [
@@ -78,6 +81,10 @@
       "hardware_equipment_and_supplies",
       "hardware_stores"
     ]
+  },
+  "hcb-revenue": {
+    "hq_only": true,
+    "label": "HCB Revenue"
   },
   "hr": {
     "label": "HR"
@@ -342,6 +349,14 @@
       "computers_peripherals_and_software",
       "direct_marketing_subscription"
     ]
+  },
+  "stripe-fee-reimbursements": {
+    "hq_only": true,
+    "label": "Stripe fee reimbursements"
+  },
+  "stripe-service-fees": {
+    "hq_only": true,
+    "label": "Stripe service fees"
   },
   "taxes-filing-fees": {
     "label": "Taxes / filing fees",

--- a/spec/models/transaction_category/definition_spec.rb
+++ b/spec/models/transaction_category/definition_spec.rb
@@ -18,13 +18,15 @@ RSpec.describe TransactionCategory::Definition do
         expect(attributes).to(be_a(Hash), "#{slug.inspect} property is not an object")
 
         attributes.each_key do |key|
-          expect(["label", "stripe_merchant_categories"]).to(
+          expect(["label", "stripe_merchant_categories", "hq_only"]).to(
             include(key),
             "#{slug.inspect} has unsupported key #{key.inspect}"
           )
         end
 
         expect(attributes["label"]).to(be_a(String).and(be_present), "#{slug.inspect} is missing a label")
+
+        expect(attributes["hq_only"]).to(be_in([true, false, nil]), "#{slug.inspect} has an invalid hq_only property")
 
         stripe_categories = attributes["stripe_merchant_categories"]
         next if stripe_categories.nil?

--- a/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
+++ b/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
+  it "maps canonical transactions to the appropriate event based on the short code" do
+    # Create a mapped pending transaction which will also create an HCB code
+    event = create(:event)
+    cpt = create(:canonical_pending_transaction)
+    cpt.create_canonical_pending_event_mapping!(event:)
+
+    ct = create(:canonical_transaction, memo: "HCB-#{cpt.local_hcb_code.short_code}")
+    # Sanity check to make sure this canonical transaction is eligible
+    expect(CanonicalTransaction.unmapped.with_short_code).to include(ct)
+
+    described_class.new.run
+
+    ct.reload
+    expect(ct.event).to eq(event)
+    expect(ct.category).to be_nil
+  end
+
+  it "adds a category to bank fee transactions" do
+    event = create(:event)
+    bank_fee = create(:bank_fee, event:, amount_cents: -12_34)
+    raw_pending_bank_fee_transaction = create(
+      :raw_pending_bank_fee_transaction,
+      amount_cents: bank_fee.amount_cents,
+      bank_fee_transaction_id: bank_fee.id.to_s,
+    )
+    cpt = create(:canonical_pending_transaction, raw_pending_bank_fee_transaction:)
+    cpt.create_canonical_pending_event_mapping!(event:)
+
+    ct = create(:canonical_transaction, memo: "HCB-#{cpt.local_hcb_code.short_code}")
+
+    described_class.new.run
+
+    ct.reload
+    expect(ct.event).to eq(event)
+    expect(ct.category.slug).to eq("bank-fees")
+    expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+  end
+
+  it "adds a category to stripe fee transactions" do
+    event = create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK)
+
+    # `StripeServiceFee` creates a `StripeTopup` on creation, which results in a
+    # call to the Stripe API
+    stub_request(:post, "https://api.stripe.com/v1/topups")
+      .to_return(status: 200, body: { id: "tu_1" }.to_json, headers: {})
+
+    stripe_service_fee = StripeServiceFee.create!(
+      amount_cents: 12_34,
+      stripe_balance_transaction_id: "txn_1",
+      stripe_description: "Test description"
+    )
+    local_hcb_code = stripe_service_fee.local_hcb_code
+
+    ct = create(:canonical_transaction, memo: "HCB-#{local_hcb_code.short_code}")
+
+    described_class.new.run
+
+    ct.reload
+    expect(ct.event).to eq(event)
+    expect(ct.category.slug).to eq("other-fees")
+    expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+  end
+
+  it "adds a category to stripe fee reimbursements" do
+    event = create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK)
+
+    # Copied over from `FeeReimbursementService::Nightly`
+    hcb_code = [
+      TransactionGroupingEngine::Calculate::HcbCode::HCB_CODE,
+      TransactionGroupingEngine::Calculate::HcbCode::OUTGOING_FEE_REIMBURSEMENT_CODE,
+      Time.now.strftime("%G_%V")
+    ].join(TransactionGroupingEngine::Calculate::HcbCode::SEPARATOR)
+
+    local_hcb_code = HcbCode.create!(hcb_code: hcb_code)
+
+    ct = create(:canonical_transaction, memo: "HCB-#{local_hcb_code.short_code}")
+
+    described_class.new.run
+
+    ct.reload
+    expect(ct.event).to eq(event)
+    expect(ct.category.slug).to eq("other-fees")
+    expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+  end
+end

--- a/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
+++ b/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
 
     ct.reload
     expect(ct.event).to eq(event)
-    expect(ct.category.slug).to eq("other-fees")
+    expect(ct.category.slug).to eq("fiscal-sponsorship-fees")
     expect(ct.category_mapping.assignment_strategy).to eq("automatic")
   end
 
@@ -62,7 +62,7 @@ RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
 
     ct.reload
     expect(ct.event).to eq(event)
-    expect(ct.category.slug).to eq("bank-fees")
+    expect(ct.category.slug).to eq("stripe-service-fees")
     expect(ct.category_mapping.assignment_strategy).to eq("automatic")
   end
 
@@ -84,7 +84,28 @@ RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
 
     ct.reload
     expect(ct.event).to eq(event)
-    expect(ct.category.slug).to eq("other-fees")
+    expect(ct.category.slug).to eq("stripe-fee-reimbursements")
     expect(ct.category_mapping.assignment_strategy).to eq("automatic")
   end
+
+  it "adds a category to fee revenue" do
+    event = create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK)
+
+    fee_revenue = FeeRevenue.create!(
+      amount_cents: 12_34,
+      start: Date.current.beginning_of_month,
+      end: Date.current.end_of_month,
+    )
+
+    local_hcb_code = fee_revenue.local_hcb_code
+    ct = create(:canonical_transaction, memo: "HCB-#{local_hcb_code.short_code}")
+
+    described_class.new.run
+
+    ct.reload
+    expect(ct.event).to eq(event)
+    expect(ct.category.slug).to eq("hcb-revenue")
+    expect(ct.category_mapping.assignment_strategy).to eq("automatic")
+  end
+
 end

--- a/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
+++ b/spec/services/event_mapping_engine/map/hcb_codes/short_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
 
     ct.reload
     expect(ct.event).to eq(event)
-    expect(ct.category.slug).to eq("bank-fees")
+    expect(ct.category.slug).to eq("other-fees")
     expect(ct.category_mapping.assignment_strategy).to eq("automatic")
   end
 
@@ -62,7 +62,7 @@ RSpec.describe EventMappingEngine::Map::HcbCodes::Short do
 
     ct.reload
     expect(ct.event).to eq(event)
-    expect(ct.category.slug).to eq("other-fees")
+    expect(ct.category.slug).to eq("bank-fees")
     expect(ct.category_mapping.assignment_strategy).to eq("automatic")
   end
 


### PR DESCRIPTION
## Summary of the problem

We want to automatically assign categories for Stripe fees, Stripe fee reimbursements, and bank fees.

## Describe your changes

Add logic to `EventMappingEngine::Map::HcbCodes::Short` which assigns the appropriate category based on the HCB code.