### PR TITLE
Fix ratelimiting method on send announcement notice job

### DIFF
--- a/app/jobs/one_time_jobs/send_announcement_notice.rb
+++ b/app/jobs/one_time_jobs/send_announcement_notice.rb
@@ -3,15 +3,11 @@
 module OneTimeJobs
   class SendAnnouncementNotice < ApplicationJob
     def self.perform
-      # Rate limit is 14/s, but putting 12 here to be safe and allow for other emails to be sent
-      queue = Limiter::RateQueue.new(12, interval: 1)
-
       Event.includes(:config).where(config: { generate_monthly_announcement: true }).find_each do |event|
         monthly_announcement = event.announcements.monthly.last
 
         if monthly_announcement.present?
-          queue.shift
-          AnnouncementMailer.with(event:, monthly_announcement:).notice.deliver_now
+          AnnouncementMailer.with(event:, monthly_announcement:).notice.deliver_later
         end
       end
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Ratelimiting is now done through ActiveJob::TrafficControl instead of the Limiter gem

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removed the Limiter gem ratelimiting and changed the job to use `deliver_later`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

