### PR TITLE
[Check Deposit] Allow member-roled depositor to view check img

### DIFF
--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -10,7 +10,13 @@ class CheckDepositPolicy < ApplicationPolicy
   end
 
   def view_image?
-    auditor_or_manager?
+    # You can view the check deposit images (front & back) as long as you meet
+    # at least one of the following conditions:
+    # - You're an auditor (admin)
+    # - You're a manager of the event
+    # - You're an organizer of the event (e.g. reader, member, etc.), but ALSO
+    #   was the person who uploaded the check deposit.
+    auditor_or_manager? || (user? && record.created_by == user)
   end
 
   def toggle_fronted?

--- a/app/views/check_deposits/index.html.erb
+++ b/app/views/check_deposits/index.html.erb
@@ -34,7 +34,7 @@
   <div class="table-container">
     <table>
       <thead>
-        <% if @check_deposits.any? { |cd| policy(cd).view_image? } %>
+        <% if (can_view_any_check_images = @check_deposits.any? { |cd| policy(cd).view_image? }) %>
           <th></th>
         <% end %>
         <th>Status</th>
@@ -48,6 +48,8 @@
           <tr>
             <% if policy(check_deposit).view_image? %>
               <td style="width: 0%"><%= image_tag check_deposit.front.representation(resize_to_limit: [64, 64]), class: "rounded mr1", width: 40 %></td>
+            <% elsif can_view_any_check_images %>
+              <td></td>
             <% end %>
             <td><span class="badge bg-<%= check_deposit.state %> m0"><%= check_deposit.state_text %></span></td>
             <td><%= format_date check_deposit.created_at %></td>


### PR DESCRIPTION
## Summary of the problem

Generally speaking, we hide check deposit images from readers and members because it contains the account & routing number of the donor (check sender).

However, we also allow members to upload check deposits. With our previous pundit policy, members would upload check deposits, but then wouldn't be able to see the image they uploaded.


## Describe your changes

This PR fixes that by allowing a user to view the check deposit images as long as they're an organizer (e.g. reader, member, etc.) AND also was the person who uploaded the check deposit.

This means the final pundit policy looks like:
```ruby
def view_image?
  # You can view the check deposit images (front & back) as long as you meet
  # at least one of the following conditions:
  # - You're an auditor (admin)
  # - You're a manager of the event
  # - You're an organizer of the event (e.g. reader, member, etc.), but ALSO
  #   was the person who uploaded the check deposit.
  auditor_or_manager? || (user? && record.created_by == user)
end
```

N.B. The "you're an organizer of the event" check is important because it prevents a user who uploaded a check deposit, but is later kicked from the organization, from accessing the check deposit images.

Although rare, this logic also intentionally allows for the following:
1. Member uploads a check deposit => they can view the check deposit images they uploaded.
2. The member gets demoted to reader => they can still view the check deposit images they uploaded.
3. The reader is removed from the org => they **lose access** to the images.

---

As a member, on the Check Deposit index page, I can only view image previews of check deposits that I uploaded.
<img width="950" height="351" alt="image" src="https://github.com/user-attachments/assets/0fd05150-3d69-4e83-8ac0-ba8f5e0e813d" />

As a member, I uploaded this check deposit, so I can view the images:
<img width="980" height="735" alt="image" src="https://github.com/user-attachments/assets/23a5b9e4-6b15-4361-bba7-89bfb98161d0" />

As a member, I did NOT upload this check deposit, so I CAN NOT view the images:
<img width="946" height="705" alt="image" src="https://github.com/user-attachments/assets/b5727bbf-095f-481c-b1e6-a63bf48c05d9" />
