### PR TITLE
Fix defaulting monthly announcements to transparent events

### DIFF
--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -29,13 +29,13 @@ class Event
     normalizes :contact_email, with: ->(contact_email) { contact_email.strip.downcase }
     validates :subevent_plan, inclusion: { in: -> { Event::Plan.available_plans.map(&:name) } }, allow_blank: true
 
-    after_create :set_defaults
+    before_create :set_defaults
     after_save :create_or_destroy_monthly_announcement
 
     private
 
     def set_defaults
-      self.generate_monthly_announcement = event.is_public unless self.generate_monthly_announcement.present?
+      self.generate_monthly_announcement = event.is_public if self.generate_monthly_announcement.nil?
     end
 
     def create_or_destroy_monthly_announcement


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Transparent events are supposed to default to having monthly announcements enabled, but the `set_defaults` callback was being run `after_create` instead of `before_create`, which meant that this default wasn't being saved.

Closes #11043

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moved the callback to run in `before_create` and changed the logic to be if nil instead of unless present.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

