### PR TITLE
Fix announcement notice job

### DIFF
--- a/app/jobs/one_time_jobs/send_announcement_notice.rb
+++ b/app/jobs/one_time_jobs/send_announcement_notice.rb
@@ -2,7 +2,7 @@
 
 module OneTimeJobs
   class SendAnnouncementNotice < ApplicationJob
-    def self.perform
+    def perform
       Event.includes(:config).where(config: { generate_monthly_announcement: true }).find_each do |event|
         monthly_announcement = event.announcements.monthly.last
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The `SendAnnouncementNotice` one-time job had the `perform` method defined on the class instead of instance, causing a `NotImplementedError`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change `self.perform` to `perform`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

