### PR TITLE
Use `Date.today` for RPCTs + `amount` for amounts

### DIFF
--- a/app/controllers/column/webhooks_controller.rb
+++ b/app/controllers/column/webhooks_controller.rb
@@ -63,8 +63,8 @@ module Column
       return if account_number.nil?
 
       RawPendingColumnTransaction.create!(
-        column_id: @object["id"],
-        amount_cents: @object["available_amount"],
+        column_id: @object[:id],
+        amount_cents: @object[:amount],
         date_posted: Date.today,
         column_transaction: @object,
         column_event_type:

--- a/app/controllers/column/webhooks_controller.rb
+++ b/app/controllers/column/webhooks_controller.rb
@@ -65,7 +65,7 @@ module Column
       RawPendingColumnTransaction.create!(
         column_id: @object["id"],
         amount_cents: @object["available_amount"],
-        date_posted: @object["settlement_date"],
+        date_posted: Date.today,
         column_transaction: @object,
         column_event_type:
       )


### PR DESCRIPTION
Seems like Column sends different data for different transaction types so I'm going to fallback.