### PR TITLE
Handle card grant top-ups in `Disbursement::TransactionsHelper`

### DIFF
--- a/app/models/disbursement/transactions_helper.rb
+++ b/app/models/disbursement/transactions_helper.rb
@@ -7,39 +7,57 @@ class Disbursement
     end
 
     def settled_source
-      canonical_transactions_by_event.fetch(@disbursement.source_event, [])
+      grouped_canonical_transactions.fetch(source_key, [])
     end
 
     def settled_destination
-      canonical_transactions_by_event.fetch(@disbursement.destination_event, [])
+      grouped_canonical_transactions.fetch(destination_key, [])
     end
 
     def pending_source
-      canonical_pending_transactions_by_event.fetch(@disbursement.source_event, [])
+      grouped_canonical_pending_transactions.fetch(source_key, [])
     end
 
     def pending_destination
-      canonical_pending_transactions_by_event.fetch(@disbursement.destination_event, [])
+      grouped_canonical_pending_transactions.fetch(destination_key, [])
     end
 
     private
 
-    def canonical_transactions_by_event
-      @canonical_transactions_by_event ||=
+    def source_key
+      [@disbursement.source_event_id, @disbursement.source_subledger_id]
+    end
+
+    def destination_key
+      [@disbursement.event_id, @disbursement.destination_subledger_id]
+    end
+
+    def grouped_canonical_transactions
+      @grouped_canonical_transactions ||=
         @disbursement
         .canonical_transactions
         .strict_loading
-        .preload(:event)
-        .group_by(&:event)
+        .preload(:canonical_event_mapping)
+        .group_by do |ct|
+          [
+            ct.canonical_event_mapping.event_id,
+            ct.canonical_event_mapping.subledger_id
+          ]
+        end
     end
 
-    def canonical_pending_transactions_by_event
-      @canonical_pending_transactions_by_event ||=
+    def grouped_canonical_pending_transactions
+      @grouped_canonical_pending_transactions ||=
         @disbursement
         .canonical_pending_transactions
         .strict_loading
-        .preload(:event)
-        .group_by(&:event)
+        .preload(:canonical_pending_event_mapping)
+        .group_by do |cpt|
+          [
+            cpt.canonical_pending_event_mapping.event_id,
+            cpt.canonical_pending_event_mapping.subledger_id
+          ]
+        end
     end
 
   end

--- a/app/models/disbursement/transactions_helper.rb
+++ b/app/models/disbursement/transactions_helper.rb
@@ -36,7 +36,6 @@ class Disbursement
       @grouped_canonical_transactions ||=
         @disbursement
         .canonical_transactions
-        .strict_loading
         .preload(:canonical_event_mapping)
         .group_by do |ct|
           [
@@ -50,7 +49,6 @@ class Disbursement
       @grouped_canonical_pending_transactions ||=
         @disbursement
         .canonical_pending_transactions
-        .strict_loading
         .preload(:canonical_pending_event_mapping)
         .group_by do |cpt|
           [


### PR DESCRIPTION
## Summary of the problem

In #11757 I added a some logic to render the source and destination transactions for disbursements but failed to account for sub-ledgers, which meant card grant top-ups (where both the source and destination event are the same) were rendered in a very chaotic way.

## Describe your changes

- Instead of grouping transactions by `event`, use `[event_id, subledger_id]`
- Remove `.strict_loading` (see reasoning in the commit message)

**Before**

<img width="1435" height="402" alt="CleanShot 2025-10-03 at 15 17 33" src="https://github.com/user-attachments/assets/ff20a306-7980-4c21-8fdd-c5e61d4e17cd" />

**After**

<img width="1431" height="303" alt="CleanShot 2025-10-03 at 15 17 47" src="https://github.com/user-attachments/assets/63c93446-1dc2-4f23-8c13-24ff965abf73" />