### PR TITLE
[Wise] Move recipient field to upper section

### DIFF
--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -173,6 +173,15 @@
                   "@keyup": "amount = +$event.target.value * 100",
                   data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
               </div>
+              <div class="mb-2">
+                <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
+                <%= form.text_field(
+                      :wise_recipient_id,
+                      style: "width: 400px;",
+                      disabled: @wise_transfer.usd_amount_cents.nil?,
+                      placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                    ) %>
+              </div>
               <p x-show="amount && balance >= amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
                 <%= inline_icon "checkmark", class: "text-green" %>
                 Sufficient funds available
@@ -191,15 +200,6 @@
             <div class="field">
               <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
               <%= form.text_field :wise_id, style: "width: 400px;", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
-            </div>
-            <div class="field">
-              <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
-              <%= form.text_field(
-                    :wise_recipient_id,
-                    style: "width: 400px;",
-                    disabled: @wise_transfer.usd_amount_cents.nil?,
-                    placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                  ) %>
             </div>
             <%= form.submit "💸 Mark transfer as sent", disabled: @wise_transfer.usd_amount_cents.nil?, class: "mb-0" %>
           <% end %>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -139,14 +139,14 @@
     <h3>Process</h3>
 
     <% if @wise_transfer.pending? %>
-      <fieldset class="p-6">
+      <fieldset class="px-6 py-3">
         <legend style="padding: 0px 8px">Approve</legend>
         <p>For this approval check, you're only looking at the transfer purpose and documentation. The balance check will be done after it is approved.</p>
         <%= button_to "💸 Approve and self-assign", approve_wise_transfer_path(@wise_transfer), method: :post %>
 
       </fieldset>
 
-      <fieldset class="p-6">
+      <fieldset class="px-6 py-3">
         <legend style="padding: 0px 8px">Reject</legend>
         <%= form_with(model: false, local: true, url: reject_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">
@@ -159,7 +159,7 @@
 
       </fieldset>
     <% elsif @wise_transfer.approved? %>
-      <fieldset class="p-6" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
+      <fieldset class="px-6 py-3" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
         <legend style="padding: 0px 8px">Send</legend>
             <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
               <div class="mb-2">
@@ -206,7 +206,7 @@
 
       </fieldset>
 
-      <fieldset class="p-6">
+      <fieldset class="px-6 py-3">
         <legend style="padding: 0px 8px">Reject</legend>
         <small class="mb-5 mt-0 block">This requires you to communicate to the organizer about the reason why.</small>
 
@@ -227,7 +227,7 @@
     <% end %>
 
     <% if @wise_transfer.may_mark_failed? %>
-      <fieldset class="p-6">
+      <fieldset class="px-6 py-3">
         <legend style="padding: 0px 8px">Fail</legend>
         <%= form_with(model: false, local: true, url: mark_failed_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -149,7 +149,7 @@
       <fieldset class="p-6">
         <legend style="padding: 0px 8px">Reject</legend>
         <%= form_with(model: false, local: true, url: reject_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
-          <div class="field">
+          <div class="mb-2">
             <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
             <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
           </div>
@@ -162,7 +162,7 @@
       <fieldset class="p-6" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
         <legend style="padding: 0px 8px">Send</legend>
             <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
-              <div class="field">
+              <div class="mb-2">
                 <%= form.label :usd_amount, "Amount (USD)", class: "bold mb1" %> <br>
                 $ <%= form.number_field :usd_amount,
                   placeholder: "500.00",
@@ -197,7 +197,7 @@
             <% end %>
 
           <%= form_with(model: @wise_transfer, local: true, url: mark_sent_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
-            <div class="field">
+            <div class="mb-2">
               <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
               <%= form.text_field :wise_id, style: "width: 400px;", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
             </div>
@@ -211,7 +211,7 @@
         <small class="mb-5 mt-0 block">This requires you to communicate to the organizer about the reason why.</small>
 
         <%= form_with(model: false, local: true, url: reject_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
-          <div class="field">
+          <div class="mb-2">
             <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
             <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
           </div>
@@ -230,7 +230,7 @@
       <fieldset class="p-6">
         <legend style="padding: 0px 8px">Fail</legend>
         <%= form_with(model: false, local: true, url: mark_failed_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
-          <div class="field">
+          <div class="mb-2">
             <%= form.label "Failure reason", class: "bold mb1" %> <br>
             <%= form.text_area :reason, style: "width: 400px;", placeholder: "(Markdown supported)" %>
           </div>


### PR DESCRIPTION
## Summary of the problem

When processing Wise requests we first create the recipient and then send the transfer

## Describe your changes

Move the recipient ID field to the upper section

<img width="641" height="454" alt="CleanShot 2025-08-29 at 11 20 29" src="https://github.com/user-attachments/assets/005c99ee-a2a7-4c00-9f6c-41c3c9b9d0ad" />
