### PR TITLE
[Accounting] Add descendant support to statement of activity

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -927,7 +927,12 @@ class EventsController < ApplicationController
   def statement_of_activity
     authorize @event
 
-    @statement_of_activity = Event::StatementOfActivity.new(@event, start_date_param: params[:start], end_date_param: params[:end])
+    @statement_of_activity = Event::StatementOfActivity.new(
+      @event,
+      start_date_param: params[:start],
+      end_date_param: params[:end],
+      include_descendants: ActiveRecord::Type::Boolean.new.cast(params[:include_descendants]),
+    )
 
     respond_to do |format|
       format.html

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -137,18 +137,6 @@ class Event
       io.string
     end
 
-    private
-
-    attr_reader(:start_date_param, :end_date_param)
-
-    def transactions
-      CanonicalTransaction
-        .joins(:canonical_event_mapping)
-        .where(canonical_event_mapping: { event_id: events.map(&:id), subledger_id: nil })
-        .where("date between ? AND ?", start_date, end_date)
-        .strict_loading
-    end
-
     memo_wise def events
       if event_group
         event_group.events.to_a
@@ -160,6 +148,18 @@ class Event
       else
         [event]
       end
+    end
+
+    private
+
+    attr_reader(:start_date_param, :end_date_param)
+
+    def transactions
+      CanonicalTransaction
+        .joins(:canonical_event_mapping)
+        .where(canonical_event_mapping: { event_id: events.map(&:id), subledger_id: nil })
+        .where("date between ? AND ?", start_date, end_date)
+        .strict_loading
     end
 
   end

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -4,9 +4,14 @@ class Event
   class StatementOfActivity
     prepend MemoWise
 
-    attr_reader(:event, :event_group)
+    attr_reader(:event, :event_group, :include_descendants)
 
-    def initialize(event_or_event_group, start_date_param: nil, end_date_param: nil)
+    def initialize(
+      event_or_event_group,
+      start_date_param: nil,
+      end_date_param: nil,
+      include_descendants: false
+    )
       @event_group, @event = nil
 
       case event_or_event_group
@@ -20,6 +25,11 @@ class Event
 
       @start_date_param = start_date_param
       @end_date_param = end_date_param
+      @include_descendants = include_descendants
+    end
+
+    def supports_descendants?
+      event.present?
     end
 
     memo_wise def start_date

--- a/app/models/event/statement_of_activity.rb
+++ b/app/models/event/statement_of_activity.rb
@@ -152,6 +152,11 @@ class Event
     memo_wise def events
       if event_group
         event_group.events.to_a
+      elsif include_descendants
+        [
+          event,
+          *Event.where(id: event.descendant_ids).to_a
+        ]
       else
         [event]
       end

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -1,23 +1,40 @@
 <%# locals: (statement_of_activity:) %>
 
-<div class="flex justify-between items-center gap-4">
-  <h1 class="border-b-0 flex-grow">Statement of Activity</h1>
-
-  <%= form_with(method: :get, data: { controller: "form" }, class: "mb-0") do |form| %>
-    <div class="flex gap-2 items-center w-fit text-nowrap">
-      <%= form.label(:start, "From") %>
-      <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
-      <%= form.label(:end, "To") %>
-      <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
-    </div>
-  <% end %>
+<div class="flex justify-between items-center gap-4 my-4">
+  <h1 class="border-b-0 flex-grow m-0 p-0">Statement of Activity</h1>
 
   <%= link_to({ format: :xlsx }, class: "btn") do %>
     <%= inline_icon "download" %>
     <small>Download XLSX</small>
   <% end %>
 </div>
