### PR TITLE
Remove promotional banner + Make robotics raffle visible

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,10 +30,6 @@ class ApplicationController < ActionController::Base
   end
 
   before_action do
-    @hide_promotional_banner = cookies[:hide_robotics_raffle_banner] == "1"
-  end
-
-  before_action do
     # Disallow indexing
     response.set_header("X-Robots-Tag", "noindex")
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -782,7 +782,11 @@ class EventsController < ApplicationController
     authorize @event
 
     @active_teenagers_count = @event.users.active_teenager.count
+
     @perks_available = OrganizerPosition.role_at_least?(current_user, @event, :manager) && !@event.demo_mode? && @event.plan.promotions_enabled?
+
+    # I'm so sorry, this is awful & temporary
+    @is_argosy = @event.plan.is_a?(Event::Plan::Argosy2025)
   end
 
   def reimbursements

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -782,7 +782,7 @@ class EventsController < ApplicationController
     authorize @event
 
     @active_teenagers_count = @event.users.active_teenager.count
-    @perks_available = OrganizerPosition.role_at_least?(current_user, @event, :manager) && !@event.demo_mode? && @event.plan.eligible_for_perks?
+    @perks_available = OrganizerPosition.role_at_least?(current_user, @event, :manager) && !@event.demo_mode? && @event.plan.promotions_enabled?
   end
 
   def reimbursements

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MyController < ApplicationController
-  skip_after_action :verify_authorized, only: [:activities, :toggle_admin_activities, :cards, :missing_receipts_list, :missing_receipts_icon, :inbox, :reimbursements, :reimbursements_icon, :tasks, :payroll, :feed, :hide_promotional_banner] # do not force pundit
+  skip_after_action :verify_authorized, only: [:activities, :toggle_admin_activities, :cards, :missing_receipts_list, :missing_receipts_icon, :inbox, :reimbursements, :reimbursements_icon, :tasks, :payroll, :feed] # do not force pundit
 
   before_action :set_reimbursement_reports, only: [:reimbursements, :reimbursements_icon]
 
@@ -17,11 +17,6 @@ class MyController < ApplicationController
   def toggle_admin_activities
     cookies[:admin_activities] = cookies[:admin_activities] == "everyone" ? "myself" : "everyone"
     redirect_to my_activities_url
-  end
-
-  def hide_promotional_banner
-    cookies.permanent[:hide_robotics_raffle_banner] = 1
-    redirect_back_or_to root_path
   end
 
   def cards

--- a/app/models/event/plan/hack_club_affiliate.rb
+++ b/app/models/event/plan/hack_club_affiliate.rb
@@ -32,7 +32,7 @@ class Event
       end
 
       def features
-        Event::Plan.available_features
+        Event::Plan.available_features - %w[promotions]
       end
 
       def exempt_from_wire_minimum?
@@ -53,10 +53,6 @@ class Event
         return 14 if date < Date.new(2025, 4, 11) # https://hackclub.slack.com/archives/C047Y01MHJQ/p1743055747682219
 
         35 # custom rate for HQ events
-      end
-
-      def eligible_for_perks?
-        false
       end
 
     end

--- a/app/models/event/plan/standard.rb
+++ b/app/models/event/plan/standard.rb
@@ -83,10 +83,6 @@ class Event
         true
       end
 
-      def eligible_for_perks?
-        true
-      end
-
       def contract_docuseal_template_id
         487784
       end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -148,7 +148,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def promotions?
-    auditor_or_reader? && record.plan.promotions_enabled?
+    auditor_or_reader?
   end
 
   def reimbursements_pending_review_icon?

--- a/app/views/events/perks/_fee_waiver.html.erb
+++ b/app/views/events/perks/_fee_waiver.html.erb
@@ -6,7 +6,7 @@
       <h3 class="h1 py-4 my0 flex items-start smoke justify-center">
         Fee Waiver
       </h3>
-      <% if !event.plan.eligible_for_perks? %>
+      <% if !event.plan.promotions_enabled? %>
         <% fee_waiver_ineligible_reason = "Perks are not available for #{event.plan.label} organizations" %>
       <% elsif !perks_available %>
         <% fee_waiver_ineligible_reason = "You must be a manager and organization must not be in demo mode" %>

--- a/app/views/events/perks/_premium_domains.html.erb
+++ b/app/views/events/perks/_premium_domains.html.erb
@@ -7,7 +7,7 @@
       <span class="badge bg-muted mr-5" style="font-size: 15px; padding: 8px 14px;">Premium</span>
     </h3>
 
-    <% if !event.plan.eligible_for_perks? %>
+    <% if !event.plan.promotions_enabled? %>
       <% domains_ineligible_reason = "Perks are not available for #{event.plan.label} organizations" %>
     <% elsif !perks_available %>
       <% domains_ineligible_reason = "You must be a manager and organization must not be in demo mode" %>

--- a/app/views/events/perks/_premium_jukebox.html.erb
+++ b/app/views/events/perks/_premium_jukebox.html.erb
@@ -7,7 +7,7 @@
       <span class="badge bg-muted mr-5" style="font-size: 15px; padding: 8px 14px;">Premium</span>
     </h3>
 
-    <% if !event.plan.eligible_for_perks? %>
+    <% if !event.plan.promotions_enabled? %>
       <% jukebox_ineligible_reason = "Perks are not available for #{event.plan.label} organizations" %>
     <% elsif !perks_available %>
       <% jukebox_ineligible_reason = "You must be a manager and organization must not be in demo mode" %>

