### PR TITLE
[Accounting] Disbursement transaction categories

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -85,7 +85,9 @@ class DisbursementsController < ApplicationController
       scheduled_on:,
       requested_by_id: current_user.id,
       should_charge_fee: disbursement_params[:should_charge_fee] == "1",
-      fronted: @source_event.plan.front_disbursements_enabled?
+      fronted: @source_event.plan.front_disbursements_enabled?,
+      source_transaction_category_slug: disbursement_params[:source_transaction_category_slug].presence,
+      destination_transaction_category_slug: disbursement_params[:destination_transaction_category_slug].presence,
     ).run
 
     if disbursement_params[:file]
@@ -169,7 +171,14 @@ class DisbursementsController < ApplicationController
       :scheduled_on,
       { file: [] }
     ]
-    attributes << :should_charge_fee if admin_signed_in?
+
+    if admin_signed_in?
+      attributes.push(
+        :should_charge_fee,
+        :source_transaction_category_slug,
+        :destination_transaction_category_slug
+      )
+    end
 
     params.require(:disbursement).permit(attributes)
   end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -226,6 +226,10 @@ class Disbursement < ApplicationRecord
     @canonical_pending_transactions ||= ::CanonicalPendingTransaction.where(hcb_code:)
   end
 
+  def transactions_helper
+    @transactions_helper ||= Disbursement::TransactionsHelper.new(self)
+  end
+
   def processed?
     in_transit? || deposited?
   end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -4,41 +4,47 @@
 #
 # Table name: disbursements
 #
-#  id                       :bigint           not null, primary key
-#  aasm_state               :string
-#  amount                   :integer
-#  deposited_at             :datetime
-#  errored_at               :datetime
-#  in_transit_at            :datetime
-#  name                     :string
-#  pending_at               :datetime
-#  rejected_at              :datetime
-#  scheduled_on             :date
-#  should_charge_fee        :boolean          default(FALSE)
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  destination_subledger_id :bigint
-#  event_id                 :bigint
-#  fulfilled_by_id          :bigint
-#  requested_by_id          :bigint
-#  source_event_id          :bigint
-#  source_subledger_id      :bigint
+#  id                                  :bigint           not null, primary key
+#  aasm_state                          :string
+#  amount                              :integer
+#  deposited_at                        :datetime
+#  errored_at                          :datetime
+#  in_transit_at                       :datetime
+#  name                                :string
+#  pending_at                          :datetime
+#  rejected_at                         :datetime
+#  scheduled_on                        :date
+#  should_charge_fee                   :boolean          default(FALSE)
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#  destination_subledger_id            :bigint
+#  destination_transaction_category_id :bigint
+#  event_id                            :bigint
+#  fulfilled_by_id                     :bigint
+#  requested_by_id                     :bigint
+#  source_event_id                     :bigint
+#  source_subledger_id                 :bigint
+#  source_transaction_category_id      :bigint
 #
 # Indexes
 #
-#  index_disbursements_on_destination_subledger_id  (destination_subledger_id)
-#  index_disbursements_on_event_id                  (event_id)
-#  index_disbursements_on_fulfilled_by_id           (fulfilled_by_id)
-#  index_disbursements_on_requested_by_id           (requested_by_id)
-#  index_disbursements_on_source_event_id           (source_event_id)
-#  index_disbursements_on_source_subledger_id       (source_subledger_id)
+#  index_disbursements_on_destination_subledger_id             (destination_subledger_id)
+#  index_disbursements_on_destination_transaction_category_id  (destination_transaction_category_id)
+#  index_disbursements_on_event_id                             (event_id)
+#  index_disbursements_on_fulfilled_by_id                      (fulfilled_by_id)
+#  index_disbursements_on_requested_by_id                      (requested_by_id)
+#  index_disbursements_on_source_event_id                      (source_event_id)
+#  index_disbursements_on_source_subledger_id                  (source_subledger_id)
+#  index_disbursements_on_source_transaction_category_id       (source_transaction_category_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (destination_transaction_category_id => transaction_categories.id)
 #  fk_rails_...  (event_id => events.id)
 #  fk_rails_...  (fulfilled_by_id => users.id)
 #  fk_rails_...  (requested_by_id => users.id)
 #  fk_rails_...  (source_event_id => events.id)
+#  fk_rails_...  (source_transaction_category_id => transaction_categories.id)
 #
 class Disbursement < ApplicationRecord
   include PgSearch::Model

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -78,6 +78,9 @@ class Disbursement < ApplicationRecord
   has_one :raw_pending_incoming_disbursement_transaction
   has_one :raw_pending_outgoing_disbursement_transaction
 
+  belongs_to(:source_transaction_category, class_name: "TransactionCategory", optional: true)
+  belongs_to(:destination_transaction_category, class_name: "TransactionCategory", optional: true)
+
   has_one :card_grant, required: false
 
   has_many :t_transactions, class_name: "Transaction", inverse_of: :disbursement

--- a/app/models/disbursement/transactions_helper.rb
+++ b/app/models/disbursement/transactions_helper.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Disbursement
+  class TransactionsHelper
+    def initialize(disbursement)
+      @disbursement = disbursement
+    end
+
+    def settled_source
+      canonical_transactions_by_event.fetch(@disbursement.source_event, [])
+    end
+
+    def settled_destination
+      canonical_transactions_by_event.fetch(@disbursement.destination_event, [])
+    end
+
+    def pending_source
+      canonical_pending_transactions_by_event.fetch(@disbursement.source_event, [])
+    end
+
+    def pending_destination
+      canonical_pending_transactions_by_event.fetch(@disbursement.destination_event, [])
+    end
+
+    private
+
+    def canonical_transactions_by_event
+      @canonical_transactions_by_event ||=
+        @disbursement
+        .canonical_transactions
+        .strict_loading
+        .preload(:event)
+        .group_by(&:event)
+    end
+
+    def canonical_pending_transactions_by_event
+      @canonical_pending_transactions_by_event ||=
+        @disbursement
+        .canonical_pending_transactions
+        .strict_loading
+        .preload(:event)
+        .group_by(&:event)
+    end
+
+  end
+
+end

