### PR TITLE
Lower mail job throttling to 10/second

### DIFF
--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -2,7 +2,8 @@
 
 class MailDeliveryJob < ActionMailer::MailDeliveryJob
   unless Rails.env.test?
-    throttle threshold: 12, period: 1.second
+    # AWS max send rate is 14/second - throttling at 10 to provide a buffer
+    throttle threshold: 10, period: 1.second
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We're still seeing some max send rate exceeded errors from AWS SES: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2243

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Lowering the mail job throttle to 10/second and adding a comment - hopefully the 4/second buffer is enough to stop most of these errors for this month's summaries.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

