### PR TITLE
[Wise transfer] Temporarily disable for maintenance

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -336,7 +336,7 @@ class UsersController < ApplicationController
       end
 
       if @user.payout_method&.errors&.any?
-        flash.now[:error] = @user.payout_method.errors.first.full_message
+        flash.now[:error] = @user.payout_method.errors.full_messages.to_sentence
         render :edit_payout, status: :unprocessable_entity
         return
       end

--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -18,6 +18,12 @@ class WiseTransfersController < ApplicationController
 
     authorize @wise_transfer
 
+    # WISE TRANSFERS ARE DISABLED RIGHT NOW
+    flash[:error] = "Wise Transfers are currently under maintenance. Please choose another transfer method."
+    return redirect_to event_transfers_path(@event)
+
+    # rubocop:disable Lint/UnreachableCode
+
     if @wise_transfer.amount_cents > 500_00
       return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
     end
@@ -35,6 +41,8 @@ class WiseTransfersController < ApplicationController
     else
       render "new", status: :unprocessable_entity
     end
+
+    #rubocop:enable Lint/UnreachableCode
   end
 
   def approve

--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -42,7 +42,7 @@ class WiseTransfersController < ApplicationController
       render "new", status: :unprocessable_entity
     end
 
-    #rubocop:enable Lint/UnreachableCode
+    # rubocop:enable Lint/UnreachableCode
   end
 
   def approve

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -109,8 +109,8 @@ module Reimbursement
         transitions from: [:draft, :reimbursement_requested], to: :submitted do
           guard do
             user.payout_method.present? && event && !exceeds_maximum_amount? && !below_minimum_amount? &&
-              expenses.any? && !missing_receipts? && user.payout_method.class != User::PayoutMethod::PaypalTransfer &&
-              !event.financially_frozen? && expenses.none? { |e| e.amount.zero? } && !mismatched_currency?
+              expenses.any? && !missing_receipts? && !event.financially_frozen? && expenses.none? { |e| e.amount.zero? } &&
+              !mismatched_currency? && payout_method_allowed?
           end
         end
         after do
@@ -374,6 +374,10 @@ module Reimbursement
       )
 
       mark_reimbursed!
+    end
+
+    def payout_method_allowed?
+      user.payout_method.present? && !user.payout_method.unsupported?
     end
 
   end

--- a/app/models/user/payout_method.rb
+++ b/app/models/user/payout_method.rb
@@ -2,6 +2,18 @@
 
 class User
   module PayoutMethod
+
+    UNSUPPORTED_METHODS = {
+      User::PayoutMethod::PaypalTransfer => {
+        status_badge: "Unavailable",
+        reason: "Due to integration issues, transfers via PayPal are currently unavailable."
+      },
+      User::PayoutMethod::WiseTransfer   => {
+        status_badge: "Temporarily Unavailable",
+        reason: "Wise Transfers are currently under maintenance."
+      }
+    }.freeze
+
     def kind
       "unknown"
     end

--- a/app/models/user/payout_method.rb
+++ b/app/models/user/payout_method.rb
@@ -2,7 +2,13 @@
 
 class User
   module PayoutMethod
-
+    ALL_METHODS = [
+      User::PayoutMethod::AchTransfer,
+      User::PayoutMethod::Check,
+      User::PayoutMethod::PaypalTransfer,
+      User::PayoutMethod::Wire,
+      User::PayoutMethod::WiseTransfer,
+    ].freeze
     UNSUPPORTED_METHODS = {
       User::PayoutMethod::PaypalTransfer => {
         status_badge: "Unavailable",
@@ -13,6 +19,7 @@ class User
         reason: "Wise Transfers are currently under maintenance."
       }
     }.freeze
+    SUPPORTED_METHODS = ALL_METHODS - UNSUPPORTED_METHODS.keys
 
     def kind
       "unknown"

--- a/app/models/user/payout_method/paypal_transfer.rb
+++ b/app/models/user/payout_method/paypal_transfer.rb
@@ -19,10 +19,6 @@ class User
       validates_presence_of :recipient_email
       normalizes :recipient_email, with: ->(recipient_email) { recipient_email.strip.downcase }
 
-      validate do
-        errors.add(:base, "Due to integration issues, transfers via PayPal are currently unavailable. Please choose another payout method.")
-      end
-
       def kind
         "paypal_transfer"
       end