--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -58,6 +58,10 @@ class DisbursementPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def set_transaction_categories?
+    user.admin?
+  end
+
   private
 
   def auditor_or_user?

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -21,7 +21,9 @@ module DisbursementService
       source_subledger_id: nil,
       should_charge_fee: false,
       skip_auto_approve: false,
-      fronted: false
+      fronted: false,
+      source_transaction_category_slug: nil,
+      destination_transaction_category_slug: nil
     )
       @source_event_id = source_event_id
       @source_event = Event.find(@source_event_id)
@@ -37,6 +39,8 @@ module DisbursementService
       @should_charge_fee = should_charge_fee
       @skip_auto_approve = skip_auto_approve
       @fronted = fronted
+      @source_transaction_category_slug = source_transaction_category_slug
+      @destination_transaction_category_slug = destination_transaction_category_slug
     end
 
     def run
@@ -95,6 +99,8 @@ module DisbursementService
         amount: amount_cents,
         requested_by:,
         should_charge_fee: @should_charge_fee,
+        source_transaction_category:,
+        destination_transaction_category:
       }
     end
 
@@ -116,6 +122,18 @@ module DisbursementService
 
     def destination_event
       @destination_event ||= Event.find(@destination_event_id)
+    end
+
+    def source_transaction_category
+      return if @source_transaction_category_slug.blank?
+
+      @source_transaction_category ||= TransactionCategory.find_or_create_by!(slug: @source_transaction_category_slug)
+    end
+
+    def destination_transaction_category
+      return if @destination_transaction_category_slug.blank?
+
+      @destination_transaction_category ||= TransactionCategory.find_or_create_by!(slug: @destination_transaction_category_slug)
     end
 
   end

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -9,10 +9,20 @@ module DisbursementService
     # issues.
     class UserError < ArgumentError; end
 
-    def initialize(source_event_id:, destination_event_id:,
-                   name:, amount:, requested_by_id:, fulfilled_by_id: nil,
-                   destination_subledger_id: nil, scheduled_on: nil, source_subledger_id: nil,
-                   should_charge_fee: false, skip_auto_approve: false, fronted: false)
+    def initialize(
+      source_event_id:,
+      destination_event_id:,
+      name:,
+      amount:,
+      requested_by_id:,
+      fulfilled_by_id: nil,
+      destination_subledger_id: nil,
+      scheduled_on: nil,
+      source_subledger_id: nil,
+      should_charge_fee: false,
+      skip_auto_approve: false,
+      fronted: false
+    )
       @source_event_id = source_event_id
       @source_event = Event.find(@source_event_id)
       @destination_event_id = destination_event_id

--- a/app/views/admin/disbursement_process.html.erb
+++ b/app/views/admin/disbursement_process.html.erb
@@ -1,6 +1,6 @@
 <%= link_to disbursements_admin_index_path, class: "btn btn-small bg-muted" do %>
-    <%= inline_icon "view-back" %>
-    Back to disbursements
+  <%= inline_icon "view-back" %>
+  Back to disbursements
 <% end %>
 
 <h1>Process Disbursement #<%= @disbursement.id %></h1>
@@ -10,33 +10,33 @@
 <table class="table--autosize">
   <tbody>
     <tr>
-      <td style="text-align: right;">From:</td>
+      <td class="text-right">From:</td>
       <td>
         <%= link_to @disbursement.source_event.name, @disbursement.source_event %>
         <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.source_event.financially_frozen? %>
       </td>
     </tr>
     <tr>
-      <td style="text-align: right;">To:</td>
+      <td class="text-right">To:</td>
       <td>
         <%= link_to @disbursement.destination_event.name, @disbursement.destination_event %>
         <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.destination_event.financially_frozen? %>
       </td>
     </tr>
     <tr>
-      <td style="text-align: right;">Amount:</td>
+      <td class="text-right">Amount:</td>
       <td><%= render_money @disbursement.amount %></td>
     </tr>
     <tr>
-      <td style="text-align: right;">Memo:</td>
+      <td class="text-right">Memo:</td>
       <td><%= @disbursement.name %></td>
     </tr>
     <tr>
-      <td style="text-align: right;">Requested by:</td>
+      <td class="text-right">Requested by:</td>
       <td><%= user_mention @disbursement.requested_by %></td>
     </tr>
     <tr>
-      <td style="text-align: right;">
+      <td class="text-right">
         <% if @disbursement.rejected? %>
           Rejected by:
         <% else %>
@@ -47,40 +47,40 @@
         <% if @disbursement.fulfilled_by.nil? %>
           N/A <span class="muted italic">(This could be you!✨)</span>
         <% else %>
-        <div>
-          <%= user_mention @disbursement.fulfilled_by %>
+          <div>
+            <%= user_mention @disbursement.fulfilled_by %>
           </div>
         <% end %>
       </td>
     </tr>
   </tbody>
 </table>
-<br>
-<hr>
+
+<hr class="mt4">
+
 <h3>Instructions</h3>
 
 <% if @disbursement.rejected? || @disbursement.pending? %>
   <p>Nothing more to do here. ✨</p>
 <% else %>
+  <p>This is a human review check.</p>
 
-    <p>This is a human review check.</p>
+  <% if @disbursement.scheduled_on.present? %>
+    <br>
+    <small>When approved, this disbursement will automatically send on <%= @disbursement.scheduled_on.strftime("%Y-%m-%d") %>.</small>
+  <% end %>
 
-    <% if @disbursement.scheduled_on.present? %>
-      <br>
-      <small>When approved, this disbursement will automatically send on <%= @disbursement.scheduled_on.strftime("%Y-%m-%d") %>.</small>
-    <% end %>
+  <%= form_with(model: false, local: true, url: disbursement_approve_admin_path(@disbursement), method: :post) do |form| %>
+    <%= form.submit "Approve disbursement" %>
+  <% end %>
 
