### PR TITLE
[v4] Pass in Stripe version to cards ephemeral key

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -145,7 +145,7 @@ module Api
         return render json: { error: "not_authorized" }, status: :forbidden unless current_token.application&.trusted?
         return render json: { error: "invalid_operation", messages: ["card must be virtual"] }, status: :bad_request unless @stripe_card.virtual?
 
-        @ephemeral_key = @stripe_card.ephemeral_key(nonce: params[:nonce])
+        @ephemeral_key = @stripe_card.ephemeral_key(nonce: params[:nonce], stripe_version: params[:stripe_version])
 
         ahoy.track "Card details shown", stripe_card_id: @stripe_card.id, user_id: current_user.id, oauth_token_id: current_token.id
 

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -387,8 +387,8 @@ class StripeCard < ApplicationRecord
     Time.now.utc > Time.new(stripe_exp_year, stripe_exp_month).end_of_month
   end
 
-  def ephemeral_key(nonce:)
-    Stripe::EphemeralKey.create({ nonce:, issuing_card: stripe_id }, { stripe_version: "2020-03-02" })
+  def ephemeral_key(nonce:, stripe_version: "2020-03-02")
+    Stripe::EphemeralKey.create({ nonce:, issuing_card: stripe_id }, { stripe_version: })
   end
 
   private


### PR DESCRIPTION
## Summary of the problem
Ideally the stripe versions between the digital wallet mobile app client which is on version `2020-08-27` should be matching the server one. (Tested this manually before but didn't change issues I had with digital wallet issuing but it is something that is expected)

## Describe your changes
Added ability to pass in `stripe_version` as param


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