--- a/app/views/events/perks/_premium_pins.html.erb
+++ b/app/views/events/perks/_premium_pins.html.erb
@@ -7,7 +7,7 @@
       <span class="badge bg-muted mr-5" style="font-size: 15px; padding: 8px 14px;">Premium</span>
     </h3>
 
-    <% if !event.plan.eligible_for_perks? %>
+    <% if !event.plan.promotions_enabled? %>
       <% pins_ineligible_reason = "Perks are not available for #{event.plan.label} organizations" %>
     <% elsif !perks_available %>
       <% pins_ineligible_reason = "You must be a manager and organization must not be in demo mode" %>

--- a/app/views/events/perks/_robotics_printer_raffle.html.erb
+++ b/app/views/events/perks/_robotics_printer_raffle.html.erb
@@ -8,7 +8,7 @@
           <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/7eb839cffb744ac3d23d6980945e3dac0903e9d8_drukarka-3d-bambu-lab-a1-578982107-removebg-preview.png" height="72px" class="mr2">
           3D Printer Raffle
         </h3>
-        <% if event.robotics_team? || event.affiliations.robotics.any? %>
+        <% if event.robotics_team? || event.affiliations.robotics.any? || @is_argosy %>
           <span class="btn disabled bg-clip-padding"><%= pluralize(active_teenagers_count, "ticket") %></span>
         <% else %>
           <div class="tooltipped tooltipped--w inline-block" aria-label="Must be tagged as a robotics team or have a robotics affiliation.">

--- a/app/views/events/promotions.html.erb
+++ b/app/views/events/promotions.html.erb
@@ -7,13 +7,13 @@
 </h1>
 
 <%# Perks for organizations ran by teenagers %>
-<% if @event.organized_by_teenagers? || @active_teenagers_count > 0 %>
+<% if @event.organized_by_teenagers? || @active_teenagers_count > 0 || @is_argosy %>
+  <%= render "events/perks/robotics_printer_raffle", event: @event, active_teenagers_count: @active_teenagers_count %>
+
   <%= render "events/perks/premium_pins", event: @event, perks_available: @perks_available, active_teenagers_count: @active_teenagers_count %>
   <%= render "events/perks/premium_domains", event: @event, perks_available: @perks_available, active_teenagers_count: @active_teenagers_count %>
 
   <%= render "events/perks/fee_waiver", event: @event, perks_available: @perks_available, active_teenagers_count: @active_teenagers_count %>
-
-  <%= render "events/perks/robotics_printer_raffle", event: @event, active_teenagers_count: @active_teenagers_count %>
 
   <%= render "events/perks/hackathons_page", event: @event, perks_available: @perks_available %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -119,22 +119,6 @@
       </div>
     <% end %>
 
-    <% if !@event&.demo_mode? && (@event&.robotics_team? || @event&.affiliations&.robotics&.any?) && organizer_signed_in? && !@hide_promotional_banner && Date.current < Date.new(2025, 12, 1) %>
-      <div class="w-100s px3 promo-robotics-raffle card--hover flex flex-row items-center" data-behavior="hide_iframe">
-        <div class="flex flex-col flex-grow">
-          <p class="h3 font-medium text-center text-balance mt2 mb0 white">
-            You currently have <%= number_to_human(@event&.users&.active_teenager&.count) %> tickets for the Robotics 3D Printer Raffle. Earn a ticket for each active teenager in your organization.
-          </p>
-          <p class="h4 text-center text-balance mt0 mb2 white">
-            Find more info <%= link_to "here", event_promotions_path(@event), class: "white" %>.
-          </p>
-        </div>
-        <span class="pr2">
-          <%= pop_icon_to "view-close", hide_promotional_banner_path, data: { turbo: true, turbo_method: :POST, turbo_frame: "_top" }, method: :post, class: "white" %>
-        </span>
-      </div>
-    <% end %>
-
     <% if @event&.demo_mode? && !@no_app_shell && !@no_transparency_header %>
       <div class="w-full dev-banner dev-banner--info rounded-b no-underline">
         <div class="flex flex-col md:flex-row gap-y-2 gap-x-6 py-6 items-center justify-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,6 @@ Rails.application.routes.draw do
     get "inbox", to: "my#inbox", as: :my_inbox
     get "activities", to: "my#activities", as: :my_activities
     post "toggle_admin_activities", to: "my#toggle_admin_activities", as: :toggle_admin_activities
-    post "hide_promotional_banner", to: "my#hide_promotional_banner", as: :hide_promotional_banner
     get "tasks", to: "my#tasks", as: :my_tasks
     get "reimbursements", to: "my#reimbursements", as: :my_reimbursements
     get "reimbursements_icon", to: "my#reimbursements_icon", as: :my_reimbursements_icon


### PR DESCRIPTION
## Summary of the problem


1. We want to remove the promotional banner
2. We want the robotics 3d printer raffle to be visible to Argosy

## Describe your changes

This is kinda a semi-hot fix to get it out there. It gets what we want, but i'm not super happy about the extra `@is_argosy` variable.

<img width="1035" height="645" alt="image" src="https://github.com/user-attachments/assets/80ce53bb-e706-4127-bdcb-212e8ce04227" />

Orgs that have the promotions feature disabled within the Event plan will now be able to see the promotions page (previously they couldn't), but all promotions on that page will be disabled.

The only exception is Argosy, which has promotions disabled, but is _**only**_ able to view the robotics 3d printer raffle promotion.


