### PR TITLE
Fix duplicated user admin page

### DIFF
--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -74,7 +74,7 @@
     <% end %>
   <% end %>
 
-  <%= admin_tool do %>
+  <% admin_tool do %>
     <h2 class="mb2 mt1">Comments</h2>
     <%= render "comments/list", comments: @user.comments, show_blankslate: true %>
     <%= render "comments/form", commentable: @user %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
There was a `<%=` instead of `<%` for an `admin_tool`, which caused the user admin settings page to be duplicated.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed `<%=` to `<%`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

