### PR TITLE
Redirect non-admins to download page for common cocuments

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -42,6 +42,12 @@ class DocumentsController < ApplicationController
   end
 
   def show
+    # For common documents (event_id: nil), redirect non-admin users to the download URL
+    if @document.common? && !current_user.admin?
+      redirect_to download_document_path(@document)
+      return
+    end
+    
     authorize @document
   end
 

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -94,7 +94,7 @@
     <% if @event.config.anonymous_donations %>
       <div class="field field--checkbox mb0">
         <%= form.check_box :anonymous, style: "margin-left: 0;" %>
-        <%= form.label :anonymous, "Keep my donation private.", style: "display: inline; flex-grow: 1;" %>
+        <%= form.label :anonymous, "Don't display my name publicly.", style: "display: inline; flex-grow: 1;" %>
         <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your information.' tabindex="0">
           <%= inline_icon "info", width: 24 %>
         </a>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -95,7 +95,7 @@
       <div class="field field--checkbox mb0">
         <%= form.check_box :anonymous, style: "margin-left: 0;" %>
         <%= form.label :anonymous, "Keep my donation private.", style: "display: inline; flex-grow: 1;" %>
-        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your name.' tabindex="0">
+        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='When you donate anonymously, you will appear as "Anonymous donor" on public pages. Team members, however, can still see your information.' tabindex="0">
           <%= inline_icon "info", width: 24 %>
         </a>
       </div>


### PR DESCRIPTION
## Summary of the problem
When sharing the link to a common doc with a user, I [often](https://hackclub.slack.com/archives/CN523HLKW/p1757272937977879?thread_ts=1757272008.806459&cid=CN523HLKW) click go into the documents tab of their org and click the document, then I share the url.

Ex: https://hcb.hackclub.com/documents/common-hack-foundation-990-2022

Unfortunately, this URL leads to a non-authorized page, when it could simply just redirect to the download page:

https://hcb.hackclub.com/documents/common-hack-foundation-990-2022/download


## Describe your changes
If a non admin user visits a common doc page, they are redirected directly to the download page.
