### PR TITLE
Refactor the admin nav logic so it isn't a big `Hash`

### DIFF
--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -110,14 +110,54 @@ module Admin
       Section.new(
         name: "Misc",
         items: [
-          make_item(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, count_type: :records),
-          make_item(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, count_type: :records),
-          make_item(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, count_type: :records),
-          make_item(name: "Users", path: users_admin_index_path, count: User.count, count_type: :records),
-          make_item(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, count_type: :records),
-          make_item(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, count_type: :records),
-          make_item(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, count_type: :records),
-          make_item(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, count_type: :records)
+          make_item(
+            name: "Bank Accounts",
+            path: bank_accounts_admin_index_path,
+            count: BankAccount.failing.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "HCB Fees",
+            path: bank_fees_admin_index_path,
+            count: BankFee.in_transit_or_pending.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Column Statements",
+            path: admin_column_statements_path,
+            count: Column::Statement.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Users",
+            path: users_admin_index_path,
+            count: User.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Card Designs",
+            path: stripe_card_personalization_designs_admin_index_path,
+            count: StripeCard::PersonalizationDesign.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Emails",
+            path: emails_admin_index_path,
+            count: Ahoy::Message.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Unknown Merchants",
+            path: unknown_merchants_admin_index_path,
+            count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0,
+            count_type: :records
+          ),
+          make_item(
+            name: "Referral Programs",
+            path: referral_programs_admin_index_path,
+            count: Referral::Program.count,
+            count_type: :records
+          )
         ]
       )
     end