-    <%= form_with(model: false, local: true, url: disbursement_approve_admin_path(@disbursement), method: :post) do |form| %>
-      <%= form.submit "Approve disbursement" %>
-    <% end %>
-
-    <%= form_with(model: false, local: true, url: disbursement_reject_admin_path(@disbursement), method: :post) do |form| %>
-      <div class="field">
-        <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
-        <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
-      </div>
-      <%= form.submit "Reject disbursement",
-        class: "admin-bg-orange",
-        data: { confirm: "Are you sure you want to reject this disbursement?" } %>
-    <% end %>
+  <%= form_with(model: false, local: true, url: disbursement_reject_admin_path(@disbursement), method: :post) do |form| %>
+    <div class="field">
+      <%= form.label "Reject with a comment", class: "bold mb1" %> <br>
+      <%= form.text_area :comment, style: "width: 400px;", placeholder: "(Markdown supported)" %>
+    </div>
+    <%= form.submit "Reject disbursement",
+      class: "admin-bg-orange",
+      data: { confirm: "Are you sure you want to reject this disbursement?" } %>
+  <% end %>
 <% end %>

--- a/app/views/admin/disbursement_process.html.erb
+++ b/app/views/admin/disbursement_process.html.erb
@@ -10,6 +10,14 @@
 <table class="table--autosize">
   <tbody>
     <tr>
+      <td class="text-right">HCB Code:</td>
+      <td>
+        <% if @disbursement.local_hcb_code %>
+          <%= link_to(@disbursement.hcb_code, @disbursement.local_hcb_code) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
       <td class="text-right">From:</td>
       <td>
         <%= link_to @disbursement.source_event.name, @disbursement.source_event %>

--- a/app/views/admin/disbursement_process.html.erb
+++ b/app/views/admin/disbursement_process.html.erb
@@ -78,25 +78,37 @@
 <h4>Destination transactions</h4>
 
 <% if @disbursement.transactions_helper.settled_destination.empty? && @disbursement.transactions_helper.pending_destination.empty? %>
-  <%= form_for(
-        @disbursement,
-        url: disbursement_set_transaction_categories_path(@disbursement),
-        method: :post,
-        data: { controller: "form" },
-        html: { class: "m-0" }
-      ) do |f| %>
+  <p>Destination transactions for this disbursement have not been created yet. Once created, they will have the following properties:</p>
 
-    <%= select_tag(
-          f.field_name(:destination_transaction_category_slug),
-          options_for_select(
-            TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] },
-            @disbursement.destination_transaction_category&.slug,
-          ),
-          include_blank: "None",
-          data: { action: "change->form#submit" },
-          class: "m-0"
-        ) %>
-  <% end %>
+  <table class="table--autosize no-stripes">
+    <tr>
+      <td class="text-right">
+        Category:
+      </td>
+      <td>
+        <%= form_for(
+              @disbursement,
+              url: disbursement_set_transaction_categories_path(@disbursement),
+              method: :post,
+              data: { controller: "form" },
+              html: { class: "m-0" }
+            ) do |f| %>
+
+          <%= select_tag(
+                f.field_name(:destination_transaction_category_slug),
+                options_for_select(
+                  TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] },
+                  @disbursement.destination_transaction_category&.slug,
+                ),
+                include_blank: "None",
+                data: { action: "change->form#submit" },
+                class: "m-0"
+              ) %>
+        <% end %>
+      </td>
+    </tr>
+  </table>
+
 <% else %>
   <%= render(
         partial: "hcb_codes/transactions_table",

--- a/app/views/admin/disbursement_process.html.erb
+++ b/app/views/admin/disbursement_process.html.erb
@@ -7,62 +7,105 @@
 <p><small>Current Status: <%= @disbursement.state_text %></small></p>
 
 <h3>Disbursement Details</h3>
-<table class="table--autosize">
+
+<table class="table--autosize no-stripes">
   <tbody>
-    <tr>
-      <td class="text-right">HCB Code:</td>
-      <td>
-        <% if @disbursement.local_hcb_code %>
-          <%= link_to(@disbursement.hcb_code, @disbursement.local_hcb_code) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr>
-      <td class="text-right">From:</td>
-      <td>
-        <%= link_to @disbursement.source_event.name, @disbursement.source_event %>
-        <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.source_event.financially_frozen? %>
-      </td>
-    </tr>
-    <tr>
-      <td class="text-right">To:</td>
-      <td>
-        <%= link_to @disbursement.destination_event.name, @disbursement.destination_event %>
-        <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.destination_event.financially_frozen? %>
-      </td>
-    </tr>
-    <tr>
-      <td class="text-right">Amount:</td>
-      <td><%= render_money @disbursement.amount %></td>
-    </tr>
-    <tr>
-      <td class="text-right">Memo:</td>
-      <td><%= @disbursement.name %></td>
-    </tr>
-    <tr>
-      <td class="text-right">Requested by:</td>
-      <td><%= user_mention @disbursement.requested_by %></td>
-    </tr>
-    <tr>
-      <td class="text-right">
-        <% if @disbursement.rejected? %>
-          Rejected by:
-        <% else %>
-          Fulfilled by:
-        <% end %>
-      </td>
-      <td>
-        <% if @disbursement.fulfilled_by.nil? %>
-          N/A <span class="muted italic">(This could be you!✨)</span>
-        <% else %>
-          <div>
-            <%= user_mention @disbursement.fulfilled_by %>
-          </div>
-        <% end %>
-      </td>
-    </tr>
+  <tr>
+    <td class="text-right">HCB Code:</td>
+    <td>
+      <% if @disbursement.local_hcb_code %>
+        <%= link_to(@disbursement.hcb_code, hcb_code_path(@disbursement.local_hcb_code)) %>
+      <% end %>
+    </td>
+  </tr>
+  <tr>
+    <td class="text-right">From:</td>
+    <td>
+      <%= link_to(@disbursement.source_event.name, event_path(@disbursement.source_event)) %>
+      <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.source_event.financially_frozen? %>
+    </td>
+  </tr>
+  <tr>
+    <td class="text-right">To:</td>
+    <td>
+      <%= link_to(@disbursement.destination_event.name, event_path(@disbursement.destination_event)) %>
+      <%= "(❄️ ⚠️ CURRENTLY FINANCIALLY FROZEN)" if @disbursement.destination_event.financially_frozen? %>
+    </td>
+  </tr>
+  <tr>
+    <td class="text-right">Amount:</td>
+    <td><%= render_money @disbursement.amount %></td>
+  </tr>
+  <tr>
+    <td class="text-right">Memo:</td>
+    <td><%= @disbursement.name %></td>
+  </tr>
+  <tr>
+    <td class="text-right">Requested by:</td>
+    <td><%= user_mention @disbursement.requested_by %></td>
+  </tr>
+  <tr>
+    <td class="text-right">
+      <% if @disbursement.rejected? %>
+        Rejected by:
+      <% else %>
+        Fulfilled by:
+      <% end %>
+    </td>
+    <td>
+      <% if @disbursement.fulfilled_by.nil? %>
+        N/A <span class="muted italic">(This could be you!✨)</span>
+      <% else %>
+        <div>
+          <%= user_mention @disbursement.fulfilled_by %>
+        </div>
+      <% end %>
+    </td>
+  </tr>
   </tbody>
 </table>
+
+<h4>Source transactions</h4>
+
+<%= render(
+      partial: "hcb_codes/transactions_table",
+      locals: {
+        canonical_transactions: @disbursement.transactions_helper.settled_source,
+        canonical_pending_transactions: @disbursement.transactions_helper.pending_source,
+      }
+    ) %>
+
+<h4>Destination transactions</h4>
+
+<% if @disbursement.transactions_helper.settled_destination.empty? && @disbursement.transactions_helper.pending_destination.empty? %>
+  <%= form_for(
+        @disbursement,
+        url: disbursement_set_transaction_categories_path(@disbursement),
+        method: :post,
+        data: { controller: "form" },
+        html: { class: "m-0" }
+      ) do |f| %>
+
+    <%= select_tag(
+          f.field_name(:destination_transaction_category_slug),
+          options_for_select(
+            TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] },
+            @disbursement.destination_transaction_category&.slug,
+          ),
+          include_blank: "None",
+          data: { action: "change->form#submit" },
+          class: "m-0"
+        ) %>
+  <% end %>
+<% else %>
+  <%= render(
+        partial: "hcb_codes/transactions_table",
+        locals: {
+          canonical_transactions: @disbursement.transactions_helper.settled_destination,
+          canonical_pending_transactions: @disbursement.transactions_helper.pending_destination,
+        }
+      ) %>
+<% end %>
 
 <hr class="mt4">
 

