### PR TITLE
Use fixed instead of absolute positioning for admin flash

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -927,7 +927,7 @@ form:has(> #admin-logout-button) {
 }
 
 #flash-container {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   right: 0;
   width: 50ch;


### PR DESCRIPTION
## Summary of the problem

In #11398 I switched the admin flash to a toast. In the course of developing it we switched from it appearing at the top of the screen to the bottom, at which point it didn't occur to me that `position: absolute` would result in it scrolling up with the rest of the page should the page height exceed the viewport.

## Describe your changes

Use fixed positioning.