### PR TITLE
Fix refresh canceling raffle submission

### DIFF
--- a/app/controllers/raffles_controller.rb
+++ b/app/controllers/raffles_controller.rb
@@ -9,12 +9,23 @@ class RafflesController < ApplicationController
   def create
     if Raffle.where(user: current_user, program: params[:program]).any?
       flash[:error] = "You are already entered in this raffle."
-      redirect_to root_path
+
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.refresh(request_id: nil) }
+        format.html do
+          redirect_to root_path
+        end
+      end
     else
       raffle = Raffle.new(user: current_user, program: params[:program])
       if raffle.save
         flash[:success] = "Raffle joined!"
-        redirect_to root_path
+        respond_to do |format|
+          format.turbo_stream { render turbo_stream: turbo_stream.refresh(request_id: nil) }
+          format.html do
+            redirect_to root_path
+          end
+        end
       else
         flash[:error] = raffle.errors.full_messages.to_sentence
         redirect_to new_raffle_path

--- a/app/views/raffles/_raffle_form.html.erb
+++ b/app/views/raffles/_raffle_form.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (program:) %>
 
-<%= form_with(url: raffles_path, html: { onsubmit: "location.reload();", action: "" }) do |f| %>
+<%= form_with(url: raffles_path) do |f| %>
   <% if program %>
     <%= f.hidden_field :program, value: program %>
   <% else %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The page was immediately refreshing when the raffle was submitted, causing the request to not send.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Removed the event handler on the frontend to refresh the page and instead used Turbo streams to respond with a refresh stream.