--- a/app/views/admin/disbursements.html.erb
+++ b/app/views/admin/disbursements.html.erb
@@ -61,10 +61,16 @@
           <% end %>
         </td>
         <td>
-          <% if disbursement.reviewing? %>
-            <%= link_to "Process", disbursement_process_admin_path(disbursement) %>
-          <% elsif disbursement.pending? %>
+          <% if disbursement.pending? %>
             AUTOMATED
+          <% end %>
+
+          <%= link_to(disbursement_process_admin_path(disbursement)) do %>
+            <% if disbursement.reviewing? %>
+              Process
+            <% else %>
+              View
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/pending_ledger.html.erb
+++ b/app/views/admin/pending_ledger.html.erb
@@ -53,11 +53,7 @@
         <td>
           <%= render(
                 partial: "hcb_codes/transaction_category_form",
-                locals: {
-                  model: cpt,
-                  url: set_category_canonical_pending_transaction_path(cpt),
-                  admin_context: true
-                }
+                locals: { model: cpt, admin_context: true }
               ) %>
         </td>
         <td>

--- a/app/views/admin/transaction.html.erb
+++ b/app/views/admin/transaction.html.erb
@@ -45,11 +45,7 @@
       <td>
         <%= render(
               partial: "hcb_codes/transaction_category_form",
-              locals: {
-                model: @canonical_transaction,
-                url: set_category_canonical_transaction_path(@canonical_transaction),
-                admin_context: true
-              }
+              locals: { model: @canonical_transaction, admin_context: true }
             ) %>
       </td>
     </tr>

--- a/app/views/disbursements/_form.html.erb
+++ b/app/views/disbursements/_form.html.erb
@@ -37,6 +37,28 @@
     <span class="muted">This is to help HCB keep record of our transactions.</span>
   </div>
 
