### PR TITLE
Validate max ActiveStorage attachment sizes

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -30,6 +30,8 @@
 class CardGrant
   class PreAuthorization < ApplicationRecord
     has_many_attached :screenshots, dependent: :destroy
+    validates :screenshots, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["screenshots"].present? }
+
     belongs_to :card_grant
     has_one :event, through: :card_grant
     has_one :user, through: :card_grant

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -71,6 +71,8 @@ class CheckDeposit < ApplicationRecord
 
   has_one_attached :front
   has_one_attached :back
+  validates :front, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["front"].present? }
+  validates :back, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["back"].present? }
 
   validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }, presence: true
   validates :front, attached: true, content_type: [:png, :jpeg], on: :create

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -32,6 +32,7 @@ class Comment < ApplicationRecord
   belongs_to :user
 
   has_one_attached :file
+  validates :file, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["file"].present? }
 
   has_paper_trail skip: [:content] # ciphertext columns will still be tracked
   has_encrypted :content

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,6 +42,8 @@ class Document < ApplicationRecord
   belongs_to :archived_by, class_name: "User", optional: true
 
   has_one_attached :file
+  validates :file, size: { less_than_or_equal_to: 25.megabytes }, if: -> { attachment_changes["file"].present? }
+
   has_many :downloads, class_name: "DocumentDownload", dependent: :destroy
 
   validates_presence_of :user, :name

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -389,15 +389,19 @@ class Event < ApplicationRecord
 
   has_one_attached :donation_header_image
   validates :donation_header_image, content_type: [:png, :jpeg]
+  validates :donation_header_image, size: { less_than_or_equal_to: 8.megabytes }, if: -> { attachment_changes["donation_header_image"].present? }
 
   has_one_attached :background_image
   validates :background_image, content_type: [:png, :jpeg, :gif]
+  validates :background_image, size: { less_than_or_equal_to: 8.megabytes }, if: -> { attachment_changes["background_image"].present? }
 
   has_one_attached :logo
   validates :logo, content_type: [:png, :jpeg]
+  validates :logo, size: { less_than_or_equal_to: 5.megabytes }, if: -> { attachment_changes["logo"].present? }
 
   has_one_attached :stripe_card_logo
   validates :stripe_card_logo, content_type: [:png, :jpeg]
+  validates :stripe_card_logo, size: { less_than_or_equal_to: 5.megabytes }, if: -> { attachment_changes["stripe_card_logo"].present? }
 
   include HasMetrics
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -148,6 +148,7 @@ class Invoice < ApplicationRecord
 
   has_one :personal_transaction, class_name: "HcbCode::PersonalTransaction", required: false
   has_one_attached :manually_marked_as_paid_attachment
+  validates :manually_marked_as_paid_attachment, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["manually_marked_as_paid_attachment0"].present? }
 
   aasm timestamps: true do
     state :open_v2, initial: true

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -72,6 +72,7 @@ class Receipt < ApplicationRecord
   end
 
   validates :file, attached: true, content_type: /(\Aimage\/.*\z|application\/pdf|text\/csv)/
+  validates :file, size: { less_than_or_equal_to: 10.megabytes }, if: -> { attachment_changes["file"].present? }
 
   before_create do
     if receiptable&.has_attribute?(:marked_no_or_lost_receipt_at)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,6 +134,7 @@ class User < ApplicationRecord
   has_many :wise_transfers
 
   has_one_attached :profile_picture
+  validates :profile_picture, size: { less_than_or_equal_to: 5.megabytes }, if: -> { attachment_changes["profile_picture"].present? }
 
   has_many :w9s, class_name: "W9", as: :entity
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

We should validate attachment sizes. If we didn't, in the worst case, someone uploads a large file, making HCB super slow for themselves & potentially others (and also wastes a bit of storage $$). To date, the largest file uploaded is 115.7 MB, and the smallest file _(non-zero)_ is ~~0 mb~~ 4 mb.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

