### PR TITLE
[Announcement] Fix the refresh block button

### DIFF
--- a/app/views/announcements/blocks/_block_actions.html.erb
+++ b/app/views/announcements/blocks/_block_actions.html.erb
@@ -2,6 +2,8 @@
 
 <% unless is_email %>
   <div class="block-actions">
-    <%= pop_icon_to "history", refresh_announcements_block_path(block), data: { turbo_method: :post }, class: "absolute top-2 right-2 tooltipped", "aria-label": "Refresh this block with the latest data" %>
+    <%= button_to refresh_announcements_block_path(block), class: "pop cursor-pointer absolute top-2 right-2 tooltipped", "aria-label": "Refresh this block with the latest data" do %>
+      <%= inline_icon "history", size: 28 %>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
For some reason, Turbo wasn't using the `data-turbo-method` attribute correctly on the refresh block button, so the button was sending a GET request instead of POST.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changes the refresh block button to use `button_to` to send a POST request.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

