### PR TITLE
[Wise] Require events to not be financially frozen for Wise transfer conversion

### DIFF
--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -39,7 +39,7 @@ module Reimbursement
     end
 
     def convert_to_wise_transfer?
-      admin
+      admin && !record.event.financially_frozen?
     end
 
     def request_changes?

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -242,6 +242,11 @@
               <% end %>
               <% turbo_confirm = "⚠️ WARNING: Approving this reimbursement will make the event balance negative. This organization does not have sufficient funds to fulfill this request. Are you sure you want to proceed?" %>
             <% end %>
+            <% if report.event.financially_frozen? %>
+              <% button_hint = capture do %>
+                <span class="bold warning">⚠️ Warning</span>: this organization is currently financially frozen.
+              <% end %>
+            <% end %>
             <% if report.user.payout_method.is_a?(User::PayoutMethod::WiseTransfer) %>
               <button class="btn bg-info" data-behavior="modal_trigger" data-modal="convert_to_wise_transfer" id="submit_button">
                 <%= inline_icon "wise" %>


### PR DESCRIPTION
## Summary of the problem

We're running into internal errors because try to process Wise transfer conversions even if an organization is financially frozen.

<img width="450" height="513" alt="image" src="https://github.com/user-attachments/assets/099d372d-5f85-4962-bbb4-2b84e8e7b0f1" />



## Describe your changes

This PR adds the financially frozen check to the reimbursement report policy and shows a warning to admins when an organization is financially frozen.

<img width="399" height="183" alt="image" src="https://github.com/user-attachments/assets/064df667-4eb8-4230-a903-3590ab8038e7" />
