### PR TITLE
[Accounting] Add XLSX download for Statement of Activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,8 @@ gem "business_time"
 gem "poppler" # PDF parsing
 gem "wicked_pdf" # HTML to PDF conversion
 
+gem "write_xlsx" # Export Excel files
+gem "rubyzip", "< 3.0", ">= 2.3.0" # Force `write_xlsx` to use an older version of `rubyzip`. See https://github.com/cxn03651/write_xlsx/issues/127
 
 gem "rack-cors" # manage CORS
 gem "rack-attack" # rate limiting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nkf (0.2.0)
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -730,6 +731,7 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
+    rubyzip (2.4.1)
     safely_block (0.4.1)
     safety_net_attestation (0.4.0)
       jwt (~> 2.0)
@@ -861,6 +863,9 @@ GEM
       activesupport
       ostruct
     wkhtmltopdf-binary (0.12.6.8)
+    write_xlsx (1.12.1)
+      nkf
+      rubyzip (>= 1.0.0)
     xxhash (0.6.0)
     yard (0.9.37)
     yard-solargraph (0.1.0)
@@ -978,6 +983,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails (~> 2.30)
   ruby-limiter
+  rubyzip (>= 2.3.0, < 3.0)
   safely_block
   sidekiq (~> 7.3.8)
   sidekiq-cron (~> 2.1)
@@ -1000,6 +1006,7 @@ DEPENDENCIES
   whitesimilarity
   wicked_pdf
   wkhtmltopdf-binary (= 0.12.6.8)
+  write_xlsx
   xxhash
   yellow_pages!
 

--- a/app/controllers/admin/event_groups_controller.rb
+++ b/app/controllers/admin/event_groups_controller.rb
@@ -46,7 +46,7 @@ module Admin
         format.xlsx do
           send_data(
             @statement_of_activity.xlsx,
-            filename: "#{@event_group.name} - Statement of Activity.xlsx",
+            filename: "#{@event_group.name} Event Group - Statement of Activity.xlsx",
             type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             disposition: "attachment"
           )

--- a/app/controllers/admin/event_groups_controller.rb
+++ b/app/controllers/admin/event_groups_controller.rb
@@ -40,6 +40,18 @@ module Admin
         start_date_param: params[:start],
         end_date_param: params[:end]
       )
+
+      respond_to do |format|
+        format.html
+        format.xlsx do
+          send_data(
+            @statement_of_activity.xlsx,
+            filename: "#{@event_group.name} - Statement of Activity.xlsx",
+            type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            disposition: "attachment"
+          )
+        end
+      end
     end
 
     def event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -924,6 +924,18 @@ class EventsController < ApplicationController
     authorize @event
 
     @statement_of_activity = Event::StatementOfActivity.new(@event, start_date_param: params[:start], end_date_param: params[:end])
+
+    respond_to do |format|
+      format.html
+      format.xlsx do
+        send_data(
+          @statement_of_activity.xlsx,
+          filename: "#{@event.name} - Statement of Activity.xlsx",
+          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          disposition: "attachment"
+        )
+      end
+    end
   end
 
   def termination

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -70,7 +70,7 @@ class Event
 
       bold = workbook.add_format(bold: 1)
 
-      worksheet = workbook.add_worksheet('Statement of Activity')
+      worksheet = workbook.add_worksheet("Statement of Activity")
       subject_name = @event_group&.name || @event.name
       worksheet.write("A1", "#{subject_name}'s Statement of Activity", bold)
 

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -100,9 +100,9 @@ class Event
 
       # Header row for transaction list
       if @event_group.present?
-        write_row.call("Transaction Memo", "Amount", "Organization", format: bold)
+        write_row.call("Transaction Memo", "Amount", "Organization", "URL", format: bold)
       else
-        write_row.call("Transaction Memo", "Amount", format: bold)
+        write_row.call("Transaction Memo", "Amount", "URL", format: bold)
       end
 
       transactions_by_category.to_a.each do |category, transactions|
@@ -110,10 +110,13 @@ class Event
         category_total = category_totals[category&.slug] / 100.0
 
         transactions.each do |transaction|
+          memo = transaction.memo
+          amount_cents = transaction.amount_cents / 100.0
+          url = Rails.application.routes.url_helpers.url_for(transaction.local_hcb_code)
           if @event_group.present?
-            write_row.call(transaction.local_hcb_code.memo, transaction.amount_cents / 100.0, transaction.event.name, level: 1)
+            write_row.call(memo, amount_cents, transaction.event.name, url, level: 1)
           else
-            write_row.call(transaction.local_hcb_code.memo, transaction.amount_cents / 100.0, level: 1)
+            write_row.call(memo, amount_cents, url, level: 1)
           end
         end
 

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -74,6 +74,8 @@ class Event
       subject_name = @event_group&.name || @event.name
       worksheet.write("A1", "#{subject_name}'s Statement of Activity", bold)
 
+      worksheet.set_column("A:A", 40) # Set first column width to 40
+
       current_row = 2
       write_row = ->(*column_values, level: nil, format: nil) do
         worksheet.write_row(current_row, 0, column_values, format)

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -40,7 +40,7 @@ class Event
       end
     end
 
