### PR TITLE
Log the response body for OpenAI errors

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -183,6 +183,13 @@ class CardGrant
       end
 
       broadcast_refresh_to self
+    rescue Faraday::Error => e
+      # Modify the original exception to append the response body to the message
+      # so these are easier to debug
+      raise(e.exception(<<~MSG))
+        #{e.message}
+        \tresponse_body: #{e.response_body.inspect}
+      MSG
     end
 
     def unauthorized?


### PR DESCRIPTION
## Summary of the problem

We're getting spikes of these errors https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1953 but we don't have enough information to figure out what's going on.

## Describe your changes

Add some error handling logic which re-raises the same exception but appends the response body to the message.