### PR TITLE
[v4] Add donation availability to event

### DIFF
--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -6,6 +6,7 @@ json.name event.name
 json.country event.country
 json.slug event.slug
 json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
+json.donation_available event.donation_page_available?
 json.playground_mode event.demo_mode?
 json.playground_mode_meeting_requested event.demo_mode_request_meeting_at.present?
 json.transparent event.is_public?

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -6,7 +6,7 @@ json.name event.name
 json.country event.country
 json.slug event.slug
 json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
-json.donation_available event.donation_page_available?
+json.donation_page_available event.donation_page_available?
 json.playground_mode event.demo_mode?
 json.playground_mode_meeting_requested event.demo_mode_request_meeting_at.present?
 json.transparent event.is_public?

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Api::V4::CardGrantsController do
         "created_at"                        => event.created_at.iso8601(3),
         "fee_percentage"                    => 0.0,
         "icon"                              => nil,
+        "donation_available"                => true,
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => false,
         "transparent"                       => true

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V4::CardGrantsController do
         "created_at"                        => event.created_at.iso8601(3),
         "fee_percentage"                    => 0.0,
         "icon"                              => nil,
-        "donation_page_available"                => true,
+        "donation_page_available"           => true,
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => false,
         "transparent"                       => true

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V4::CardGrantsController do
         "created_at"                        => event.created_at.iso8601(3),
         "fee_percentage"                    => 0.0,
         "icon"                              => nil,
-        "donation_available"                => true,
+        "donation_page_available"                => true,
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => false,
         "transparent"                       => true


### PR DESCRIPTION
## Summary of the problem
@polypixeldev brought up a very good point. If an organization doesn't have donations enabled (or stuff like frozen) we should disable the Tap to Pay functionality for it on mobile. 


## Describe your changes
simple boolean `donation_available` to let yk if its supported


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