-    memo_wise def transactions_by_category
+    memo_wise def category_totals
       transactions.includes(:category).group("category.slug").sum(:amount_cents)
     end
 

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -89,11 +89,12 @@ class Event
       transactions_by_category.to_a.each do |category, transactions|
         category_name = category&.label || "Uncategorized"
         category_total = category_totals[category&.slug] / 100.0
-        write_row.call(category_name, category_total, format: bold)
 
         transactions.each do |transaction|
           write_row.call(transaction.local_hcb_code.memo, transaction.amount_cents / 100.0, level: 1)
         end
+
+        write_row.call(category_name, category_total, format: bold)
       end
 
       workbook.close

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -1,15 +1,20 @@
 <%# locals: (statement_of_activity:) %>
 
-<div class="flex justify-between items-baseline">
-  <h1 class="border-b-0">Statement of Activity</h1>
+<div class="flex justify-between items-center gap-4">
+  <h1 class="border-b-0 flex-grow">Statement of Activity</h1>
 
-  <%= form_with(method: :get, data: { controller: "form" }) do |form| %>
-    <div class="flex gap-2 items-center w-fit">
+  <%= form_with(method: :get, data: { controller: "form" }, class: "mb-0") do |form| %>
+    <div class="flex gap-2 items-center w-fit text-nowrap">
       From
-      <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" } %>
+      <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
       To
-      <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" } %>
+      <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
     </div>
+  <% end %>
+
+  <%= link_to({format: :xlsx}, class: "btn") do %>
+    <%= inline_icon "download" %>
+    <small>Download XLSX</small>
   <% end %>
 </div>
 <hr class="mt-0">

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -12,7 +12,7 @@
     </div>
   <% end %>
 
-  <%= link_to({format: :xlsx}, class: "btn") do %>
+  <%= link_to({ format: :xlsx }, class: "btn") do %>
     <%= inline_icon "download" %>
     <small>Download XLSX</small>
   <% end %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -53,14 +53,14 @@
   </tr>
   </thead>
   <tbody>
-  <% if statement_of_activity.transactions_by_category.empty? %>
+  <% if statement_of_activity.category_totals.empty? %>
     <tr>
       <td colspan="2" class="text-center p-14">
         There were no transactions in this date range.
       </td>
     </tr>
   <% else %>
-    <% statement_of_activity.transactions_by_category.each do |category_slug, amount_cents_sum| %>
+    <% statement_of_activity.category_totals.each do |category_slug, amount_cents_sum| %>
       <% category = TransactionCategory::Definition::ALL[category_slug] %>
       <tr>
         <td title="<%= category&.slug %>"><%= category&.label || "Uncategorized" %></td>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -6,3 +6,4 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register "text/ledger", :ledger
+Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx


### PR DESCRIPTION
## Summary of the problem

We already have a web version of the Statement of Activity for Events and Event Groups (see https://github.com/hackclub/hcb/pull/11437 and https://github.com/hackclub/hcb/pull/11496).

Now we want an XLSX download for it. The advantage of XLSX over the web version is that XLSX allows you to expand into each category to view the transactions that make up said category. It uses the [Excel Outline feature](https://support.microsoft.com/en-us/office/outline-group-data-in-a-worksheet-08ce98c4-0063-4d42-8ac7-8278c49e9aff).

## Describe your changes

To make this happen, I added a new gem [`write_xlsx`](https://github.com/cxn03651/write_xlsx). I also needed to explicitly install Rubyzip (a dependency of `write_xlsx`). See https://github.com/cxn03651/write_xlsx/issues/127 for more info on why.

This PR adds a new "Download XLSX" button to the Statement of Activity pages.

_Screenshot from an Event Group's Statement of Activity:_
<img width="1428" height="136" alt="image" src="https://github.com/user-attachments/assets/81ee7151-2d39-4a17-9403-33acb6c1ac7f" />

_Screenshot from an Event's Statement of Activity:_
<img width="915" height="132" alt="image" src="https://github.com/user-attachments/assets/76e6c118-4d0e-4ab0-af6e-7f9649a6f9c0" />
<sup>sorry, i know it looks jank— that's a problem for later lol<sup>

Upon clicking the button, it downloads an XLSX that looks like:

<img width="353" height="252" alt="image" src="https://github.com/user-attachments/assets/57ddcd6f-80f4-4716-8ad6-ddeb61a438be" />

Categories can be expanded by clicking the `+`:
<img width="372" height="825" alt="image" src="https://github.com/user-attachments/assets/162d6fdc-d3d4-41f2-88c2-8b47acd1ab41" />

Event groups have a bit more information:
- List of Events included in the event group
   <img width="217" height="75" alt="image" src="https://github.com/user-attachments/assets/8794ab48-27c6-47f9-b97b-b544bb465a2a" />
   <img width="365" height="49" alt="image" src="https://github.com/user-attachments/assets/e27f84eb-fcb9-416d-abd5-0286b324458e" />

- Name of organization next to each transaction
   <img width="465" height="162" alt="image" src="https://github.com/user-attachments/assets/20783906-408f-44ab-af19-d80bed38cd1d" />
