### PR TITLE
Indicate whether CPTs are settled or declined

### DIFF
--- a/app/views/hcb_codes/_transactions_table.html.erb
+++ b/app/views/hcb_codes/_transactions_table.html.erb
@@ -21,6 +21,11 @@
         <td>
           <% if transaction.is_a?(CanonicalPendingTransaction) %>
             PENDING
+            <% if transaction.declined? %>
+              (declined)
+            <% elsif transaction.settled? %>
+              (settled)
+            <% end %>
           <% else %>
             SETTLED
           <% end %>


### PR DESCRIPTION
## Summary of the problem

When looking at a list of canonical pending transactions it can be useful to differentiate them based on whether they were cancelled or settled.

## Describe your changes

Add extra detail to the `TYPE` colum in the transaction table (rendered on the HCB code page and on disbursements)

<img width="751" height="300" alt="CleanShot 2025-10-03 at 14 27 26" src="https://github.com/user-attachments/assets/864f9396-63a4-4add-b349-be2250a093f3" />

<img width="361" height="153" alt="CleanShot 2025-10-03 at 14 29 05" src="https://github.com/user-attachments/assets/9bacafa2-69c4-4031-aa74-0f4d6506e5d0" />
