### PR TITLE
For common document, redirect non_admins to document download path

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -42,6 +42,12 @@ class DocumentsController < ApplicationController
   end
 
   def show
+    # For common documents (event_id: nil), redirect non-admin users to the download URL
+    if @document.common? && !current_user.admin?
+      redirect_to download_document_path(@document)
+      return
+    end
+    
     authorize @document
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -43,7 +43,7 @@ class DocumentsController < ApplicationController
 
   def show
     # For common documents (event_id: nil), redirect non-admin users to the download URL
-    if @document.common? && !current_user.admin?
+    if @document.common? && !admin_signed_in?
       redirect_to download_document_path(@document)
       return
     end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -47,6 +47,7 @@ class DocumentsController < ApplicationController
       redirect_to download_document_path(@document)
       return
     end
+
     authorize @document
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -47,7 +47,6 @@ class DocumentsController < ApplicationController
       redirect_to download_document_path(@document)
       return
     end
-    
     authorize @document
   end
 


### PR DESCRIPTION
## Summary of the problem
When sharing the link to a common doc with a user, I [often](https://hackclub.slack.com/archives/CN523HLKW/p1757272937977879?thread_ts=1757272008.806459&cid=CN523HLKW) click go into the documents tab of their org and click the document, then I share the url.

Ex: https://hcb.hackclub.com/documents/common-hack-foundation-990-2022

Unfortunately, this URL leads to a non-authorized page, when it could simply just redirect to the download page:

https://hcb.hackclub.com/documents/common-hack-foundation-990-2022/download


## Describe your changes
If a non admin user visits a common doc page, they are redirected directly to the download page.