-<hr class="mt-0">
+
+<%= form_with(
+      method: :get,
+      data: { controller: "form" },
+      class: "mb-0 flex items-center gap-4"
+    ) do |form| %>
+  <div class="flex gap-2 items-center w-fit text-nowrap">
+    <%= form.label(:start, "From") %>
+    <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
+    <%= form.label(:end, "To") %>
+    <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
+  </div>
+
+  <div>
+    <% if statement_of_activity.supports_descendants? %>
+      <%= form.check_box(
+            :include_descendants,
+            checked: statement_of_activity.include_descendants,
+            data: { action: "change->form#submit" },
+            class: "mb-0"
+          ) %>
+      <%= form.label(:include_descendants, "Include descendants", class: "inline") %>
+    <% end %>
+  </div>
+<% end %>
+
+<hr class="my-4">
 
 <p>
   From <%= statement_of_activity.start_date.strftime("%B %-d, %Y") %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -54,14 +54,14 @@
   spent <%= render_money statement_of_activity.total_expense.abs %>.
 </p>
 
-<% if statement_of_activity.event_group %>
+<% if statement_of_activity.event_group || statement_of_activity.include_descendants %>
   <details>
     <summary>Included events</summary>
-    <% if statement_of_activity.event_group.events.empty? %>
+    <% if statement_of_activity.event_group && statement_of_activity.events.empty? %>
       <p>This group does not have any associated events</p>
     <% else %>
       <ul>
-        <% statement_of_activity.event_group.events.each do |event| %>
+        <% statement_of_activity.events.each do |event| %>
           <li>
             <%= link_to(event.name, event_path(event)) %>
           </li>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -5,9 +5,9 @@
 
   <%= form_with(method: :get, data: { controller: "form" }, class: "mb-0") do |form| %>
     <div class="flex gap-2 items-center w-fit text-nowrap">
-      From
+      <%= form.label(:start, "From") %>
       <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
-      To
+      <%= form.label(:end, "To") %>
       <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
     </div>
   <% end %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -26,6 +26,7 @@
       <%= form.check_box(
             :include_descendants,
             checked: statement_of_activity.include_descendants,
+            include_hidden: false,
             data: { action: "change->form#submit" },
             class: "mb-0"
           ) %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -44,6 +44,9 @@
     the <strong><%= statement_of_activity.event_group.name %></strong> event group
   <% else %>
     <strong><%= link_to statement_of_activity.event.name, statement_of_activity.event %></strong>
+    <% if statement_of_activity.include_descendants %>
+      and its descendants
+    <% end %>
   <% end %>
   had a change in net assets
   of <%= render_money statement_of_activity.net_asset_change %>;

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -3,7 +3,13 @@
 <div class="flex justify-between items-center gap-4 my-4">
   <h1 class="border-b-0 flex-grow m-0 p-0">Statement of Activity</h1>
 
-  <%= link_to({ format: :xlsx, **params.permit(:include_descendants) }, class: "btn") do %>
+  <%= link_to(
+        {
+          format: :xlsx,
+          **params.permit(:include_descendants, :start, :end)
+        },
+        class: "btn"
+      ) do %>
     <%= inline_icon "download" %>
     <small>Download XLSX</small>
   <% end %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -3,7 +3,7 @@
 <div class="flex justify-between items-center gap-4 my-4">
   <h1 class="border-b-0 flex-grow m-0 p-0">Statement of Activity</h1>
 
-  <%= link_to({ format: :xlsx }, class: "btn") do %>
+  <%= link_to({ format: :xlsx, **params.permit(:include_descendants) }, class: "btn") do %>
     <%= inline_icon "download" %>
     <small>Download XLSX</small>
   <% end %>

--- a/app/views/events/_statement_of_activity_contents.html.erb
+++ b/app/views/events/_statement_of_activity_contents.html.erb
@@ -1,45 +1,45 @@
 <%# locals: (statement_of_activity:) %>
 