--- a/app/models/user/payout_method/shared.rb
+++ b/app/models/user/payout_method/shared.rb
@@ -21,12 +21,13 @@ class User
         }
 
         validate do
-          if User::PayoutMethod::DISABLED_METHODS.include?(self.class)
-            errors.add(:base, "#{title_kind} is currently unavailable. Please choose another method.")
+          if User::PayoutMethod::UNSUPPORTED_METHODS.include?(self.class)
+            errors.add(:base, "#{self.unsupported_details[:reason]} Please choose another method.")
           end
         end
 
         delegate :unsupported?, to: :class
+        delegate :unsupported_details, to: :class
       end
 
       class_methods do

--- a/app/models/user/payout_method/shared.rb
+++ b/app/models/user/payout_method/shared.rb
@@ -32,7 +32,7 @@ class User
 
       class_methods do
         def unsupported?
-          self.in?(User::PayoutMethod::UNSUPPORTED_METHODS.keys)
+          User::PayoutMethod::UNSUPPORTED_METHODS.key?(self)
         end
 
         def unsupported_details

--- a/app/models/user/payout_method/shared.rb
+++ b/app/models/user/payout_method/shared.rb
@@ -19,6 +19,24 @@ class User
           Reimbursement::PayoutHolding.where(report: user.reimbursement_reports).failed.each(&:mark_settled!)
           Employee::Payment.where(employee: user.jobs).failed.each(&:mark_approved!)
         }
+
+        validate do
+          if User::PayoutMethod::DISABLED_METHODS.include?(self.class)
+            errors.add(:base, "#{title_kind} is currently unavailable. Please choose another method.")
+          end
+        end
+
+        delegate :unsupported?, to: :class
+      end
+
+      class_methods do
+        def unsupported?
+          self.in?(User::PayoutMethod::UNSUPPORTED_METHODS.keys)
+        end
+
+        def unsupported_details
+          User::PayoutMethod::UNSUPPORTED_METHODS[self]
+        end
       end
     end
   end

--- a/app/models/user/payout_method/wire.rb
+++ b/app/models/user/payout_method/wire.rb
@@ -22,8 +22,9 @@
 class User
   module PayoutMethod
     class Wire < ApplicationRecord
+      include Shared
+
       self.table_name = "user_payout_method_wires"
-      has_one :user, inverse_of: :payout_method, as: :payout_method
       after_save_commit -> { Reimbursement::PayoutHolding.where(report: user.reimbursement_reports).failed.each(&:mark_settled!) }
       has_encrypted :account_number, :bic_code
       blind_index :account_number, :bic_code

--- a/app/models/user/payout_method/wise_transfer.rb
+++ b/app/models/user/payout_method/wise_transfer.rb
@@ -21,8 +21,9 @@
 class User
   module PayoutMethod
     class WiseTransfer < ApplicationRecord
+      include Shared
+
       self.table_name = "user_payout_method_wise_transfers"
-      has_one :user, inverse_of: :payout_method, as: :payout_method
       has_encrypted :recipient_information, type: :json
 
       include HasWiseRecipient

--- a/app/views/events/_transfer_form.html.erb
+++ b/app/views/events/_transfer_form.html.erb
@@ -19,10 +19,11 @@
             <small>United States</small>
           <% end %>
           <% if Flipper.enabled?(:wise_transfers_2025_07_31, current_user) %>
-            <%= link_to new_event_wise_transfer_path(@event), class: "text-decoration-none btn--form-option", data: { turbo_frame: "_top" } do %>
+            <%= link_to new_event_wise_transfer_path(@event), class: "text-decoration-none btn--form-option opacity-75 pointer-events-none", data: { turbo_frame: "_top" }, disabled: true do %>
               <%= inline_icon "wise", size: 28 %>
               <strong>Wise transfer</strong>
-              <small>International</small>
+              <div class="badge bg-warning m1 mt0" style="width: fit-content;">Temporarily Unavailable</div>
+              <small>Wise Transfers are currently under maintenance.</small>
             <% end %>
           <% end %>
           <%= link_to new_event_wire_path(@event), class: "text-decoration-none btn--form-option relative overflow-hidden", data: { turbo_frame: "_top" } do %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -86,7 +86,7 @@
       <% end %>
 
       <div style="flex-grow: 1;" class="flex justify-end">
