### PR TITLE
Don't send the invite accepted email to the user that was invited

### DIFF
--- a/app/mailers/organizer_position_invites_mailer.rb
+++ b/app/mailers/organizer_position_invites_mailer.rb
@@ -8,7 +8,7 @@ class OrganizerPositionInvitesMailer < ApplicationMailer
   end
 
   def accepted
-    @emails = (@invite.event.users.except(@invite.user).map(&:email_address_with_name) + [@invite.event.config.contact_email]).compact
+    @emails = (@invite.event.users.excluding(@invite.user).map(&:email_address_with_name) + [@invite.event.config.contact_email]).compact
 
     @announcement = Announcement::Templates::NewTeamMember.new(
       invite: @invite,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This was part of the original PR for the accepted email, but `.except` was used, which doesn't work as expected on arrays.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Switch to use `.excluding` instead of `.except`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

