### PR TITLE
Improve donation tier card layout

### DIFF
--- a/app/views/donations/_donation_tiers.html.erb
+++ b/app/views/donations/_donation_tiers.html.erb
@@ -32,8 +32,8 @@
     </div>
   <% else %>
     <h2 class="mt-8 px-5 sm:px-2">Make a contribution</h2>
-    <div class="mt-4 px-2 -mx-2 flex gap-4 overflow-x-auto whitespace-nowrap pb-2 mx-auto">
-      <div class="card w-[250px] shrink-0 mb-8 flex flex-col">
+    <div class="mt-4 px-2 -mx-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 pb-2 mx-auto">
+      <div class="card w-full flex-1 flex flex-col">
         <h3 class="mb-0 mt-0">
           Custom
         </h3>
@@ -46,7 +46,7 @@
         <% end %>
       </div>
       <% @event.donation_tiers.each do |donation_tier| %>
-        <div class="card w-[250px] shrink-0 mb-8 flex flex-col">
+        <div class="card w-full flex-1 shrink-0 flex flex-col">
           <h3 class="mb-0 mt-0">
             <%= donation_tier.name %>
           </h3>


### PR DESCRIPTION
This PR improves the layout of tiers on donation tiers by removing the scroll container on larger devices and wrapping tiers into separate rows (3 tiers max per row)

<img width="1332" height="817" alt="image" src="https://github.com/user-attachments/assets/d6019cf1-17bd-4dd2-9b9a-4784bda1ab07" />
