### PR TITLE
[Event] Add Statement of Activity as an alpha feature

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -917,6 +917,20 @@ class EventsController < ApplicationController
     @end_date = Date.today.prev_month.beginning_of_month.to_date
   end
 
+  def statement_of_activity
+    authorize @event
+
+    @start_date = params[:start]&.to_date || (@event.activated_at || @event.created_at).to_date
+    @end_date = params[:end]&.to_date || Time.now.to_date
+
+    transactions = @event.canonical_transactions.where("date between ? AND ?", @start_date, @end_date)
+    @transactions_by_category = transactions.includes(:category).group("category.slug").sum(:amount_cents)
+
+    @net_asset_change = transactions.sum(:amount_cents)
+    @total_revenue = transactions.where("amount_cents > 0").sum(:amount_cents)
+    @total_expense = transactions.where("amount_cents < 0").sum(:amount_cents)
+  end
+
   def termination
     authorize @event
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -112,6 +112,10 @@ class EventPolicy < ApplicationPolicy
     show?
   end
 
+  def statement_of_activity?
+    show? && admin?
+  end
+
   def async_balance?
     show?
   end

--- a/app/views/events/statement_of_activity.html.erb
+++ b/app/views/events/statement_of_activity.html.erb
@@ -1,0 +1,43 @@
+<% title "Statement of Activity" %>
+<% page_md %>
+
+<div class="flex justify-between items-baseline">
+  <h1 class="border-b-0">Statement of Activity</h1>
+
+  <%= form_with method: :get do |form| %>
+    <div class="flex gap-2 items-center w-fit">
+      From
+      <%= form.date_field :start, value: @start_date, onchange: "this.form.requestSubmit();" %>
+      To
+      <%= form.date_field :end, value: @end_date, onchange: "this.form.requestSubmit();" %>
+    </div>
+  <% end %>
+</div>
+<hr class="mt-0" />
+
+<p>
+  From <%= @start_date.strftime("%B %-d, %Y") %>
+  to <%= @end_date.strftime("%B %-d, %Y") %>,
+  <strong><%= link_to @event.name, @event %></strong> had a change in net asset
+  of <%= render_money @net_asset_change %>;
+  after having raised <%= render_money @total_revenue %> and
+  spent <%= render_money @total_expense.abs %>.
+</p>
+
+<table>
+  <thead>
+  <tr>
+    <th>Category</th>
+    <th>Total Amount</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @transactions_by_category.each do |category_slug, amount_cents_sum| %>
+    <% category = TransactionCategory::Definition::ALL[category_slug] %>
+    <tr>
+      <td title="<%= category&.slug %>"><%= category&.label || "Uncategorized" %></td>
+      <td><%= render_money amount_cents_sum.abs %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/events/statement_of_activity.html.erb
+++ b/app/views/events/statement_of_activity.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% end %>
 </div>
-<hr class="mt-0" />
+<hr class="mt-0">
 
 <p>
   From <%= @start_date.strftime("%B %-d, %Y") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -796,6 +796,7 @@ Rails.application.routes.draw do
     get "documentation", to: redirect("/%{event_id}/documents", status: 302)
     get "transfers"
     get "statements"
+    get "statement_of_activity"
     get "promotions"
     get "reimbursements"
     get "employees"


### PR DESCRIPTION
This adds a very bare bones Statement of Activity using the new transaction categories we just added.

@MelSmith104 needs this for a demo of the new accounting/category feature for a meeting later today, so this new endpoint is simple and **admin only** for the time being. When we actually launch this feature, it'll be more feature-full and look better.

Anyways, here's what it looks like right now (in this PR).

<img width="939" height="860" alt="image" src="https://github.com/user-attachments/assets/7f7f13a1-91c0-4fd8-90ca-c829144ff744" />

You can change the date range via the form inputs, which autosubmit.

<img width="925" height="635" alt="image" src="https://github.com/user-attachments/assets/67945790-6939-4a25-a487-d5e9f2139cb4" />


This page is accessible at http://localhost:4000/assemble/statement_of_activity (again, only for admins).