### PR TITLE
Use the correct currency in the expenses email

### DIFF
--- a/app/views/reimbursement_mailer/expenses_approved.html.erb
+++ b/app/views/reimbursement_mailer/expenses_approved.html.erb
@@ -8,7 +8,7 @@
 
 <ul>
   <% @expenses.each do |expense| %>
-    <li><em><%= expense.memo %></em> for <%= render_money(expense.amount_cents, unit: expense.currency.to_currency.symbol) %></li>
+    <li><em><%= expense.memo %></em> for <%= expense.amount.format(with_currency: true) %></li>
   <% end %>
 </ul>
 

--- a/app/views/reimbursement_mailer/expenses_approved.html.erb
+++ b/app/views/reimbursement_mailer/expenses_approved.html.erb
@@ -8,7 +8,7 @@
 
 <ul>
   <% @expenses.each do |expense| %>
-    <li><em><%= expense.memo %></em> for <%= render_money expense.amount_cents %></li>
+    <li><em><%= expense.memo %></em> for <%= render_money(expense.amount_cents, unit: expense.currency.to_currency.symbol) %></li>
   <% end %>
 </ul>
 

--- a/spec/mailers/reimbursement_mailer_spec.rb
+++ b/spec/mailers/reimbursement_mailer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReimbursementMailer do
+  describe "#expenses_approved" do
+    it "renders the list of expenses in their original currency" do
+      user = create(
+        :user,
+        full_name: "Test User",
+        email: "user@example.com",
+        payout_method: User::PayoutMethod::WiseTransfer.new(
+          address_line1: "123 Rue Main",
+          address_city: "Shawinigan",
+          address_state: "QC",
+          recipient_country: "CA",
+          address_postal_code: "G0X1L0",
+          currency: "CAD",
+        )
+      )
+      event = create(:event, name: "Daydream")
+
+      report = Reimbursement::Report.create!(
+        name: "Food & drinks for event",
+        user:,
+        event:,
+        currency: "CAD",
+      )
+
+      drinks = report.expenses.create!(value: 12.34, memo: "Drinks")
+      ReceiptService::Create.new(
+        receiptable: drinks,
+        uploader: user,
+        attachments: [file_fixture("receipt.png")],
+        upload_method: :receipts_page
+      ).run!
+
+      food = report.expenses.create!(value: 34.56, memo: "Food")
+      ReceiptService::Create.new(
+        receiptable: food,
+        uploader: user,
+        attachments: [file_fixture("receipt.png")],
+        upload_method: :receipts_page
+      ).run!
+
+      report.mark_submitted!
+
+      mail = described_class.with(report:, expenses: report.expenses).expenses_approved
+
+      expect { mail.deliver_now }.to send_email(
+        from: "hcb@staging.hcb.hackclub.com",
+        to: "user@example.com",
+        subject: "[Reimbursements] Expenses approved for Food & drinks for event"
+      )
+
+      body = Nokogiri::HTML5.parse(mail.html_part.body.to_s)
+
+      expect(body.css("ul li").map { |el| el.text.squish }).to eq(
+        ["Drinks for $12.34 CAD", "Food for $34.56 CAD"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
The expenses aproved email always uses USD regardless of the currency the report is set to.

<img width="870" height="600" alt="image" src="https://github.com/user-attachments/assets/26ec46c7-009d-43a5-b309-68c413329049" />
(should be EUR, not USD)

## Describe your changes
Added the unit parameter to the `render_money` call (taken from the expense's currency)

(im _pretty_ sure this works but i have no clue how i would even test this :sob: )

