### PR TITLE
[Announcement] Fix styling on donation goal block when there's 0 progress

### DIFF
--- a/app/views/announcements/blocks/_donation_goal.html.erb
+++ b/app/views/announcements/blocks/_donation_goal.html.erb
@@ -12,7 +12,9 @@
       </p>
       <div class="bg-gray-200 dark:bg-neutral-700 rounded-full w-full">
         <div class="h-full bg-primary rounded flex items-center justify-center" style="width: <%= percentage * 100 %>%">
-          <p class="text-sm text-black p-[1px] my-0"><%= number_with_precision(percentage * 100, precision: 1) %>%</p>
+          <p class="text-sm text-black p-[1px] my-0">
+            <%= percentage > 0 ? "#{number_with_precision(percentage * 100, precision: 1)}%" : "&nbsp".html_safe %>
+          </p>
         </div>
       </div>
     <% end %>

--- a/app/views/announcements/blocks/_donation_goal.html.erb
+++ b/app/views/announcements/blocks/_donation_goal.html.erb
@@ -12,9 +12,7 @@
       </p>
       <div class="bg-gray-200 dark:bg-neutral-700 rounded-full w-full">
         <div class="h-full bg-primary rounded flex items-center justify-center" style="width: <%= percentage * 100 %>%">
-          <p class="text-sm text-black p-[1px] my-0">
-            <%= percentage > 0 ? "#{number_with_precision(percentage * 100, precision: 1)}%" : "&nbsp".html_safe %>
-          </p>
+          <p class="text-sm text-black p-[1px] my-0 h-5"><%= "#{number_with_precision(percentage * 100, precision: 1)}%" if percentage > 0 %></p>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
When there's zero progress made towards the goal, the donation goal block showed the "0%" to the far left of the progress bar, partially cut off.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed it to have whitespace instead of a percentage to keep the progress bar height.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

