### PR TITLE
Explain announcement feature for new users

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -13,6 +13,8 @@ class AnnouncementsController < ApplicationController
 
     authorize @announcement
 
+    @show_announcement_explanation = Announcement.where(author: current_user).where.not(published_at: nil).empty?
+
     @announcement.save!
   end
 

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -2,10 +2,15 @@
 
 <%= form_with model: @announcement, url: announcement_path(@announcement), data: { controller: "tiptap", "tiptap-target": "form", "tiptap-content-value": content, "tiptap-announcement-id-value": @announcement.id, "tiptap-autosave-value": autosave, "tiptap-followers-value": @event.followers.size, "tiptap-published-value": @announcement.published?, "turbo-frame": "_top" }.compact do |form| %>
   <% if @show_announcement_explanation %>
-    <div class="callout callout--info w-full ml-0">
-      <p class="py-0">
-        Announcements are a great way to keep your followers updated on important news and events.
+    <div class="callout callout--info w-full ml-0 block">
+      <p class="mt-0 mb-1 text-lg" style="font-weight: 700">
+        Keep your supporters in the loop
       </p>
+      <ul class="pl-4 my-0">
+        <li>👥 Followers can subscribe to your org</li>
+        <li>📣 Share updates with a rich-text editor + HCB data blocks</li>
+        <li>🗒️ Updates show up in the Feed + inbox</li>
+      </ul>
     </div>
   <% end %>
   <div class="field">

--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -1,6 +1,13 @@
 <%# locals: (content: nil, autosave: true) %>
 
 <%= form_with model: @announcement, url: announcement_path(@announcement), data: { controller: "tiptap", "tiptap-target": "form", "tiptap-content-value": content, "tiptap-announcement-id-value": @announcement.id, "tiptap-autosave-value": autosave, "tiptap-followers-value": @event.followers.size, "tiptap-published-value": @announcement.published?, "turbo-frame": "_top" }.compact do |form| %>
+  <% if @show_announcement_explanation %>
+    <div class="callout callout--info w-full ml-0">
+      <p class="py-0">
+        Announcements are a great way to keep your followers updated on important news and events.
+      </p>
+    </div>
+  <% end %>
   <div class="field">
     <%= form.label :title, class: "text-lg" %>
     <%= form.text_field :title, placeholder: "#{@event.name}'s June Update", class: "!max-w-none w-full mt-1" %>


### PR DESCRIPTION
This resolves #10960 by showing a callout banner when a user hasn't used the announcement feature before

<img width="847" height="847" alt="image" src="https://github.com/user-attachments/assets/d5983a4c-03d6-46bc-a490-9c429df2a746" />