### PR TITLE
Use `>=` so that we raise the correct error

### DIFF
--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -162,7 +162,7 @@ class CardGrant < ApplicationRecord
 
   def withdraw!(amount_cents:, withdrawn_by: sent_by)
     raise ArgumentError, "Card grant should have a non-zero balance." if balance.zero?
-    raise ArgumentError, "Card grant should have more money than being withdrawn." if amount_cents > balance.amount * 100
+    raise ArgumentError, "Card grant should have more money than being withdrawn." if amount_cents >= balance.amount * 100
 
     custom_memo = "Withdrawal from grant to #{user.name}"
 


### PR DESCRIPTION
You can't use `withdraw!` to zero a card grant