### PR TITLE
Allow feature-flagged admins to assign parent organizations

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1095,7 +1095,7 @@ class EventsController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def event_params
-    result_params = params.require(:event).permit(
+    permitted_params = [
       :name,
       :short_name,
       :description,
@@ -1131,26 +1131,30 @@ class EventsController < ApplicationController
       :stripe_card_shipping_type,
       :plan,
       :financially_frozen,
-      card_grant_setting_attributes: [
-        :merchant_lock,
-        :category_lock,
-        :keyword_lock,
-        :invite_message,
-        :banned_merchants,
-        :banned_categories,
-        :expiration_preference,
-        :reimbursement_conversions_enabled,
-        :pre_authorization_required
-      ],
-      config_attributes: [
-        :id,
-        :anonymous_donations,
-        :cover_donation_fees,
-        :contact_email,
-        :generate_monthly_announcement,
-        :subevent_plan
-      ]
-    )
+      {
+        card_grant_setting_attributes: [
+          :merchant_lock,
+          :category_lock,
+          :keyword_lock,
+          :invite_message,
+          :banned_merchants,
+          :banned_categories,
+          :expiration_preference,
+          :reimbursement_conversions_enabled,
+          :pre_authorization_required
+        ],
+        config_attributes: [
+          :id,
+          :anonymous_donations,
+          :cover_donation_fees,
+          :contact_email,
+          :generate_monthly_announcement,
+          :subevent_plan
+        ]
+      }
+    ]
+
+    result_params = params.require(:event).permit(*permitted_params)
 
     # convert whatever the user inputted into something that is a legal slug
     result_params[:slug] = ActiveSupport::Inflector.parameterize(user_event_params[:slug]) if result_params[:slug]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1154,6 +1154,10 @@ class EventsController < ApplicationController
       }
     ]
 
+    if Flipper.enabled?(:parent_event_assignment_2025_09_18, current_user)
+      permitted_params << :parent_id
+    end
+
     result_params = params.require(:event).permit(*permitted_params)
 
     # convert whatever the user inputted into something that is a legal slug

--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -114,9 +114,27 @@
     <% end %>
   <% end %>
 
+  <% if Flipper.enabled?(:parent_event_assignment_2025_09_18, current_user) %>
+    <% admin_tool do %>
+      <%= form_with(model: event, local: true) do |form| %>
+        <h3 id="parent_organization" class="mb2 mt1">Parent Organization</h3>
+
+        <div class="field">
+          <%= form.select(
+            :parent_id,
+            Event.order(name: :asc, id: :asc).where.not(id: event.id).map { |event| [event.name, event.id] },
+            include_blank: "None") %>
+        </div>
+
+        <div class="action">
+          <%= form.submit "Update", disabled:, data: { turbo: false } %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% admin_tool do %>
     <%= form_with(model: event, local: true) do |form| %>
-
       <h3 id="sub_organizations" class="mb2 mt1">Sub-organizations</h3>
 
       <ul>

--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -121,9 +121,10 @@
 
         <div class="field">
           <%= form.select(
-            :parent_id,
-            Event.order(name: :asc, id: :asc).where.not(id: event.id).map { |event| [event.name, event.id] },
-            include_blank: "None") %>
+                :parent_id,
+                Event.order(name: :asc, id: :asc).where.not(id: event.id).map { |event| [event.name, event.id] },
+                include_blank: "None"
+              ) %>
         </div>
 
         <div class="action">
@@ -135,6 +136,7 @@
 
   <% admin_tool do %>
     <%= form_with(model: event, local: true) do |form| %>
+
       <h3 id="sub_organizations" class="mb2 mt1">Sub-organizations</h3>
 
       <ul>


### PR DESCRIPTION
## Summary of the problem

We want to gradually move to a hierarchy of events to help us improve budgeting and permissions. As part of that it would be handy to be able to assign existing events to a parent event.

## Describe your changes

1. Adds a new parent event dropdown to the event admin settings page
    <img width="1856" height="376" alt="CleanShot 2025-09-18 at 16 25 05@2x" src="https://github.com/user-attachments/assets/df779d7f-9433-49b3-82db-d5753607f57f" />
3. Wires `parent_id` through the controller
4. Gates the above behind the `parent_event_assignment_2025_09_18` flag