### PR TITLE
Take payout method accessors not the standard transfer object

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -472,7 +472,7 @@ class UsersController < ApplicationController
             :address_postal_code,
             :recipient_country,
             :currency,
-          ] + WiseTransfer.recipient_information_accessors
+          ] + User::PayoutMethod::WiseTransfer.recipient_information_accessors
         }
       end
 


### PR DESCRIPTION
We now have payout-specific fields