### PR TITLE
[Wise] Make sure `wise_id` and `wise_recipient_id` are populated when marked as sent

### DIFF
--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -66,13 +66,16 @@ class WiseTransfersController < ApplicationController
   def mark_sent
     authorize @wise_transfer
 
-    @wise_transfer.mark_sent!
+    @wise_transfer.assign_attributes(wise_transfer_params)
 
-    if @wise_transfer.update(wise_transfer_params)
-      redirect_to wise_transfer_process_admin_path(@wise_transfer), flash: { success: "Marked as sent." }
-    else
-      redirect_to wise_transfer_process_admin_path(@wise_transfer), flash: { error: @wise_transfer.errors.full_messages.to_sentence }
+    begin
+      @wise_transfer.mark_sent!
+      flash[:success] = "Marked as sent."
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:error] = e.record.errors.full_messages.to_sentence
     end
+
+    redirect_to(wise_transfer_process_admin_path(@wise_transfer))
   end
 
   def reject

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -74,12 +74,12 @@ class WiseTransfer < ApplicationRecord
   WISE_ID_FORMAT = /\A\d+\z/
   before_validation(:normalize_wise_id)
   validates(:wise_id, format: { with: WISE_ID_FORMAT, message: "is not a valid Wise ID" }, allow_nil: true)
-  validates(:wise_id, presence: true, if: :sent?)
+  validates(:wise_id, presence: true, if: :processed?)
 
   WISE_RECIPIENT_ID_FORMAT = /\A[\h-]{36}\z/
   before_validation(:normalize_wise_recipient_id)
   validates(:wise_recipient_id, format: { with: WISE_RECIPIENT_ID_FORMAT, message: "is not a valid Wise recipient ID" }, allow_nil: true)
-  validates(:wise_recipient_id, presence: true, if: :sent?)
+  validates(:wise_recipient_id, presence: true, if: :processed?)
 
   after_create do
     generate_quote!
@@ -138,6 +138,10 @@ class WiseTransfer < ApplicationRecord
         canonical_pending_transaction.decline!
       end
     end
+  end
+
+  def processed?
+    sent? || deposited?
   end
 
   validates :amount_cents, numericality: { greater_than: 0, message: "must be positive!" }

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -74,10 +74,12 @@ class WiseTransfer < ApplicationRecord
   WISE_ID_FORMAT = /\A\d+\z/
   before_validation(:normalize_wise_id)
   validates(:wise_id, format: { with: WISE_ID_FORMAT, message: "is not a valid Wise ID" }, allow_nil: true)
+  validates(:wise_id, presence: true, if: :sent?)
 
   WISE_RECIPIENT_ID_FORMAT = /\A[\h-]{36}\z/
   before_validation(:normalize_wise_recipient_id)
   validates(:wise_recipient_id, format: { with: WISE_RECIPIENT_ID_FORMAT, message: "is not a valid Wise recipient ID" }, allow_nil: true)
+  validates(:wise_recipient_id, presence: true, if: :sent?)
 
   after_create do
     generate_quote!

--- a/spec/models/wise_transfer_spec.rb
+++ b/spec/models/wise_transfer_spec.rb
@@ -20,11 +20,16 @@ RSpec.describe WiseTransfer do
       expect(instance.errors[:wise_id]).to be_empty
     end
 
-    it "is required if the wise transfer is marked as sent" do
-      instance = build_instance(wise_id: nil, aasm_state: "sent")
-      instance.validate
+    it "is required if the wise transfer is marked as sent or deposited" do
+      ["sent", "deposited"].each do |aasm_state|
+        instance = build_instance(wise_id: nil, aasm_state:)
+        instance.validate
 
-      expect(instance.errors[:wise_id]).to eq(["can't be blank"])
+        expect(instance.errors[:wise_id]).to(
+          eq(["can't be blank"]),
+          "wise transfer with aasm state #{aasm_state.inspect} should require wise_id"
+        )
+      end
     end
 
     it "must be a number" do
@@ -58,11 +63,16 @@ RSpec.describe WiseTransfer do
       expect(instance.errors[:wise_recipient_id]).to be_empty
     end
 
-    it "is required if the wise transfer is marked as sent" do
-      instance = build_instance(wise_recipient_id: nil, aasm_state: "sent")
-      instance.validate
+    it "is required if the wise transfer is marked as sent or deposited" do
+      ["sent", "deposited"].each do |aasm_state|
+        instance = build_instance(wise_recipient_id: nil, aasm_state:)
+        instance.validate
 
-      expect(instance.errors[:wise_recipient_id]).to eq(["can't be blank"])
+        expect(instance.errors[:wise_recipient_id]).to(
+          eq(["can't be blank"]),
+          "wise transfer with aasm state #{aasm_state.inspect} should require wise_recipient_id"
+        )
+      end
     end
 
     it "must be a UUID-like string" do

--- a/spec/models/wise_transfer_spec.rb
+++ b/spec/models/wise_transfer_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe WiseTransfer do
       expect(instance.errors[:wise_id]).to be_empty
     end
 
+    it "is required if the wise transfer is marked as sent" do
+      instance = build_instance(wise_id: nil, aasm_state: "sent")
+      instance.validate
+
+      expect(instance.errors[:wise_id]).to eq(["can't be blank"])
+    end
+
     it "must be a number" do
       instance = build_instance(wise_id: "NOPE")
       instance.validate
@@ -49,6 +56,13 @@ RSpec.describe WiseTransfer do
       instance = build_instance(wise_recipient_id: nil)
       instance.validate
       expect(instance.errors[:wise_recipient_id]).to be_empty
+    end
+
+    it "is required if the wise transfer is marked as sent" do
+      instance = build_instance(wise_recipient_id: nil, aasm_state: "sent")
+      instance.validate
+
+      expect(instance.errors[:wise_recipient_id]).to eq(["can't be blank"])
     end
 
     it "must be a UUID-like string" do


### PR DESCRIPTION
## Summary of the problem

At the moment
- We mark the transfer as sent before updating it based on the params so if a validation failure occurs, users no longer see the fields
- We don't validate that these fields are populated

## Describe your changes

- Adds presence validation on the fields that only takes effect when the transfer is sent
- Coalesce the operations in `WiseTransfersController#mark_sent` so that 
    1. The action is idempotent (as only one DB call is performed)
    2. We don't proceed if the record is invalid