### PR TITLE
Make sure sub-events cannot be cyclical

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -64,4 +64,32 @@ RSpec.describe Event, type: :model do
       }.to change { event.reload.total_fee_payments_v2_cents }.from(0).to(1000)
     end
   end
+
+  describe "#parent_id" do
+    it "cannot be cyclical" do
+      event1, event2, event3 = create_list(:event, 3)
+
+      # Set up 1 -> 2 -> 3
+      event2.update!(parent_id: event1.id)
+      event3.update!(parent_id: event2.id)
+
+      event1.parent_id = event3.id
+      expect(event1.valid?).to eq(false)
+      expect(event1.errors[:parent]).to eq(["is cyclical"])
+    end
+
+    it "cannot exceed the maximum depth" do
+      stub_const("Event::MAX_PARENT_DEPTH", 3)
+
+      event1, event2, event3, event4 = create_list(:event, 4)
+
+      # Set up 1 -> 2 -> 3
+      event2.update!(parent_id: event1.id)
+      event3.update!(parent_id: event2.id)
+
+      event4.parent_id = event3.id
+      expect(event4.valid?).to eq(false)
+      expect(event4.errors[:parent]).to eq(["max depth exceeded"])
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

In https://github.com/hackclub/hcb/pull/11705 I added a mechanism for admins to set the parent for a given event. This open up the possibility for cycles in the event &rarr; sub-event graph which would cause infinite loops in a few places.

## Describe your changes

Adds a validation to `Event` to ensure `parent_id` cannot be changed to a value that would create a cycle.