### PR TITLE
[Admin][Referral] Make users unique

### DIFF
--- a/app/models/referral/program.rb
+++ b/app/models/referral/program.rb
@@ -31,6 +31,7 @@ module Referral
       attributions.joins(:user)
                   .where("EXTRACT(EPOCH FROM (referral_attributions.created_at - users.created_at)) < 60*60")
                   .map(&:user)
+                  .uniq
     end
 
   end


### PR DESCRIPTION
## Summary of the problem

On the admin referrals page, we have a stat that shows how many new users each referral is responsible for. We use this to see which of our initiatives are working and which ones need improvement. This isn't used for goal reporting purposes.

Anyways, I found that it joins attributions with users but didn't `uniq` the users. This is needed because a single user may have multiple attributions per referral program.

## Describe your changes


add 5 characters lol



