### PR TITLE
Allow auditors to view statements of activity

### DIFF
--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -113,7 +113,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def statement_of_activity?
-    show? && admin?
+    show? && auditor?
   end
 
   def async_balance?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Statements of activity don't modify any data, so HCB auditors should be able to view them.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change the policy to allow auditors

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