+  <% admin_tool do %>
+      <% category_select = ->(field) {
+           form.select(
+             field,
+             options_for_select(
+               TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] }
+             ),
+             include_blank: "None",
+           )
+         } %>
+
+    <div class="field">
+      <%= form.label(:source_transaction_category_slug, "Source transaction category") %>
+      <%= category_select.call(:source_transaction_category_slug) %>
+    </div>
+
+    <div class="field">
+      <%= form.label(:destination_transaction_category_slug, "Destination transaction category") %>
+      <%= category_select.call(:destination_transaction_category_slug) %>
+    </div>
+  <% end %>
+
   <%= form.label :file, "Attach a receipt / invoice (optional)", class: "mt2" %>
   <div class="field field--fileupload mb1 mt1" data-controller="file-drop form" data-file-drop-title-value="Drop to add a receipt.">
     <%= form.label :file, "Choose file", class: "field--fileupload__label", data: {

--- a/app/views/disbursements/show.html.erb
+++ b/app/views/disbursements/show.html.erb
@@ -2,11 +2,22 @@
 <% page_sm %>
 <% render "events/nav" %>
 
-<% admin_tool("mt3 mb0") do %>
+<% admin_tool("mt3") do %>
   <%= link_to "All disbursements", disbursements_admin_index_path, class: "breadcrumb" %>
 <% end %>
 
-<% admin_tool do %>
+<% if @disbursement.local_hcb_code %>
+  <% admin_tool("mt1") do %>
+    <p>
+      <strong>HCB Code:</strong>
+      <span>
+        <%= link_to(@disbursement.hcb_code, hcb_code_path(@disbursement.local_hcb_code)) %>
+      </span>
+    </p>
+  <% end %>
+<% end %>
+
+<% admin_tool("mt1") do %>
   <ul>
     <li>
       v2

--- a/app/views/hcb_codes/_admin_tools.html.erb
+++ b/app/views/hcb_codes/_admin_tools.html.erb
@@ -52,10 +52,7 @@
           <td>
             <%= render(
                   partial: "transaction_category_form",
-                  locals: {
-                    model: ct,
-                    url: set_category_canonical_pending_transaction_path(ct)
-                  }
+                  locals: { model: ct }
                 ) %>
           </td>
           <td>
@@ -88,10 +85,7 @@
           <td>
             <%= render(
                   partial: "transaction_category_form",
-                  locals: {
-                    model: ct,
-                    url: set_category_canonical_transaction_path(ct)
-                  }
+                  locals: { model: ct }
                 ) %>
           </td>
           <td>

--- a/app/views/hcb_codes/_admin_tools.html.erb
+++ b/app/views/hcb_codes/_admin_tools.html.erb
@@ -18,100 +18,22 @@
 
       </tr>
     </table>
-    <table>
-      <tr>
-        <th>ID</th>
-        <th>TYPE</th>
-        <th>DATE</th>
-        <th>MEMO</th>
-        <th>AMOUNT</th>
-        <th>CATEGORY</th>
-        <th></th>
-      </tr>
-      <% @hcb_code
-           .canonical_pending_transactions
-           .preload(:category)
-           .strict_loading
-           .each do |ct| %>
-        <tr>
-          <td>
-            <%= ct.id %>
-          </td>
-          <td>
-            PENDING
-          </td>
-          <td>
-            <%= ct.date %>
-          </td>
-          <td>
-            <%= ct.memo %>
-          </td>
-          <td>
-            <%= ct.amount %>
-          </td>
-          <td>
-            <%= render(
-                  partial: "transaction_category_form",
-                  locals: { model: ct }
-                ) %>
-          </td>
-          <td>
-            <%= link_to "view", "/canonical_pending_transactions/#{ct.id}" %>
-          </td>
-        </tr>
-      <% end %>
-
-      <% @hcb_code
-           .canonical_transactions
-           .preload(:category)
-           .strict_loading
-           .each do |ct| %>
-        <tr>
-          <td>
-            <%= ct.id %>
-          </td>
-          <td>
-            SETTLED
-          </td>
-          <td>
-            <%= ct.date %>
-          </td>
-          <td>
-            <%= ct.memo %>
-          </td>
-          <td>
-            <%= ct.amount %>
-          </td>
-          <td>
-            <%= render(
-                  partial: "transaction_category_form",
-                  locals: { model: ct }
-                ) %>
-          </td>
-          <td>
-            <%= link_to "view", "/transactions/#{ct.id}" %>
-          </td>
-        </tr>
-      <% end %>
-
-      <% if @hcb_code.ach_transfer? && @hcb_code.ach_transfer.present? && @hcb_code.ach_transfer.t_transaction.present? %>
-        <td>
-          OLD
-        </td>
-        <td>
-          <%= @hcb_code.ach_transfer.t_transaction.date %>
-        </td>
-        <td>
-          <%= @hcb_code.ach_transfer.t_transaction.memo %>
-        </td>
-        <td>
-          <%= render_money_amount @hcb_code.ach_transfer.t_transaction.amount %>
-        </td>
-        <td>
-          <%= link_to "view", @hcb_code.ach_transfer.t_transaction %>
-        </td>
-      <% end %>
-
-    </table>
+    <%= render(
+          partial: "transactions_table",
+          locals: {
+            canonical_transactions:
+              @hcb_code
+                .canonical_pending_transactions
+                .preload(:category)
+                .strict_loading,
+            canonical_pending_transactions:
+              @hcb_code
+                .canonical_transactions
+                .preload(:category)
+                .strict_loading
+                .to_a,
+            t_transaction: @hcb_code.ach_transfer&.t_transaction
+          }
+        ) %>
   <% end %>
 <% end %>

--- a/app/views/hcb_codes/_transaction_category_form.html.erb
+++ b/app/views/hcb_codes/_transaction_category_form.html.erb
@@ -1,4 +1,13 @@
-<%# locals: (model:, url:, admin_context: false) %>
+<%# locals: (model:, admin_context: false) %>
+
+<% url = case model
+         when CanonicalTransaction
+           set_category_canonical_transaction_path(model)
+         when CanonicalPendingTransaction
+           set_category_canonical_pending_transaction_path(model)
+         else
+           raise(ArgumentError, "unsupported model class: #{model.class.name.inspect}")
+         end %>
 
 <%= form_for(
       model,

--- a/app/views/hcb_codes/_transactions_table.html.erb
+++ b/app/views/hcb_codes/_transactions_table.html.erb
@@ -1,0 +1,73 @@
+<%# locals: (canonical_transactions: [], canonical_pending_transactions: [], t_transaction: nil) %>
+
+<table>
+  <thread>
+    <tr>
+      <th>ID</th>
+      <th>TYPE</th>
+      <th>DATE</th>
+      <th>MEMO</th>
+      <th>AMOUNT</th>
+      <th>CATEGORY</th>
+      <th></th>
+    </tr>
+  </thread>
+  <tbody>
+    <% canonical_transactions.to_a.concat(canonical_pending_transactions.to_a).each do |transaction| %>
+      <tr>
+        <td>
+          <%= transaction.id %>
+        </td>
+        <td>
+          <% if transaction.is_a?(CanonicalPendingTransaction) %>
+            PENDING
+          <% else %>
+            SETTLED
+          <% end %>
+        </td>
+        <td>
+          <%= transaction.date %>
+        </td>
+        <td>
+          <%= transaction.memo %>
+        </td>
+        <td>
+          <%= transaction.amount %>
+        </td>
+        <td>
+          <%= render(
+                partial: "hcb_codes/transaction_category_form",
+                locals: { model: transaction }
+              ) %>
+        </td>
+        <td>
+          <% if transaction.is_a?(CanonicalPendingTransaction) %>
+            <%= link_to("view", canonical_pending_transaction_path(transaction)) %>
+          <% else %>
+            <%= link_to("view", canonical_transaction_path(transaction)) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+
+    <% if t_transaction %>
+      <tr>
+        <td>
+          OLD
+        </td>
+        <td>
+          <%= t_transaction.date %>
+        </td>
+        <td>
+          <%= t_transaction.memo %>
+        </td>
+        <td>
+          <%= render_money_amount(t_transaction.amount) %>
+        </td>
+        <td>
+          <%= link_to("view", @hcb_code.t_transaction) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/hcb_codes/_transactions_table.html.erb
+++ b/app/views/hcb_codes/_transactions_table.html.erb
@@ -52,21 +52,13 @@
 
     <% if t_transaction %>
       <tr>
-        <td>
-          OLD
-        </td>
-        <td>
-          <%= t_transaction.date %>
-        </td>
-        <td>
-          <%= t_transaction.memo %>
-        </td>
-        <td>
-          <%= render_money_amount(t_transaction.amount) %>
-        </td>
-        <td>
-          <%= link_to("view", @hcb_code.t_transaction) %>
-        </td>
+        <td></td>
+        <td>OLD</td>
+        <td><%= t_transaction.date %></td>
+        <td><%= t_transaction.memo %></td>
+        <td><%= render_money_amount(t_transaction.amount) %></td>
+        <td></td>
+        <td><%= link_to("view", @hcb_code.t_transaction) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -457,6 +457,7 @@ Rails.application.routes.draw do
     post "mark_fulfilled"
     post "reject"
     post "cancel"
+    post "set_transaction_categories"
     get "confirmation", to: "disbursements#transfer_confirmation_letter"
   end
 

--- a/db/migrate/20250926155400_add_transaction_categories_to_disbursements.rb
+++ b/db/migrate/20250926155400_add_transaction_categories_to_disbursements.rb
@@ -1,0 +1,19 @@
+class AddTransactionCategoriesToDisbursements < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference(
+      :disbursements,
+      :source_transaction_category,
+      index: { algorithm: :concurrently },
+      null: true
+    )
+
+    add_reference(
+      :disbursements,
+      :destination_transaction_category,
+      index: { algorithm: :concurrently },
+      null: true
+    )
+  end
+end

--- a/db/migrate/20250926160634_add_transaction_category_foreign_keys_to_disbursements.rb
+++ b/db/migrate/20250926160634_add_transaction_category_foreign_keys_to_disbursements.rb
@@ -1,0 +1,17 @@
+class AddTransactionCategoryForeignKeysToDisbursements < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key(
+      :disbursements,
+      :transaction_categories,
+      column: :source_transaction_category_id,
+      validate: false
+    )
+
+    add_foreign_key(
+      :disbursements,
+      :transaction_categories,
+      column: :destination_transaction_category_id,
+      validate: false
+    )
+  end
+end

--- a/db/migrate/20250926160925_validate_transaction_category_foreign_keys_on_disbursements.rb
+++ b/db/migrate/20250926160925_validate_transaction_category_foreign_keys_on_disbursements.rb
@@ -1,0 +1,13 @@
+class ValidateTransactionCategoryForeignKeysOnDisbursements < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key(
+      :disbursements,
+      column: :source_transaction_category_id,
+    )
+
+    validate_foreign_key(
+      :disbursements,
+      column: :destination_transaction_category_id,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_05_005653) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_26_160925) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -642,12 +642,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_005653) do
     t.bigint "source_subledger_id"
     t.date "scheduled_on"
     t.boolean "should_charge_fee", default: false
