### PR TITLE
Fix HCB code type capitalization in comments

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -125,6 +125,13 @@ class HcbCode < ApplicationRecord
     t.to_s.humanize
   end
 
+  def humanized_type_sentence_case
+    return "ACH" if ach_transfer?
+    return "Wise transfer" if wise_transfer?
+
+    humanized_type.downcase
+  end
+
   def amount_cents
     @amount_cents ||= begin
       return canonical_transactions.sum(:amount_cents) if canonical_transactions.any?

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -127,7 +127,7 @@ class MarkdownService
         return nil unless hcb
 
         Pundit.authorize(@current_user, hcb, :show?)
-        link_to "#{'comment on ' if comment.present?}#{hcb.humanized_type.downcase} (HCB-#{hcb.hashid})",
+        link_to "#{'comment on ' if comment.present?}#{hcb.humanized_type_sentence_case} (HCB-#{hcb.hashid})",
                 link,
                 target: "_blank",
                 class: "tooltipped tooltipped--e autolink",


### PR DESCRIPTION
## Summary of the problem
Transaction types are all lowercase even when they shouldn't be


## Describe your changes
Respect naming conventions that require uppercase letters (proper nouns, acronyms, etc.)