### PR TITLE
Store Discord message ID on activities after they're sent to Discord

### DIFF
--- a/app/jobs/discord/process_notification_job.rb
+++ b/app/jobs/discord/process_notification_job.rb
@@ -29,12 +29,14 @@ module Discord
 
       text = ReverseMarkdown.convert(html)[0..4000]
 
-      Discord::Bot.bot.send_message(@event.discord_channel_id, nil, false, {
-                                      description: text,
-                                      timestamp: @activity.created_at.iso8601,
-                                      author: { name: @user.name, icon_url: profile_picture_for(@activity.owner) },
-                                      color:
-                                    })
+      message = Discord::Bot.bot.send_message(@event.discord_channel_id, nil, false, {
+                                                description: text,
+                                                timestamp: @activity.created_at.iso8601,
+                                                author: { name: @user.name, icon_url: profile_picture_for(@activity.owner) },
+                                                color:
+                                              })
+
+      @activity.update(discord_message_id: message.id.to_s)
     end
 
     private

--- a/db/migrate/20251013183626_add_discord_message_id_to_activity.rb
+++ b/db/migrate/20251013183626_add_discord_message_id_to_activity.rb
@@ -1,0 +1,5 @@
+class AddDiscordMessageIdToActivity < ActiveRecord::Migration[7.2]
+  def change
+    add_column :activities, :discord_message_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_05_204939) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_13_183626) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
## Summary of the problem

We eventually want to handle replies to certain types of activity messages. However, I don't want to rely on parsing message content for us to understand the context behind a Discord message; it would be much better for us to store a reference to the message and look it up in our systems when we need to.


## Describe your changes

Adds `discord_message_id` to `activities`