### PR TITLE
Explain the lack of pagination for Column reports

### DIFF
--- a/app/services/column_service.rb
+++ b/app/services/column_service.rb
@@ -58,14 +58,6 @@ class ColumnService
       to_date: to_date.iso8601,
     )["reports"].select { |r| r["from_date"] == r["to_date"] && r["row_count"]&.>(0) }
 
-    document_ids = reports.pluck "json_document_id"
-
-    dates = reports.pluck "from_date"
-
-    # if (from_date.to_date..to_date.to_date).reject { |date| dates.include?(date.to_date.iso8601) }.any?
-    #  raise StandardError.new("Missing Column reports for #{from_date.to_date.iso8601} to #{to_date.to_date.iso8601}")
-    # end
-
     reports.to_h do |report|
       url = get("/documents/#{report["json_document_id"]}")["url"]
       transactions = JSON.parse(Faraday.get(url).body).select { |t| t["bank_account_id"] == bank_account && t["available_amount"].present? && t["available_amount"] != 0 }

--- a/app/services/column_service.rb
+++ b/app/services/column_service.rb
@@ -51,6 +51,8 @@ class ColumnService
     reports = get(
       "/reporting",
       type: "bank_account_transaction",
+      # We don't need to paginate here as there is one report per day and we
+      # check that our date range does not exceed 100 days.
       limit: 100,
       from_date: from_date.iso8601,
       to_date: to_date.iso8601,

--- a/app/services/column_service.rb
+++ b/app/services/column_service.rb
@@ -40,13 +40,20 @@ class ColumnService
   end
 
   def self.transactions(from_date: 1.week.ago, to_date: Date.today, bank_account: Accounts::FS_MAIN)
+    from_date = from_date.to_date
+    to_date = to_date.to_date
+
+    if (to_date - from_date).to_i > 100
+      raise ArgumentError, "cannot fetch transactions for a range of more than 100 days"
+    end
+
     # 1: fetch daily reports from Column
     reports = get(
       "/reporting",
       type: "bank_account_transaction",
       limit: 100,
-      from_date: from_date.to_date.iso8601,
-      to_date: to_date.to_date.iso8601,
+      from_date: from_date.iso8601,
+      to_date: to_date.iso8601,
     )["reports"].select { |r| r["from_date"] == r["to_date"] && r["row_count"]&.>(0) }
 
     document_ids = reports.pluck "json_document_id"


### PR DESCRIPTION
## Summary of the problem

https://hackclub.slack.com/archives/C047Y01MHJQ/p1758733559361789

This code is a bit scary to the uninitiated as on the surface it looks like we could be skipping data by not checking the `has_more` property of the response object.

## Describe your changes

- Add a guard to make sure we never exceed 100 days
- Add a comment explaining why we don't need to paginate
- Remove dead code