### PR TITLE
Fix admin tools navigation

### DIFF
--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag(:admin, target: "_top", class: "w-full") do %>
+<%= turbo_frame_tag(:admin_tools, target: "_top", class: "w-full") do %>
   <% admin_tool("w-100 center mt3") do %>
     <div x-data="{
       pinned_cards: $persist([]),

--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :admin do %>
+<%= turbo_frame_tag(:admin, target: "_top", class: "w-full") do %>
   <% admin_tool("w-100 center mt3") do %>
     <div x-data="{
       pinned_cards: $persist([]),

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -151,7 +151,7 @@
     <% end %>
   <% end %>
   <% if auditor_signed_in? %>
-    <%= turbo_frame_tag(:admin, src: admin_tools_path, loading: :lazy, target: "_top", class: "w-full") do %>
+    <%= turbo_frame_tag(:admin_tools, src: admin_tools_path, loading: :lazy, target: "_top", class: "w-full") do %>
       <p>Loading admin tools</p>
     <% end %>
   <% end %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -151,7 +151,7 @@
     <% end %>
   <% end %>
   <% if auditor_signed_in? %>
-    <%= turbo_frame_tag :admin, src: admin_tools_path, loading: :lazy, class: "w-full" do %>
+    <%= turbo_frame_tag(:admin, src: admin_tools_path, loading: :lazy, target: "_top", class: "w-full") do %>
       <p>Loading admin tools</p>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary of the problem

In https://github.com/hackclub/hcb/pull/11448 (updating in https://github.com/hackclub/hcb/pull/11449) we moved the admin tools section of the home page into a lazily-loaded turbo frame. However we forgot to set `target="_top"` so all navigation stays within the frame (see https://turbo.hotwired.dev/handbook/frames#targeting-navigation-into-or-out-of-a-frame).

## Describe your changes

- Set the `target` attribute to promote all navigation to the top-level context
- Update the frame tag name to match the controller action and path