### PR TITLE
Notify organizers when a pre-authorization is flagged as fraudulent

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -26,8 +26,7 @@ class AnnouncementMailer < ApplicationMailer
     @announcement = params[:announcement]
     @event = @announcement.event
 
-    @emails = @event.managers.map(&:email_address_with_name)
-    @emails << @event.config.contact_email if @event.config.contact_email.present?
+    @emails = @event.organizer_contact_emails(only_managers: true)
 
     @scheduled_for = Date.today.next_month.beginning_of_month
   end

--- a/app/mailers/card_grant/pre_authorization_mailer.rb
+++ b/app/mailers/card_grant/pre_authorization_mailer.rb
@@ -5,7 +5,7 @@ class CardGrant
     def notify_fraudulent
       @pre_authorization = params[:pre_authorization]
 
-      mail to: @pre_authorization.event.organizer_contact_emails(only_managers: true), subject: "A card grant pre-authorization requires your review"
+      mail to: @pre_authorization.event.organizer_contact_emails(only_managers: true), subject: "[#{@pre_authorization.event.name}] A card grant pre-authorization requires your review"
     end
 
   end

--- a/app/mailers/card_grant/pre_authorization_mailer.rb
+++ b/app/mailers/card_grant/pre_authorization_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CardGrant
+  class PreAuthorizationMailer < ApplicationMailer
+    def notify_fraudulent
+      @pre_authorization = params[:pre_authorization]
+
+      mail to: @pre_authorization.event.organizer_contact_emails(only_managers: true), subject: "A card grant pre-authorization requires your review"
+    end
+
+  end
+
+end

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -65,6 +65,9 @@ class CardGrant
 
       event :mark_fraudulent do
         transitions from: :submitted, to: :fraudulent
+        after do
+          PreAuthorizationMailer.with(pre_authorization: self).notify_fraudulent.deliver_later
+        end
       end
 
       event :mark_rejected do

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -848,8 +848,10 @@ class Event < ApplicationRecord
     config.subevent_plan.present?
   end
 
-  def organizer_contact_emails
-    emails = users.map(&:email_address_with_name)
+  def organizer_contact_emails(only_managers: false)
+    included_users = only_managers ? managers : users
+
+    emails = included_users.map(&:email_address_with_name)
     emails << config.contact_email if config.contact_email.present?
 
     emails

--- a/app/views/card_grant/pre_authorization_mailer/notify_fraudulent.html.erb
+++ b/app/views/card_grant/pre_authorization_mailer/notify_fraudulent.html.erb
@@ -1,0 +1,14 @@
+<p>
+  Hey team,
+</p>
+
+<p>
+  <%= @pre_authorization.user.name %> has submitted a card grant pre-authorization that has been marked as potentially fraudulent.
+  <%= link_to "Review this pre-authorization on HCB.", card_grant_pre_authorizations_url(@pre_authorization.card_grant) %>
+</p>
+
+<p>
+  Thanks,
+  <br><br>
+  The HCB Team
+</p>

--- a/app/views/card_grant/pre_authorization_mailer/notify_fraudulent.html.erb
+++ b/app/views/card_grant/pre_authorization_mailer/notify_fraudulent.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  <%= @pre_authorization.user.name %> has submitted a card grant pre-authorization that has been marked as potentially fraudulent.
+  <%= @pre_authorization.user.name %> has submitted a card grant pre-authorization for <%= @pre_authorization.event.name %> that has been marked as potentially fraudulent.
   <%= link_to "Review this pre-authorization on HCB.", card_grant_pre_authorizations_url(@pre_authorization.card_grant) %>
 </p>
 

--- a/spec/mailers/previews/card_grant/pre_authorization_mailer_preview.rb
+++ b/spec/mailers/previews/card_grant/pre_authorization_mailer_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CardGrant
+  class PreAuthorizationMailerPreview < ActionMailer::Preview
+    def notify_fraudulent
+      PreAuthorizationMailer.with(pre_authorization: PreAuthorization.last).notify_fraudulent
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Organizers should know when there's a potentially fraudulent pre-authorization that they need to review!

Closes #11501 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds `CardGrant::PreAuthorizationMailer` and the `notify_fraudulent` action to send an email to managers of the organization that issued the card grant, along with a mailer preview.

<img width="1253" height="585" alt="image" src="https://github.com/user-attachments/assets/2f71ea50-7b6c-4cd5-a929-b55c54113cae" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

