### PR TITLE
Add transaction category to Event's transaction CSV export

### DIFF
--- a/app/models/export/event/transactions/csv.rb
+++ b/app/models/export/event/transactions/csv.rb
@@ -80,12 +80,14 @@ class Export
               public_only ? "" : ct.local_hcb_code.comments.not_admin_only.pluck(:content).join("\n\n"),
               ct.local_hcb_code.author&.public_id || "",
               ct.local_hcb_code.author&.name || "",
+              ct.category&.slug,
+              ct.category&.label,
             ]
           )
         end
 
         def headers
-          [:date, :memo, :amount_cents, :tags, :comments, :user_id, :user_name]
+          [:date, :memo, :amount_cents, :tags, :comments, :user_id, :user_name, :category_slug, :category_label]
         end
 
       end

--- a/app/models/export/event/transactions/csv.rb
+++ b/app/models/export/event/transactions/csv.rb
@@ -66,7 +66,7 @@ class Export
         end
 
         def header
-          ::CSV::Row.new(headers, ["date", "memo", "amount_cents", "tags", "comments", "user_id", "user_name"], true)
+          ::CSV::Row.new(headers, headers.map(&:to_s), true)
         end
 
         def row(ct)
@@ -85,7 +85,7 @@ class Export
         end
 
         def headers
-          [:date, :memo, :amount_cents, :tags, :comments]
+          [:date, :memo, :amount_cents, :tags, :comments, :user_id, :user_name]
         end
 
       end

--- a/app/models/transaction_category.rb
+++ b/app/models/transaction_category.rb
@@ -38,7 +38,7 @@ class TransactionCategory < ApplicationRecord
   delegate :label, to: :definition
 
   def definition
-    TransactionCategory::Definition::ALL[slug]
+    TransactionCategory::Definition::ALL.fetch(slug)
   end
 
 end

--- a/app/models/transaction_category.rb
+++ b/app/models/transaction_category.rb
@@ -35,4 +35,10 @@ class TransactionCategory < ApplicationRecord
     inclusion: { in: TransactionCategory::Definition::ALL.keys }
   )
 
+  delegate :label, to: :definition
+
+  def definition
+    TransactionCategory::Definition::ALL[slug]
+  end
+
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

We want to make these categories easily exportable by users.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

I'm adding it to the existing Event transaction CSV export, located here in the UI:

<img width="1381" height="537" alt="image" src="https://github.com/user-attachments/assets/ed9f11c6-58b4-4a77-974d-93f794c6f62c" />


Here's an example of what the new CSV columns look like:
<img width="338" height="940" alt="image" src="https://github.com/user-attachments/assets/6ff9800f-9e81-4c13-8a4f-a984c2543af2" />



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

