### PR TITLE
Allow for updating feature previews of other users

### DIFF
--- a/app/views/features/_preview.html.erb
+++ b/app/views/features/_preview.html.erb
@@ -1,6 +1,7 @@
-<% disabled = !policy(local_assigns[:event] || current_user).update? %>
+<%# leaving current_user just so we don't get a NilClassPolicy error ever %>
+<% disabled = !policy(local_assigns[:event] || local_assigns[:user] || current_user).update? %>
 
-<% if !defined?(unlisted) || !defined?(@shown_private_feature_previews) || @shown_private_feature_previews&.include?(local_assigns[:id]) || Flipper.enabled?(local_assigns[:feature_flag], local_assigns[:event] || current_user) %>
+<% if !defined?(unlisted) || !defined?(@shown_private_feature_previews) || @shown_private_feature_previews&.include?(local_assigns[:id]) || Flipper.enabled?(local_assigns[:feature_flag], local_assigns[:event] || local_assigns[:user]) %>
   <div class="card pb0 mb3" id="<%= local_assigns[:id] %>">
     <div class="card__banner card__banner--top flex justify-between items-center <%= local_assigns[:classes]&.any? ? local_assigns[:classes].join(" ") : "feature-generic" %>">
       <h3 class="h1 pt2 pb2 my0 color-black"><%= local_assigns[:name] %></h3>
@@ -9,10 +10,10 @@
         <div class="actions tooltipped tooltipped--w inline-block mt1" aria-label="This feature is now generally available!">
           <span class="btn bg-accent disabled">Shipped!</span>
         </div>
-      <% elsif Flipper.enabled?(local_assigns[:feature_flag], local_assigns[:event] || current_user) %>
-        <%= link_to "Disable", disable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id), method: :post, class: "btn bg-accent", data: { turbo_confirm: local_assigns[:disable_warning], turbo_method: :post }, disabled: %>
+      <% elsif Flipper.enabled?(local_assigns[:feature_flag], local_assigns[:event] || local_assigns[:user]) %>
+        <%= link_to "Disable", disable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id, user_id: local_assigns[:user]&.id), method: :post, class: "btn bg-accent", data: { turbo_confirm: local_assigns[:disable_warning], turbo_method: :post }, disabled: %>
       <% else %>
-        <%= link_to "Enable", enable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id), method: :post, class: "btn bg-info", disabled: %>
+        <%= link_to "Enable", enable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id, user_id: local_assigns[:user]&.id), method: :post, class: "btn bg-info", disabled: %>
       <% end %>
     </div>
     <p>

--- a/app/views/users/edit_featurepreviews.html.erb
+++ b/app/views/users/edit_featurepreviews.html.erb
@@ -12,25 +12,26 @@
           id: "transaction-popovers",
           feature_flag: :hcb_code_popovers_2023_06_16,
           name: "Popovers",
-          description: "This feature flag enables a popover allowing quick and easy access to transaction details, card information, and more!"
+          description: "This feature flag enables a popover allowing quick and easy access to transaction details, card information, and more!",
+          user: @user
         } %>
 
     <%= render partial: "features/preview", locals: {
           id: "minimalistic-ledger",
           feature_flag: :transactions_background_2024_06_05,
           name: "Minimalistic Ledger",
-          description: "This feature flag makes the ledger more minimalistic by removing the colored backgrounds from transactions."
-        } if Flipper.enabled?(:transactions_background_2024_06_05, current_user) %>
+          description: "This feature flag makes the ledger more minimalistic by removing the colored backgrounds from transactions.",
+          user: @user
+        } if Flipper.enabled?(:transactions_background_2024_06_05, @user) %>
 
     <%= render partial: "features/preview", locals: {
           id: "sudo-mode",
           feature_flag: :sudo_mode_2015_07_21,
           name: "Sudo mode",
-          description: <<~TXT
-            This feature flag improves the security of your account by requiring
+          description: "This feature flag improves the security of your account by requiring
             you to confirm access before performing a potentially sensitive
-            action.
-          TXT
+            action.",
+          user: @user
         } %>
 
     <details>
@@ -43,7 +44,8 @@
             name: "Two factor authentication",
             classes: ["feature-two-factor-authentication"],
             description: "Looking to keep your account secure? This feature flag will require you to log in with two authentication factors (eg. a code from your email as well as your fingerprint) every time.",
-            footer: ("⚠️ This feature will only work if you have a verified phone number on file. Please update your #{link_to "settings", my_settings_path, data: { turbo_action: "advance" }} to add one." if !@user.phone_number_verified?)
+            footer: ("⚠️ This feature will only work if you have a verified phone number on file. Please update your #{link_to "settings", @user == current_user ? my_settings_path : edit_user_path(@user), data: { turbo_action: "advance" }} to add one." if !@user.phone_number_verified?),
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -52,7 +54,8 @@
             fully_shipped: true,
             name: "Time-based one time passwords",
             classes: ["feature-totp"],
