### PR TITLE
Revert ruby version back to 3.4.5p51

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1004,7 +1004,7 @@ DEPENDENCIES
   yellow_pages!
 
 RUBY VERSION
-   ruby 3.3.7p123
+   ruby 3.4.5p51
 
 BUNDLED WITH
    2.5.22


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This was mistakenly updated in #11707


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

