### PR TITLE
[Wrapped] Abstract year into the Metric class

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -78,4 +78,8 @@ class Metric < ApplicationRecord
     metric
   end
 
+  def self.year
+    2024
+  end
+
 end

--- a/app/models/metric/event/spending_by_category.rb
+++ b/app/models/metric/event/spending_by_category.rb
@@ -29,7 +29,7 @@ class Metric
         )
                             .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
                             .joins("LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where("event_mapping.event_id = ?", event.id)
                             .group(
                               "trim(upper(split_part(raw_stripe_transactions.stripe_transaction->'merchant_data'->>'category', '*', 1)))"

--- a/app/models/metric/event/spending_by_date.rb
+++ b/app/models/metric/event/spending_by_date.rb
@@ -25,7 +25,7 @@ class Metric
       def calculate
         CanonicalTransaction
           .joins("LEFT JOIN canonical_event_mappings ON canonical_transactions.id = canonical_event_mappings.canonical_transaction_id")
-          .where("canonical_event_mappings.event_id = ? AND EXTRACT(YEAR FROM canonical_transactions.created_at) = ?", event.id, 2024)
+          .where("canonical_event_mappings.event_id = ? AND EXTRACT(YEAR FROM canonical_transactions.created_at) = ?", event.id, Metric.year)
           .group("date(canonical_transactions.created_at)")
           .select(
             "date(canonical_transactions.created_at) AS transaction_date",

--- a/app/models/metric/event/spending_by_location.rb
+++ b/app/models/metric/event/spending_by_location.rb
@@ -45,7 +45,7 @@ class Metric
         )
                             .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
                             .joins("LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where("event_mapping.event_id = ?", event.id)
                             .group(
                               "CASE

--- a/app/models/metric/event/spending_by_merchant.rb
+++ b/app/models/metric/event/spending_by_merchant.rb
@@ -33,7 +33,7 @@ class Metric
         )
                             .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
                             .joins("LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where("event_mapping.event_id = ?", event.id)
                             .group(
                               "CASE

--- a/app/models/metric/event/spending_by_user.rb
+++ b/app/models/metric/event/spending_by_user.rb
@@ -31,7 +31,7 @@ class Metric
               LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'
               LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id
               LEFT JOIN "stripe_cardholders" on stripe_cardholders.stripe_id = raw_stripe_transactions.stripe_transaction->>'cardholder'
-              WHERE EXTRACT(YEAR FROM raw_stripe_transactions.date_posted) = 2024
+              WHERE EXTRACT(YEAR FROM raw_stripe_transactions.date_posted) = #{Metric.year}
               AND event_mapping.event_id = :event_id
 
               UNION ALL
@@ -40,7 +40,7 @@ class Metric
               FROM "ach_transfers"
               LEFT JOIN canonical_transactions ct ON CONCAT('HCB-300-', ach_transfers.id) = ct.hcb_code
               LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id
-              WHERE EXTRACT(YEAR FROM ach_transfers.created_at) = 2024
+              WHERE EXTRACT(YEAR FROM ach_transfers.created_at) = #{Metric.year}
               AND event_mapping.event_id = :event_id
 
               UNION ALL
@@ -49,7 +49,7 @@ class Metric
               FROM "disbursements"
               LEFT JOIN canonical_transactions ct ON CONCAT('HCB-500-', disbursements.id) = ct.hcb_code
               LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id
-              WHERE EXTRACT(YEAR FROM disbursements.created_at) = 2024
+              WHERE EXTRACT(YEAR FROM disbursements.created_at) = #{Metric.year}
               AND event_mapping.event_id = :event_id
 
               UNION ALL
@@ -58,7 +58,7 @@ class Metric
               FROM "increase_checks"
               LEFT JOIN canonical_transactions ct ON CONCAT('HCB-401-', increase_checks.id) = ct.hcb_code
               LEFT JOIN canonical_event_mappings event_mapping ON ct.id = event_mapping.canonical_transaction_id
-              WHERE EXTRACT(YEAR FROM increase_checks.created_at) = 2024
+              WHERE EXTRACT(YEAR FROM increase_checks.created_at) = #{Metric.year}
               AND event_mapping.event_id = :event_id
           ) results
           group by user_id

--- a/app/models/metric/event/words.rb
+++ b/app/models/metric/event/words.rb
@@ -25,12 +25,12 @@ class Metric
       def calculate
         # 1. Get memos from event
         transactions = event.canonical_transactions
-                            .where("EXTRACT(YEAR FROM date) = 2024")
+                            .where("EXTRACT(YEAR FROM date) = #{Metric.year}")
                             .select("COALESCE(custom_memo, memo) as memo, hcb_code")
                             .to_h { |r| [r.hcb_code, r.memo] }
 
         event.canonical_pending_transactions
-             .where("EXTRACT(YEAR FROM date) = 2024")
+             .where("EXTRACT(YEAR FROM date) = #{Metric.year}")
              .select("COALESCE(custom_memo, memo) as memo, hcb_code")
              .each { |r| transactions[r.hcb_code] ||= r.memo }
 

--- a/app/models/metric/hcb/merchant_count.rb
+++ b/app/models/metric/hcb/merchant_count.rb
@@ -33,7 +33,7 @@ class Metric
           "SUM(raw_stripe_transactions.amount_cents) * -1 AS amount_spent"
         )
                                         .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
-                                        .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                                        .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                                         .group(
                                           "raw_stripe_transactions.stripe_transaction->'merchant_data'->>'network_id'",
                                           "CASE

--- a/app/models/metric/hcb/new_events.rb
+++ b/app/models/metric/hcb/new_events.rb
@@ -27,7 +27,7 @@ class Metric
                .not_hidden
                .not_demo_mode
                .approved
-               .where("EXTRACT(YEAR FROM events.created_at) = ?", 2024)
+               .where("EXTRACT(YEAR FROM events.created_at) = ?", Metric.year)
                .count
       end
 

--- a/app/models/metric/hcb/new_users.rb
+++ b/app/models/metric/hcb/new_users.rb
@@ -24,7 +24,7 @@ class Metric
 
       def calculate
         organizers.or(card_grant_recipients).or(reimbursement_report_users)
-                  .where("EXTRACT(YEAR FROM users.created_at) = ?", 2024)
+                  .where("EXTRACT(YEAR FROM users.created_at) = ?", Metric.year)
                   .count
       end
 

--- a/app/models/metric/hcb/spending_by_category.rb
+++ b/app/models/metric/hcb/spending_by_category.rb
@@ -28,7 +28,7 @@ class Metric
           "(SUM(raw_stripe_transactions.amount_cents)) * -1 AS amount_spent"
         )
                             .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .group(
                               "trim(upper(split_part(raw_stripe_transactions.stripe_transaction->'merchant_data'->>'category', '*', 1)))"
                             )

--- a/app/models/metric/hcb/spending_by_location.rb
+++ b/app/models/metric/hcb/spending_by_location.rb
@@ -43,7 +43,7 @@ class Metric
           END AS location",
           "(SUM(amount_cents)) * -1 AS amount_spent"
         )
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .group(
                               "CASE
             WHEN COALESCE(stripe_transaction->'merchant_data'->>'state', '') <> '' THEN

--- a/app/models/metric/hcb/spending_by_merchant.rb
+++ b/app/models/metric/hcb/spending_by_merchant.rb
@@ -33,7 +33,7 @@ class Metric
           "SUM(raw_stripe_transactions.amount_cents) * -1 AS amount_spent"
         )
                             .joins("LEFT JOIN canonical_transactions ct ON raw_stripe_transactions.id = ct.transaction_source_id AND ct.transaction_source_type = 'RawStripeTransaction'")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .group(
                               "raw_stripe_transactions.stripe_transaction->'merchant_data'->>'network_id'",
                               "CASE

--- a/app/models/metric/hcb/spending_by_user.rb
+++ b/app/models/metric/hcb/spending_by_user.rb
@@ -32,20 +32,20 @@ class Metric
             FROM "raw_stripe_transactions"
             WHERE raw_stripe_transactions.stripe_transaction->>\'cardholder\' IN (
                 SELECT stripe_id FROM "stripe_cardholders" WHERE user_id = users.id
-            ) AND EXTRACT(YEAR FROM date_posted) = 2024
+            ) AND EXTRACT(YEAR FROM date_posted) = ' + Metric.year + '
 
             UNION ALL
 
             SELECT SUM(amount) AS dollars_spent
             FROM "ach_transfers"
-            WHERE EXTRACT(YEAR FROM created_at) = 2024
+            WHERE EXTRACT(YEAR FROM created_at) = ' + Metric.year + '
             AND creator_id = users.id
 
             UNION ALL
 
             SELECT SUM(amount) AS dollars_spent
             FROM "disbursements"
-            WHERE EXTRACT(YEAR FROM created_at) = 2024
+            WHERE EXTRACT(YEAR FROM created_at) = ' + Metric.year + '
             AND requested_by_id = users.id
 
             UNION ALL
@@ -54,12 +54,12 @@ class Metric
             FROM (
                 SELECT amount
                 FROM "increase_checks"
-                WHERE EXTRACT(YEAR FROM created_at) = 2024
+                WHERE EXTRACT(YEAR FROM created_at) = ' + Metric.year + '
                 AND user_id IN (users.id)
                 UNION ALL
                 SELECT amount
                 FROM "checks"
-                WHERE EXTRACT(YEAR FROM created_at) = 2024
+                WHERE EXTRACT(YEAR FROM created_at) = ' + Metric.year + '
                 AND creator_id IN (users.id)
             ) AS combined_table
         ) AS combined_result)

