### PR TITLE
Block `wires_money_orders`

### DIFF
--- a/app/services/stripe_authorization_service.rb
+++ b/app/services/stripe_authorization_service.rb
@@ -11,6 +11,7 @@ module StripeAuthorizationService
         "government_licensed_horse_dog_racing_us_region_only",
         "government_owned_lotteries_non_us_region",
         "government_owned_lotteries_us_region_only",
+        "wires_money_orders"
       ]
     ).freeze
 end


### PR DESCRIPTION
https://hackclub.slack.com/archives/C026RKHLPNJ/p1758057161094449

Long time policy has been that these should go through HCB operations for documentation
