### PR TITLE
Don't show a declined error if reversed

### DIFF
--- a/app/views/hcb_codes/_stripe_card.html.erb
+++ b/app/views/hcb_codes/_stripe_card.html.erb
@@ -91,7 +91,7 @@
   </section>
 
   <section class="details pt2 pb2 details--wide details--tall">
-    <% if @hcb_code.pt&.declined? %>
+    <% if @hcb_code.pt&.declined? && @hcb_code.pt.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") != "reversed" %>
       <% reason = @hcb_code.pt.decline_reason %>
       <% webhook_declined_reason = @hcb_code.pt.raw_pending_stripe_transaction.stripe_transaction.dig("metadata", "declined_reason") %>
       <p>


### PR DESCRIPTION
These aren't declined in Stripe's eyes, they're reversed. Just we merge the concepts.