--- a/app/models/metric/hcb/total_raised.rb
+++ b/app/models/metric/hcb/total_raised.rb
@@ -30,7 +30,7 @@ class Metric
           LEFT JOIN "event_plans" ON event_plans.event_id = events.id AND event_plans.aasm_state = 'active'
           LEFT JOIN "disbursements" ON canonical_transactions.hcb_code = CONCAT('HCB-500-', disbursements.id)
           WHERE amount_cents > 0
-          AND date_part('year', date) = 2024
+          AND date_part('year', date) = #{Metric.year}
           #{Event::Plan.that(:omit_stats).map(&:name).map { |p| "AND event_plans.type != '#{p}'" }.join(' ')}
           AND (disbursements.id IS NULL or disbursements.should_charge_fee = true)
           AND NOT (

--- a/app/models/metric/hcb/total_spent.rb
+++ b/app/models/metric/hcb/total_spent.rb
@@ -24,7 +24,7 @@ class Metric
 
       def calculate
         CanonicalTransaction.included_in_stats
-                            .where(date: Date.new(2024, 1, 1)..Date.new(2024, 12, 31))
+                            .where(date: Date.new(Metric.year, 1, 1)..Date.new(Metric.year, 12, 31))
                             .expense
                             .sum(:amount_cents)
       end

--- a/app/models/metric/user/card_grant_amount.rb
+++ b/app/models/metric/user/card_grant_amount.rb
@@ -23,7 +23,7 @@ class Metric
       include Subject
 
       def calculate
-        user.card_grants.where("EXTRACT(YEAR FROM created_at) = ?", 2024).sum(:amount_cents)
+        user.card_grants.where("EXTRACT(YEAR FROM created_at) = ?", Metric.year).sum(:amount_cents)
       end
 
     end

--- a/app/models/metric/user/card_grant_count.rb
+++ b/app/models/metric/user/card_grant_count.rb
@@ -23,7 +23,7 @@ class Metric
       include Subject
 
       def calculate
-        user.card_grants.where("EXTRACT(YEAR FROM created_at) = ?", 2024).count
+        user.card_grants.where("EXTRACT(YEAR FROM created_at) = ?", Metric.year).count
       end
 
     end

--- a/app/models/metric/user/most_interacted_with.rb
+++ b/app/models/metric/user/most_interacted_with.rb
@@ -35,7 +35,7 @@ class Metric
           LEFT JOIN "stripe_cardholders" on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id
           LEFT JOIN "paypal_transfers" on hcb_codes.hcb_code = CONCAT('HCB-350-', paypal_transfers.id)
           WHERE
-              comments.created_at >= '2024-01-01'
+              comments.created_at >= '#{Metric.year}-01-01'
               AND CONCAT(ach_transfers.creator_id, checks.creator_id, increase_checks.user_id, disbursements.requested_by_id, stripe_cardholders.user_id, paypal_transfers.user_id) != '' AND CONCAT(ach_transfers.creator_id, checks.creator_id, increase_checks.user_id, disbursements.requested_by_id, stripe_cardholders.user_id, paypal_transfers.user_id) != CAST(comments.user_id as text)
               AND (CONCAT(ach_transfers.creator_id, checks.creator_id, increase_checks.user_id, disbursements.requested_by_id, stripe_cardholders.user_id, paypal_transfers.user_id) = '#{user.id}' OR comments.user_id = #{user.id})
               AND comments.user_id != 2891 -- This is the HCB user for automated comments

--- a/app/models/metric/user/spending_by_category.rb
+++ b/app/models/metric/user/spending_by_category.rb
@@ -28,7 +28,7 @@ class Metric
           "(SUM(raw_stripe_transactions.amount_cents)) * -1 AS amount_spent"
         )
                             .joins("JOIN stripe_cardholders on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where(stripe_cardholders: { user_id: user.id })
                             .group(
                               "trim(upper(split_part(raw_stripe_transactions.stripe_transaction->'merchant_data'->>'category', '*', 1)))"

--- a/app/models/metric/user/spending_by_date.rb
+++ b/app/models/metric/user/spending_by_date.rb
@@ -26,21 +26,21 @@ class Metric
 
         stripe_transactions_subquery = RawStripeTransaction.select("date(date_posted) AS transaction_date, SUM(amount_cents) * -1 AS amount")
                                                            .where("raw_stripe_transactions.stripe_transaction->>'cardholder' IN (?)", StripeCardholder.select(:stripe_id).where(user_id: user.id))
-                                                           .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                                                           .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                                                            .group("date(date_posted)")
 
         ach_transfers_subquery = AchTransfer.select("date(created_at) AS transaction_date, SUM(amount) AS amount")
-                                            .where("EXTRACT(YEAR FROM created_at) = ?", 2024)
+                                            .where("EXTRACT(YEAR FROM created_at) = ?", Metric.year)
                                             .where(creator_id: user.id)
                                             .group("date(created_at)")
 
         increase_checks_subquery = IncreaseCheck.select("date(created_at) AS transaction_date, SUM(amount) AS amount")
-                                                .where("EXTRACT(YEAR FROM created_at) = ?", 2024)
+                                                .where("EXTRACT(YEAR FROM created_at) = ?", Metric.year)
                                                 .where(user_id: user.id)
                                                 .group("date(created_at)")
 
         checks_subquery = Check.select("date(created_at) AS transaction_date, SUM(amount) AS amount")
-                               .where("EXTRACT(YEAR FROM created_at) = ?", 2024)
+                               .where("EXTRACT(YEAR FROM created_at) = ?", Metric.year)
                                .where(creator_id: user.id)
                                .group("date(created_at)")
 
@@ -62,7 +62,7 @@ class Metric
         SQL
 
         hash = {}
-        (Date.new(2024, 1, 1)..Date.new(2024, 12, 31)).each do |date|
+        (Date.new(Metric.year, 1, 1)..Date.new(Metric.year, 12, 31)).each do |date|
           hash[date.to_s] = 0
         end
 

--- a/app/models/metric/user/spending_by_location.rb
+++ b/app/models/metric/user/spending_by_location.rb
@@ -44,7 +44,7 @@ class Metric
           "(SUM(raw_stripe_transactions.amount_cents)) * -1 AS amount_spent"
         )
                             .joins("JOIN stripe_cardholders on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where(stripe_cardholders: { user_id: user.id })
                             .group(
                               "CASE

--- a/app/models/metric/user/spending_by_merchant.rb
+++ b/app/models/metric/user/spending_by_merchant.rb
@@ -33,7 +33,7 @@ class Metric
           "SUM(raw_stripe_transactions.amount_cents) * -1 AS amount_spent"
         )
                             .joins("JOIN stripe_cardholders on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id")
-                            .where("EXTRACT(YEAR FROM date_posted) = ?", 2024)
+                            .where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year)
                             .where(stripe_cardholders: { user_id: user.id })
                             .group(
                               "raw_stripe_transactions.stripe_transaction->'merchant_data'->>'network_id'",

--- a/app/models/metric/user/time_to_receipt.rb
+++ b/app/models/metric/user/time_to_receipt.rb
@@ -24,7 +24,7 @@ class Metric
 
       def calculate
         Receipt.joins("JOIN hcb_codes h ON receipts.receiptable_id = h.id")
-               .where("EXTRACT(YEAR FROM receipts.created_at) = ?", 2024)
+               .where("EXTRACT(YEAR FROM receipts.created_at) = ?", Metric.year)
                .where(receiptable_type: "HcbCode")
                .where(user_id: user.id)
                .average("EXTRACT(EPOCH FROM (receipts.created_at - h.created_at))")

--- a/app/models/metric/user/total_spent.rb
+++ b/app/models/metric/user/total_spent.rb
@@ -23,9 +23,9 @@ class Metric
       include Subject
 
       def calculate
-        card = RawStripeTransaction.joins("JOIN stripe_cardholders on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id").where("EXTRACT(YEAR FROM date_posted) = ?", 2024).where(stripe_cardholders: { user_id: user.id }).sum(:amount_cents)
-        ach = AchTransfer.where(creator_id: user.id, rejected_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", 2024).sum(:amount)
-        checks = Check.where(creator_id: user.id, rejected_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", 2024).sum(:amount) + IncreaseCheck.where(user_id: user.id, increase_status: "deposited").where.not(approved_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", 2024).sum(:amount)
+        card = RawStripeTransaction.joins("JOIN stripe_cardholders on raw_stripe_transactions.stripe_transaction->>'cardholder' = stripe_cardholders.stripe_id").where("EXTRACT(YEAR FROM date_posted) = ?", Metric.year).where(stripe_cardholders: { user_id: user.id }).sum(:amount_cents)
+        ach = AchTransfer.where(creator_id: user.id, rejected_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", Metric.year).sum(:amount)
+        checks = Check.where(creator_id: user.id, rejected_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", Metric.year).sum(:amount) + IncreaseCheck.where(user_id: user.id, increase_status: "deposited").where.not(approved_at: nil).where("EXTRACT(YEAR FROM created_at) = ?", Metric.year).sum(:amount)
         card.abs + ach.abs + checks.abs
       end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -464,8 +464,31 @@
         79
       ],
       "note": "Domain is validated to not have a javascript: url scheme & dns_check_url is injecting that domain in a https url"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "f90eb66c77db0dbe90ae47634a8c3ece1ddd9cf5bbccf6f5726535c0d58f01b1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/metric/hcb/total_raised.rb",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"SELECT SUM(amount_cents) as amount_cents FROM \\\"canonical_transactions\\\"\\nLEFT JOIN \\\"canonical_event_mappings\\\" ON canonical_transactions.id = canonical_event_mappings.canonical_transaction_id\\nLEFT JOIN \\\"events\\\" ON canonical_event_mappings.event_id = events.id\\nLEFT JOIN \\\"event_plans\\\" ON event_plans.event_id = events.id AND event_plans.aasm_state = 'active'\\nLEFT JOIN \\\"disbursements\\\" ON canonical_transactions.hcb_code = CONCAT('HCB-500-', disbursements.id)\\nWHERE amount_cents > 0\\nAND date_part('year', date) = #{2024}\\n#{Event::Plan.that(:omit_stats).map(&:name).map do\n \"AND event_plans.type != '#{p}'\"\n end.join(\" \")}\\nAND (disbursements.id IS NULL or disbursements.should_charge_fee = true)\\nAND NOT (\\n  canonical_transactions.hcb_code ILIKE 'HCB-300%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-310%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-350%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-400%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-401%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-600%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-601%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-710%' OR\\n  canonical_transactions.hcb_code ILIKE 'HCB-712%'\\n)\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "TotalRaised",
+        "method": "calculate"
+      },
+      "user_input": "Event::Plan.that(:omit_stats)",
+      "confidence": "High",
+      "cwe_id": [
+        89
+      ],
+      "note": "This value is hardcoded and will only ever be a year"
     }
   ],
-  "updated": "2025-09-22 17:03:25 -0400",
+  "updated": "2025-10-08 13:59:18 -0700",
   "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
## Summary of the problem
Most `Metric`s are all based on data from the current or previous year. It can be a pain to update the year in every place, and it makes it hard to iterate on data for a new year.

## Describe your changes
This PR removes all hardcoded instances of `2024` in any metric and instead calls `Metric.year`.