+    t.bigint "source_transaction_category_id"
+    t.bigint "destination_transaction_category_id"
     t.index ["destination_subledger_id"], name: "index_disbursements_on_destination_subledger_id"
+    t.index ["destination_transaction_category_id"], name: "index_disbursements_on_destination_transaction_category_id"
     t.index ["event_id"], name: "index_disbursements_on_event_id"
     t.index ["fulfilled_by_id"], name: "index_disbursements_on_fulfilled_by_id"
     t.index ["requested_by_id"], name: "index_disbursements_on_requested_by_id"
     t.index ["source_event_id"], name: "index_disbursements_on_source_event_id"
     t.index ["source_subledger_id"], name: "index_disbursements_on_source_subledger_id"
+    t.index ["source_transaction_category_id"], name: "index_disbursements_on_source_transaction_category_id"
   end
 
   create_table "document_downloads", force: :cascade do |t|
@@ -2504,6 +2508,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_005653) do
   add_foreign_key "comment_reactions", "users", column: "reactor_id"
   add_foreign_key "disbursements", "events"
   add_foreign_key "disbursements", "events", column: "source_event_id"
+  add_foreign_key "disbursements", "transaction_categories", column: "destination_transaction_category_id"
+  add_foreign_key "disbursements", "transaction_categories", column: "source_transaction_category_id"
   add_foreign_key "disbursements", "users", column: "fulfilled_by_id"
   add_foreign_key "disbursements", "users", column: "requested_by_id"
   add_foreign_key "document_downloads", "documents"

