### PR TITLE
[Reimbursements] Use local amount on admin page

### DIFF
--- a/app/views/admin/reimbursements.html.erb
+++ b/app/views/admin/reimbursements.html.erb
@@ -54,7 +54,7 @@
         <td>
           <%= report.user.name %> (<%= report.user.id %>)
         </td>
-        <td class="w-24"><%= render_money(report.amount) %></td>
+        <td class="w-24"><%= report.amount.format %></td>
         <td><%= report.admin_status_text %></td>
         <td>
           <%= link_to "View", reimbursement_report_path(report) %>


### PR DESCRIPTION
## Summary of the problem
The admin page renders every amount as USD, which is wrong and makes it hard to track reimbursements


## Describe your changes
Use `.format` instead of `render_money`