-<div class="flex justify-between items-center gap-4 my-4">
-  <h1 class="border-b-0 flex-grow m-0 p-0">Statement of Activity</h1>
+<h1 class="border-b-0">Statement of Activity</h1>
+
+<div class="flex gap-4 items-center">
+  <%= form_with(
+        method: :get,
+        data: { controller: "form" },
+        class: "mb-0 flex-grow flex items-center gap-4"
+      ) do |form| %>
+    <div class="flex gap-2 items-center w-fit text-nowrap">
+      <%= form.label(:start, "From") %>
+      <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
+      <%= form.label(:end, "To") %>
+      <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
+    </div>
+
+    <div>
+      <% if statement_of_activity.supports_descendants? %>
+        <%= form.check_box(
+              :include_descendants,
+              checked: statement_of_activity.include_descendants,
+              include_hidden: false,
+              data: { action: "change->form#submit" },
+              class: "mb-0"
+            ) %>
+        <%= form.label(:include_descendants, "Include descendants", class: "inline") %>
+      <% end %>
+    </div>
+  <% end %>
 
   <%= link_to(
         {
           format: :xlsx,
           **params.permit(:include_descendants, :start, :end)
         },
-        class: "btn"
+        class: "btn btn-small"
       ) do %>
     <%= inline_icon "download" %>
     <small>Download XLSX</small>
   <% end %>
 </div>
-
-<%= form_with(
-      method: :get,
-      data: { controller: "form" },
-      class: "mb-0 flex items-center gap-4"
-    ) do |form| %>
-  <div class="flex gap-2 items-center w-fit text-nowrap">
-    <%= form.label(:start, "From") %>
-    <%= form.date_field :start, value: statement_of_activity.start_date, data: { action: "change->form#submit" }, class: "mb-0" %>
-    <%= form.label(:end, "To") %>
-    <%= form.date_field :end, value: statement_of_activity.end_date, data: { action: "change->form#submit" }, class: "mb-0" %>
-  </div>
-
-  <div>
-    <% if statement_of_activity.supports_descendants? %>
-      <%= form.check_box(
-            :include_descendants,
-            checked: statement_of_activity.include_descendants,
-            include_hidden: false,
-            data: { action: "change->form#submit" },
-            class: "mb-0"
-          ) %>
-      <%= form.label(:include_descendants, "Include descendants", class: "inline") %>
-    <% end %>
-  </div>
-<% end %>
 
 <hr class="my-4">
 

--- a/spec/controllers/admin/event_group_memberships_controller_spec.rb
+++ b/spec/controllers/admin/event_group_memberships_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::EventGroupMembershipsController do
       sign_in(user)
 
       event = create(:event)
-      group = Event::Group.create!(user:, name: "Scrapyard")
+      group = create(:event_group, user:)
       membership = Event::GroupMembership.create!(group:, event:)
 
       delete(:destroy, params: { event_group_id: group.id, id: membership.id })

--- a/spec/controllers/admin/event_groups_controller_spec.rb
+++ b/spec/controllers/admin/event_groups_controller_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Admin::EventGroupsController do
   describe "#index" do
     it "renders a list of groups along with their owners and events" do
       orpheus = create(:user, :make_admin, full_name: "Orpheus Dinosaur")
-      scrapyard = Event::Group.create!(user: orpheus, name: "Scrapyard")
+      scrapyard = create(:event_group, user: orpheus, name: "Scrapyard")
       scrapyard.memberships.create!(event: create(:event, name: "Scrapyard Vermont"))
       scrapyard.memberships.create!(event: create(:event, name: "Scrapyard London"))
 
       barney = create(:user, :make_admin, full_name: "Barney Dinosaur")
-      daydream = Event::Group.create!(user: barney, name: "Daydream")
+      daydream = create(:event_group, user: barney, name: "Daydream")
       daydream.memberships.create!(event: create(:event, name: "Daydream Ottawa"))
 
       sign_in(orpheus)

--- a/spec/factories/event_group_factory.rb
+++ b/spec/factories/event_group_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:event_group, class: "Event::Group") do
+    name { Faker::Adjective.positive }
+    association(:user)
+  end
+end

--- a/spec/models/event/group_membership_spec.rb
+++ b/spec/models/event/group_membership_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 RSpec.describe Event::GroupMembership do
   it "cannot contain duplicate entries" do
     event = create(:event)
