### PR TITLE
[Sudo mode] Fix disabling and improve frame handling

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -32,7 +32,8 @@ class FeaturesController < ApplicationController
     else
       flash[:error] = "Sorry, this feature flag doesn't currently exist."
     end
-    redirect_back fallback_location: @actor
+
+    redirect_to(actor_features_index(@actor))
   end
 
   def disable_feature
@@ -61,8 +62,11 @@ class FeaturesController < ApplicationController
     else
       flash[:error] = "Sorry, this feature flag doesn't currently exist."
     end
-    redirect_back fallback_location: @actor
+
+    redirect_to(actor_features_index(@actor))
   end
+
+  private
 
   def set_actor_and_feature
     if params[:event_id]
@@ -74,6 +78,21 @@ class FeaturesController < ApplicationController
     end
     @feature = params[:feature]
     authorize @actor
+  end
+
+  def actor_features_index(actor)
+    case actor
+    when Event
+      edit_event_path(actor, tab: :features)
+    when User
+      if actor == current_user
+        settings_previews_path
+      else
+        previews_user_path(actor)
+      end
+    else
+      root_path
+    end
   end
 
 end

--- a/app/controllers/sudo_mode_handler.rb
+++ b/app/controllers/sudo_mode_handler.rb
@@ -243,10 +243,15 @@ class SudoModeHandler
         login:,
         additional_factors:,
         default_factor:,
+        break_out_of_turbo_frame:,
         **form_locals,
       },
       status: :unprocessable_entity
     )
+  end
+
+  def break_out_of_turbo_frame
+    request.get? && controller_instance.send(:turbo_frame_request?)
   end
 
 end

--- a/app/views/features/_preview.html.erb
+++ b/app/views/features/_preview.html.erb
@@ -11,9 +11,29 @@
           <span class="btn bg-accent disabled">Shipped!</span>
         </div>
       <% elsif Flipper.enabled?(local_assigns[:feature_flag], local_assigns[:event] || local_assigns[:user]) %>
-        <%= link_to "Disable", disable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id, user_id: local_assigns[:user]&.id), method: :post, class: "btn bg-accent", data: { turbo_confirm: local_assigns[:disable_warning], turbo_method: :post }, disabled: %>
+        <%= button_to(
+              "Disable",
+              disable_feature_path(
+                feature: local_assigns[:feature_flag],
+                event_id: local_assigns[:event]&.id,
+                user_id: local_assigns[:user]&.id
+              ),
+              data: { turbo_confirm: local_assigns[:disable_warning], turbo_frame: "_top" },
+              class: "btn bg-accent",
+              disabled:
+            ) %>
       <% else %>
-        <%= link_to "Enable", enable_feature_path(feature: local_assigns[:feature_flag], event_id: local_assigns[:event]&.id, user_id: local_assigns[:user]&.id), method: :post, class: "btn bg-info", disabled: %>
+        <%= button_to(
+              "Enable",
+              enable_feature_path(
+                feature: local_assigns[:feature_flag],
+                event_id: local_assigns[:event]&.id,
+                user_id: local_assigns[:user]&.id
+              ),
+              data: { turbo_frame: "_top" },
+              class: "btn bg-info",
+              disabled:
+            ) %>
       <% end %>
     </div>
     <p>

--- a/app/views/sudo_mode/reauthenticate.html.erb
+++ b/app/views/sudo_mode/reauthenticate.html.erb
@@ -1,13 +1,19 @@
 <% content_for(:container_class, "container--sm py-20") %>
 
-<% content_for(:head) do %>
-  <%#
-    If sudo mode is triggered from within a Turbo frame, the default behaviour
-    would be to render the response within that frame. This meta tag tells Turbo
-    to treat it as a full page navigation.
-    https://turbo.hotwired.dev/handbook/frames#%E2%80%9Cbreaking-out%E2%80%9D-from-a-frame
-  %>
-  <meta name="turbo-visit-control" content="reload">
+<%#
+  If sudo mode is triggered from within a Turbo frame, the default behaviour
+  would be to render the response within that frame. This meta tag tells Turbo
+  to treat it as a full page navigation.
+  https://turbo.hotwired.dev/handbook/frames#%E2%80%9Cbreaking-out%E2%80%9D-from-a-frame
+
+  Note that we only do this for GET requests as in the case of a POST this
+  results in a subsequent GET request being made to the same path, which breaks
+  the interception flow (and often results in a 404).
+%>
+<% if break_out_of_turbo_frame %>
+  <% content_for(:head) do %>
+    <meta name="turbo-visit-control" content="reload">
+  <% end %>
 <% end %>
 
 <div class="flex">


### PR DESCRIPTION
Fixes https://github.com/hackclub/hcb/issues/11604

## Summary of the problem

When presented with a sudo prompt, 
- switching authentication types can lead to a 404
- in the case of feature rollouts, completing the prompt results in a 404

## Describe your changes

- Refactor `FeaturesController` so we're no longer reliant on `redirect_back`
- Refactor the disable and enable buttons to use a real `<form>` and `<button>` so we don't end up with conflicts between `rails-ujs` and Turbo
    - Use `data-turbo-frame="_top"` so we get the flash message, confetti, and properly render the reauthentication form
- Only render the `turbo-visit-control` meta tag when it is safe to reload (i.e. the intercepted request is a `GET` and coming from within a turbo frame)