### PR TITLE
Allow stopped checked to be reissued

### DIFF
--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -231,12 +231,16 @@ class IncreaseCheck < ApplicationRecord
     mark_approved!
   end
 
+  def stopped?
+    column_status == 'stopped'
+  end
+
   def reissue!
     return unless column_id.present? && column_issued?
 
     stopped_id = column_id
 
-    ColumnService.post("/transfers/checks/#{stopped_id}/stop-payment", idempotency_key: "stop_#{stopped_id}")
+    ColumnService.post("/transfers/checks/#{stopped_id}/stop-payment", idempotency_key: "stop_#{stopped_id}") unless stopped?
 
     update!(
       column_id: nil,

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -232,7 +232,7 @@ class IncreaseCheck < ApplicationRecord
   end
 
   def stopped?
-    column_status == 'stopped'
+    column_status == "stopped"
   end
 
   def reissue!


### PR DESCRIPTION
Currently when reissuing a check we stop the check but sometimes checks are already stopped, see example here: https://hackclub.slack.com/archives/C026RKHLPNJ/p1758033523120619