### PR TITLE
[HcbCode] Fix `receipt_required?` to not require for revenue

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -503,9 +503,11 @@ class HcbCode < ApplicationRecord
     return false unless event&.plan&.receipts_required?
 
     # Before Feb. 2024, receipts were not required for ACHs, checks, PayPal transfers, and Wires
-    return false if [:ach, :check, :paypal_transfer, :wire].include?(type) && created_at <= Time.utc(2024, 2, 1)
+    return false if [:ach, :check, :increase_check, :paypal_transfer, :wire].include?(type) && created_at <= Time.utc(2024, 2, 1)
 
-    true
+    return true if [:card_charge, :ach, :check, :increase_check, :paypal_transfer, :wire, :wise_transfer].include?(type)
+
+    false
   end
 
   def receipt_optional?

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -507,6 +507,7 @@ class HcbCode < ApplicationRecord
 
     return true if [:card_charge, :ach, :check, :increase_check, :paypal_transfer, :wire, :wise_transfer].include?(type)
 
+    # This HcbCode is likely revenue (e.g. donation, invoice, etc.) so receipts are not required
     false
   end
 


### PR DESCRIPTION
## Summary of the problem

The previous PR that I helped Luke with was buggy. I forgot that this method also needs to consider revenue HcbCodes such as donations and invoices.


## Describe your changes

We now explicitly list which types require receipts (like how the code previously was)