### PR TITLE
Fix error reporting in `SyncWithLoops#contact_details`

### DIFF
--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -69,7 +69,11 @@ module UserService
 
         JSON[resp.body][0]
       rescue => e
-        Rails.error.report(Exception.new("Received exception #{e.full_message} while attempting to get contact details for email #{@user.email} from Loops."), handled: false, severity: :error, context: "service")
+        Rails.error.unexpected(
+          "Received exception #{e.full_message} while attempting to get contact details for email #{@user.email} from Loops.",
+          handled: false,
+          severity: :error
+        )
         raise e
       end
     end


### PR DESCRIPTION
## Summary of the problem

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2264

We're passing a string for the `context` param of `Rails.error.report` (https://api.rubyonrails.org/v8.0.3/classes/ActiveSupport/ErrorReporter.html#method-i-report).

## Describe your changes

- Switch to `Rails.error.unexpected` so we don't need to construct an exception object here
- Remove the `context` argument altogether as it's not particularly helpful