--- a/spec/controllers/disbursements_controller_spec.rb
+++ b/spec/controllers/disbursements_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DisbursementsController do
+  include SessionSupport
+  render_views
+
+  describe "#create" do
+    it "creates a disbursement" do
+      sender = create(:user)
+      source_event = create(:event, :with_positive_balance)
+      create(:organizer_position, user: sender, event: source_event)
+
+      destination_event = create(:event)
+      create(:organizer_position, user: sender, event: destination_event)
+
+      sign_in(sender)
+
+      expect do
+        post(
+          :create,
+          params: {
+            disbursement: {
+              name: "Boba Drops",
+              source_event_id: source_event.public_id,
+              event_id: destination_event.public_id,
+              amount: "123.45"
+            }
+          }
+        )
+      end.to change(Disbursement, :count).by(1)
+
+      expect(flash[:success]).to eq("Transfer successfully requested.")
+      expect(response).to redirect_to(event_transfers_path(source_event))
+
+      disbursement = Disbursement.last
+      expect(disbursement.name).to eq("Boba Drops")
+      expect(disbursement.amount).to eq(123_45)
+      expect(disbursement.source_event).to eq(source_event)
+      expect(disbursement.destination_event).to eq(destination_event)
+    end
+
+    it "allows transaction categories to be set by admins" do
+      sender = create(:user, :make_admin)
+      source_event = create(:event, :with_positive_balance)
+      create(:organizer_position, user: sender, event: source_event)
+
+      destination_event = create(:event)
+
+      sign_in(sender)
+
+      expect do
+        post(
+          :create,
+          params: {
+            disbursement: {
+              name: "Boba Drops",
+              source_event_id: source_event.public_id,
+              event_id: destination_event.public_id,
+              amount: "123.45",
+              source_transaction_category_slug: "donations",
+              destination_transaction_category_slug: "fundraising",
+            }
+          }
+        )
+      end.to change(Disbursement, :count).by(1)
+
+      expect(flash[:success]).to eq("Transfer successfully requested.")
+      expect(response).to redirect_to(disbursements_admin_index_path)
+
+      disbursement = Disbursement.last
+      expect(disbursement.name).to eq("Boba Drops")
+      expect(disbursement.amount).to eq(123_45)
+      expect(disbursement.source_event).to eq(source_event)
+      expect(disbursement.destination_event).to eq(destination_event)
+      expect(disbursement.source_transaction_category.slug).to eq("donations")
+      expect(disbursement.destination_transaction_category.slug).to eq("fundraising")
+    end
+  end
+end

--- a/spec/services/disbursement_service/create_spec.rb
+++ b/spec/services/disbursement_service/create_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DisbursementService::Create do
+  it "runs successfully" do
+    freeze_time
+
+    requestor = create(:user)
+    source_event = create(:event, :with_positive_balance)
+    create(:organizer_position, event: source_event, user: requestor)
+
+    destination_event = create(:event)
+
+    disbursement = described_class.new(
+      name: "Boba Drops",
+      amount: "123.45",
+      requested_by_id: requestor.id,
+      source_event_id: source_event.id,
+      destination_event_id: destination_event.id,
+    ).run
+
+    expect(disbursement).to be_a(Disbursement)
+    expect(disbursement).to be_reviewing
+    expect(disbursement.name).to eq("Boba Drops")
+    expect(disbursement.amount).to eq(123_45)
+    expect(disbursement.requested_by).to eq(requestor)
+    expect(disbursement.source_event).to eq(source_event)
+    expect(disbursement.destination_event).to eq(destination_event)
+    expect(disbursement.source_subledger).to be_nil
+    expect(disbursement.destination_subledger).to be_nil
+    expect(disbursement.scheduled_on).to be_nil
+    expect(disbursement.should_charge_fee).to eq(false)
+    expect(disbursement.source_transaction_category).to be_nil
+    expect(disbursement.destination_transaction_category).to be_nil
+
+    pending_outgoing = disbursement.raw_pending_outgoing_disbursement_transaction
+    expect(pending_outgoing.amount_cents).to eq(-123_45)
+    expect(pending_outgoing.date_posted).to eq(Date.today)
+
+    cpt_outgoing = pending_outgoing.canonical_pending_transaction
+    expect(cpt_outgoing.event).to eq(source_event)
+    expect(cpt_outgoing.amount_cents).to eq(-123_45)
+    expect(cpt_outgoing.memo).to eq("Outgoing transfer")
+    expect(cpt_outgoing.custom_memo).to be_nil
+    expect(cpt_outgoing.date).to eq(Date.today)
+    expect(cpt_outgoing.fronted).to eq(false)
+    expect(cpt_outgoing.hcb_code).to eq("HCB-500-#{disbursement.id}")
+    expect(cpt_outgoing.category).to be_nil
+
+    pending_incoming = disbursement.raw_pending_incoming_disbursement_transaction
+    expect(pending_incoming.amount_cents).to eq(123_45)
+    expect(pending_incoming.date_posted).to eq(Date.today)
+
+    cpt_incoming = pending_incoming.canonical_pending_transaction
+    expect(cpt_incoming.event).to eq(destination_event)
+    expect(cpt_incoming.amount_cents).to eq(123_45)
+    expect(cpt_incoming.memo).to eq("Incoming transfer")
+    expect(cpt_incoming.custom_memo).to be_nil
+    expect(cpt_incoming.date).to eq(Date.today)
+    expect(cpt_incoming.fronted).to eq(false)
+    expect(cpt_incoming.hcb_code).to eq("HCB-500-#{disbursement.id}")
+    expect(cpt_incoming.category).to be_nil
+  end
+
+  it "auto-approves when requested by an admin" do
+    requestor = create(:user, :make_admin)
+    source_event = create(:event, :with_positive_balance)
+    create(:organizer_position, event: source_event, user: requestor)
+
+    destination_event = create(:event)
+
+    disbursement = described_class.new(
+      name: "Boba Drops",
+      amount: "123.45",
+      requested_by_id: requestor.id,
+      source_event_id: source_event.id,
+      destination_event_id: destination_event.id,
+    ).run
+
+    expect(disbursement).to be_a(Disbursement)
+    expect(disbursement).to be_pending
+    expect(disbursement.fulfilled_by).to eq(requestor)
+  end
+
+  it "skips the incoming transaction when scheduled" do
+    freeze_time
+
+    requestor = create(:user)
+    source_event = create(:event, :with_positive_balance)
+    create(:organizer_position, event: source_event, user: requestor)
+
+    destination_event = create(:event)
+
+    disbursement = described_class.new(
+      name: "Boba Drops",
+      amount: "123.45",
+      requested_by_id: requestor.id,
+      source_event_id: source_event.id,
+      destination_event_id: destination_event.id,
+      scheduled_on: Date.today + 7
+    ).run
+
+    expect(disbursement).to be_a(Disbursement)
+    expect(disbursement.scheduled_on).to eq(Date.today + 7)
+
+    expect(
+      disbursement
+        .raw_pending_outgoing_disbursement_transaction
+        .canonical_pending_transaction
+    ).to be_present
+
+    expect(disbursement.raw_pending_incoming_disbursement_transaction).to be_nil
+  end
+
+  it "applies transaction categories when provided" do
+    requestor = create(:user)
+    source_event = create(:event, :with_positive_balance)
+    create(:organizer_position, event: source_event, user: requestor)
+
+    destination_event = create(:event)
+
+    disbursement = described_class.new(
+      name: "Boba Drops",
+      amount: "123.45",
+      requested_by_id: requestor.id,
+      source_event_id: source_event.id,
+      destination_event_id: destination_event.id,
+      source_transaction_category_slug: "donations",
+      destination_transaction_category_slug: "fundraising",
+    ).run
+
+    expect(disbursement).to be_a(Disbursement)
+    expect(disbursement.source_transaction_category.slug).to eq("donations")
+    expect(disbursement.destination_transaction_category.slug).to eq("fundraising")
+  end
+
+end

