### PR TITLE
Don't charge fees on failed payout holdings

### DIFF
--- a/app/services/fee_engine/create.rb
+++ b/app/services/fee_engine/create.rb
@@ -41,6 +41,7 @@ module FeeEngine
 
       reason = :transfer_returned if canonical_transaction.local_hcb_code.ach_transfer? # outgoing ACH transfers are sometimes returned to the account upon failure
       reason = :transfer_returned if canonical_transaction.local_hcb_code.wire? # outgoing wires are sometimes returned to the account upon failure
+      reason = :transfer_returned if canonical_transaction.local_hcb_code.reimbursement_payout_holding? # payout holdings are sometimes returned to the account upon failure
 
       # don't run fee if other transactions in it's HCB Code have fees waived
       reason = :revenue_waived if canonical_transaction.local_hcb_code.canonical_transactions.includes(:fee).any? { |ct| ct.fee&.revenue_waived? }


### PR DESCRIPTION
> can someone help me look into this account and why we charged the most recent fiscal sponsorship fee that made them negative? From what I can tell they've only had 2 deposits from almost a year ago and we took the correct fee amount back then, but then we randomly took an FS fee this June which made them negative