@@ -126,9 +166,23 @@ module Admin
       Section.new(
         name: "Payroll",
         items: [
-          make_item(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
-          make_item(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, count_type: :records),
-          make_item(name: "W9s", path: admin_w9s_path, count: W9.all.count, count_type: :records)
+          make_item(
+            name: "Employees",
+            path: employees_admin_index_path,
+            count: Employee.onboarding.count
+          ),
+          make_item(
+            name: "Payments",
+            path: employee_payments_admin_index_path,
+            count: Employee::Payment.paid.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "W9s",
+            path: admin_w9s_path,
+            count: W9.all.count,
+            count_type: :records
+          )
         ]
       )
     end
@@ -137,9 +191,24 @@ module Admin
       Section.new(
         name: "Organizations",
         items: [
-          make_item(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, count_type: :records),
-          make_item(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
-          make_item(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, count_type: :records)
+          make_item(
+            name: "Organizations",
+            path: events_admin_index_path,
+            count: Event.approved.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Google Workspace Requests",
+            path: google_workspaces_admin_index_path,
+            count: GSuite.needs_ops_review.count
+          ),
+
+          make_item(
+            name: "Account Numbers",
+            path: account_numbers_admin_index_path,
+            count: Column::AccountNumber.count,
+            count_type: :records
+          )
         ]
       )
     end
@@ -148,10 +217,26 @@ module Admin
       Section.new(
         name: "Incoming Money",
         items: [
-          make_item(name: "Donations", path: donations_admin_index_path, count: 0),
-          make_item(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
-          make_item(name: "Invoices", path: invoices_admin_index_path, count: 0),
-          make_item(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
+          make_item(
+            name: "Donations",
+            path: donations_admin_index_path,
+            count: 0
+          ),
+          make_item(
+            name: "Recurring Donations",
+            path: recurring_donations_admin_index_path,
+            count: 0
+          ),
+          make_item(
+            name: "Invoices",
+            path: invoices_admin_index_path,
+            count: 0
+          ),
+          make_item(
+            name: "Sponsors",
+            path: sponsors_admin_index_path,
+            count: 0
+          )
         ]
       )
     end
@@ -160,12 +245,39 @@ module Admin
       Section.new(
         name: "Ledger",
         items: [
-          make_item(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
-          make_item(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, count_type: :records),
-          make_item(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
-          make_item(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, count_type: :records),
-          make_item(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, count_type: :records),
-          make_item(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
+          make_item(
+            name: "Ledger",
+            path: ledger_admin_index_path,
+            count: CanonicalTransaction.not_stripe_top_up.unmapped.count
+          ),
+          make_item(
+            name: "Pending Ledger",
+            path: pending_ledger_admin_index_path,
+            count: CanonicalPendingTransaction.unsettled.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "Raw Transactions",
+            path: raw_transactions_admin_index_path,
+            count: RawCsvTransaction.unhashed.count
+          ),
+          make_item(
+            name: "Intrafi Transactions",
+            path: raw_intrafi_transactions_admin_index_path,
+            count: RawIntrafiTransaction.count,
+            count_type: :records
+          ),
+          make_item(
+            name: "HCB codes",
+            path: hcb_codes_admin_index_path,
+            count: 0,
+            count_type: :records
+          ),
+          make_item(
+            name: "Audits",
+            path: admin_ledger_audits_path,
+            count: Admin::LedgerAudit.pending.count
+          ),
         ]
       )
     end
@@ -174,13 +286,41 @@ module Admin
       Section.new(
         name: "Spending",
         items: [
-          make_item(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
-          make_item(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
-          make_item(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
-          make_item(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
-          make_item(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
-          make_item(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
-          make_item(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
+          make_item(
+            name: "ACHs",
+            path: ach_admin_index_path,
+            count: AchTransfer.pending.count
+          ),
+          make_item(
+            name: "Checks",
+            path: increase_checks_admin_index_path,
+            count: IncreaseCheck.pending.count
+          ),
+          make_item(
+            name: "Disbursements",
+            path: disbursements_admin_index_path,
+            count: Disbursement.reviewing.count
+          ),
+          make_item(
+            name: "PayPal",
+            path: paypal_transfers_admin_index_path,
+            count: PaypalTransfer.pending.count
+          ),
+          make_item(
+            name: "Wires",
+            path: wires_admin_index_path,
+            count: Wire.pending.count
+          ),
+          make_item(
+            name: "Wise transfers",
+            path: wise_transfers_admin_index_path,
+            count: WiseTransfer.pending.count
+          ),
+          make_item(
+            name: "Reimbursements",
+            path: reimbursements_admin_index_path,
+            count: Reimbursement::Report.reimbursement_requested.count
+          )
         ]
       )
     end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Admin
+  class Nav
+    include Rails.application.routes.url_helpers
+
+    def sections
+      {
+        Spending: {
+          ACHs: [ach_admin_index_path, AchTransfer.pending.count, %i[]],
+          Checks: [increase_checks_admin_index_path, IncreaseCheck.pending.count, %i[]],
+          Disbursements: [disbursements_admin_index_path, Disbursement.reviewing.count, %i[]],
+          PayPal: [paypal_transfers_admin_index_path, PaypalTransfer.pending.count, %i[]],
+          Wires: [wires_admin_index_path, Wire.pending.count, %i[]],
+          "Wise transfers": [wise_transfers_admin_index_path, WiseTransfer.pending.count, %i[]],
+          Reimbursements: [reimbursements_admin_index_path, Reimbursement::Report.reimbursement_requested.count, %i[]]
+        },
+        Ledger: {
+          Ledger: [ledger_admin_index_path, CanonicalTransaction.not_stripe_top_up.unmapped.count, %i[]],
+          "Pending Ledger": [pending_ledger_admin_index_path, CanonicalPendingTransaction.unsettled.count, %i[counter]],
+          "Raw Transactions": [raw_transactions_admin_index_path, RawCsvTransaction.unhashed.count, %i[]],
+          "Intrafi Transactions": [raw_intrafi_transactions_admin_index_path, RawIntrafiTransaction.count, %i[counter]],
+          "HCB codes": [hcb_codes_admin_index_path, 0, %i[counter]],
+          "Audits": [admin_ledger_audits_path, Admin::LedgerAudit.pending.count, %i[]],
+        },
+        "Incoming Money": {
+          Donations: [donations_admin_index_path, 0, %i[]],
+          "Recurring Donations": [recurring_donations_admin_index_path, 0, %i[]],
+          Invoices: [invoices_admin_index_path, 0, %i[]],
+          Sponsors: [sponsors_admin_index_path, 0, %i[]]
+        },
+        Organizations: {
+          Organizations: [events_admin_index_path, Event.approved.count, %i[counter]],
+          "Google Workspace Requests": [google_workspaces_admin_index_path, GSuite.needs_ops_review.count, %i[]],
+          "Account Numbers": [account_numbers_admin_index_path, Column::AccountNumber.count, %i[counter]]
+        },
+        Payroll: {
+          Employees: [employees_admin_index_path, Employee.onboarding.count, %i[]],
+          Payments: [employee_payments_admin_index_path, Employee::Payment.paid.count, %i[counter]],
+          W9s: [admin_w9s_path, W9.all.count, %i[counter]]
+        },
+        Misc: {
+          "Bank Accounts": [bank_accounts_admin_index_path, BankAccount.failing.count, %i[counter]],
+          "HCB Fees": [bank_fees_admin_index_path, BankFee.in_transit_or_pending.count, %i[counter]],
+          "Column Statements": [admin_column_statements_path, Column::Statement.count, %i[counter]],
+          "Users": [users_admin_index_path, User.count, %i[counter]],
+          "Card Designs": [stripe_card_personalization_designs_admin_index_path, StripeCard::PersonalizationDesign.count, %i[counter]],
+          "Emails": [emails_admin_index_path, Ahoy::Message.count, %i[counter]],
+          "Unknown Merchants": [unknown_merchants_admin_index_path, Rails.cache.fetch("admin_unknown_merchants")&.length || 0, %i[counter]],
+          "Referral Programs": [referral_programs_admin_index_path, Referral::Program.count, %i[counter]]
+        }
+      }
+    end
+
+  end
+end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -19,6 +19,10 @@ module Admin
 
     end
 
+    def initialize(page_title:)
+      @page_title = page_title
+    end
+
     def sections
       [
         spending,
@@ -33,6 +37,8 @@ module Admin
     memo_wise(:sections)
 
     private
+
+    attr_reader(:page_title)
 
     def misc
       Section.new(

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -21,13 +21,13 @@ module Admin
       memo_wise(:active?)
 
       def task_sum
-        items.reject { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum
+        items.sum { |item| item.flags.include?(:counter) ? 0 : item.count }
       end
 
       memo_wise(:task_sum)
 
       def counter_sum
-        items.select { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum
+        items.sum { |item| item.flags.include?(:counter) ? item.count : 0 }
       end
 
       memo_wise(:counter_sum)

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -3,6 +3,8 @@
 module Admin
   class Nav
     include Rails.application.routes.url_helpers
+    prepend MemoWise
+
 
     def sections
       {
@@ -51,6 +53,8 @@ module Admin
         }
       }
     end
+
+    memo_wise(:sections)
 
   end
 end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -21,71 +21,97 @@ module Admin
 
     def sections
       [
-        Section.new(
-          name: "Spending",
-          items: [
-            Item.new(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
-            Item.new(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
-            Item.new(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
-            Item.new(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
-            Item.new(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
-            Item.new(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
-            Item.new(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
-          ]
-        ),
-        Section.new(
-          name: "Ledger",
-          items: [
-            Item.new(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
-            Item.new(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, flags: %i[counter]),
-            Item.new(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
-            Item.new(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, flags: %i[counter]),
-            Item.new(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, flags: %i[counter]),
-            Item.new(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
-          ]
-        ),
-        Section.new(
-          name: "Incoming Money",
-          items: [
-            Item.new(name: "Donations", path: donations_admin_index_path, count: 0),
-            Item.new(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
-            Item.new(name: "Invoices", path: invoices_admin_index_path, count: 0),
-            Item.new(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
-          ]
-        ),
-        Section.new(
-          name: "Organizations",
-          items: [
-            Item.new(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, flags: %i[counter]),
-            Item.new(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
-            Item.new(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, flags: %i[counter])
-          ]
-        ),
-        Section.new(
-          name: "Payroll",
-          items: [
-            Item.new(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
-            Item.new(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, flags: %i[counter]),
-            Item.new(name: "W9s", path: admin_w9s_path, count: W9.all.count, flags: %i[counter])
-          ]
-        ),
-        Section.new(
-          name: "Misc",
-          items: [
-            Item.new(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, flags: %i[counter]),
-            Item.new(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, flags: %i[counter]),
-            Item.new(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, flags: %i[counter]),
-            Item.new(name: "Users", path: users_admin_index_path, count: User.count, flags: %i[counter]),
-            Item.new(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, flags: %i[counter]),
-            Item.new(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, flags: %i[counter]),
-            Item.new(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, flags: %i[counter]),
-            Item.new(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, flags: %i[counter])
-          ]
-        )
+        spending,
+        ledger,
+        incoming_money,
+        organizations,
+        payroll,
+        misc
       ]
     end
 
     memo_wise(:sections)
+
+    private
+
+    def misc
+      Section.new(
+        name: "Misc",
+        items: [
+          Item.new(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, flags: %i[counter]),
+          Item.new(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, flags: %i[counter]),
+          Item.new(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, flags: %i[counter]),
+          Item.new(name: "Users", path: users_admin_index_path, count: User.count, flags: %i[counter]),
+          Item.new(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, flags: %i[counter]),
+          Item.new(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, flags: %i[counter]),
+          Item.new(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, flags: %i[counter]),
+          Item.new(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, flags: %i[counter])
+        ]
+      )
+    end
+
+    def payroll
+      Section.new(
+        name: "Payroll",
+        items: [
+          Item.new(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
+          Item.new(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, flags: %i[counter]),
+          Item.new(name: "W9s", path: admin_w9s_path, count: W9.all.count, flags: %i[counter])
+        ]
+      )
+    end
+
+    def organizations
+      Section.new(
+        name: "Organizations",
+        items: [
+          Item.new(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, flags: %i[counter]),
+          Item.new(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
+          Item.new(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, flags: %i[counter])
+        ]
+      )
+    end
+
+    def incoming_money
+      Section.new(
+        name: "Incoming Money",
+        items: [
+          Item.new(name: "Donations", path: donations_admin_index_path, count: 0),
+          Item.new(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
+          Item.new(name: "Invoices", path: invoices_admin_index_path, count: 0),
+          Item.new(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
+        ]
+      )
+    end
+
+    def ledger
+      Section.new(
+        name: "Ledger",
+        items: [
+          Item.new(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
+          Item.new(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, flags: %i[counter]),
+          Item.new(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
+          Item.new(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, flags: %i[counter]),
+          Item.new(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, flags: %i[counter]),
+          Item.new(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
+        ]
+      )
+    end
+
+    def spending
+      Section.new(
+        name: "Spending",
+        items: [
+          Item.new(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
+          Item.new(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
+          Item.new(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
+          Item.new(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
+          Item.new(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
+          Item.new(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
+          Item.new(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
+        ]
+      )
+    end
 
   end
 end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -49,6 +49,10 @@ module Admin
         @active
       end
 
+      def record_count?
+        flags.include?(:counter)
+      end
+
     end
 
     def initialize(page_title:)

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -20,6 +20,18 @@ module Admin
 
       memo_wise(:active?)
 
+      def task_sum
+        items.reject { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum
+      end
+
+      memo_wise(:task_sum)
+
+      def counter_sum
+        items.select { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum
+      end
+
+      memo_wise(:counter_sum)
+
     end
 
     class Item

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -5,53 +5,72 @@ module Admin
     include Rails.application.routes.url_helpers
     prepend MemoWise
 
+    Section = Struct.new(:name, :items, keyword_init: true)
 
     def sections
-      {
-        Spending: {
-          ACHs: [ach_admin_index_path, AchTransfer.pending.count, %i[]],
-          Checks: [increase_checks_admin_index_path, IncreaseCheck.pending.count, %i[]],
-          Disbursements: [disbursements_admin_index_path, Disbursement.reviewing.count, %i[]],
-          PayPal: [paypal_transfers_admin_index_path, PaypalTransfer.pending.count, %i[]],
-          Wires: [wires_admin_index_path, Wire.pending.count, %i[]],
-          "Wise transfers": [wise_transfers_admin_index_path, WiseTransfer.pending.count, %i[]],
-          Reimbursements: [reimbursements_admin_index_path, Reimbursement::Report.reimbursement_requested.count, %i[]]
-        },
-        Ledger: {
-          Ledger: [ledger_admin_index_path, CanonicalTransaction.not_stripe_top_up.unmapped.count, %i[]],
-          "Pending Ledger": [pending_ledger_admin_index_path, CanonicalPendingTransaction.unsettled.count, %i[counter]],
-          "Raw Transactions": [raw_transactions_admin_index_path, RawCsvTransaction.unhashed.count, %i[]],
-          "Intrafi Transactions": [raw_intrafi_transactions_admin_index_path, RawIntrafiTransaction.count, %i[counter]],
-          "HCB codes": [hcb_codes_admin_index_path, 0, %i[counter]],
-          "Audits": [admin_ledger_audits_path, Admin::LedgerAudit.pending.count, %i[]],
-        },
-        "Incoming Money": {
-          Donations: [donations_admin_index_path, 0, %i[]],
-          "Recurring Donations": [recurring_donations_admin_index_path, 0, %i[]],
-          Invoices: [invoices_admin_index_path, 0, %i[]],
-          Sponsors: [sponsors_admin_index_path, 0, %i[]]
-        },
-        Organizations: {
-          Organizations: [events_admin_index_path, Event.approved.count, %i[counter]],
-          "Google Workspace Requests": [google_workspaces_admin_index_path, GSuite.needs_ops_review.count, %i[]],
-          "Account Numbers": [account_numbers_admin_index_path, Column::AccountNumber.count, %i[counter]]
-        },
-        Payroll: {
-          Employees: [employees_admin_index_path, Employee.onboarding.count, %i[]],
-          Payments: [employee_payments_admin_index_path, Employee::Payment.paid.count, %i[counter]],
-          W9s: [admin_w9s_path, W9.all.count, %i[counter]]
-        },
-        Misc: {
-          "Bank Accounts": [bank_accounts_admin_index_path, BankAccount.failing.count, %i[counter]],
-          "HCB Fees": [bank_fees_admin_index_path, BankFee.in_transit_or_pending.count, %i[counter]],
-          "Column Statements": [admin_column_statements_path, Column::Statement.count, %i[counter]],
-          "Users": [users_admin_index_path, User.count, %i[counter]],
-          "Card Designs": [stripe_card_personalization_designs_admin_index_path, StripeCard::PersonalizationDesign.count, %i[counter]],
-          "Emails": [emails_admin_index_path, Ahoy::Message.count, %i[counter]],
-          "Unknown Merchants": [unknown_merchants_admin_index_path, Rails.cache.fetch("admin_unknown_merchants")&.length || 0, %i[counter]],
-          "Referral Programs": [referral_programs_admin_index_path, Referral::Program.count, %i[counter]]
-        }
-      }
+      [
+        Section.new(
+          name: "Spending",
+          items: {
+            ACHs: [ach_admin_index_path, AchTransfer.pending.count, %i[]],
+            Checks: [increase_checks_admin_index_path, IncreaseCheck.pending.count, %i[]],
+            Disbursements: [disbursements_admin_index_path, Disbursement.reviewing.count, %i[]],
+            PayPal: [paypal_transfers_admin_index_path, PaypalTransfer.pending.count, %i[]],
+            Wires: [wires_admin_index_path, Wire.pending.count, %i[]],
+            "Wise transfers": [wise_transfers_admin_index_path, WiseTransfer.pending.count, %i[]],
+            Reimbursements: [reimbursements_admin_index_path, Reimbursement::Report.reimbursement_requested.count, %i[]]
+          }
+        ),
+        Section.new(
+          name: "Ledger",
+          items: {
+            Ledger: [ledger_admin_index_path, CanonicalTransaction.not_stripe_top_up.unmapped.count, %i[]],
+            "Pending Ledger": [pending_ledger_admin_index_path, CanonicalPendingTransaction.unsettled.count, %i[counter]],
+            "Raw Transactions": [raw_transactions_admin_index_path, RawCsvTransaction.unhashed.count, %i[]],
+            "Intrafi Transactions": [raw_intrafi_transactions_admin_index_path, RawIntrafiTransaction.count, %i[counter]],
+            "HCB codes": [hcb_codes_admin_index_path, 0, %i[counter]],
+            "Audits": [admin_ledger_audits_path, Admin::LedgerAudit.pending.count, %i[]],
+          }
+        ),
+        Section.new(
+          name: "Incoming Money",
+          items: {
+            Donations: [donations_admin_index_path, 0, %i[]],
+            "Recurring Donations": [recurring_donations_admin_index_path, 0, %i[]],
+            Invoices: [invoices_admin_index_path, 0, %i[]],
+            Sponsors: [sponsors_admin_index_path, 0, %i[]]
+          }
+        ),
+        Section.new(
+          name: "Organizations",
+          items: {
+            Organizations: [events_admin_index_path, Event.approved.count, %i[counter]],
+            "Google Workspace Requests": [google_workspaces_admin_index_path, GSuite.needs_ops_review.count, %i[]],
+            "Account Numbers": [account_numbers_admin_index_path, Column::AccountNumber.count, %i[counter]]
+          }
+        ),
+        Section.new(
+          name: "Payroll",
+          items: {
+            Employees: [employees_admin_index_path, Employee.onboarding.count, %i[]],
+            Payments: [employee_payments_admin_index_path, Employee::Payment.paid.count, %i[counter]],
+            W9s: [admin_w9s_path, W9.all.count, %i[counter]]
+          }
+        ),
+        Section.new(
+          name: "Misc",
+          items: {
+            "Bank Accounts": [bank_accounts_admin_index_path, BankAccount.failing.count, %i[counter]],
+            "HCB Fees": [bank_fees_admin_index_path, BankFee.in_transit_or_pending.count, %i[counter]],
+            "Column Statements": [admin_column_statements_path, Column::Statement.count, %i[counter]],
+            "Users": [users_admin_index_path, User.count, %i[counter]],
+            "Card Designs": [stripe_card_personalization_designs_admin_index_path, StripeCard::PersonalizationDesign.count, %i[counter]],
+            "Emails": [emails_admin_index_path, Ahoy::Message.count, %i[counter]],
+            "Unknown Merchants": [unknown_merchants_admin_index_path, Rails.cache.fetch("admin_unknown_merchants")&.length || 0, %i[counter]],
+            "Referral Programs": [referral_programs_admin_index_path, Referral::Program.count, %i[counter]]
+          }
+        )
+      ]
     end
 
     memo_wise(:sections)

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -5,16 +5,36 @@ module Admin
     include Rails.application.routes.url_helpers
     prepend MemoWise
 
-    Section = Struct.new(:name, :items, keyword_init: true)
+    class Section
+      prepend MemoWise
+      attr_reader(:name, :items)
+
+      def initialize(name:, items:)
+        @name = name
+        @items = items
+      end
+
+      def active?
+        items.any?(&:active?)
+      end
+
+      memo_wise(:active?)
+
+    end
 
     class Item
       attr_reader(:name, :path, :count, :flags)
 
-      def initialize(name:, path:, count:, flags: [])
+      def initialize(name:, path:, count:, flags: [], active: false)
         @name = name
         @path = path
         @count = count
         @flags = flags
+        @active = active
+      end
+
+      def active?
+        @active
       end
 
     end
@@ -40,18 +60,34 @@ module Admin
 
     attr_reader(:page_title)
 
+    def normalize_string(str)
+      str.to_s.downcase.gsub(" ", "")
+    end
+
+    def normalized_page_title
+      @normalized_page_title ||= normalize_string(page_title)
+    end
+
+    def make_item(name:, **properties)
+      Item.new(
+        name:,
+        **properties,
+        active: normalize_string(name) == normalized_page_title
+      )
+    end
+
     def misc
       Section.new(
         name: "Misc",
         items: [
-          Item.new(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, flags: %i[counter]),
-          Item.new(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, flags: %i[counter]),
-          Item.new(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, flags: %i[counter]),
-          Item.new(name: "Users", path: users_admin_index_path, count: User.count, flags: %i[counter]),
-          Item.new(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, flags: %i[counter]),
-          Item.new(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, flags: %i[counter]),
-          Item.new(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, flags: %i[counter]),
-          Item.new(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, flags: %i[counter])
+          make_item(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, flags: %i[counter]),
+          make_item(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, flags: %i[counter]),
+          make_item(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, flags: %i[counter]),
+          make_item(name: "Users", path: users_admin_index_path, count: User.count, flags: %i[counter]),
+          make_item(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, flags: %i[counter]),
+          make_item(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, flags: %i[counter]),
+          make_item(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, flags: %i[counter]),
+          make_item(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, flags: %i[counter])
         ]
       )
     end
@@ -60,9 +96,9 @@ module Admin
       Section.new(
         name: "Payroll",
         items: [
-          Item.new(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
-          Item.new(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, flags: %i[counter]),
-          Item.new(name: "W9s", path: admin_w9s_path, count: W9.all.count, flags: %i[counter])
+          make_item(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
+          make_item(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, flags: %i[counter]),
+          make_item(name: "W9s", path: admin_w9s_path, count: W9.all.count, flags: %i[counter])
         ]
       )
     end
@@ -71,9 +107,9 @@ module Admin
       Section.new(
         name: "Organizations",
         items: [
-          Item.new(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, flags: %i[counter]),
-          Item.new(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
-          Item.new(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, flags: %i[counter])
+          make_item(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, flags: %i[counter]),
+          make_item(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
+          make_item(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, flags: %i[counter])
         ]
       )
     end
@@ -82,10 +118,10 @@ module Admin
       Section.new(
         name: "Incoming Money",
         items: [
-          Item.new(name: "Donations", path: donations_admin_index_path, count: 0),
-          Item.new(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
-          Item.new(name: "Invoices", path: invoices_admin_index_path, count: 0),
-          Item.new(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
+          make_item(name: "Donations", path: donations_admin_index_path, count: 0),
+          make_item(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
+          make_item(name: "Invoices", path: invoices_admin_index_path, count: 0),
+          make_item(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
         ]
       )
     end
@@ -94,12 +130,12 @@ module Admin
       Section.new(
         name: "Ledger",
         items: [
-          Item.new(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
-          Item.new(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, flags: %i[counter]),
-          Item.new(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
-          Item.new(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, flags: %i[counter]),
-          Item.new(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, flags: %i[counter]),
-          Item.new(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
+          make_item(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
+          make_item(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, flags: %i[counter]),
+          make_item(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
+          make_item(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, flags: %i[counter]),
+          make_item(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, flags: %i[counter]),
+          make_item(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
         ]
       )
     end
@@ -108,13 +144,13 @@ module Admin
       Section.new(
         name: "Spending",
         items: [
-          Item.new(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
-          Item.new(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
-          Item.new(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
-          Item.new(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
-          Item.new(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
-          Item.new(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
-          Item.new(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
+          make_item(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
+          make_item(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
+          make_item(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
+          make_item(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
+          make_item(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
+          make_item(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
+          make_item(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
         ]
       )
     end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -56,6 +56,12 @@ module Admin
 
     memo_wise(:sections)
 
+    def active_section
+      sections.find(&:active?)
+    end
+
+    memo_wise(:active_section)
+
     private
 
     attr_reader(:page_title)

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -7,68 +7,80 @@ module Admin
 
     Section = Struct.new(:name, :items, keyword_init: true)
 
+    class Item
+      attr_reader(:name, :path, :count, :flags)
+
+      def initialize(name:, path:, count:, flags: [])
+        @name = name
+        @path = path
+        @count = count
+        @flags = flags
+      end
+
+    end
+
     def sections
       [
         Section.new(
           name: "Spending",
-          items: {
-            ACHs: [ach_admin_index_path, AchTransfer.pending.count, %i[]],
-            Checks: [increase_checks_admin_index_path, IncreaseCheck.pending.count, %i[]],
-            Disbursements: [disbursements_admin_index_path, Disbursement.reviewing.count, %i[]],
-            PayPal: [paypal_transfers_admin_index_path, PaypalTransfer.pending.count, %i[]],
-            Wires: [wires_admin_index_path, Wire.pending.count, %i[]],
-            "Wise transfers": [wise_transfers_admin_index_path, WiseTransfer.pending.count, %i[]],
-            Reimbursements: [reimbursements_admin_index_path, Reimbursement::Report.reimbursement_requested.count, %i[]]
-          }
+          items: [
+            Item.new(name: "ACHs", path: ach_admin_index_path, count: AchTransfer.pending.count),
+            Item.new(name: "Checks", path: increase_checks_admin_index_path, count: IncreaseCheck.pending.count),
+            Item.new(name: "Disbursements", path: disbursements_admin_index_path, count: Disbursement.reviewing.count),
+            Item.new(name: "PayPal", path: paypal_transfers_admin_index_path, count: PaypalTransfer.pending.count),
+            Item.new(name: "Wires", path: wires_admin_index_path, count: Wire.pending.count),
+            Item.new(name: "Wise transfers", path: wise_transfers_admin_index_path, count: WiseTransfer.pending.count),
+            Item.new(name: "Reimbursements", path: reimbursements_admin_index_path, count: Reimbursement::Report.reimbursement_requested.count)
+          ]
         ),
         Section.new(
           name: "Ledger",
-          items: {
-            Ledger: [ledger_admin_index_path, CanonicalTransaction.not_stripe_top_up.unmapped.count, %i[]],
-            "Pending Ledger": [pending_ledger_admin_index_path, CanonicalPendingTransaction.unsettled.count, %i[counter]],
-            "Raw Transactions": [raw_transactions_admin_index_path, RawCsvTransaction.unhashed.count, %i[]],
-            "Intrafi Transactions": [raw_intrafi_transactions_admin_index_path, RawIntrafiTransaction.count, %i[counter]],
-            "HCB codes": [hcb_codes_admin_index_path, 0, %i[counter]],
-            "Audits": [admin_ledger_audits_path, Admin::LedgerAudit.pending.count, %i[]],
-          }
+          items: [
+            Item.new(name: "Ledger", path: ledger_admin_index_path, count: CanonicalTransaction.not_stripe_top_up.unmapped.count),
+            Item.new(name: "Pending Ledger", path: pending_ledger_admin_index_path, count: CanonicalPendingTransaction.unsettled.count, flags: %i[counter]),
+            Item.new(name: "Raw Transactions", path: raw_transactions_admin_index_path, count: RawCsvTransaction.unhashed.count),
+            Item.new(name: "Intrafi Transactions", path: raw_intrafi_transactions_admin_index_path, count: RawIntrafiTransaction.count, flags: %i[counter]),
+            Item.new(name: "HCB codes", path: hcb_codes_admin_index_path, count: 0, flags: %i[counter]),
+            Item.new(name: "Audits", path: admin_ledger_audits_path, count: Admin::LedgerAudit.pending.count),
+          ]
         ),
         Section.new(
           name: "Incoming Money",
-          items: {
-            Donations: [donations_admin_index_path, 0, %i[]],
-            "Recurring Donations": [recurring_donations_admin_index_path, 0, %i[]],
-            Invoices: [invoices_admin_index_path, 0, %i[]],
-            Sponsors: [sponsors_admin_index_path, 0, %i[]]
-          }
+          items: [
+            Item.new(name: "Donations", path: donations_admin_index_path, count: 0),
+            Item.new(name: "Recurring Donations", path: recurring_donations_admin_index_path, count: 0),
+            Item.new(name: "Invoices", path: invoices_admin_index_path, count: 0),
+            Item.new(name: "Sponsors", path: sponsors_admin_index_path, count: 0)
+          ]
         ),
         Section.new(
           name: "Organizations",
-          items: {
-            Organizations: [events_admin_index_path, Event.approved.count, %i[counter]],
-            "Google Workspace Requests": [google_workspaces_admin_index_path, GSuite.needs_ops_review.count, %i[]],
-            "Account Numbers": [account_numbers_admin_index_path, Column::AccountNumber.count, %i[counter]]
-          }
+          items: [
+            Item.new(name: "Organizations", path: events_admin_index_path, count: Event.approved.count, flags: %i[counter]),
+            Item.new(name: "Google Workspace Requests", path: google_workspaces_admin_index_path, count: GSuite.needs_ops_review.count),
+            Item.new(name: "Account Numbers", path: account_numbers_admin_index_path, count: Column::AccountNumber.count, flags: %i[counter])
+          ]
         ),
         Section.new(
           name: "Payroll",
-          items: {
-            Employees: [employees_admin_index_path, Employee.onboarding.count, %i[]],
-            Payments: [employee_payments_admin_index_path, Employee::Payment.paid.count, %i[counter]],
-            W9s: [admin_w9s_path, W9.all.count, %i[counter]]
-          }
+          items: [
+            Item.new(name: "Employees", path: employees_admin_index_path, count: Employee.onboarding.count),
+            Item.new(name: "Payments", path: employee_payments_admin_index_path, count: Employee::Payment.paid.count, flags: %i[counter]),
+            Item.new(name: "W9s", path: admin_w9s_path, count: W9.all.count, flags: %i[counter])
+          ]
         ),
         Section.new(
           name: "Misc",
-          items: {
-            "Bank Accounts": [bank_accounts_admin_index_path, BankAccount.failing.count, %i[counter]],
-            "HCB Fees": [bank_fees_admin_index_path, BankFee.in_transit_or_pending.count, %i[counter]],
-            "Column Statements": [admin_column_statements_path, Column::Statement.count, %i[counter]],
-            "Users": [users_admin_index_path, User.count, %i[counter]],
-            "Card Designs": [stripe_card_personalization_designs_admin_index_path, StripeCard::PersonalizationDesign.count, %i[counter]],
-            "Emails": [emails_admin_index_path, Ahoy::Message.count, %i[counter]],
-            "Unknown Merchants": [unknown_merchants_admin_index_path, Rails.cache.fetch("admin_unknown_merchants")&.length || 0, %i[counter]],
-            "Referral Programs": [referral_programs_admin_index_path, Referral::Program.count, %i[counter]]
-          }
+          items: [
+            Item.new(name: "Bank Accounts", path: bank_accounts_admin_index_path, count: BankAccount.failing.count, flags: %i[counter]),
+            Item.new(name: "HCB Fees", path: bank_fees_admin_index_path, count: BankFee.in_transit_or_pending.count, flags: %i[counter]),
+            Item.new(name: "Column Statements", path: admin_column_statements_path, count: Column::Statement.count, flags: %i[counter]),
+            Item.new(name: "Users", path: users_admin_index_path, count: User.count, flags: %i[counter]),
+            Item.new(name: "Card Designs", path: stripe_card_personalization_designs_admin_index_path, count: StripeCard::PersonalizationDesign.count, flags: %i[counter]),
+            Item.new(name: "Emails", path: emails_admin_index_path, count: Ahoy::Message.count, flags: %i[counter]),
+            Item.new(name: "Unknown Merchants", path: unknown_merchants_admin_index_path, count: Rails.cache.fetch("admin_unknown_merchants")&.length || 0, flags: %i[counter]),
+            Item.new(name: "Referral Programs", path: referral_programs_admin_index_path, count: Referral::Program.count, flags: %i[counter])
+          ]
         )
       ]
     end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -21,12 +21,12 @@
   <body>
     <a class="skip-to-main" href="#main">Skip to main content</a>
 
-    <% nav = Admin::Nav.new.sections %>
+    <% nav = Admin::Nav.new %>
 
     <% title = yield(:title) if content_for?(:title) %>
-    <% parent, active = *(title ? nav.map do |name, items|
-                                    items.map do |item, value|
-                                      [item.to_s.downcase.gsub(" ", ""), [name, item]]
+    <% parent, active = *(title ? nav.sections.map do |section|
+                                    section.items.map do |item, value|
+                                      [item.to_s.downcase.gsub(" ", ""), [section.name, item]]
                                     end
                                   end.flatten(1).to_h[title.to_s.downcase.gsub(" ", "")] : ["Admin", nil]) %>
 
@@ -67,19 +67,19 @@
       </div>
 
       <div class="nav-row" style="width: 100%; display: flex; padding: 8px 0px;">
-        <% nav.each do |name, items| %>
-          <% task_sum = items.reject { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
-          <% counter_sum = items.select { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
+        <% nav.sections.each do |section| %>
+          <% task_sum = section.items.reject { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
+          <% counter_sum = section.items.select { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
           <details open class="admin-nav-item pb0">
-            <summary class="nav-item" style="<%= name == parent ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
-              <%= name %>
+            <summary class="nav-item" style="<%= section.name == parent ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
+              <%= section.name %>
               <span class="badge <%= task_sum > 0 ? "bg-success" : "bg-muted" %> h-fit-content">
                 <%= task_sum > 0 ? task_sum : counter_sum %>
               </span>
             </summary>
             <div class="dropdown">
               <div class="sub-items">
-                <% items.each do |name, item| %>
+                <% section.items.each do |name, item| %>
                   <% link, count, flags = *item %>
 
                   <%= link_to link, style: active == name ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -24,11 +24,6 @@
     <% title = yield(:title) if content_for?(:title) %>
 
     <% nav = Admin::Nav.new(page_title: title) %>
-    <% parent, active = *(title ? nav.sections.map do |section|
-                                    section.items.map do |item|
-                                      [item.name.to_s.downcase.gsub(" ", ""), [section.name, item]]
-                                    end
-                                  end.flatten(1).to_h[title.to_s.downcase.gsub(" ", "")] : ["Admin", nil]) %>
 
     <nav style="display: flex; flex-direction: column; background: var(--hcb-bg-2-5); gap: 0px">
       <div style="width: 100%; display: flex; gap: 8px; align-items: center; font-size: 22px; padding: 8px; border-bottom: 1px solid var(--hcb-bg-2);">
@@ -42,7 +37,7 @@
         <% title = yield(:title) if content_for?(:title) %>
         <% if title %>
           <span>
-            <%= parent %>
+            <%= nav.active_section&.name || "Admin" %>
           </span>
           <span style="color: var(--hcb-link-2); font-weight: 200;">/</span>
           <b style="font-weight: 600;">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -75,7 +75,7 @@
                 <% section.items.each do |item| %>
                   <%= link_to item.path, style: item.active? ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>
                     <%= item.name %>
-                    <span class="badge <%= (:counter.in? item.flags) || item.count.zero? ? "bg-muted" : "" %> h-fit-content">
+                    <span class="badge <%= item.record_count? || item.count.zero? ? "bg-muted" : "" %> h-fit-content">
                       <%= item.count %>
                     </span>
                   <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,8 +25,8 @@
 
     <% title = yield(:title) if content_for?(:title) %>
     <% parent, active = *(title ? nav.sections.map do |section|
-                                    section.items.map do |item, value|
-                                      [item.to_s.downcase.gsub(" ", ""), [section.name, item]]
+                                    section.items.map do |item|
+                                      [item.name.to_s.downcase.gsub(" ", ""), [section.name, item]]
                                     end
                                   end.flatten(1).to_h[title.to_s.downcase.gsub(" ", "")] : ["Admin", nil]) %>
 
@@ -68,8 +68,8 @@
 
       <div class="nav-row" style="width: 100%; display: flex; padding: 8px 0px;">
         <% nav.sections.each do |section| %>
-          <% task_sum = section.items.reject { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
-          <% counter_sum = section.items.select { |name, item| item.third.include?(:counter) }.map { |name, item| item.second }.sum %>
+          <% task_sum = section.items.reject { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
+          <% counter_sum = section.items.select { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
           <details open class="admin-nav-item pb0">
             <summary class="nav-item" style="<%= section.name == parent ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
               <%= section.name %>
@@ -79,13 +79,11 @@
             </summary>
             <div class="dropdown">
               <div class="sub-items">
-                <% section.items.each do |name, item| %>
-                  <% link, count, flags = *item %>
-
-                  <%= link_to link, style: active == name ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>
-                    <%= name %>
-                    <span class="badge <%= (:counter.in? flags) || count.zero? ? "bg-muted" : "" %> h-fit-content">
-                      <%= count %>
+                <% section.items.each do |item| %>
+                  <%= link_to item.path, style: active == item.name ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>
+                    <%= item.name %>
+                    <span class="badge <%= (:counter.in? item.flags) || item.count.zero? ? "bg-muted" : "" %> h-fit-content">
+                      <%= item.count %>
                     </span>
                   <% end %>
                 <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -21,51 +21,7 @@
   <body>
     <a class="skip-to-main" href="#main">Skip to main content</a>
 
-    <% nav = {
-         Spending: {
-           ACHs: [ach_admin_index_path, AchTransfer.pending.count, %i[]],
-           Checks: [increase_checks_admin_index_path, IncreaseCheck.pending.count, %i[]],
-           Disbursements: [disbursements_admin_index_path, Disbursement.reviewing.count, %i[]],
-           PayPal: [paypal_transfers_admin_index_path, PaypalTransfer.pending.count, %i[]],
-           Wires: [wires_admin_index_path, Wire.pending.count, %i[]],
-           "Wise transfers": [wise_transfers_admin_index_path, WiseTransfer.pending.count, %i[]],
-           Reimbursements: [reimbursements_admin_index_path, Reimbursement::Report.reimbursement_requested.count, %i[]]
-         },
-         Ledger: {
-           Ledger: [ledger_admin_index_path, CanonicalTransaction.not_stripe_top_up.unmapped.count, %i[]],
-           "Pending Ledger": [pending_ledger_admin_index_path, CanonicalPendingTransaction.unsettled.count, %i[counter]],
-           "Raw Transactions": [raw_transactions_admin_index_path, RawCsvTransaction.unhashed.count, %i[]],
-           "Intrafi Transactions": [raw_intrafi_transactions_admin_index_path, RawIntrafiTransaction.count, %i[counter]],
-           "HCB codes": [hcb_codes_admin_index_path, 0, %i[counter]],
-           "Audits": [admin_ledger_audits_path, Admin::LedgerAudit.pending.count, %i[]]
-         },
-         "Incoming Money": {
-           Donations: [donations_admin_index_path, 0, %i[]],
-           "Recurring Donations": [recurring_donations_admin_index_path, 0, %i[]],
-           Invoices: [invoices_admin_index_path, 0, %i[]],
-           Sponsors: [sponsors_admin_index_path, 0, %i[]]
-         },
-         Organizations: {
-           Organizations: [events_admin_index_path, Event.approved.count, %i[counter]],
-           "Google Workspace Requests": [google_workspaces_admin_index_path, GSuite.needs_ops_review.count, %i[]],
-           "Account Numbers": [account_numbers_admin_index_path, Column::AccountNumber.count, %i[counter]]
-         },
-         Payroll: {
-           Employees: [employees_admin_index_path, Employee.onboarding.count, %i[]],
-           Payments: [employee_payments_admin_index_path, Employee::Payment.paid.count, %i[counter]],
-           W9s: [admin_w9s_path, W9.all.count, %i[counter]]
-         },
-         Misc: {
-           "Bank Accounts": [bank_accounts_admin_index_path, BankAccount.failing.count, %i[counter]],
-           "HCB Fees": [bank_fees_admin_index_path, BankFee.in_transit_or_pending.count, %i[counter]],
-           "Column Statements": [admin_column_statements_path, Column::Statement.count, %i[counter]],
-           "Users": [users_admin_index_path, User.count, %i[counter]],
-           "Card Designs": [stripe_card_personalization_designs_admin_index_path, StripeCard::PersonalizationDesign.count, %i[counter]],
-           "Emails": [emails_admin_index_path, Ahoy::Message.count, %i[counter]],
-           "Unknown Merchants": [unknown_merchants_admin_index_path, Rails.cache.fetch("admin_unknown_merchants")&.length || 0, %i[counter]],
-           "Referral Programs": [referral_programs_admin_index_path, Referral::Program.count, %i[counter]]
-         }
-       } %>
+    <% nav = Admin::Nav.new.sections %>
 
     <% title = yield(:title) if content_for?(:title) %>
     <% parent, active = *(title ? nav.map do |name, items|

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -71,7 +71,7 @@
           <% task_sum = section.items.reject { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
           <% counter_sum = section.items.select { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
           <details open class="admin-nav-item pb0">
-            <summary class="nav-item" style="<%= section.name == parent ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
+            <summary class="nav-item" style="<%= section.active? ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
               <%= section.name %>
               <span class="badge <%= task_sum > 0 ? "bg-success" : "bg-muted" %> h-fit-content">
                 <%= task_sum > 0 ? task_sum : counter_sum %>
@@ -80,7 +80,7 @@
             <div class="dropdown">
               <div class="sub-items">
                 <% section.items.each do |item| %>
-                  <%= link_to item.path, style: active == item.name ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>
+                  <%= link_to item.path, style: item.active? ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" do %>
                     <%= item.name %>
                     <span class="badge <%= (:counter.in? item.flags) || item.count.zero? ? "bg-muted" : "" %> h-fit-content">
                       <%= item.count %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -34,7 +34,7 @@
               height: @home_size || 36,
               alt: "HCB logo" %>
         <% end %>
-        <% title = yield(:title) if content_for?(:title) %>
+
         <% if title %>
           <span>
             <%= nav.active_section&.name || "Admin" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -63,13 +63,11 @@
 
       <div class="nav-row" style="width: 100%; display: flex; padding: 8px 0px;">
         <% nav.sections.each do |section| %>
-          <% task_sum = section.items.reject { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
-          <% counter_sum = section.items.select { |item| item.flags.include?(:counter) }.map { |item| item.count }.sum %>
           <details open class="admin-nav-item pb0">
             <summary class="nav-item" style="<%= section.active? ? "color: var(--hcb-accent)" : "color: var(--hcb-tx-1)" %>">
               <%= section.name %>
-              <span class="badge <%= task_sum > 0 ? "bg-success" : "bg-muted" %> h-fit-content">
-                <%= task_sum > 0 ? task_sum : counter_sum %>
+              <span class="badge <%= section.task_sum > 0 ? "bg-success" : "bg-muted" %> h-fit-content">
+                <%= section.task_sum > 0 ? section.task_sum : section.counter_sum %>
               </span>
             </summary>
             <div class="dropdown">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -21,9 +21,9 @@
   <body>
     <a class="skip-to-main" href="#main">Skip to main content</a>
 
-    <% nav = Admin::Nav.new %>
-
     <% title = yield(:title) if content_for?(:title) %>
+
+    <% nav = Admin::Nav.new(page_title: title) %>
     <% parent, active = *(title ? nav.sections.map do |section|
                                     section.items.map do |item|
                                       [item.name.to_s.downcase.gsub(" ", ""), [section.name, item]]

--- a/spec/models/admin/nav_spec.rb
+++ b/spec/models/admin/nav_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Nav do
+  describe "#sections" do
+    it "returns a list of sections" do
+      instance = described_class.new(page_title: "")
+
+      expect(instance.sections).to be_a(Array)
+      expect(instance.sections).to all(be_a(described_class::Section))
+    end
+
+    it "marks the appropriate section and item as active" do
+      instance = described_class.new(page_title: "Donations")
+
+      active_section = instance.sections.filter(&:active?).sole
+      expect(instance.active_section).to eq(active_section)
+      expect(active_section.name).to eq("Incoming Money")
+
+      active_item = instance.sections.flat_map(&:items).filter(&:active?).sole
+      expect(active_item.name).to eq("Donations")
+    end
+
+    it "performs basic normalization when finding the active item and section" do
+      instance = described_class.new(page_title: "  donations")
+
+      expect(instance.active_section.items.find(&:active?).name).to eq("Donations")
+    end
+  end
+
+  describe described_class::Section do
+    describe "#task_sum" do
+      it "returns the sum of all counts marked as tasks" do
+        instance = described_class.new(
+          name: "Dinosaurs",
+          items: [
+            Admin::Nav::Item.new(name: "Orpheus", path: "/", count: 11, count_type: :tasks),
+            Admin::Nav::Item.new(name: "Littlefoot", path: "/", count: 22, count_type: :tasks),
+            Admin::Nav::Item.new(name: "Barney", path: "/", count: 44, count_type: :records)
+          ]
+        )
+
+        expect(instance.task_sum).to eq(33)
+      end
+    end
+
+    describe "#counter_sum" do
+      it "returns the sum of all counts marked as records" do
+        instance = described_class.new(
+          name: "Dinosaurs",
+          items: [
+            Admin::Nav::Item.new(name: "Orpheus", path: "/", count: 11, count_type: :records),
+            Admin::Nav::Item.new(name: "Littlefoot", path: "/", count: 22, count_type: :records),
+            Admin::Nav::Item.new(name: "Barney", path: "/", count: 44, count_type: :tasks)
+          ]
+        )
+
+        expect(instance.counter_sum).to eq(33)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

There's a whole bunch of logic embedded in `app/views/layouts/admin.html.erb` which handles constructing the admin nav (including making database queries for the various counters and figuring out which item is active).

Rather than add yet another item and move along I figured it'd be worth giving this part of the code some love before making my changes (https://x.com/KentBeck/status/250733358307500032).

## Describe your changes

1. Introduces `Admin::Nav` along with `Section` and `Item` classes
2. Moves the active item and section tracking logic into (1)
3. Moves the `task_sum` and `counter_sum` logic into (1)
4. Removes the notion of `flags`, replacing it with `count_type` (either `:tasks` or `:records`)
5. Adds basic tests

> [!TIP]
> Reviewing this refactor commit by commit should make it a lot easier to understand