--- a/spec/services/disbursement_service/create_spec.rb
+++ b/spec/services/disbursement_service/create_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe DisbursementService::Create do
     expect(disbursement).to be_a(Disbursement)
     expect(disbursement.source_transaction_category.slug).to eq("donations")
     expect(disbursement.destination_transaction_category.slug).to eq("fundraising")
+
+    expect(
+      disbursement
+        .raw_pending_outgoing_disbursement_transaction
+        .canonical_pending_transaction
+        .category
+        .slug
+    ).to eq("donations")
+
+    expect(
+      disbursement
+        .raw_pending_incoming_disbursement_transaction
+        .canonical_pending_transaction
+        .category
+        .slug
+    ).to eq("fundraising")
   end
 
 end

--- a/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/incoming_disbursement_spec.rb
+++ b/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/incoming_disbursement_spec.rb
@@ -120,7 +120,12 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
     end
 
     context "when processed" do
-      let(:disbursement) { create(:disbursement) }
+      let(:disbursement) do
+        create(
+          :disbursement,
+          destination_transaction_category: TransactionCategory.find_or_create_by!(slug: "donations")
+        )
+      end
 
       it "copies the attributes over to the pending canonical transaction" do
         expect do
@@ -130,6 +135,7 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
         canonical_pending_transaction = CanonicalPendingTransaction.last
         expect(canonical_pending_transaction.date).to eq(raw_pending_incoming_disbursement_transaction.date_posted)
         expect(canonical_pending_transaction.memo).to eq(raw_pending_incoming_disbursement_transaction.memo)
+        expect(canonical_pending_transaction.category.slug).to eq("donations")
       end
     end
   end

--- a/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement_spec.rb
+++ b/spec/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement_spec.rb
@@ -82,7 +82,12 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
     end
 
     context "when processed" do
-      let(:disbursement) { create(:disbursement) }
+      let(:disbursement) do
+        create(
+          :disbursement,
+          source_transaction_category: TransactionCategory.find_or_create_by!(slug: "fundraising")
+        )
+      end
 
       it "copies the attributes over to the pending canonical transaction" do
         expect do
@@ -92,6 +97,7 @@ describe PendingTransactionEngine::CanonicalPendingTransactionService::ImportSin
         canonical_pending_transaction = CanonicalPendingTransaction.last
         expect(canonical_pending_transaction.date).to eq(raw_pending_outgoing_disbursement_transaction.date_posted)
         expect(canonical_pending_transaction.memo).to eq(raw_pending_outgoing_disbursement_transaction.memo)
+        expect(canonical_pending_transaction.category.slug).to eq("fundraising")
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem

We want to be able to tag the two transactions associated with a disbursement when the disbursement is created (by admins or via the API) or reviewed.

## Describe your changes

1. Adds `source_transaction_category_id` and `destination_transaction_category_id` columns to the `disbursements` table
2. Adds fields for (1) on the new disbursement form that are visible to admins
    <img width="213" height="140" alt="CleanShot 2025-09-29 at 15 46 23" src="https://github.com/user-attachments/assets/f68634ac-3806-4ec2-a1b8-ead0fc26c177" />
3. Updates `PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::IncomingDisbursement` and `PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::OutgoingDisbursement` to apply (1) to the canonical pending transactions they are responsible for creating
    - This has the benefit of handling both immediate and scheduled disbursements as in the latter case we end up calling `...::OutgoingDisbursement` to process them https://github.com/hackclub/hcb/blob/9d308531227888e63cb5afe4ffbe405bc6b1b225/app/jobs/disbursement/daily_job.rb#L13-L14
4. Adds a link to the HCB code page (as it's a convenient place to edit transaction categories)
    1. On the disbursement page
        <img width="307" height="352" alt="CleanShot 2025-09-29 at 15 52 07" src="https://github.com/user-attachments/assets/1a141a99-cc83-4da3-80f0-231be0e3a25c" />
    2. On the disbursement processing page
        <img width="275" height="224" alt="CleanShot 2025-09-29 at 15 54 28" src="https://github.com/user-attachments/assets/d7296ed5-cc87-42eb-8b6e-29b51c0a00b1" />
5. Updates the disbursement processing page to show related transactions so their categories can be updated (using the same table as the HCB code page)
    Immediate | Scheduled
    ---- | ----
    <img width="1219" height="753" alt="CleanShot 2025-09-29 at 15 57 57" src="https://github.com/user-attachments/assets/b2595f00-33f9-49e0-b06a-c5dbfc1351e7" /> | <img width="1216" height="760" alt="CleanShot 2025-09-29 at 15 58 14" src="https://github.com/user-attachments/assets/93728e20-c6eb-489d-b010-6f7ebf44717d" />
6. Updates the admin disbursements index to always link to the processing page (as it now has a use case beyond approving/rejecting)
    <img width="608" height="282" alt="CleanShot 2025-09-29 at 16 00 14" src="https://github.com/user-attachments/assets/d30a8c93-3b26-490c-bcab-501a2eb819a8" />
