### PR TITLE
[Announcement] Fix donation goal block title

### DIFF
--- a/app/views/announcements/blocks/_donation_goal.html.erb
+++ b/app/views/announcements/blocks/_donation_goal.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (goal: nil, percentage: 0, is_email: false, block: nil) %>
 
-<%= render "announcements/blocks/block_shell", block:, type: "donationGoal", is_email:, title: "#{goal.event.name}'s donation goal" do %>
+<%= render "announcements/blocks/block_shell", block:, type: "donationGoal", is_email:, title: "#{block.event.name}'s donation goal" do %>
   <% if goal.nil? %>
     <p>This organization doesn't have a donation goal yet! Organizers can configure one in the organization settings.</p>
   <% else %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Donation goal blocks can be created for events that do not have donation goals, but the partial was assuming that the donation goal existed.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changed the partial to get the event reference through `block` instead of `goal`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

