### PR TITLE
Remove "my" from heading

### DIFF
--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="heading">
   <span>
-    My receipts
+    Receipts
   </span>
 </h1>
 

--- a/app/views/my/reimbursements.html.erb
+++ b/app/views/my/reimbursements.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="heading">
   <span>
-    My reimbursements
+    Reimbursements
   </span>
 
   <% if @payout_method.present? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This matches the feed and card pages now. We include my in the title but not the heading.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

