### PR TITLE
Don't report `RTesseract::Error`

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -15,6 +15,7 @@ default: &defaults
     - ActionDispatch::Http::MimeNegotiation::InvalidType
     - ActionDispatch::Http::Parameters::ParseError
     - ActiveRecord::RecordNotFound
+    - RTesseract::Error
 
 production:
   <<: *defaults


### PR DESCRIPTION
These errors aren't caused by us and we don't rely on RTesseract outside of auto-retrying jobs