### PR TITLE
Clarify tooltip for anonymous donation option

### DIFF
--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -94,7 +94,7 @@
     <% if @event.config.anonymous_donations %>
       <div class="field field--checkbox mb0">
         <%= form.check_box :anonymous, style: "margin-left: 0;" %>
-        <%= form.label :anonymous, "Keep my donation private.", style: "display: inline; flex-grow: 1;" %>
+        <%= form.label :anonymous, "Don't display my name publicly.", style: "display: inline; flex-grow: 1;" %>
         <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your information.' tabindex="0">
           <%= inline_icon "info", width: 24 %>
         </a>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -95,7 +95,7 @@
       <div class="field field--checkbox mb0">
         <%= form.check_box :anonymous, style: "margin-left: 0;" %>
         <%= form.label :anonymous, "Keep my donation private.", style: "display: inline; flex-grow: 1;" %>
-        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your name.' tabindex="0">
+        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your information.' tabindex="0">
           <%= inline_icon "info", width: 24 %>
         </a>
       </div>


### PR DESCRIPTION
## Summary of the problem
Donors are misled into believing that an anonymous donation hides their email from team members.


## Describe your changes
Update copy on anonymous donation page to better reflect our policies.