### PR TITLE
[Wise] Use `amount` for both reimbursement quote calculations

### DIFF
--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -341,7 +341,7 @@ module Reimbursement
     end
 
     def wise_transfer_quote_without_fees_amount
-      @wise_transfer_quote_without_fees_amount ||= WiseTransfer.generate_detailed_quote(draft? ? amount : amount_to_reimburse)[:without_fees_usd_amount]
+      @wise_transfer_quote_without_fees_amount ||= WiseTransfer.generate_detailed_quote(amount)[:without_fees_usd_amount]
     rescue
       Money.from_cents(0)
     end


### PR DESCRIPTION
## Summary of the problem
For transfers that have been submitted but have no approved expenses, the total cost of the transfer is being rendered as a Wise fee.

<img width="820" height="402" alt="image" src="https://github.com/user-attachments/assets/b86b6a04-0b5d-462a-a47b-8655daa60941" />

This is caused by a discrepancy in the amounts we feed into the Wise quote generator.

## Describe your changes

Fixes this discrepancy by always using `amount`.

<img width="825" height="406" alt="image" src="https://github.com/user-attachments/assets/a1c72776-bc3e-4b9c-a41d-b160f1d2b684" />