-        <% if !user.payout_method.present? || report.payout_holding&.failed? || (user.payout_method.present? && user.payout_method.class == User::PayoutMethod::PaypalTransfer) || report.mismatched_currency? %>
+        <% if !user.payout_method.present? || report.payout_holding&.failed? || (user.payout_method.present? && user.payout_method.unsupported?) || report.mismatched_currency? %>
           <% if user == current_user %>
             <%= link_to settings_payouts_path, class: "btn bg-warning", data: { behavior: "modal_trigger", modal: "edit_payout" } do %>
               <%= inline_icon "profile" %>
@@ -96,8 +96,8 @@
                   <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.payout_method.currency %>.
                 <% else %>
                   <span class="bold">Your next step:</span> before you can be reimbursed, you need to
-                  <% if user.payout_method.present? && user.payout_method.class == User::PayoutMethod::PaypalTransfer %>
-                    update your payout information. Due to integration issues, transfers via PayPal are currently unavailable.
+                  <% if user.payout_method.present? && user.payout_method.unsupported? %>
+                    update your payout information. <%= user.payout_method.unsupported_details[:reason] %>
                   <% else %>
                     provide HCB your payout information.
                   <% end %>
@@ -120,8 +120,8 @@
               <%= report.payout_holding&.failed? ? "Edit" : "Add" %> <%= user.first_name %>'s Payout Information
               <% button_hint = capture do %>
                 <span class="bold">Status:</span> before <%= user.first_name %> can be reimbursed, they need to
-                <% if user.payout_method.present? && user.payout_method.class == User::PayoutMethod::PaypalTransfer %>
-                  update your payout information. Due to integration issues, transfers via PayPal are currently unavailable.
+                <% if user.payout_method.present? && user.payout_method.unsupported? %>
+                  update your payout information. <%= user.payout_method.unsupported_details[:reason] %>
                 <% else %>
                   add their payout information.
                 <% end %>

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -4,32 +4,16 @@
   <fieldset>
     <legend class="heading h3 pb2 bold">How would you like to be reimbursed?</legend>
     <div class="field field--options" style="max-width: none;">
-      <%= form.radio_button :payout_method_type, "User::PayoutMethod::AchTransfer" %>
-      <%= form.label :payout_method_type, value: "User::PayoutMethod::AchTransfer" do %>
-        <%= inline_icon "payment-transfer", size: 28 %>
-        <strong>ACH transfer</strong>
-        <small>(1-3 biz. days)</small>
-      <% end %>
-      <%= form.radio_button :payout_method_type, "User::PayoutMethod::Check" %>
-      <%= form.label :payout_method_type, value: "User::PayoutMethod::Check" do %>
-        <%= inline_icon "email", size: 28 %>
-        <strong>Mailed check</strong>
-        <small>(10-12 biz. days)</small>
-      <% end %>
-      <%= form.radio_button :payout_method_type, "User::PayoutMethod::Wire" %>
-      <%= form.label :payout_method_type, value: "User::PayoutMethod::Wire" do %>
-        <%= inline_icon "web", size: 28 %>
-        <strong>International wire</strong>
+      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::AchTransfer, title: "ACH transfer", description: "(1-3 biz. days)", icon: "payment-transfer" %>
+
+      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::Check, title: "Mailed check", description: "(10-12 biz. days)", icon: "email" %>
+
+      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::Wire, title: "International wire", description: "(1-5 biz. days)", icon: "web" do %>
         <div class="badge badge--corner bg-info m1 mt0" style="width: fit-content;">$500 minimum</div>
-        <small>(1-5 biz. days)</small>
       <% end %>
+
       <% if Flipper.enabled?(:wise_reimbursements_2025_08_25, user) %>
-        <%= form.radio_button :payout_method_type, "User::PayoutMethod::WiseTransfer" %>
-        <%= form.label :payout_method_type, value: "User::PayoutMethod::WiseTransfer" do %>
-          <%= inline_icon "wise", size: 28 %>
-          <strong>Wise transfer</strong>
-          <small>(1-3 biz. days)</small>
-        <% end %>
+        <%= render "users/payout_form/option", form:, model: User::PayoutMethod::WiseTransfer, title: "Wise transfer", description: "(1-3 biz. days)", icon: "wise" %>
       <% end %>
     </div>
   </fieldset>

--- a/app/views/users/payout_form/_option.html.erb
+++ b/app/views/users/payout_form/_option.html.erb
@@ -8,7 +8,7 @@
   <%= yield %><%# in case you wanna add more flare to a specific option %>
 
   <% if model.unsupported? %>
