### PR TITLE
Replace session object with just IP address in StripeCardService::Create

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -115,7 +115,7 @@ module Api
 
         authorize @card_grant
 
-        @card_grant.create_stripe_card(current_session)
+        @card_grant.create_stripe_card(request.remote_ip)
 
         render :show
 

--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -52,7 +52,7 @@ module Api
 
         @stripe_card = ::StripeCardService::Create.new(
           current_user:,
-          current_session: { ip: request.remote_ip },
+          ip_address: request.remote_ip,
           event_id: event.id,
           card_type: card[:card_type],
           stripe_shipping_name: card[:shipping_name],

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -147,7 +147,7 @@ class CardGrantsController < ApplicationController
   def activate
     authorize @card_grant
 
-    @card_grant.create_stripe_card(current_session.ip)
+    @card_grant.create_stripe_card(request.remote_ip)
 
     redirect_to @card_grant
   rescue Stripe::InvalidRequestError => e

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -147,7 +147,7 @@ class CardGrantsController < ApplicationController
   def activate
     authorize @card_grant
 
-    @card_grant.create_stripe_card(current_session)
+    @card_grant.create_stripe_card(current_session.ip)
 
     redirect_to @card_grant
   rescue Stripe::InvalidRequestError => e

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -113,7 +113,7 @@ class StripeCardsController < ApplicationController
 
     new_card = ::StripeCardService::Create.new(
       current_user:,
-      current_session:,
+      ip_address: current_session.ip,
       event_id: event.id,
       card_type: sc[:card_type],
       stripe_shipping_name: sc[:stripe_shipping_name],

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -228,14 +228,14 @@ class CardGrant < ApplicationRecord
     stripe_card&.cancel!
   end
 
-  def create_stripe_card(session)
+  def create_stripe_card(ip_address)
     return if stripe_card.present?
 
     self.stripe_card = StripeCardService::Create.new(
       card_type: "virtual",
       event_id:,
       current_user: user,
-      current_session: session,
+      ip_address:,
       subledger:,
     ).run
 

--- a/app/services/stripe_card_service/create.rb
+++ b/app/services/stripe_card_service/create.rb
@@ -2,14 +2,14 @@
 
 module StripeCardService
   class Create
-    def initialize(current_user:, current_session:, event_id:,
+    def initialize(current_user:, ip_address:, event_id:,
                    card_type:, subledger: nil,
                    stripe_shipping_name: nil, stripe_shipping_address_city: nil,
                    stripe_shipping_address_state: nil, stripe_shipping_address_line1: nil,
                    stripe_shipping_address_line2: nil, stripe_shipping_address_postal_code: nil,
                    stripe_shipping_address_country: "US", stripe_card_personalization_design_id: nil)
       @current_user = current_user
-      @current_session = current_session
+      @ip_address = ip_address
       @event_id = event_id
       @subledger = subledger
 
@@ -120,7 +120,7 @@ module StripeCardService
     def cardholder_attrs
       {
         current_user: @current_user,
-        current_session: @current_session,
+        ip_address: @ip_address,
         event_id: event.id
       }
     end

--- a/app/services/stripe_cardholder_service/create.rb
+++ b/app/services/stripe_cardholder_service/create.rb
@@ -2,9 +2,9 @@
 
 module StripeCardholderService
   class Create
-    def initialize(current_user:, current_session:, event_id:)
+    def initialize(current_user:, ip_address:, event_id:)
       @current_user = current_user
-      @current_session = current_session
+      @ip_address = ip_address
       @event_id = event_id
     end
 
@@ -49,7 +49,7 @@ module StripeCardholderService
           card_issuing: {
             user_terms_acceptance: {
               date: DateTime.now.to_i,
-              ip: @current_session.ip
+              ip: @ip_address
             }
           }
         }


### PR DESCRIPTION
## Summary of the problem
For #11772 I can't use the `current_session` object as it is not defined in the API and we are only passing in current session for the IP address in the service. 


## Describe your changes
I just changed the parameters to just take in the IP address instead of the whole session object. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

