### PR TITLE
[Announcement] Fix automatically deleting monthly announcement when disabled

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -54,7 +54,9 @@ class Announcement < ApplicationRecord
     end
   end
 
-  scope :monthly, -> { joins(event: :config).where(:template_type => Announcement::Templates::Monthly.name, "event_configurations.generate_monthly_announcement" => true) }
+  scope :all_monthly, -> { where(template_type: Announcement::Templates::Monthly.name) }
+  scope :monthly, -> { all_monthly.joins(event: :config).where("event_configurations.generate_monthly_announcement" => true) }
+  scope :all_monthly_for, ->(date) { all_monthly.where("announcements.created_at BETWEEN ? AND ?", date.beginning_of_month, date.end_of_month) }
   scope :monthly_for, ->(date) { monthly.where("announcements.created_at BETWEEN ? AND ?", date.beginning_of_month, date.end_of_month) }
   scope :approved_monthly_for, ->(date) { monthly_for(date).draft }
   validate :content_is_json

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -30,7 +30,7 @@ class Event
     validates :subevent_plan, inclusion: { in: -> { Event::Plan.available_plans.map(&:name) } }, allow_blank: true
 
     after_create :set_defaults
-    before_save :create_or_destroy_monthly_announcement
+    after_save :create_or_destroy_monthly_announcement
 
     private
 
@@ -39,11 +39,12 @@ class Event
     end
 
     def create_or_destroy_monthly_announcement
-      if self.generate_monthly_announcement_changed?
+      if self.generate_monthly_announcement_previously_changed?
         if self.generate_monthly_announcement
-          Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create if self.event.announcements.monthly_for(Date.today).empty?
+          Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create if self.event.announcements.all_monthly_for(Date.today).empty?
         else
-          self.event.announcements.monthly_for(Date.today).first&.destroy!
+          monthly_announcement_draft = self.event.announcements.all_monthly_for(Date.today).first
+          monthly_announcement_draft&.destroy! unless monthly_announcement_draft&.published?
         end
       end
     end

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -30,7 +30,7 @@ class Event
     validates :subevent_plan, inclusion: { in: -> { Event::Plan.available_plans.map(&:name) } }, allow_blank: true
 
     after_create :set_defaults
-    after_save :create_or_destroy_monthly_announcement
+    before_save :create_or_destroy_monthly_announcement
 
     private
 
@@ -39,7 +39,7 @@ class Event
     end
 
     def create_or_destroy_monthly_announcement
-      if self.generate_monthly_announcement_previously_changed?
+      if self.generate_monthly_announcement_changed?
         if self.generate_monthly_announcement
           Announcement::Templates::Monthly.new(event: self.event, author: User.system_user).create if self.event.announcements.monthly_for(Date.today).empty?
         else


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#11401 changed the `monthly` scope on `Announcement` to not include monthly announcements for events with monthly announcements disabled, but this broke the logic in `Event::Configuration` that automatically deletes monthly announcement drafts if generating monthly announcements is disabled.

Already published monthly announcements could also have been deleted if they were manually published before the end of the month and then the feature was disabled.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds the new `all_monthly` and `all_monthly_for` scopes that don't check for the configuration value so that the callback in `Event::Configuration` works, and adds a check before deleting an announcement that it has not already been published.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

