### PR TITLE
Default to `financially_frozen` and remove that freeze after a contract is signed

### DIFF
--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -34,12 +34,6 @@ class DocusealController < ActionController::Base
         document.save!
         contract.update(document:)
         contract.mark_signed!
-
-        # Unfreeze the event if this is the first signed contract
-        event = contract.organizer_position_invite.event
-        if event.organizer_position_contracts.signed.count == 1
-          event.update!(financially_frozen: false)
-        end
       elsif params[:event_type] == "form.declined"
         contract.mark_voided!
       elsif cosigner.present? && cosigner["status"] != "completed"

--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -34,6 +34,12 @@ class DocusealController < ActionController::Base
         document.save!
         contract.update(document:)
         contract.mark_signed!
+
+        # Unfreeze the event if this is the first signed contract
+        event = contract.organizer_position_invite.event
+        if event.organizer_position_contracts.signed.count == 1
+          event.update!(financially_frozen: false)
+        end
       elsif params[:event_type] == "form.declined"
         contract.mark_voided!
       elsif cosigner.present? && cosigner["status"] != "completed"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -407,7 +407,7 @@ class Event < ApplicationRecord
   attr_accessor :demo_mode_limit_email
 
   validate :demo_mode_limit, if: proc{ |e| e.demo_mode_limit_email }
-  validate :contract_signed, unless: :demo_mode?
+  validate :contract_signed, unless: -> { demo_mode? || financially_frozen? }
 
   validates :name, presence: true
   before_validation { self.name = name.gsub(/\s/, " ").strip unless name.nil? }

--- a/app/models/organizer_position/contract.rb
+++ b/app/models/organizer_position/contract.rb
@@ -71,6 +71,11 @@ class OrganizerPosition
         transitions from: [:pending, :sent], to: :signed
         after do
           organizer_position_invite.deliver
+          # Unfreeze the event if this is the first signed contract
+          event = organizer_position_invite.event
+          if event.organizer_position_contracts.signed.count == 1
+            event.update!(financially_frozen: false)
+          end
         end
       end
 

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -79,6 +79,7 @@ module EventService
         can_front_balance: @can_front_balance,
         point_of_contact_id: @point_of_contact_id,
         demo_mode: @demo_mode,
+        financially_frozen: true,
         parent: @parent_event,
         plan: Event::Plan.new(type: @plan)
       }.tap do |hash|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -156,6 +156,14 @@
             <p class="font-bold text-xl m0"><%= @event.name %> has been terminated, thanks for working with HCB!</p>
           </div>
         </div>
+      <% elsif @event.organizer_position_contracts.any? && @event.organizer_position_contracts.signed.none? %>
+        <div class="w-full dev-banner dev-banner--info rounded-b no-underline">
+          <div class="flex flex-col md:flex-row gap-y-2 gap-x-6 py-6 items-center justify-center">
+            <p class="font-bold text-xl m0">
+              <%= @event.name %> is currently inactive on HCB; to activate the organization, a fiscal sponsorship contract must be signed.
+            </p>
+          </div>
+        </div>
       <% else %>
         <div class="w-full dev-banner no-underline">
           <div class="flex flex-col md:flex-row gap-y-2 gap-x-6 py-6 items-center justify-center">


### PR DESCRIPTION
Closes https://github.com/hackclub/hcb/issues/11760, see Slack thread for context behind decision: https://hackclub.slack.com/archives/C026RKHLPNJ/p1758917526179979.

This is a common frustration:

<img width="783" height="377" alt="image (44)" src="https://github.com/user-attachments/assets/83bf29ec-a159-48b8-8d90-6ca0cb5806e7" />

And an equally pressing issue is how an event can spend money without a contract?

Visual change:

<img width="1203" height="105" alt="Screenshot 2025-10-01 at 11 00 33 PM" src="https://github.com/user-attachments/assets/7f2e2190-ddb8-40f6-bb23-bad7c48ad6fc" />
