### PR TITLE
Fix card grants modal on homepage

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -77,6 +77,7 @@
     </div>
     <%= render "reimbursement/reports/create_form", modal_id: "create_reimbursement" %>
     <%= render "transfer_modal" %>
+    <%= render "card_grants/create_modal" %>
     <%= render "invoices/modal" %>
 
     <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="deposit_check">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The new event homepage wasn't rendering the card grant modal so the button to send card grants did nothing.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I added it.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

