### PR TITLE
Fix finalized_at field failing to be set to a timestamp

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -280,7 +280,14 @@ class Invoice < ApplicationRecord
     self.auto_advance = inv.auto_advance
     self.due_date = Time.at(inv.due_date).to_datetime # convert from unixtime
     self.ending_balance = inv.ending_balance
-    self.finalized_at = inv.respond_to?(:status_transitions) ? inv.status_transitions.finalized_at : inv.try(:finalized_at)
+
+    finalized_value = if inv.respond_to?(:status_transitions)
+                        inv.status_transitions.finalized_at
+                      else
+                        inv.try(:finalized_at)
+                      end
+    self.finalized_at = finalized_value ? Time.at(finalized_value.to_i).to_datetime : nil
+
     self.hosted_invoice_url = inv.hosted_invoice_url
     self.invoice_pdf = inv.invoice_pdf
     self.livemode = inv.livemode

--- a/spec/services/invoice_service/create_spec.rb
+++ b/spec/services/invoice_service/create_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe InvoiceService::Create, type: :model do
       expect(invoice.statement_descriptor).to eq("Statement Descriptor")
       expect(invoice.status).to eq("paid")
       expect(invoice.stripe_charge_id).to eq("ch_1234")
+      expect(invoice.finalized_at).to be_present
     end
   end
 


### PR DESCRIPTION
## Summary of the problem

The Rails 7 behavior was to silently set it to nil and it was never being assigned correctly. Rails 8 will raise a `PG::DatetimeFieldOverflow` error.

- https://github.com/rails/rails/issues/53679
- https://github.com/rails/rails/issues/54110


## Describe your changes

PR extracted from last commit of https://github.com/hackclub/hcb/pull/10836/commits/47a94a6dd62c15ab322c4198e4f680cf1f9b0afd#r2203418417

Bringing over some additional @KiKoS0 comments

> I'm not sure if there are other occurrences of this that aren't covered by tests; If there are it might not be a bad idea to monkey patch it like in: https://github.com/rails/rails/issues/53679#issuecomment-2530827971

> not really sure why we need respond_to? when status_transitions isn't nullable: https://docs.stripe.com/api/invoices/object?api-version=2024-06-20#invoice_object-status_transitions. also doesn't look like the Invoice object can ever have a finalized_at field.
