### PR TITLE
Fix receipt expanding in popovers

### DIFF
--- a/app/assets/stylesheets/components/_receipts.scss
+++ b/app/assets/stylesheets/components/_receipts.scss
@@ -138,11 +138,11 @@
 
 .modal--popover--receipt-expanded
   > turbo-frame
-  > :not(.receipt--expanded):not(header):not(#receipts_list),
-.modal--popover--receipt-expanded > #receipts_list > :not(.receipt--expanded),
+  > :not(.receipt--expanded):not(header):not(.receipts_list),
+.modal--popover--receipt-expanded > .receipts_list > :not(.receipt--expanded),
 .modal--popover--receipt-expanded
   > turbo-frame
-  > #receipts_list
+  > .receipts_list
   > :not(.receipt--expanded) {
   display: none !important;
 }

--- a/app/views/receipts/_list_v2.html.erb
+++ b/app/views/receipts/_list_v2.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (hcb_code:, frame: false, transaction_show_receipt_button: false, transaction_show_author_img: false, ledger_instance: "") %>
 
-<ul class="grid grid--medium-narrow left-align w-100 mt0" id="<%= @ledger_instance %>_receipts_list">
+<ul class="grid grid--medium-narrow left-align w-100 mt0 receipts_list" id="<%= @ledger_instance %>_receipts_list">
   <%= render partial: "receipts/receipt", collection: hcb_code.receipts.with_attached_file.includes(:user).order(created_at: :asc), as: :receipt, locals: { show_delete_button: true, link_to_file: true, popover: frame ? "HcbCode:#{hcb_code.hashid}" : nil, show_receipt_button: transaction_show_receipt_button, show_author_img: transaction_show_author_img } %>
 </ul>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#10510 changed some IDs to avoid collisions with Turbo, but some CSS still targeted these changed IDs. This was causing receipt expanding in popovers to seem to hide the entire popover content.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added the `receipts_list` class to the receipt list and changed the CSS to target the class instead of the ID.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