-    user = create(:user)
-    group = Event::Group.create!(user:, name: "Scrapyard")
+    group = create(:event_group)
 
     _existing = described_class.create!(group:, event:)
 

--- a/spec/models/event/statement_of_activity_spec.rb
+++ b/spec/models/event/statement_of_activity_spec.rb
@@ -90,6 +90,28 @@ RSpec.describe Event::StatementOfActivity do
       expect(result[nil]).to eq([unknown])
     end
 
+    it "takes into account all transactions within a group" do
+      group = create(:event_group)
+
+      event1 = create(:event)
+      group.memberships.create!(event: event1)
+      event1_rent = create(:canonical_transaction, category_slug: "rent")
+      create(:canonical_event_mapping, event: event1, canonical_transaction: event1_rent)
+
+      event2 = create(:event)
+      group.memberships.create!(event: event2)
+      event2_unknown = create(:canonical_transaction)
+      create(:canonical_event_mapping, event: event2, canonical_transaction: event2_unknown)
+
+      instance = described_class.new(group, start_date_param: "1970-01-01")
+      result = instance.transactions_by_category
+
+      expect(result).to be_a(Hash)
+      expect(result.keys).to eq([event1_rent.category, nil])
+      expect(result[event1_rent.category]).to eq([event1_rent])
+      expect(result[nil]).to eq([event2_unknown])
+    end
+
     it "honors the start date and end date" do
       event = create(:event, created_at: Time.new(2024, 1, 1))
 
@@ -116,8 +138,8 @@ RSpec.describe Event::StatementOfActivity do
     end
   end
 
-  describe "aggregates" do
-    specify "#category_totals, #net_asset_change, #total_revenue, #total_expense" do
+  describe "#category_totals, #net_asset_change, #total_revenue, #total_expense" do
+    specify "single event" do
       event = create(:event)
 
       2.times do
@@ -131,6 +153,33 @@ RSpec.describe Event::StatementOfActivity do
       end
 
       instance = described_class.new(event, start_date_param: "1970-01-01")
+
+      category_totals = instance.category_totals
+      expect(category_totals).to be_a(Hash)
+      expect(category_totals.keys).to eq(["rent", nil])
+      expect(category_totals["rent"]).to eq(24_68)
+      expect(category_totals[nil]).to eq(-113_56)
+
+      expect(instance.net_asset_change).to eq(-88_88)
+      expect(instance.total_revenue).to eq(24_68)
+      expect(instance.total_expense).to eq(-113_56)
+    end
+
+    specify "group" do
+      group = create(:event_group)
+      event1, event2 = create_list(:event, 2)
+
+      [event1, event2].each do |event|
+        group.memberships.create!(event: event)
+
+        rent = create(:canonical_transaction, category_slug: "rent", amount_cents: 12_34)
+        create(:canonical_event_mapping, event:, canonical_transaction: rent)
+
+        unknown = create(:canonical_transaction, amount_cents: -56_78)
+        create(:canonical_event_mapping, event:, canonical_transaction: unknown)
+      end
+
+      instance = described_class.new(group, start_date_param: "1970-01-01")
 
       category_totals = instance.category_totals
       expect(category_totals).to be_a(Hash)

--- a/spec/models/event/statement_of_activity_spec.rb
+++ b/spec/models/event/statement_of_activity_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Event::StatementOfActivity do
       expect(instance.start_date).to eq(Date.new(2024, 1, 1))
     end
 
+    it "picks the oldest creation date when including descendants" do
+      event1 = create(:event, created_at: Time.new(2025, 1, 1))
+      _event2 = create(:event, created_at: Time.new(2024, 1, 1), parent: event1)
+
+      instance = described_class.new(event1, include_descendants: true)
+
+      expect(instance.start_date).to eq(Date.new(2024, 1, 1))
+    end
+
     it "falls back to the current date" do
       freeze_time do
         travel_to(Time.new(2025, 1, 1))
