### PR TITLE
Fix current tier highlight on fee waiver

### DIFF
--- a/app/views/events/perks/_fee_waiver.html.erb
+++ b/app/views/events/perks/_fee_waiver.html.erb
@@ -35,7 +35,7 @@
         <td>5-9 active teenagers</td>
         <td>3.5% fee</td>
       </tr>
-      <tr class="<%= "card__darker" if active_teenagers_count > 10 %>">
+      <tr class="<%= "card__darker" if active_teenagers_count >= 10 %>">
         <td>10+ active teenagers</td>
         <td>0.0% fee</td>
       </tr>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It wouldn't highlight the selection if they had exactly 10 active teens.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

