### PR TITLE
Block non-fi money orders on issuing cards

### DIFF
--- a/app/services/stripe_authorization_service.rb
+++ b/app/services/stripe_authorization_service.rb
@@ -11,7 +11,8 @@ module StripeAuthorizationService
         "government_licensed_horse_dog_racing_us_region_only",
         "government_owned_lotteries_non_us_region",
         "government_owned_lotteries_us_region_only",
-        "wires_money_orders"
+        "wires_money_orders",
+        "non_fi_money_orders"
       ]
     ).freeze
 end


### PR DESCRIPTION
## Describe your changes
Blocks the non-fi money order category on Stripe