### PR TITLE
[ReceiptReport::SendJob] Queue as `:low`

### DIFF
--- a/app/jobs/receipt_report/send_job.rb
+++ b/app/jobs/receipt_report/send_job.rb
@@ -2,7 +2,7 @@
 
 module ReceiptReport
   class SendJob < ApplicationJob
-    queue_as :default
+    queue_as :low
     def perform(user_id, force_send: false)
       @user = User.includes(:stripe_cards).find user_id
 


### PR DESCRIPTION
## Summary of the problem

We send quite a few of these. To prevent any latency delay for more important/real-time jobs, I'm moving this to the `:low` queue since it's primarily a cron-based background job.

<img width="1180" height="568" alt="image" src="https://github.com/user-attachments/assets/05ee25cc-65ee-4606-894b-c6283a6dcab5" />
<img width="1164" height="544" alt="image" src="https://github.com/user-attachments/assets/f44a83ec-8756-47a9-bf20-678e97858e36" />


## Describe your changes

Moved from default queue to low queue.