### PR TITLE
Fix announcement edit page

### DIFF
--- a/app/views/announcements/_announcement_form.html.erb
+++ b/app/views/announcements/_announcement_form.html.erb
@@ -23,7 +23,7 @@
     <%= form.hidden_field :json_content, data: { "tiptap-target": "contentInput" } %>
     <div class="border-smoke dark:border-0 border-[1px] border-solid rounded-md mt-1 relative">
       <div class="flex gap-2 bg-snow dark:bg-darkless p-2 rounded-md rounded-b-none dark:border-b-dark border-b-smoke border-b-[1px] border-solid border-0">
-        <%= render partial: "announcements/format_menu", event: announcement.event %>
+        <%= render partial: "announcements/format_menu", locals: { event: announcement.event } %>
       </div>
       <div data-tiptap-target="editor" data-action="click->tiptap#focus" class="dark:bg-darkless bg-snow p-2 rounded-md rounded-t-none py-1 min-h-32"></div>
       <div class="tooltipped absolute right-1 bottom-1 h-8" aria-label="Styling with Markdown is supported">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
`locals` was missing in the `render` for `format_menu`, causing the edit page to error

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add the `locals` hash

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

