### PR TITLE
[Statement of Activity] Drop `abs` on category total

### DIFF
--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -69,7 +69,7 @@
       <% category = TransactionCategory::Definition::ALL[category_slug] %>
       <tr>
         <td title="<%= category&.slug %>"><%= category&.label || "Uncategorized" %></td>
-        <td><%= render_money amount_cents_sum.abs %></td>
+        <td><%= render_money amount_cents_sum %></td>
       </tr>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary of the problem

Since our categories contain both positives and negatives, calling `abs` loses data.


## Describe your changes

Drop `abs` call