### PR TITLE
[User Payout] Move presence validation from frontend to backend

### DIFF
--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -8,7 +8,7 @@ module HasWiseRecipient
     has_country_enum(field: :recipient_country)
 
     validate do
-      if POSTAL_CODE_FORMATS[recipient_country.to_sym] && !address_postal_code.match(POSTAL_CODE_FORMATS[recipient_country.to_sym])
+      if POSTAL_CODE_FORMATS[recipient_country&.to_sym] && !address_postal_code.match(POSTAL_CODE_FORMATS[recipient_country.to_sym])
         errors.add(:address_postal_code, "does not meet the required format for this country")
       end
     end

--- a/app/models/user/payout_method/wise_transfer.rb
+++ b/app/models/user/payout_method/wise_transfer.rb
@@ -27,6 +27,8 @@ class User
 
       include HasWiseRecipient
 
+      validates_presence_of :address_line1, :address_city, :address_state, :address_postal_code, :recipient_country, :currency
+
       def kind
         "wise_transfer"
       end

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -99,7 +99,7 @@
 
         <div class="field">
           <%= form.label :currency, "Currency" %>
-          <%= form.select :currency, WiseTransfer::AVAILABLE_CURRENCIES, { required: true, disabled: true }, { "@change" => "currency = $event.target.value;" } %>
+          <%= form.select :currency, WiseTransfer::AVAILABLE_CURRENCIES, { disabled: true }, { "@change" => "currency = $event.target.value;" } %>
         </div>
 
         <%= form.hidden_field :wise_recipient_id, value: "" %>

--- a/app/views/wise_transfers/_recipient_details.html.erb
+++ b/app/views/wise_transfers/_recipient_details.html.erb
@@ -2,7 +2,7 @@
 
 <div class="field mb1">
   <%= form.label :address_line1, "Street address" %>
-  <%= form.text_field :address_line1, placeholder: "Phase II, Udyog Vihar", required: true %>
+  <%= form.text_field :address_line1, placeholder: "Phase II, Udyog Vihar" %>
 </div>
 
 <div class="field mt0">
@@ -12,20 +12,20 @@
 <div class="flex">
   <div class="field flex-auto mr1">
     <%= form.label :address_city, "City" %>
-    <%= form.text_field :address_city, placeholder: "Gurgaon", required: true %>
+    <%= form.text_field :address_city, placeholder: "Gurgaon" %>
   </div>
   <div class="field flex-auto mr1">
     <%= form.label :address_state, "State / province" %>
-    <%= form.text_field :address_state, placeholder: "Haryana", required: true %>
+    <%= form.text_field :address_state, placeholder: "Haryana" %>
   </div>
 </div>
 
 <div class="field">
   <%= form.label :address_postal_code, "Postal code / ZIP code" %>
-  <%= form.text_field :address_postal_code, placeholder: "122022", required: true %>
+  <%= form.text_field :address_postal_code, placeholder: "122022" %>
 </div>
 
 <div class="field">
   <%= form.label :recipient_country, "Country" %>
-  <%= form.collection_select :recipient_country, Event.countries_for_select.excluding([["US", "United States"]]), :first, :last, { include_blank: "Select a country", required: true }, { "@change": "country = $event.target.value" } %>
+  <%= form.collection_select :recipient_country, Event.countries_for_select.excluding([["US", "United States"]]), :first, :last, { include_blank: "Select a country" }, { "@change": "country = $event.target.value" } %>
 </div>


### PR DESCRIPTION
Hot fix to get the form working again

## Summary of the problem

<img width="535" height="812" alt="image" src="https://github.com/user-attachments/assets/67c3fe84-556a-484a-a08d-9109a241f080" />

The issue is that the Wise transfer form has required field which are irrlevant when you aren't using wise for your payout. This causes the form to be unsubmittable since JS tried to validate that the required fields are filled.


## Describe your changes


Move presence validation from frontend to backend