@@ -104,6 +113,24 @@ RSpec.describe Event::StatementOfActivity do
       create(:canonical_event_mapping, event: event2, canonical_transaction: event2_unknown)
 
       instance = described_class.new(group, start_date_param: "1970-01-01")
+      result = instance.transactions_by_category
+
+      expect(result).to be_a(Hash)
+      expect(result.keys).to eq([event1_rent.category, nil])
+      expect(result[event1_rent.category]).to eq([event1_rent])
+      expect(result[nil]).to eq([event2_unknown])
+    end
+
+    it "includes transactions from descendants when configured" do
+      event1 = create(:event)
+      event1_rent = create(:canonical_transaction, category_slug: "rent")
+      create(:canonical_event_mapping, event: event1, canonical_transaction: event1_rent)
+
+      event2 = create(:event, parent: event1)
+      event2_unknown = create(:canonical_transaction)
+      create(:canonical_event_mapping, event: event2, canonical_transaction: event2_unknown)
+
+      instance = described_class.new(event1, start_date_param: "1970-01-01", include_descendants: true)
       result = instance.transactions_by_category
 
       expect(result).to be_a(Hash)
@@ -180,6 +207,31 @@ RSpec.describe Event::StatementOfActivity do
       end
 
       instance = described_class.new(group, start_date_param: "1970-01-01")
+
+      category_totals = instance.category_totals
+      expect(category_totals).to be_a(Hash)
+      expect(category_totals.keys).to eq(["rent", nil])
+      expect(category_totals["rent"]).to eq(24_68)
+      expect(category_totals[nil]).to eq(-113_56)
+
+      expect(instance.net_asset_change).to eq(-88_88)
+      expect(instance.total_revenue).to eq(24_68)
+      expect(instance.total_expense).to eq(-113_56)
+    end
+
+    specify "with descendants" do
+      event1, event2 = create_list(:event, 2)
+      event2.update!(parent: event1)
+
+      [event1, event2].each do |event|
+        rent = create(:canonical_transaction, category_slug: "rent", amount_cents: 12_34)
+        create(:canonical_event_mapping, event:, canonical_transaction: rent)
+
+        unknown = create(:canonical_transaction, amount_cents: -56_78)
+        create(:canonical_event_mapping, event:, canonical_transaction: unknown)
+      end
+
+      instance = described_class.new(event1, start_date_param: "1970-01-01", include_descendants: true)
 
       category_totals = instance.category_totals
       expect(category_totals).to be_a(Hash)

--- a/spec/models/event/statement_of_activity_spec.rb
+++ b/spec/models/event/statement_of_activity_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Event::StatementOfActivity do
     end
 
     it "picks the oldest creation date when dealing with a group" do
-      user = create(:user)
-      group = Event::Group.create!(user:, name: "Group")
+      group = create(:event_group)
 
       event1 = create(:event, created_at: Time.new(2025, 1, 1))
       group.memberships.create!(event: event1)
@@ -44,8 +43,7 @@ RSpec.describe Event::StatementOfActivity do
       freeze_time do
         travel_to(Time.new(2025, 1, 1))
 
-        user = create(:user)
-        group = Event::Group.create!(user:, name: "Group")
+        group = create(:event_group)
 
         instance = described_class.new(group)
 


### PR DESCRIPTION
## Summary of the problem

1. In #11474 we added the ability for users to create arbitrary lists of events so that a single statement of activity can be generated from their combined transactions. 
2. (1) is a stopgap measure as our ideal scenario is to leverage sub-events (https://github.com/hackclub/hcb/pull/9739) for this kind of reporting, but we don't yet support sub-events when generating statements of activity.

## Describe your changes

- Restructure the page so the various filters appear under the heading
- Show a checkbox to include sub-events when rendering a statement of activity for an `Event` (as opposed to an `Event::Group`)
- Add support for sub-events to `Event::StatementOfActivity`

<img width="1110" height="788" alt="image" src="https://github.com/user-attachments/assets/9bacef57-4e7a-4e2d-8b99-a61b965734b0" />
