### PR TITLE
Always show admin tool in user_mention

### DIFF
--- a/app/assets/stylesheets/components/_badges.scss
+++ b/app/assets/stylesheets/components/_badges.scss
@@ -243,15 +243,10 @@ summary.pop::-webkit-details-marker {
   svg:first-child {
     vertical-align: bottom;
   }
-  &:hover {
-    .mention__link {
-      display: flex;
-      align-items: center;
-    }
-  }
 
   .mention__link {
-    display: none;
+    display: flex;
+    align-items: center;
     margin-left: 4px;
     text-decoration: none;
     cursor: pointer;


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
These always mess with the spacing on elements because they were able to change size. We also can't do transparency because it would leave a strange gap after the user mention while not hovered.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

