### PR TITLE
[v4 API][Check Deposit] Check policy before rendering check images

### DIFF
--- a/app/views/api/v4/transactions/_check_deposit.json.jbuilder
+++ b/app/views/api/v4/transactions/_check_deposit.json.jbuilder
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 json.status check_deposit.state_text.parameterize(separator: "_")
-json.front_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.front)
-json.back_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.back)
+
+if policy(check_deposit).view_image?
+  json.front_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.front)
+  json.back_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.back)
+end
 
 json.submitter do
   if check_deposit.created_by.present?


### PR DESCRIPTION



## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

On the normal web UI, we only show the check deposit image to managers or auditors. This means that members and readers aren't able to view it.

On the v4 API, we weren't performing the same policy check. As a result, all organizers of the event could view check deposit images.

Thank you @thedev132 for reporting this!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->


This PR fixes the bug by checking `CheckDepositPolicy#view_image?` before rendering the check deposit image URLs.

Now that this is fixed, as a manager or admin:

<img width="365" height="275" alt="image" src="https://github.com/user-attachments/assets/5a028000-642e-41bc-b65e-8352f97bd3d7" />

As a member: (note how `front_url` and `back_url` are not there)
<img width="243" height="200" alt="image" src="https://github.com/user-attachments/assets/33b0879c-448c-4be8-994a-a490d4567197" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

