### PR TITLE
Add option for operations to charge fee for low-value wire transfers

### DIFF
--- a/app/controllers/wires_controller.rb
+++ b/app/controllers/wires_controller.rb
@@ -71,6 +71,19 @@ class WiresController < ApplicationController
 
     @wire.send_wire!
 
+    if params[:charge_fee] == "1"
+      disbursement = DisbursementService::Create.new(
+        name: "Low-value wire transfer fee",
+        destination_event_id: EventMappingEngine::EventIds::HACK_CLUB_BANK,
+        source_event_id: @wire.event.id,
+        amount: 25,
+        requested_by_id: current_user.id,
+        fronted: @wire.event.plan.front_disbursements_enabled?
+      ).run
+
+      disbursement.local_hcb_code.comments.create(content: "Associated with #{hcb_code_url(@wire.local_hcb_code)}", user: current_user)
+    end
+
     redirect_to wire_process_admin_path(@wire), flash: { success: "Thanks for approving that wire." }
 
   rescue Faraday::Error => e

--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -99,8 +99,16 @@
 <hr>
 
 <% if @wire.pending? %>
-  <%= button_to "💸 Approve and automatically send transfer", send_wire_path(@wire), method: :post, data: { confirm: "This will automatically send the wire. You don't need to send it manually!" } %>
-  <%= button_to "💸 Approve and manually send transfer", approve_wire_path(@wire), method: :post, data: { confirm: "Have you manually sent this wire? This option requires you send this wire." } %>
+  <fieldset class="p-4">
+    <%= form_with(model: false, local: true, url: send_wire_path(@wire), method: :post, class: "mb-0") do |form| %>
+      <div class="field mb-2">
+        <%= form.check_box :charge_fee %>
+        <%= form.label :charge_fee, "Charge #{@wire.event.name} $25 to cover transfer fee?", class: "bold ml-2" %>
+    </div>
+      <%= form.submit "💸 Approve and automatically send transfer", data: { confirm: "This will automatically send the wire. You don't need to send it manually!" }, class: "mb-0" %>
+    <% end %>
+  </fieldset>
+  <%= button_to "🔧 Approve and manually send transfer", approve_wire_path(@wire), method: :post, data: { confirm: "Have you manually sent this wire? This option requires you send this wire." } %>
   <%= button_to "✏️ Edit wire", edit_wire_path(@wire), method: :get %>
   <%= form_with(mode: false, local: true, url: reject_wire_path(@wire), method: :post) do |form| %>
     <div class="field">


### PR DESCRIPTION
## Summary of the problem
Currently, operations needs to manually make a disbursement if charging a fee for a low-value transfer is desired.


## Describe your changes
This PR adds a simple checkbox to accomplish the same thing:

<img width="380" height="111" alt="image" src="https://github.com/user-attachments/assets/99b55412-2b5d-441b-b381-0014f03bac0d" />
