### PR TITLE
Remove partial cent expenses

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -225,7 +225,7 @@ module Reimbursement
 
             conversion_rate = (wise_total_without_fees_cents / @report.amount_to_reimburse_cents).round(4)
             @report.update(conversion_rate:)
-            approved_amount_usd_cents = @report.expenses.approved.sum { |expense| expense.amount_cents * expense.conversion_rate }
+            approved_amount_usd_cents = Reimbursement::Report.find("RnSKLM").expenses.approved.sum { |expense| (expense.amount_cents * expense.conversion_rate).floor }
             fee_expense_value = (wise_total_including_fees_cents - approved_amount_usd_cents.to_f) / 100
 
             @report.expenses.create!(

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -225,7 +225,7 @@ module Reimbursement
 
             conversion_rate = (wise_total_without_fees_cents / @report.amount_to_reimburse_cents).round(4)
             @report.update(conversion_rate:)
-            approved_amount_usd_cents = Reimbursement::Report.find("RnSKLM").expenses.approved.sum { |expense| (expense.amount_cents * expense.conversion_rate).floor }
+            approved_amount_usd_cents = @report.expenses.approved.sum { |expense| (expense.amount_cents * expense.conversion_rate).floor }
             fee_expense_value = (wise_total_including_fees_cents - approved_amount_usd_cents.to_f) / 100
 
             @report.expenses.create!(

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -404,7 +404,7 @@ module Reimbursement
       expense_payouts = []
 
       expenses.approved.each do |expense|
-        expense_payouts << Reimbursement::ExpensePayout.create!(amount_cents: -expense.amount_cents * expense.conversion_rate, event: expense.report.event, expense:)
+        expense_payouts << Reimbursement::ExpensePayout.create!(amount_cents: (-expense.amount_cents * expense.conversion_rate).floor, event: expense.report.event, expense:)
       end
 
       return if expense_payouts.empty?


### PR DESCRIPTION
Cents should be whole numbers, never partial this code allowed for that. We will floor this and then pick up the reminder in the fee expense.