### PR TITLE
[User] Only validate payout method on change

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -525,7 +525,7 @@ class User < ApplicationRecord
   end
 
   def valid_payout_method
-    if payout_method_type.present? && User::PayoutMethod::SUPPORTED_METHODS.none? { |method| payout_method.is_a?(method) }
+    if payout_method_type_changed? && payout_method_type.present? && User::PayoutMethod::SUPPORTED_METHODS.none? { |method| payout_method.is_a?(method) }
       # I'm using `try` here in the slim chance that `payout_method` is some
       # random model and doesn't include `User::PayoutMethod::Shared`.
       if payout_method.try(:unsupported?)


### PR DESCRIPTION
## Summary of the problem

When a job is trying to update the User, an invalid payout method type shouldn't block that from happening.

## Describe your changes

Moving forwarding, User will only validate the payout method if it's change. If you ever want to explicitly validate a user's payout method, then you can validate the `payout_method` association, and it'll provide similar checks/errors.
