### PR TITLE
Fix and test `build_plan` behaviour of `before_validation` hook in `Event`

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -425,7 +425,7 @@ class Event < ApplicationRecord
   end
 
   before_validation do
-    build_plan(type: parent&.subevent_plan&.class || parent&.plan&.class || Event::Plan::Standard) if plan.nil?
+    build_plan(type: fallback_plan_class) if plan.nil?
   end
 
   # Explanation: https://github.com/norman/friendly_id/blob/0500b488c5f0066951c92726ee8c3dcef9f98813/lib/friendly_id/reserved.rb#L13-L28
@@ -980,6 +980,20 @@ class Event < ApplicationRecord
     if outcome != :halted
       errors.add(:parent, "max depth exceeded")
     end
+  end
+
+  def fallback_plan_class
+    if parent
+      if parent.config&.subevent_plan.present?
+        return parent.config.subevent_plan.constantize
+      end
+
+      if parent.plan
+        return parent.plan.class
+      end
+    end
+
+    Event::Plan::Standard
   end
 
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     after(:create) do |event, context|
-      event.plan.update(type: context.plan_type)
+      event.plan.update!(type: context.plan_type) if context.plan_type.present?
 
       context.organizers.each do |user|
         create(:organizer_position, event:, user:)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -92,4 +92,28 @@ RSpec.describe Event, type: :model do
       expect(event4.errors[:parent]).to eq(["max depth exceeded"])
     end
   end
+
+  describe "#plan" do
+    it "uses the parent event's subevent plan by default" do
+      parent = create(:event)
+      parent.config.update!(subevent_plan: Event::Plan::HackClubAffiliate.name)
+      child = create(:event, plan_type: nil, parent:)
+      expect(child.plan).to be_instance_of(Event::Plan::HackClubAffiliate)
+    end
+
+    it "uses the parent's plan if a subevent plan isn't set" do
+      parent = create(:event, plan_type: Event::Plan::HackClubAffiliate)
+      child = create(:event, plan_type: nil, parent:)
+
+      expect(child.plan).to be_instance_of(Event::Plan::HackClubAffiliate)
+    end
+
+    it "uses the standard plan as a fallback" do
+      parent = create(:event)
+      parent.plans.destroy_all
+      child = create(:event, plan_type: nil, parent:)
+
+      expect(child.plan).to be_instance_of(Event::Plan::Standard)
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

We have logic that sets an event's plan based on its parent (if present) which is currently broken.

## Describe your changes

- Extract the plan selection logic to a separate method (given the complexity of the conditional expression)
- Add tests