### PR TITLE
Cascade delete event follows

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -290,7 +290,7 @@ class Event < ApplicationRecord
   has_many :g_suites
   has_many :g_suite_accounts, through: :g_suites
 
-  has_many :event_follows, class_name: "Event::Follow"
+  has_many :event_follows, class_name: "Event::Follow", dependent: :destroy
   has_many :followers, through: :event_follows, source: :user
 
   has_many :fee_relationships


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C047Y01MHJQ/p1756772723340589 - there were follows in the production database for an event that had been deleted, which was causing errors.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added `dependent: :destroy` to the relation on `Event` to `Event::Follow`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

