### PR TITLE
Improve card grant setting creation logic

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -326,6 +326,8 @@ class EventsController < ApplicationController
     @activities = PublicActivity::Activity.for_event(@event).before(@activities_before).order(created_at: :desc).page(params[:page]).per(25) if @settings_tab == "audit_log"
     @affiliations = @event.affiliations if @settings_tab == "affiliations"
 
+    CardGrantSetting.find_or_create_by!(event: @event) if @event.plan.card_grants_enabled? && @settings_tab == "card_grants"
+
     render :edit, layout: !@frame
   end
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -21,7 +21,7 @@
           <%= link_to "Reimbursements", edit_event_path(@event, tab: "reimbursements"), data: { turbo: true, turbo_action: "advance" } %>
         <% end %>
       <% end %>
-      <% if @event.card_grant_setting.present? %>
+      <% if @event.plan.card_grants_enabled? %>
         <%= settings_tab active: @settings_tab == "card_grants" do %>
           <%= link_to "Card grants", edit_event_path(@event, tab: "card_grants"), data: { turbo: true, turbo_action: "advance" } %>
         <% end %>
@@ -51,7 +51,7 @@
   <%= render "events/settings/donations", event: @event, frame: @frame %>
 <% elsif @settings_tab == "reimbursements" && @event.approved? && @event.plan.reimbursements_enabled? %>
   <%= render "events/settings/reimbursements", event: @event, frame: @frame %>
-<% elsif @settings_tab == "card_grants" && @event.approved? && @event.card_grant_setting.present? %>
+<% elsif @settings_tab == "card_grants" && @event.approved? && @event.plan.card_grants_enabled? %>
   <%= render "events/settings/card_grants", event: @event %>
 <% elsif @settings_tab == "tags" %>
   <%= render "events/settings/tags", event: @event %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
You would need to issue a card grant before the card grant settings appeared and then the settings page would remain accessible after the organization had its plan changed.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

