### PR TITLE
[Wise] Move recipient ID field into its own section

### DIFF
--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -186,7 +186,6 @@
               placeholder: "500.00",
               step: 0.01,
               required: true,
-              class: "mb-0",
               "@change": "amount = +$event.target.value * 100",
               "@keyup": "amount = +$event.target.value * 100",
               data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -205,6 +205,8 @@
           </div>
         <% end %>
 
+        <hr>
+
         <%= form_with(model: @wise_transfer, local: true, url: mark_sent_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">
             <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -178,7 +178,6 @@
                 <%= form.text_field(
                       :wise_recipient_id,
                       class: "w-[400px]",
-                      disabled: @wise_transfer.usd_amount_cents.nil?,
                       placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                     ) %>
               </div>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -161,47 +161,48 @@
     <% elsif @wise_transfer.approved? %>
       <fieldset class="px-6 py-3" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
         <legend class="py-0 px-2">Send</legend>
-            <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
-              <div class="mb-2">
-                <%= form.label :usd_amount, "Amount (USD)", class: "bold mb1" %> <br>
-                $ <%= form.number_field :usd_amount,
-                  placeholder: "500.00",
-                  step: 0.01,
-                  required: true,
-                  class: "mb-0",
-                  "@change": "amount = +$event.target.value * 100",
-                  "@keyup": "amount = +$event.target.value * 100",
-                  data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
-              </div>
-              <div class="mb-2">
-                <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
-                <%= form.text_field(
-                      :wise_recipient_id,
-                      class: "w-[400px]",
-                      placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                    ) %>
-              </div>
-              <p x-show="amount && balance >= amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
-                <%= inline_icon "checkmark", class: "text-green" %>
-                Sufficient funds available
-              </p>
-              <p x-show="amount && balance < amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
-                <%= inline_icon "important", class: "text-red" %>
-                Insufficient funds, please reject this transfer
-              </p>
-              <div class="flex flex-row justify-start items-center gap-3 mb-4 mt-2">
-                <%= form.submit "🏦 Update amount", class: "mb-0" %>
-                <em class="m-0"><small class="m-0">This will update the pending amount</small></em>
-              </div>
-            <% end %>
 
-          <%= form_with(model: @wise_transfer, local: true, url: mark_sent_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
-            <div class="mb-2">
-              <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
-              <%= form.text_field :wise_id, class: "w-[400px]", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
-            </div>
-            <%= form.submit "💸 Mark transfer as sent", disabled: @wise_transfer.usd_amount_cents.nil?, class: "mb-0" %>
-          <% end %>
+        <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
+          <div class="mb-2">
+            <%= form.label :usd_amount, "Amount (USD)", class: "bold mb1" %> <br>
+            $ <%= form.number_field :usd_amount,
+              placeholder: "500.00",
+              step: 0.01,
+              required: true,
+              class: "mb-0",
+              "@change": "amount = +$event.target.value * 100",
+              "@keyup": "amount = +$event.target.value * 100",
+              data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
+          </div>
+          <div class="mb-2">
+            <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
+            <%= form.text_field(
+                  :wise_recipient_id,
+                  class: "w-[400px]",
+                  placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                ) %>
+          </div>
+          <p x-show="amount && balance >= amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
+            <%= inline_icon "checkmark", class: "text-green" %>
+            Sufficient funds available
+          </p>
+          <p x-show="amount && balance < amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
+            <%= inline_icon "important", class: "text-red" %>
+            Insufficient funds, please reject this transfer
+          </p>
+          <div class="flex flex-row justify-start items-center gap-3 mb-4 mt-2">
+            <%= form.submit "🏦 Update amount", class: "mb-0" %>
+            <em class="m-0"><small class="m-0">This will update the pending amount</small></em>
+          </div>
+        <% end %>
+
+        <%= form_with(model: @wise_transfer, local: true, url: mark_sent_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
+          <div class="mb-2">
+            <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
+            <%= form.text_field :wise_id, class: "w-[400px]", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
+          </div>
+          <%= form.submit "💸 Mark transfer as sent", disabled: @wise_transfer.usd_amount_cents.nil?, class: "mb-0" %>
+        <% end %>
 
       </fieldset>
 

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -11,7 +11,7 @@
 
   <div class="flex-grow"></div>
 
-  <%= link_to @wise_transfer.wise_url || "https://wise.com/send", class: "btn btn-small bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank" do %>
+  <%= link_to(@wise_transfer.wise_url || "https://wise.com/send", class: "btn btn-small bg-none bg-[#9fe870] text-[#163300] flex-shrink-0", target: "_blank") do %>
     <%= inline_icon "wise" %>
     Open Wise
   <% end %>
@@ -140,18 +140,18 @@
 
     <% if @wise_transfer.pending? %>
       <fieldset class="px-6 py-3">
-        <legend style="padding: 0px 8px">Approve</legend>
+        <legend class="py-0 px-2">Approve</legend>
         <p>For this approval check, you're only looking at the transfer purpose and documentation. The balance check will be done after it is approved.</p>
         <%= button_to "💸 Approve and self-assign", approve_wise_transfer_path(@wise_transfer), method: :post %>
 
       </fieldset>
 
       <fieldset class="px-6 py-3">
-        <legend style="padding: 0px 8px">Reject</legend>
+        <legend class="py-0 px-2">Reject</legend>
         <%= form_with(model: false, local: true, url: reject_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">
             <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
-            <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
+            <%= form.text_area :comment, class: "w-[400px]", placeholder: "(Markdown supported)" %>
           </div>
           <%= form.submit "Reject", data: { confirm: "Mark as rejected? This requires you to communicate to the organizer about the reason why." } %>
           <small>(This requires you to communicate to the organizer about the reason why.)</small>
@@ -160,7 +160,7 @@
       </fieldset>
     <% elsif @wise_transfer.approved? %>
       <fieldset class="px-6 py-3" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
-        <legend style="padding: 0px 8px">Send</legend>
+        <legend class="py-0 px-2">Send</legend>
             <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
               <div class="mb-2">
                 <%= form.label :usd_amount, "Amount (USD)", class: "bold mb1" %> <br>
@@ -177,7 +177,7 @@
                 <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
                 <%= form.text_field(
                       :wise_recipient_id,
-                      style: "width: 400px;",
+                      class: "w-[400px]",
                       disabled: @wise_transfer.usd_amount_cents.nil?,
                       placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                     ) %>
@@ -199,7 +199,7 @@
           <%= form_with(model: @wise_transfer, local: true, url: mark_sent_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
             <div class="mb-2">
               <%= form.label :wise_id, "Wise ID / URL", class: "bold mb1" %> <br>
-              <%= form.text_field :wise_id, style: "width: 400px;", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
+              <%= form.text_field :wise_id, class: "w-[400px]", placeholder: "https://wise.com/transactions/activities/by-resource/TRANSFER/XXXXXXXX", disabled: @wise_transfer.usd_amount_cents.nil?, onpaste: "var urlPrefix = 'https://wise.com/transactions/activities/by-resource/TRANSFER/'; var clipboardData = event.clipboardData.getData('Text'); clipboardData.startsWith(urlPrefix) ? (event.preventDefault(), event.target.value = clipboardData.substring(urlPrefix.length)) : null" %>
             </div>
             <%= form.submit "💸 Mark transfer as sent", disabled: @wise_transfer.usd_amount_cents.nil?, class: "mb-0" %>
           <% end %>
@@ -207,13 +207,13 @@
       </fieldset>
 
       <fieldset class="px-6 py-3">
-        <legend style="padding: 0px 8px">Reject</legend>
+        <legend class="py-0 px-2">Reject</legend>
         <small class="mb-5 mt-0 block">This requires you to communicate to the organizer about the reason why.</small>
 
         <%= form_with(model: false, local: true, url: reject_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">
             <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
-            <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
+            <%= form.text_area :comment, class: "w-[400px]", placeholder: "(Markdown supported)" %>
           </div>
           <%= form.submit "Reject", data: { confirm: "Mark as rejected? This requires you to communicate to the organizer about the reason why." } %>
         <% end %>
@@ -228,11 +228,11 @@
 
     <% if @wise_transfer.may_mark_failed? %>
       <fieldset class="px-6 py-3">
-        <legend style="padding: 0px 8px">Fail</legend>
+        <legend class="py-0 px-2">Fail</legend>
         <%= form_with(model: false, local: true, url: mark_failed_wise_transfer_path(@wise_transfer), method: :post) do |form| %>
           <div class="mb-2">
             <%= form.label "Failure reason", class: "bold mb1" %> <br>
-            <%= form.text_area :reason, style: "width: 400px;", placeholder: "(Markdown supported)" %>
+            <%= form.text_area :reason, class: "w-[400px]", placeholder: "(Markdown supported)" %>
           </div>
           <%= form.submit "Mark failed", data: { confirm: "Mark as failed?" } %>
         <% end %>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -159,6 +159,23 @@
 
       </fieldset>
     <% elsif @wise_transfer.approved? %>
+      <fieldset class="px-6 py-3">
+        <legend class="py-0 px-2">Metadata</legend>
+
+        <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
+          <div class="mb-2">
+            <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
+            <%= form.text_field(
+                  :wise_recipient_id,
+                  class: "w-[400px]",
+                  placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                ) %>
+          </div>
+
+          <%= form.submit "Save", class: "mb-0" %>
+        <% end %>
+      </fieldset>
+
       <fieldset class="px-6 py-3" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
         <legend class="py-0 px-2">Send</legend>
 
@@ -173,14 +190,6 @@
               "@change": "amount = +$event.target.value * 100",
               "@keyup": "amount = +$event.target.value * 100",
               data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
-          </div>
-          <div class="mb-2">
-            <%= form.label(:wise_recipient_id, "Wise recipient ID", class: "bold mb1") %> <br>
-            <%= form.text_field(
-                  :wise_recipient_id,
-                  class: "w-[400px]",
-                  placeholder: "https://wise.com/recipients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                ) %>
           </div>
           <p x-show="amount && balance >= amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
             <%= inline_icon "checkmark", class: "text-green" %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "AnnouncementsController",
           "method": "show",
-          "line": 43,
+          "line": 45,
           "file": "app/controllers/announcements_controller.rb",
           "rendered": {
             "name": "announcements/show",
@@ -25,7 +25,7 @@
         {
           "type": "template",
           "name": "announcements/show",
-          "line": 55,
+          "line": 59,
           "file": "app/views/announcements/show.html.erb",
           "rendered": {
             "name": "announcements/_announcement_body",
@@ -59,7 +59,7 @@
           "type": "controller",
           "class": "StripeCardsController",
           "method": "show",
-          "line": 90,
+          "line": 89,
           "file": "app/controllers/stripe_cards_controller.rb",
           "rendered": {
             "name": "stripe_cards/show",
@@ -151,7 +151,7 @@
           "type": "controller",
           "class": "CanonicalPendingTransactionsController",
           "method": "show",
-          "line": 10,
+          "line": 12,
           "file": "app/controllers/canonical_pending_transactions_controller.rb",
           "rendered": {
             "name": "canonical_pending_transactions/show",
@@ -196,19 +196,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "6a82c5e649d0b925f7f1d62680a6e2aa12392aa77c32b7018bc053bb8534d820",
+      "fingerprint": "735bbf85ca21b70bf3b08f8ad5615ad3f037fe183b1f7801d13df4fdf761f66d",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/admin/wise_transfer_process.html.erb",
       "line": 14,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((WiseTransfer.find(params[:id]).wise_url or \"https://wise.com/send\"), :class => \"btn btn-small bg-[#9FE870] text-[#163300] flex-shrink-0\", :style => \"color: #163300!important; background: #9FE870\", :target => \"_blank\")",
+      "code": "link_to((WiseTransfer.find(params[:id]).wise_url or \"https://wise.com/send\"), :class => \"btn btn-small bg-none bg-[#9fe870] text-[#163300] flex-shrink-0\", :target => \"_blank\")",
       "render_path": [
         {
           "type": "controller",
           "class": "AdminController",
           "method": "wise_transfer_process",
-          "line": 722,
+          "line": 735,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/wise_transfer_process",
@@ -225,7 +225,7 @@
       "cwe_id": [
         79
       ],
-      "note": "`wise_url` is constructed from validated fields and uses `CGI.escape`"
+      "note": "This parameter is validated to match a specific format"
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -234,7 +234,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/admin/wise_transfer_process.html.erb",
-      "line": 83,
+      "line": 89,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"view on Wise\", WiseTransfer.find(params[:id]).wise_recipient_url, :target => \"_blank\")",
       "render_path": [
@@ -242,7 +242,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "wise_transfer_process",
-          "line": 722,
+          "line": 735,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/wise_transfer_process",
@@ -276,7 +276,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "google_workspace_process",
-          "line": 982,
+          "line": 995,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/google_workspace_process",
@@ -344,7 +344,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "invoice_process",
-          "line": 910,
+          "line": 923,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/invoice_process",
@@ -378,7 +378,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "invoice_process",
-          "line": 910,
+          "line": 923,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/invoice_process",
@@ -446,7 +446,7 @@
           "type": "controller",
           "class": "AdminController",
           "method": "google_workspace_process",
-          "line": 982,
+          "line": 995,
           "file": "app/controllers/admin_controller.rb",
           "rendered": {
             "name": "admin/google_workspace_process",
@@ -466,6 +466,6 @@
       "note": "Domain is validated to not have a javascript: url scheme & dns_check_url is injecting that domain in a https url"
     }
   ],
-  "updated": "2025-08-07 17:03:40 -0400",
+  "updated": "2025-09-22 17:03:25 -0400",
   "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
## Summary of the problem

From @leowilkin:

<img width="702" height="460" alt="CleanShot 2025-09-22 at 16 12 35@2x" src="https://github.com/user-attachments/assets/49a83bd7-e6b3-4416-9705-a250d6ab0aa1" />

## Describe your changes

- Split out the recipient ID field into its own section so it can be updated independently
- Remove the `disabled` attribute so it is always active

<img width="442" height="551" alt="CleanShot 2025-09-22 at 16 04 36" src="https://github.com/user-attachments/assets/d45bc737-33f7-47b6-91ba-889497f4016f" />