-    <div class="badge bg-warning m1 mt0" style="width: fit-content;"><%= model.unsupported_details[:status_badge] %></div>
+    <div class="badge bg-warning m1 mt0 w-fit"><%= model.unsupported_details[:status_badge] %></div>
     <small><%= model.unsupported_details[:reason] %></small>
   <% else %>
     <small><%= description %></small>

--- a/app/views/users/payout_form/_option.html.erb
+++ b/app/views/users/payout_form/_option.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (form:, model:, title:, description:, icon:) %>
+
+<%= form.radio_button :payout_method_type, model.name, disabled: model.unsupported? %>
+<%= form.label :payout_method_type, value: model.name do %>
+  <%= inline_icon icon, size: 28 %>
+  <strong><%= title %></strong>
+
+  <%= yield %><%# in case you wanna add more flare to a specific option %>
+
+  <% if model.unsupported? %>
+    <div class="badge bg-warning m1 mt0" style="width: fit-content;"><%= model.unsupported_details[:status_badge] %></div>
+    <small><%= model.unsupported_details[:reason] %></small>
+  <% else %>
+    <small><%= description %></small>
+  <% end %>
+<% end %>

--- a/app/views/wise_transfers/new.html.erb
+++ b/app/views/wise_transfers/new.html.erb
@@ -1,4 +1,4 @@
-<% disabled = !policy(@event).create_transfer? %>
+<% disabled = !policy(@event).create_transfer? || true %>
 
 <% title "Send a Wise transfer" %>
 <%= render "events/nav", selected: :transfers %>
@@ -9,6 +9,10 @@
 <% end %>
 
 <h1>Send a Wise transfer</h1>
+
+<%= render "callout", type: "warning", icon: "wise", title: "Wise Transfers are currently under maintenance." do %>
+  Please choose another transfer method.
+<% end %>
 
 <%= render "callout",
     type: "info",

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -116,12 +116,13 @@ RSpec.describe UsersController do
     end
 
     it "does not allow saving an unsupported payout method" do
+      reason = "Due to integration issues, transfers via PayPal are currently unavailable in tests."
       stub_const(
         "User::PayoutMethod::UNSUPPORTED_METHODS",
         {
           User::PayoutMethod::PaypalTransfer => {
             status_badge: "Unavailable",
-            reason: "Due to integration issues, transfers via PayPal are currently unavailable."
+            reason:
           },
         }
       )
@@ -143,7 +144,7 @@ RSpec.describe UsersController do
       )
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("Payout method is invalid. Due to integration issues, transfers via PayPal are currently unavailable. Please choose another option.")
+      expect(flash.to_h).to eq("error" => "#{reason} Please choose another method.")
       expect(user.reload.payout_method_type).to eq(nil)
     end
   end

--- a/spec/mailers/reimbursement_mailer_spec.rb
+++ b/spec/mailers/reimbursement_mailer_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.describe ReimbursementMailer do
   describe "#expenses_approved" do
     it "renders the list of expenses in their original currency" do
+      # This is temporarily required while we work to re-enable Wise transfers
+      # (which are the only payout method that supports multiple currencies)
+      stub_const("User::PayoutMethod::SUPPORTED_METHODS", [User::PayoutMethod::WiseTransfer])
+      stub_const("User::PayoutMethod::UNSUPPORTED_METHODS", {})
+
       user = create(
         :user,
         full_name: "Test User",


### PR DESCRIPTION
## Summary of the problem

At the moment, operations is overwhelmed with the number of Wise transfers, and there are a few serious bugs that are making it even harder for them. We've [decided to temporarily disable Wise transfers](https://hackclub.slack.com/archives/C026RKHLPNJ/p1759263275754389?thread_ts=1759261355.207749&cid=C026RKHLPNJ) until we get these bugs fixed up.


This PR disables Wise transfers for both reimbursements (as a payout method) and also for event transfers.

## Describe your changes

I've decided to add more tooling around disabling payout methods. It's typically a pain to disable a payout method since there are so many locations you need to add checks and messaging. Now, you can simply update the `User::PayoutMethod::UNSUPPORTED_METHODS` constant to declaratively disable a payout method.

`User::PayoutMethod::UNSUPPORTED_METHODS` does not affect the transfer options that events have access to. The process for disabling that is still fairly manual, although it's [not as bad](https://github.com/hackclub/hcb/commit/275b46906a7587633081743084e4211002dde98e) as reimbursement payout methods.