### PR TITLE
[v4 API] Add email to card grant in v4 API

### DIFF
--- a/app/views/api/v4/card_grants/_card_grant.jbuilder
+++ b/app/views/api/v4/card_grants/_card_grant.jbuilder
@@ -10,7 +10,8 @@ json.call(
   :allowed_merchants,
   :allowed_categories,
   :one_time_use,
-  :pre_authorization_required
+  :pre_authorization_required,
+  :email
 )
 json.balance_cents card_grant.balance.cents if expand?(:balance_cents)
 json.status card_grant.status

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Api::V4::CardGrantsController do
           "category_lock"              => [],
           "merchant_lock"              => [],
           "keyword_lock"               => "some keywords",
+          "email"                      => "orpheus@hackclub.com",
           "disbursements"              => [
             {
               "id"             => disbursement.public_id,

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::V4::CardGrantsController do
           "category_lock"              => [],
           "merchant_lock"              => [],
           "keyword_lock"               => "some keywords",
-          "email"                      => "orpheus@hackclub.com",
+          "email"                      => "recipient@example.com",
           "disbursements"              => [
             {
               "id"             => disbursement.public_id,


### PR DESCRIPTION
## Summary of the problem
Organizers using the v4 API can't view the card grant recipient email after creating the grant, even though this data is available in the UI.


## Describe your changes
Adds `email` to the v4 card grant object.