### PR TITLE
Fix disabling the remove follow button

### DIFF
--- a/app/views/events/_followers_modal.html.erb
+++ b/app/views/events/_followers_modal.html.erb
@@ -16,7 +16,7 @@
                             turbo_method: :delete,
                             turbo_confirm: "Are you sure you want to remove this follower?",
                           },
-                          disabled: policy(event_follow).destroy? %>
+                          disabled: !policy(event_follow).destroy? %>
         </span>
       </li>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The remove follow button was being disabled when the user was authorized to destroy the follow instead of the other way around.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add `!` 

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

