### PR TITLE
Change SoM Explore Link to Blueprint

### DIFF
--- a/app/views/static_pages/index/_explore.html.erb
+++ b/app/views/static_pages/index/_explore.html.erb
@@ -53,16 +53,16 @@
         </p>
       </li>
     <% end %>
-    <%= link_to "https://summer.hackclub.com/?ref=hcb", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
-      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/1b8340020a77988cb3e6b18c1fefdba8ac665471_frame_22.png')">
+    <%= link_to "https://blueprint.hackclub.com/?ref=hcb", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://blueprint.hackclub.com/?utm_source=site-cta')">
         <div class="flex gap-2 items-center">
-          <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/1cb0b459884b32a0c984d457faed42d26de92f9c_compass_favicon.png" height="24" weight="24" class="rounded align-bottom" alt="Summer of Making logo">
+          <img src="https://blueprint.hackclub.com/favicon-32x32.png" height="24" weight="24" class="rounded align-bottom" alt="Blueprint logo">
           <strong class="text-xl leading-tight">
-            Summer of Making
+            Blueprint
           </strong>
         </div>
         <p>
-          Build stuff. Get stuff. Repeat. For ages 18 and under. Ends September 30th, 2025.
+          Build cool hardware projects (or learn how to) and get funding to make them real! 
         </p>
       </li>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
SoM is completely over

## Describe your changes
Since Moonshot hasn't started (or been confirmed), blueprint seems like the next best HC program to advertise on HCB explore

**Note:** I don't know Ruby and am aware that cdn links will need to be created from the template source links I have provided (sourced from blueprint.hackclub.com). If there is a way for me to do this lmk but otherwise I have enabled edits by maintainers on this PR
