### PR TITLE
Remove comment functionality from `TransactionsController#show_deprecated`

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -18,10 +18,6 @@ class TransactionsController < ApplicationController
       @transaction = Transaction.with_deleted.find(params[:id])
       @event = @transaction.event
 
-      @commentable = @transaction
-      @comments = @commentable.comments
-      @comment = Comment.new
-
       authorize @transaction
 
       render :show_deprecated

--- a/app/views/transactions/show_deprecated.html.erb
+++ b/app/views/transactions/show_deprecated.html.erb
@@ -117,5 +117,3 @@
   <% end %>
 
 </article>
-
-<%= render "comments/comments" %>


### PR DESCRIPTION
## Summary of the problem

`Transaction#comments` was removed in https://github.com/hackclub/hcb/commit/1d7e7a99e47dbc3911f69a6710d23a43901d4fce (https://github.com/hackclub/hcb/pull/8294) but this related code was not updated, which is causing these exceptions to crop up: https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/979

## Describe your changes

- Remove all comment-related instance variable initialization
- Remove the comments partial from the view