### PR TITLE
[Wise] Make sure `recipient_information` is never `nil`

### DIFF
--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -113,7 +113,7 @@ module HasWiseRecipient
       fields.collect{ |field| field[:key] }.uniq
     end
 
-    store_accessor :recipient_information, *self.recipient_information_accessors
+    store(:recipient_information, accessors: self.recipient_information_accessors)
   end
 
   # Postal code formats sourced from https://column.com/docs/international-wires/country-specific-details

--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -46,7 +46,7 @@
       <td>Recipient country:</td>
       <td><%= report.user.payout_method.recipient_country %></td>
     </tr>
-    <% WiseTransfer.recipient_information_accessors&.each do |key| %>
+    <% WiseTransfer.recipient_information_accessors.each do |key| %>
       <% if report.user.payout_method.recipient_information[key].presence != nil %>
         <tr>
           <td><%= key.humanize %></td>


### PR DESCRIPTION
## Summary of the problem

We are running into errors in production (e.g. https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/551/samples/timestamp/2025-09-23T16:22:45Z)

```
ActionView::Template::Error: undefined method '[]' for nil
app/views/reimbursement/reports/_wise_information.html.erb:50
app/views/reimbursement/reports/_wise_information.html.erb:49 in Array#each
app/views/reimbursement/reports/_wise_information.html.erb:49
app/views/reimbursement/reports/_actions.html.erb:276
```

where `recipient_information` appears to be `nli`. 

This is surprising as these types of columns are a common pattern https://github.com/hackclub/hcb/blob/7895cc474b362e55d27672beb3a4aa2c4f9a3802/app/models/payment_recipient.rb#L38-L39 but upon further investigation it appears we are using `store_accessor` https://github.com/hackclub/hcb/blob/166a8e163380fd3e1de82aebae5fba61300b34d8/app/models/concerns/has_wise_recipient.rb#L116 without first calling `store`  in the case of `User::PayoutMethod::WiseTransfer` https://github.com/hackclub/hcb/blob/9c82c07226d87888da4a057ebeafd6382047a0a3/app/models/user/payout_method/wise_transfer.rb#L26-L28 and `WiseTransfer` https://github.com/hackclub/hcb/blob/745a1ad42785ea47aeca92fd971b40084a5bc5fa/app/models/wise_transfer.rb#L49-L56 which means we don't ever configure a serializer for the `recipient_information` column.

## Describe your changes

- Remove an unnecessary `&`
- Use `store` instead of `store_accessor` in `HasWiseRecipient`

