### PR TITLE
[Reimbursements] Make it clear that the report cap is in USD

### DIFF
--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -15,7 +15,7 @@
       <%= "is requesting " unless @report.closed? %>
       <%= render "total", report: @report %>
       <% if @report.maximum_amount_cents %>
-        (<%= render_money @report.maximum_amount_cents %> <%= "USD" if @report.currency != "USD" %> cap)
+        (<%= render_money @report.maximum_amount_cents %> <%= "USD" unless @report.currency == "USD" %> cap)
       <% end %>
       <%= "from #{@event.name}" if @event && @use_user_nav %> for
     </span>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -15,7 +15,7 @@
       <%= "is requesting " unless @report.closed? %>
       <%= render "total", report: @report %>
       <% if @report.maximum_amount_cents %>
-        (<%= render_money @report.maximum_amount_cents %> cap)
+        (<%= "#{render_money(@report.maximum_amount_cents)}#{" USD" if @report.currency != "USD"}" %> cap)
       <% end %>
       <%= "from #{@event.name}" if @event && @use_user_nav %> for
     </span>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -15,7 +15,7 @@
       <%= "is requesting " unless @report.closed? %>
       <%= render "total", report: @report %>
       <% if @report.maximum_amount_cents %>
-        (<%= "#{render_money(@report.maximum_amount_cents)}#{" USD" if @report.currency != "USD"}" %> cap)
+        (<%= render_money @report.maximum_amount_cents %> <%= "USD" if @report.currency != "USD" %> cap)
       <% end %>
       <%= "from #{@event.name}" if @event && @use_user_nav %> for
     </span>


### PR DESCRIPTION
## Summary of the problem
It can be unclear that the report cap is in USD after switching to a different currency.


## Describe your changes
Explicitly show "USD" when the report amount is in a non-USD currency.