### PR TITLE
Hide frozen by when frozen by system user

### DIFF
--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -15,7 +15,7 @@
           </span>
         </div>
 
-        <% if stripe_card.frozen? && stripe_card.last_frozen_by %>
+        <% if stripe_card.frozen? && stripe_card.last_frozen_by && stripe_card.last_frozen_by != User.system_user %>
           <div class="fs-mask">
             <strong>Frozen by</strong>
             <%= user_mention stripe_card.last_frozen_by %>

--- a/app/views/stripe_cards/_details.html.erb
+++ b/app/views/stripe_cards/_details.html.erb
@@ -32,7 +32,7 @@
       </p>
     <% end %>
 
-    <% if stripe_card.frozen? && stripe_card.last_frozen_by %>
+    <% if stripe_card.frozen? && stripe_card.last_frozen_by && stripe_card.last_frozen_by != User.system_user %>
       <div class="fs-mask">
         <strong>Frozen by</strong>
         <%= user_mention stripe_card.last_frozen_by %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This is because there have been numerous people asking HCB to unfreeze their card when it was actually just the unknown default.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

