### PR TITLE
Fix show explore hack club migrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,7 +1004,7 @@ DEPENDENCIES
   yellow_pages!
 
 RUBY VERSION
-   ruby 3.3.7p123
+   ruby 3.4.5p51
 
 BUNDLED WITH
    2.5.22

--- a/db/migrate/20250830235107_remove_show_explore_hack_club_from_referral_programs.rb
+++ b/db/migrate/20250830235107_remove_show_explore_hack_club_from_referral_programs.rb
@@ -1,6 +1,6 @@
 class RemoveShowExploreHackClubFromReferralPrograms < ActiveRecord::Migration[7.2]
   def up
-    safety_assured { remove_column :referral_programs, :show_explore_hack_club }
+    safety_assured { remove_column :referral_programs, :show_explore_hack_club, if_exists: true }
   end
 
   def down

--- a/db/migrate/20250901045714_make_show_explore_hack_club_nullable_in_referral_programs.rb
+++ b/db/migrate/20250901045714_make_show_explore_hack_club_nullable_in_referral_programs.rb
@@ -1,5 +1,0 @@
-class MakeShowExploreHackClubNullableInReferralPrograms < ActiveRecord::Migration[7.2]
-  def change
-    change_column_null :referral_programs, :show_explore_hack_club, true
-  end
-end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

> here’s my assumption:
PR for 20250830235107 RemoveShowExploreHackClubFromReferralPrograms was made
PR for 20250901045714 MakeShowExploreHackClubNullableInReferralPrograms was made
MakeShowExploreHackClubNullableInReferralPrograms was merged
RemoveShowExploreHackClubFromReferralPrograms was merged
This order migrated fine in production because it make the column NULLable then removed it.
However, when someone runs the two migrations in proper date order, it removes the column, then attempts to NULLable; which errors.

- @garyhtou 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

> If that's the case, I'd delete the MakeShowExploreHackClubNullableInReferralPrograms migration and make RemoveShowExploreHackClubFromReferralPrograms remove the column if it exists

- @davidcornu 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

