### PR TITLE
Set input mode to numeric on login code inputs

### DIFF
--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -36,7 +36,8 @@
             class: "!max-w-full w-max",
             autocomplete: "one-time-code",
             required: true,
-            autofocus: true
+            autofocus: true,
+            inputmode: "numeric",
           ) %>
     <% end %>
 

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -44,6 +44,7 @@
          required: true,
          autofocus: true,
          autocomplete: "one-time-code",
+         inputmode: "numeric",
        )
      } %>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C068U0JMV19/p1756832006346219 - it would be nice for users on mobile to see the numpad when entering in login codes!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Set `inputmode="numeric"` on login code inputs, which will make mobile keyboards show the numpad instead of the normal keyboard. Pasting codes still works the same on both desktop and mobile.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

