### PR TITLE
Update event_create_from_airtable to add robotics tag based on airtable

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -112,7 +112,6 @@ class AdminController < Admin::BaseController
     if ["Robotics", "FIRST/Robotics", "FIRST - Argosy"].include?(application["Org Type"])
       tags << EventTag::Tags::ROBOTICS_TEAM
     end
-    
     event = ::EventService::Create.new(
       name: application["Event Name"],
       country: country&.alpha2,

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -108,9 +108,11 @@ class AdminController < Admin::BaseController
 
     tags = []
     tags << EventTag::Tags::ORGANIZED_BY_TEENAGERS if application["TEEN"]
+
     if ["Robotics", "FIRST/Robotics", "FIRST - Argosy"].include?(application["Org Type"])
       tags << EventTag::Tags::ROBOTICS_TEAM
     end
+
     event = ::EventService::Create.new(
       name: application["Event Name"],
       country: country&.alpha2,

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -105,12 +105,20 @@ class AdminController < Admin::BaseController
     record = ApplicationsTable.find(params[:airtable_record_id])
     application = record.fields
     country = ISO3166::Country.find_country_by_any_name(application["Event Location"])
+
+    tags = []
+    tags << EventTag::Tags::ORGANIZED_BY_TEENAGERS if application["TEEN"]
+  
+    if ["Robotics", "FIRST/Robotics", "FIRST - Argosy"].include?(application["Org Type"])
+      tags << EventTag::Tags::ROBOTICS_TEAM
+    end
+    
     event = ::EventService::Create.new(
       name: application["Event Name"],
       country: country&.alpha2,
       point_of_contact_id: current_user.id,
       approved: true,
-      tags: application["TEEN"] ? [EventTag::Tags::ORGANIZED_BY_TEENAGERS] : [],
+      tags: tags,
       demo_mode: true
     ).run
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -116,7 +116,7 @@ class AdminController < Admin::BaseController
       country: country&.alpha2,
       point_of_contact_id: current_user.id,
       approved: true,
-      tags: tags,
+      tags:,
       demo_mode: true
     ).run
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -108,7 +108,6 @@ class AdminController < Admin::BaseController
 
     tags = []
     tags << EventTag::Tags::ORGANIZED_BY_TEENAGERS if application["TEEN"]
-  
     if ["Robotics", "FIRST/Robotics", "FIRST - Argosy"].include?(application["Org Type"])
       tags << EventTag::Tags::ROBOTICS_TEAM
     end


### PR DESCRIPTION
Refactor event creation to use dynamic tags based on application data.

## Summary of the problem
Closes #11626 


## Describe your changes
If the robotics tag is present, add it to the event.