-            description: "Loving 2FA? Here's an additional authentication factor for you! This feature let's you use Google Authenticator, Authy or a similar app to sign into HCB."
+            description: "Loving 2FA? Here's an additional authentication factor for you! This feature let's you use Google Authenticator, Authy or a similar app to sign into HCB.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -61,7 +64,8 @@
             fully_shipped: true,
             name: "Receipt Bin",
             description: "Keeping track of receipts for every transaction can be tiring, and it's easy to forget to upload them. We're introducing a new way to manage receipts: Receipt Bin. After uploading receipts to the Receipt Bin, you can link receipts to transactions or save them for later.",
-            footer: "We also support uploading receipts to your Receipt Bin via emailing and texting!"
+            footer: "We also support uploading receipts to your Receipt Bin via emailing and texting!",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -75,7 +79,8 @@
                 <li>Possibly broken UI behavior</li>
                 <li>Flashes of cached content</li>
               </ul>",
-            footer: "This feature is an early tech preview and <strong>will have bugs</strong>. Please let us know when you encounter them!"
+            footer: "This feature is an early tech preview and <strong>will have bugs</strong>. Please let us know when you encounter them!",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -84,7 +89,8 @@
             fully_shipped: true,
             name: "Receipt Report",
             description: "Opting into this preview will send you a weekly reminder with a list of all your missing receipts.",
-            footer: "Try #{link_to "triggering an email for yourself", trigger_receipt_report_path, method: :post, data: { turbo: false } }!"
+            footer: "Try #{link_to "triggering an email for yourself", trigger_receipt_report_path, method: :post, data: { turbo: false } }!",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -96,7 +102,8 @@
         upload a receipt for your $10 charge\" with a link to a form on HCB
         to upload receipts.
         After opting-in to this feature preview, you can reply directly to
-        that email with your receipt attached to upload it."
+        that email with your receipt attached to upload it.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -110,7 +117,8 @@
       Transfer\" button and tools for searching and sorting the existing
       transfers list.",
             footer: "This feature is on a per-user basis. Co-organizers will also have to
-        opt-in for access."
+        opt-in for access.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -127,7 +135,8 @@
       result, organizations with more renamed transactions will have more
       accurate suggestions!",
             footer: "This feature is on a per-user basis. Co-organizers will also have to
-        opt-in for access."
+        opt-in for access.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -135,21 +144,26 @@
             feature_flag: :recently_on_hcb_2024_05_23,
             fully_shipped: true,
             name: "Recently on HCB...",
-            description: "This feature preview adds a panel to your sidebar with things that have happened recently on your organizations, for example, when an invoice is paid or a new team member is invited."
+            description: "This feature preview adds a panel to your sidebar with things that have happened recently on your organizations, for example, when an invoice is paid or a new team member is invited.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
             id: "command_bar",
             feature_flag: :command_bar_2024_02_05,
+            fully_shipped: true,
             name: "Command Bar (⌘+K)",
-            description: "Looking to whizz around HCB's interface? Enable the command bar and use it to switch between different organizations and pages. It also features a search tool that allows you to search transactions, cards and events."
+            description: "Looking to whizz around HCB's interface? Enable the command bar and use it to switch between different organizations and pages. It also features a search tool that allows you to search transactions, cards and events.",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
             id: "rename_on_homepage",
             feature_flag: :rename_on_homepage_2023_12_06,
+            fully_shipped: true,
             name: "Rename Transactions on the Ledger",
-            description: "This feature flag enables you to directly rename transactions on your organization's home page. Try it out by shift clicking on a transaction, typing out a new memo, and pressing enter!"
+            description: "This feature flag enables you to directly rename transactions on your organization's home page. Try it out by shift clicking on a transaction, typing out a new memo, and pressing enter!",
+            user: @user
           } %>
 
       <%= render partial: "features/preview", locals: {
@@ -162,7 +176,8 @@
         upload a receipt. After opting-in, you'll get a text whenever your
         card is charged asking for a receipt. You can change your phone
         number in your user settings.",
-            footer: ("⚠️ This feature will only work if you have a verified phone number on file. Please update your #{link_to "settings", my_settings_path, data: { turbo_action: "advance" }} to add one." if !@user.phone_number_verified?)
+            footer: ("⚠️ This feature will only work if you have a verified phone number on file. Please update your #{link_to "settings", @user == current_user ? my_settings_path : edit_user_path(@user), data: { turbo_action: "advance" }} to add one." if !@user.phone_number_verified?),
+            user: @user
           } %>
     </details>
   </section>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Before the page would show the feature previews for the current user instead of the selected user.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Now admins can toggle a user's feature previews from the UI.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