To help me determine a sane max file size value for each attachment, I created this query: https://hcb.hackclub.com/blazer/queries/982-active-storage-stats-on-blob-sizes

Here are the results.
<img width="1167" height="307" alt="image" src="https://github.com/user-attachments/assets/1b76c1bb-a33c-4899-8acb-7d68abb973fb" />
_^ with `max_megabytes` hidden_

<img width="1152" height="307" alt="image" src="https://github.com/user-attachments/assets/e7de6628-3974-435c-8dab-31ecfeb7a159" />

_^ with `max_megabytes` shown_


attachment | avg_megabytes | median_megabytes | p95_megabytes | p99_megabytes | min_megabytes | max_megabytes
-- | -- | -- | -- | -- | -- | --
CheckDeposit.front | 2.675399697687208 | 2.6520605087280273 | 4.879197597503661 | 7.864796590805043 | 0.0 | 17.9867525100708008
CheckDeposit.back | 2.3058075688548924 | 2.232445240020752 | 4.697220802307128 | 7.679335107803337 | 0.00400447845458984375 | 15.9151477813720703
Column::Statement.file | 0.69616937637329101563 | 0.6512012481689453 | 1.235794734954834 | 1.4744714069366451 | 0.00016117095947265625 | 1.5363607406616211
Document.file | 0.36232045350226648331 | 0.2686481475830078 | 0.5448728561401366 | 1.6825780868530273 | 0.00205516815185546875 | 88.1312685012817383
Event.donation_header_image | 1.6966616652881023 | 0.26828670501708984 | 6.674102306365954 | 27.29337882995593 | 0.0001373291015625 | 45.4092283248901367
Event.background_image | 1.1795369503544826 | 0.23984527587890625 | 4.633216381072996 | 14.195185127258322 | 0.0001277923583984375 | 43.0013322830200195
User.profile_picture | 1.0070530645138852 | 0.2179098129272461 | 4.01512050628662 | 9.659098072052013 | 0.0000667572021484375 | 100.3533554077148438
Receipt.file | 0.74269437552982748222 | 0.18230533599853516 | 3.3091844558715815 | 5.175960044860841 | 0.0 | 109.8804187774658203
CardGrant::PreAuthorization.screenshots | 0.30815443829593495464 | 0.1692509651184082 | 0.8872607707977294 | 2.192201852798459 | 0.00383663177490234375 | 5.4515542984008789
Comment.file | 0.81204669140872320461 | 0.16847705841064453 | 2.974888896942139 | 5.954672813415527 | 0.00023365020751953125 | 103.5666446685791016
ActiveStorage::VariantRecord.image | 0.14811906812247132492 | 0.11303234100341797 | 0.39185647964477527 | 1.0358097839355471 | 0.000072479248046875 | 3.9725875854492188
Invoice.manually_marked_as_paid_attachment | 0.28336939281887478256 | 0.11018848419189453 | 1.323369741439819 | 1.9498625659942626 | 0.0020580291748046875 | 2.1524801254272461
Event.logo | 0.29359507014733234406 | 0.0724024772644043 | 1.2162955760955798 | 3.561884450912484 | 0.00041103363037109375 | 12.852025032043457
ActiveStorage::Blob.preview_image | 0.11610697914802881908 | 0.06125068664550781 | 0.19637775421142578 | 1.372182846069336 | 0.00225067138671875 | 24.6629085540771484
ActionMailbox::InboundEmail.raw_email | 0.45127795919587340546 | 0.05834150314331055 | 3.0763245105743344 | 5.540304422378539 | 0.001796722412109375 | 11.214146614074707
Event.stripe_card_logo | 0.08666382451211252499 | 0.0452265739440918 | 0.32744970321655276 | 0.47657631874084494 | 0.0008373260498046875 | 1.3998908996582031
StripeCard::PersonalizationDesign.logo | 0.01889681084338126183 | 0.013802528381347656 | 0.03424634933471677 | 0.1821155548095703 | 0.00021457672119140625 | 0.467227935791015625


I'm only running these max size validations on change so that existing attachments remain valid