### PR TITLE
[Wise] Honor payout method account holder when converting to transfer

### DIFF
--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -353,6 +353,11 @@ module Reimbursement
     def convert_to_wise_transfer!(as: User.system_user)
       raise "Can only convert reports in 'Reimbursement Requested' state" unless reimbursement_requested?
 
+      account_holder =
+        if user.payout_method.respond_to?(:account_holder)
+          user.payout_method.account_holder.presence
+        end
+
       ActiveRecord::Base.transaction do
         wise_transfer = WiseTransfer.create!(
           user: as,
@@ -360,7 +365,7 @@ module Reimbursement
           amount:,
           currency:,
           payment_for: name,
-          recipient_name: user.full_name,
+          recipient_name: account_holder || user.full_name,
           recipient_email: user.email,
           address_city: user.payout_method.address_city,
           address_line1: user.payout_method.address_line1,


### PR DESCRIPTION
## Summary of the problem

https://hackclub.slack.com/archives/C026RKHLPNJ/p1759503377571179

When we are creating a `WiseTransfer` from a `ReimbursementReport` (see #11783), we are using `user.name` as the recipient when the user might have configured a different value in `User::PayoutMethod::WiseTransfer#account_holder`.

## Describe your changes

Check whether the payout method has a `account_holder` and use it instead of `user.name` if present.