### PR TITLE
[Subevent] Allow for downloading subevents as CSV

### DIFF
--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -4,6 +4,9 @@
 
 <h1 class="heading flex">
   <span class="flex-grow">Sub-organizations</span>
+  <%= pop_icon_to "download",
+                  {format: :csv},
+                  class: "align-middle tooltipped tooltipped--w", "aria-label": "Download all as CSV" %>
   <%= link_to "#", class: "btn bg-success", data: { behavior: "modal_trigger", modal: "create" }, disabled: !policy(@event).create_sub_organization? do %>
     <%= inline_icon "plus" %>
     Create a subsidiary

--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -5,7 +5,7 @@
 <h1 class="heading flex">
   <span class="flex-grow">Sub-organizations</span>
   <%= pop_icon_to "download",
-                  {format: :csv},
+                  { format: :csv },
                   class: "align-middle tooltipped tooltipped--w", "aria-label": "Download all as CSV" %>
   <%= link_to "#", class: "btn bg-success", data: { behavior: "modal_trigger", modal: "create" }, disabled: !policy(@event).create_sub_organization? do %>
     <%= inline_icon "plus" %>


### PR DESCRIPTION
## Summary of the problem

One of our partners wants to use the v3 API to fetch information regarding each of their subevents. Right now, there's no way for them to easily retrieve a list of subevents with their IDs. 

## Describe your changes

This PR adds a CSV export to the org's Subevents page. The CSV export includes ID, Name, Slug, and Balance.

<img width="957" height="190" alt="image" src="https://github.com/user-attachments/assets/d42225fd-74c3-408e-8418-2a9620862a1e" />

Example:
<img width="514" height="100" alt="image" src="https://github.com/user-attachments/assets/0e4c46b7-7b78-4b94-b0f9-5967fdc2a562" />
[The Orpheus Foundation's sub-organizations.csv](https://github.com/user-attachments/files/22566814/The.Orpheus.Foundation.s.sub-organizations.csv)



We should maybe also consider adding a subevents route to the v3 API, but in the meantime, this will do.


