### PR TITLE
Pre-fill "account_type" & "use_same_email_for_interac" on Wise reimbursement payout form

### DIFF
--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -93,7 +93,7 @@
   </section>
 
   <% if Flipper.enabled?(:wise_reimbursements_2025_08_25, user) %>
-    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: false, email: null }">
+    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: <%= user.payout_method.try(:use_same_email_for_interac) ? "'#{user.payout_method.use_same_email_for_interac}'" : "null" %>, email: null }">
       <%= form.fields_for :payout_method_wise_transfer, user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) ? user.payout_method : User::PayoutMethod::WiseTransfer.new do |form| %>
         <%= render partial: "wise_transfers/recipient_details", locals: { form:, disabled: false } %>
 

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -93,7 +93,7 @@
   </section>
 
   <% if Flipper.enabled?(:wise_reimbursements_2025_08_25, user) %>
-    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: <%= user.payout_method.try(:use_same_email_for_interac) ? "'#{user.payout_method.use_same_email_for_interac}'" : "null" %>, email: null }">
+    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: <%= user.payout_method.try(:use_same_email_for_interac) ? "'#{user.payout_method.use_same_email_for_interac}'" : "false" %>, email: null }">
       <%= form.fields_for :payout_method_wise_transfer, user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) ? user.payout_method : User::PayoutMethod::WiseTransfer.new do |form| %>
         <%= render partial: "wise_transfers/recipient_details", locals: { form:, disabled: false } %>
 

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -93,7 +93,7 @@
   </section>
 
   <% if Flipper.enabled?(:wise_reimbursements_2025_08_25, user) %>
-    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: null, use_same_email_for_interac: false, email: null }">
+    <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "display-none-not-important" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: false, email: null }">
       <%= form.fields_for :payout_method_wise_transfer, user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) ? user.payout_method : User::PayoutMethod::WiseTransfer.new do |form| %>
         <%= render partial: "wise_transfers/recipient_details", locals: { form:, disabled: false } %>
 


### PR DESCRIPTION
This conditionally renders fields.