### PR TITLE
Notify organizers when they have a new spending allowance

### DIFF
--- a/app/mailers/organizer_position/spending/controls_mailer.rb
+++ b/app/mailers/organizer_position/spending/controls_mailer.rb
@@ -9,6 +9,13 @@ class OrganizerPosition
         mail to: @control.organizer_position.user.email_address_with_name, subject: "Your spending balance on #{@control.organizer_position.event.name} is getting low"
       end
 
+      def new_allowance
+        @allowance = params[:allowance]
+        @control = @allowance.control
+
+        mail to: @control.organizer_position.user.email_address_with_name, subject: "Your spending balance on #{@control.organizer_position.event.name} has #{@allowance.amount_cents > 0 ? "increased" : "decreased"}"
+      end
+
     end
   end
 

--- a/app/models/organizer_position/spending/control/allowance.rb
+++ b/app/models/organizer_position/spending/control/allowance.rb
@@ -37,6 +37,8 @@ class OrganizerPosition
         validate :balance_is_non_zero, on: :create
         validates :amount_cents, numericality: { less_than_or_equal_to: 999_999_99 }
 
+        after_create :notify_organizer
+
         private
 
         def balance_is_positive
@@ -45,6 +47,10 @@ class OrganizerPosition
 
         def balance_is_non_zero
           errors.add(:allowance, "must be nonzero") if amount_cents.zero?
+        end
+
+        def notify_organizer
+          ControlsMailer.with(allowance: self).new_allowance.deliver_later
         end
 
       end

--- a/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
+++ b/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
@@ -6,4 +6,3 @@
 <p>Your spending balance is now <%= render_money @control.balance_cents %>.</p>
 
 <p><em><%= link_to "See our blog post to learn more about spending controls on HCB.", "https://blog.hcb.hackclub.com/posts/spending-controls-295539" %></em></p>
-

--- a/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
+++ b/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
@@ -1,0 +1,9 @@
+<p>Hey <%= @control.organizer_position.user.name %>,</p>
+
+<p>Your spending balance for <%= @control.organizer_position.event.name %> has <%= @allowance.amount_cents > 0 ? "increased" : "decreased" %> by <%= render_money @allowance.amount_cents.abs %> with the following memo:</p>
+<blockquote><%= @allowance.memo %></blockquote>
+
+<p>Your spending balance is now <%= render_money @control.balance_cents %>.</p>
+
+<p><em><%= link_to "See our blog post to learn more about spending controls on HCB.", "https://blog.hcb.hackclub.com/posts/spending-controls-295539" %></em></p>
+

--- a/spec/mailers/previews/organizer_position/spending/controls_mailer_preview.rb
+++ b/spec/mailers/previews/organizer_position/spending/controls_mailer_preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class OrganizerPosition
+  module Spending
+    class ControlsMailerPreview < ActionMailer::Preview
+      def low_balance_warning
+        ControlsMailer.with(control: Control.last).low_balance_warning
+      end
+
+      def new_allowance
+        ControlsMailer.with(allowance: Control::Allowance.last).new_allowance
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Organizers currently have no notification when their spending balance is increased or decreased, just an email when it's getting low.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a mailer that is sent to the organizer whenever an allowance is created, along with the preview.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="1070" height="546" alt="image" src="https://github.com/user-attachments/assets/5a56cb58-7144-435c-87ef-981b4a10490c" />


