### PR TITLE
[Discord] Add user and event integrations tabs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -258,6 +258,7 @@ summary {
 @import 'components/filter_menu';
 @import 'components/home_page';
 @import 'components/send_invoice_modal';
+@import 'components/integrations';
 
 .turbo-progress-bar {
   height: 0.125rem;

--- a/app/assets/stylesheets/components/_integrations.scss
+++ b/app/assets/stylesheets/components/_integrations.scss
@@ -1,6 +1,6 @@
 .integration-discord {
   color: white;
-  
+
   background-color: #f5f5f5;
   background-image:
     linear-gradient(

--- a/app/assets/stylesheets/components/_integrations.scss
+++ b/app/assets/stylesheets/components/_integrations.scss
@@ -1,0 +1,21 @@
+.integration-discord {
+  color: white;
+  
+  background-color: #f5f5f5;
+  background-image:
+    linear-gradient(
+      to right,
+      rgba(245, 246, 252, 0.25),
+      rgba(248, 248, 248, 0.05)
+    ),
+    url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/03659550ddee837a06c9c3281fba0f02aadbcb8a_discord-banner.png');
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+html[data-dark='true'] {
+  .integration-discord {
+    background-color: #363a44;
+  }
+}

--- a/app/controllers/discord_controller.rb
+++ b/app/controllers/discord_controller.rb
@@ -141,7 +141,7 @@ class DiscordController < ApplicationController
     Rails.error.unexpected("Exception unlinking discord user: #{e.message}")
     flash[:error] = "We could not unlink your Discord user"
   ensure
-    redirect_to integrations_user_path(@user)
+    redirect_to root_path
   end
 
   def unlink_server

--- a/app/controllers/discord_controller.rb
+++ b/app/controllers/discord_controller.rb
@@ -123,6 +123,27 @@ class DiscordController < ApplicationController
     end
   end
 
+  def unlink_user
+    @user = Discord::Bot.bot.user(current_user.discord_id)
+
+    authorize nil, policy_class: DiscordPolicy
+  end
+
+  def unlink_user_action
+    authorize nil, policy_class: DiscordPolicy
+
+    if current_user.update(discord_id: nil)
+      flash[:success] = "Successfully unlinked your Discord user"
+    else
+      flash[:error] = event.errors.full_messages.to_sentence
+    end
+  rescue => e
+    Rails.error.unexpected("Exception unlinking discord user: #{e.message}")
+    flash[:error] = "We could not unlink your Discord user"
+  ensure
+    redirect_to integrations_user_path(@user)
+  end
+
   def unlink_server
     @signed_guild_id = params[:signed_guild_id]
     @guild_id = Discord.verify_signed(@signed_guild_id, purpose: :unlink_server)
@@ -148,7 +169,7 @@ class DiscordController < ApplicationController
       flash[:error] = event.errors.full_messages.to_sentence
     end
   rescue => e
-    Rails.error.unexpected("Exception linking discord server: #{e.message}")
+    Rails.error.unexpected("Exception unlinking discord server: #{e.message}")
     flash[:error] = "We could not unlink your organization from your Discord server"
   ensure
     if event.present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -183,6 +183,11 @@ class UsersController < ApplicationController
     authorize @user
   end
 
+  def edit_integrations
+    @user = params[:id] ? User.friendly.find(params[:id]) : current_user
+    authorize @user
+  end
+
   def generate_totp
     @user = params[:id] ? User.friendly.find(params[:id]) : current_user
     authorize @user

--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -258,7 +258,7 @@ module Discord
           fields: [
             {
               name: "Discord Account (`@#{user_name}`) ↔ Your HCB Account",
-              value: "Allows you to open reimbursement reports, view missing receipts, and take action on HCB.\n\n#{@user.present? ? "✅ Linked to #{@user.preferred_name.presence || @user.first_name} on HCB" : "❌ Not linked. #{link_to("Set up here", generate_discord_link_url)}"}\n",
+              value: "Allows you to open reimbursement reports, view missing receipts, and take action on HCB.\n\n#{@user.present? ? "✅ Linked to #{@user.preferred_name.presence || @user.first_name} on HCB (#{link_to("disconnect", url_helpers.discord_unlink_user_url)})" : "❌ Not linked. #{link_to("Set up here", generate_discord_link_url)}"}\n",
             },
             (if @guild_id.present?
                {

--- a/app/policies/discord_policy.rb
+++ b/app/policies/discord_policy.rb
@@ -25,4 +25,12 @@ class DiscordPolicy < ApplicationPolicy
     true
   end
 
+  def unlink_user?
+    true
+  end
+
+  def unlink_user_action?
+    true
+  end
+
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -57,6 +57,10 @@ class UserPolicy < ApplicationPolicy
     user.auditor? || record == user
   end
 
+  def edit_integrations?
+    user.auditor? || record == user
+  end
+
   def edit_admin?
     user.auditor? || (record == user && user.admin_override_pretend?)
   end

--- a/app/views/discord/unlink_user.html.erb
+++ b/app/views/discord/unlink_user.html.erb
@@ -1,0 +1,29 @@
+<% title "Unlink Discord user" %>
+
+<% page_xs %>
+<% no_app_shell if params[:no_app_shell] %>
+<% @hide_footer = true %>
+
+<div class="flex justify-center mt5">
+  <img class="w-20 h-20 mx-auto center rounded-lg" src="<%= @user.avatar_url || Discord.random_avatar %>">
+</div>
+<h2 class="border-none center regular mb2">Unlink Discord user <strong><%= @user.name %></strong> from your HCB account?</h2>
+
+<section class="mb2">
+  <div class="flex items-start">
+    <span class="muted mr2"><%= inline_icon "important" %></span>
+
+    <p class="mt0">You will no longer be able to use the Discord bot to access information about your organizations.</p>
+  </div>
+</section>
+
+<div class="flex items-center justify-center g1">
+  <%= button_to "Unlink", discord_unlink_user_path, class: "btn bg-error h2" %>
+  <%= link_to "Cancel", root_path, class: "btn bg-muted" %>
+</div>
+
+<div class="center mt2">
+  <div class="flex items-center justify-center muted">Signed in as <%= user_mention current_user, class: "ml1" %></div>
+
+  <%= link_to "Switch accounts", auth_users_path(return_to: request.fullpath), class: "center" %>
+</div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -36,6 +36,9 @@
     <%= settings_tab active: @settings_tab == "features" do %>
       <%= link_to "Feature previews", edit_event_path(@event, tab: "features"), data: { turbo: true, turbo_action: "advance" } %>
     <% end %>
+    <%= settings_tab active: @settings_tab == "integrations" do %>
+      <%= link_to "Integrations", edit_event_path(@event, tab: "integrations"), data: { turbo: true, turbo_action: "advance" } %>
+    <% end %>
     <%= settings_tab active: @settings_tab == "audit_log" do %>
       <%= link_to "Audit log", edit_event_path(@event, tab: "audit_log"), data: { turbo: true, turbo_action: "advance" } %>
     <% end %>
@@ -59,6 +62,8 @@
   <%= render "events/settings/affiliations", event: @event %>
 <% elsif @settings_tab == "features" %>
   <%= render "events/settings/features", event: @event %>
+<% elsif @settings_tab == "integrations" %>
+  <%= render "events/settings/integrations", event: @event %>
 <% elsif @settings_tab == "audit_log" %>
   <%= render "events/settings/audit_log", event: @event, activities: @activities, activities_before: @activities_before %>
 <% elsif @settings_tab == "admin" && auditor_signed_in? %>

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -1,0 +1,40 @@
+<%# locals: (event:) %>
+
+<% disabled = !policy(current_user).update? %>
+
+<div class="card pb0 mb3">
+  <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
+    <h3 class="h1 pt2 pb2 my0">Discord</h3>
+    <% if event.has_discord_guild? %>
+      <%= link_to(
+            "Unlink",
+            discord_unlink_server_path(signed_guild_id: Discord.generate_signed(event.discord_guild_id, purpose: :unlink_server)),
+            data: { turbo_frame: "_top" },
+            class: "btn bg-error",
+            disabled:
+          ) %>
+    <% else %>
+      <%= link_to(
+            "Setup",
+            Discord::Bot.install_link,
+            data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "discord_integration" },
+            class: "btn bg-info",
+            disabled:
+          ) %>
+    <% end %>
+  </div>
+  <p>
+    Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
+  </p>
+</div>
+
+<section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
+  <%= modal_header "Setup Discord integration" %>
+
+  <ol>
+    <li>Create a channel for HCB in your team's Discord server - we recommend calling it #finance</li>
+    <li><%= link_to "Click this link to add the bot", Discord::Bot.install_link, target: "_blank" %></li>
+    <li>Run /link in the channel you created for HCB</li>
+  </ol>
+</section>
+

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -2,9 +2,7 @@
 
 <% disabled = !policy(current_user).update? %>
 
-<%= render "integrations/discord_integration", active: event.has_discord_guild?, unlink_path: discord_unlink_server_path(signed_guild_id: Discord.generate_signed(event.discord_guild_id, purpose: :unlink_server)), disabled: %>
-
-<section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
+<%= render "integrations/discord_integration", active: event.has_discord_guild?, unlink_path: discord_unlink_server_path(signed_guild_id: Discord.generate_signed(event.discord_guild_id, purpose: :unlink_server)), disabled: do %>
   <%= modal_header "Setup Discord integration" %>
 
   <ol>
@@ -12,4 +10,4 @@
     <li><%= link_to "Click this link to add the bot", Discord::Bot.install_link, target: "_blank" %></li>
     <li>Run /link in the channel you created for HCB</li>
   </ol>
-</section>
+<% end %>

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -6,8 +6,8 @@
   <%= modal_header "Setup Discord integration" %>
 
   <ol>
-    <li>Create a channel for HCB in your team's Discord server - we recommend calling it #finance</li>
-    <li><%= link_to "Click this link to add the bot", Discord::Bot.install_link, target: "_blank" %></li>
-    <li>Run /link in the channel you created for HCB</li>
+    <li>Create a channel for HCB in your team's Discord server - we recommend calling it <code>#finance</code>.</li>
+    <li><%= link_to "Add bot", Discord::Bot.install_link, target: "_blank" %> to Discord server.</li>
+    <li>Run <code>/link</code> in the channel you created for HCB.</li>
   </ol>
 <% end %>

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -2,31 +2,7 @@
 
 <% disabled = !policy(current_user).update? %>
 
-<div class="card pb0 mb3">
-  <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
-    <h3 class="h1 pt2 pb2 my0">Discord</h3>
-    <% if event.has_discord_guild? %>
-      <%= link_to(
-            "Unlink",
-            discord_unlink_server_path(signed_guild_id: Discord.generate_signed(event.discord_guild_id, purpose: :unlink_server)),
-            data: { turbo_frame: "_top" },
-            class: "btn bg-error",
-            disabled:
-          ) %>
-    <% else %>
-      <%= link_to(
-            "Setup",
-            Discord::Bot.install_link,
-            data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "discord_integration" },
-            class: "btn bg-info",
-            disabled:
-          ) %>
-    <% end %>
-  </div>
-  <p>
-    Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
-  </p>
-</div>
+<%= render "integrations/discord_integration", active: event.has_discord_guild?, unlink_path: discord_unlink_server_path(signed_guild_id: Discord.generate_signed(event.discord_guild_id, purpose: :unlink_server)), disabled: %>
 
 <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
   <%= modal_header "Setup Discord integration" %>

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -37,4 +37,3 @@
     <li>Run /link in the channel you created for HCB</li>
   </ol>
 </section>
-

--- a/app/views/integrations/_discord_integration.html.erb
+++ b/app/views/integrations/_discord_integration.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (active:, unlink_path:, disabled:) %>
+
+<div class="card pb0 mb3">
+  <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
+    <h3 class="h1 pt2 pb2 my0">Discord</h3>
+    <% if active %>
+      <%= link_to(
+            "Unlink",
+            unlink_path,
+            data: { turbo_frame: "_top" },
+            class: "btn bg-error",
+            disabled:
+          ) %>
+    <% else %>
+      <%= link_to(
+            "Setup",
+            "#",
+            data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "discord_integration" },
+            class: "btn bg-info",
+            disabled:
+          ) %>
+    <% end %>
+  </div>
+  <p>
+    Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
+  </p>
+</div>

--- a/app/views/integrations/_discord_integration.html.erb
+++ b/app/views/integrations/_discord_integration.html.erb
@@ -25,3 +25,7 @@
     Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
   </p>
 </div>
+
+<section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
+  <%= yield %>
+</section>

--- a/app/views/users/_settings_nav.html.erb
+++ b/app/views/users/_settings_nav.html.erb
@@ -25,6 +25,9 @@
       <span class="xs-capitalize">previews</span>
     <% end %>
   <% end %>
+  <%= settings_tab active: active == "integrations" do %>
+    <%= link_to "Integrations", @user == current_user ? settings_integrations_path : integrations_user_path(@user), data: { turbo: true, turbo_action: "advance" } %>
+  <% end %>
   <% admin_tool("py0 px2 overflow-hidden", override_pretend: true) do %>
     <%= settings_tab active: active == "admin" do %>
       <%= link_to "Admin", @user == current_user ? settings_admin_path : admin_user_path(@user), data: { turbo: true, turbo_action: "advance" } %>

--- a/app/views/users/edit_integrations.html.erb
+++ b/app/views/users/edit_integrations.html.erb
@@ -10,13 +10,11 @@
 <turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
   <%= render "settings_nav", active: "integrations" %>
   <section>
-    <%= render "integrations/discord_integration", active: @user.has_discord_account?, unlink_path: discord_unlink_user_path, disabled: %>
-
-    <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
+    <%= render "integrations/discord_integration", active: @user.has_discord_account?, unlink_path: discord_unlink_user_path, disabled: do %>
       <%= modal_header "Setup Discord integration" %>
 
       <p><strong>If your team is already using the HCB Discord integration,</strong> run /link in your team's Discord server.</p>
       <p><strong>If your team isn't using the HCB Discord integration yet,</strong> organization managers can set it up in the organization settings tab.</p>
-    </section>
+    <% end %>
   </section>
 </turbo-frame>

--- a/app/views/users/edit_integrations.html.erb
+++ b/app/views/users/edit_integrations.html.erb
@@ -10,31 +10,7 @@
 <turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
   <%= render "settings_nav", active: "integrations" %>
   <section>
-    <div class="card pb0 mb3">
-      <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
-        <h3 class="h1 pt2 pb2 my0">Discord</h3>
-        <% if current_user.has_discord_account? %>
-          <%= link_to(
-                "Unlink",
-                discord_unlink_user_path,
-                data: { turbo_frame: "_top" },
-                class: "btn bg-error",
-                disabled:
-              ) %>
-        <% else %>
-          <%= link_to(
-                "Setup",
-                "#",
-                data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "discord_integration" },
-                class: "btn bg-info",
-                disabled:
-              ) %>
-        <% end %>
-      </div>
-      <p>
-        Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
-      </p>
-    </div>
+    <%= render "integrations/discord_integration", active: current_user.has_discord_account?, unlink_path: discord_unlink_user_path, disabled: %>
 
     <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
       <%= modal_header "Setup Discord integration" %>

--- a/app/views/users/edit_integrations.html.erb
+++ b/app/views/users/edit_integrations.html.erb
@@ -1,0 +1,46 @@
+<% title "Account settings" %>
+<% page_md %>
+<% disabled = !policy(current_user).update? %>
+
+<%= render "users/nav", selected: :settings %>
+
+<h1>
+  Settings
+</h1>
+<turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
+  <%= render "settings_nav", active: "integrations" %>
+  <section>
+    <div class="card pb0 mb3">
+      <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
+        <h3 class="h1 pt2 pb2 my0">Discord</h3>
+        <% if current_user.has_discord_account? %>
+          <%= link_to(
+                "Unlink",
+                discord_unlink_user_path,
+                data: { turbo_frame: "_top" },
+                class: "btn bg-error",
+                disabled:
+              ) %>
+        <% else %>
+          <%= link_to(
+                "Setup",
+                "#",
+                data: { turbo_frame: "_top", behavior: "modal_trigger", modal: "discord_integration" },
+                class: "btn bg-info",
+                disabled:
+              ) %>
+        <% end %>
+      </div>
+      <p>
+        Install the HCB Discord bot to check your balance, view recent transactions, open reimbursement reports, and more from your team's Discord server!
+      </p>
+    </div>
+
+    <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
+      <%= modal_header "Setup Discord integration" %>
+
+      <p><strong>If your team is already using the HCB Discord integration,</strong> run /link in your team's Discord server.</p>
+      <p><strong>If your team isn't using the HCB Discord integration yet,</strong> organization managers can set it up in the organization settings tab.</p>
+    </section>
+  </section>
+</turbo-frame>

--- a/app/views/users/edit_integrations.html.erb
+++ b/app/views/users/edit_integrations.html.erb
@@ -1,6 +1,6 @@
 <% title "Account settings" %>
 <% page_md %>
-<% disabled = !policy(current_user).update? %>
+<% disabled = !policy(@user).update? %>
 
 <%= render "users/nav", selected: :settings %>
 
@@ -10,7 +10,7 @@
 <turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
   <%= render "settings_nav", active: "integrations" %>
   <section>
-    <%= render "integrations/discord_integration", active: current_user.has_discord_account?, unlink_path: discord_unlink_user_path, disabled: %>
+    <%= render "integrations/discord_integration", active: @user.has_discord_account?, unlink_path: discord_unlink_user_path, disabled: %>
 
     <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="discord_integration">
       <%= modal_header "Setup Discord integration" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,8 +72,8 @@ Rails.application.routes.draw do
     get "settings/previews", to: "users#edit_featurepreviews"
     get "settings/security", to: "users#edit_security"
     get "settings/notifications", to: "users#edit_notifications"
-    get "settings/admin", to: "users#edit_admin"
     get "settings/integrations", to: "users#edit_integrations"
+    get "settings/admin", to: "users#edit_admin"
     get "payroll", to: "my#payroll", as: :my_payroll
 
     get "feed", to: "my#feed", as: :my_feed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
       get "previews", to: "users#edit_featurepreviews"
       get "security", to: "users#edit_security"
       get "notifications", to: "users#edit_notifications"
+      get "integrations", to: "users#edit_integrations"
       get "admin", to: "users#edit_admin"
       get "admin_details", to: "users#admin_details"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
     get "settings/security", to: "users#edit_security"
     get "settings/notifications", to: "users#edit_notifications"
     get "settings/admin", to: "users#edit_admin"
+    get "settings/integrations", to: "users#edit_integrations"
     get "payroll", to: "my#payroll", as: :my_payroll
 
     get "feed", to: "my#feed", as: :my_feed
@@ -714,6 +715,8 @@ Rails.application.routes.draw do
   get "discord/setup", to: "discord#setup"
   get "discord/unlink_server", to: "discord#unlink_server"
   post "discord/unlink_server", to: "discord#unlink_server_action"
+  get "discord/unlink_user", to: "discord#unlink_user"
+  post "discord/unlink_user", to: "discord#unlink_user_action"
   post "discord/create_server_link", to: "discord#create_server_link"
 
   post "extract/invoice", to: "extraction#invoice"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The new HCB Discord integration needs a place to live in settings to let users set it up and disable it from the HCB website!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds integration tabs to both user and event settings with the Discord integration card. Clicking setup will open a modal with instructions, and clicking unlink will redirect to the respective unlink page. The user unlink page and action have been added in this PR.

<img width="1916" height="1003" alt="image" src="https://github.com/user-attachments/assets/29745aaf-60c2-46de-a84e-38fa68ec43f6" />
<img width="1916" height="1003" alt="image" src="https://github.com/user-attachments/assets/413f78f0-7adf-4d48-b54a-3f275a28119e" />
<img width="1916" height="1003" alt="image" src="https://github.com/user-attachments/assets/4fbff34a-c2f1-46a6-88e5-7be4285f671d" />

new card look: _(images above are outdated)_
<img width="926" height="204" alt="image" src="https://github.com/user-attachments/assets/09733336-d0fe-42a9-bd14-9eeed525e460" />

