### PR TITLE
Don't require a signed in user for receipt status image

### DIFF
--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -205,7 +205,7 @@ class HcbCodesController < ApplicationController
   def receipt_status
     @secret = params[:s]
     @hcb_code = HcbCode.find_signed(@secret, purpose: :receipt_status)
-    
+
     raise Pundit::NotAuthorizedError if @hcb_code.nil?
   end
 

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -4,7 +4,7 @@ class HcbCodesController < ApplicationController
   include TagsHelper
 
   skip_before_action :signed_in_user, only: [:receipt, :attach_receipt, :receipt_status, :show]
-  skip_after_action :verify_authorized, only: [:receipt]
+  skip_after_action :verify_authorized, only: [:receipt, :receipt_status]
 
   def show
     @hcb_code = HcbCode.find_by(hcb_code: params[:id]) || HcbCode.find(params[:id])
@@ -203,13 +203,8 @@ class HcbCodesController < ApplicationController
   end
 
   def receipt_status
-    @hcb_code = HcbCode.find(params[:id])
     @secret = params[:s]
-
-    authorize @hcb_code
-
-  rescue Pundit::NotAuthorizedError
-    raise unless HcbCode.find_signed(@secret, purpose: :receipt_status) == @hcb_code
+    @hcb_code = HcbCode.find_signed(@secret, purpose: :receipt_status)
   end
 
   def toggle_tag

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -205,6 +205,8 @@ class HcbCodesController < ApplicationController
   def receipt_status
     @secret = params[:s]
     @hcb_code = HcbCode.find_signed(@secret, purpose: :receipt_status)
+    
+    raise Pundit::NotAuthorizedError if @hcb_code.nil?
   end
 
   def toggle_tag

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -3,7 +3,7 @@
 class HcbCodesController < ApplicationController
   include TagsHelper
 
-  skip_before_action :signed_in_user, only: [:receipt, :attach_receipt, :show]
+  skip_before_action :signed_in_user, only: [:receipt, :attach_receipt, :receipt_status, :show]
   skip_after_action :verify_authorized, only: [:receipt]
 
   def show

--- a/app/policies/hcb_code_policy.rb
+++ b/app/policies/hcb_code_policy.rb
@@ -33,10 +33,6 @@ class HcbCodePolicy < ApplicationPolicy
     gte_member_in_events?
   end
 
-  def receipt_status?
-    user&.admin? || present_in_events? || user_made_purchase?
-  end
-
   def pin?
     gte_member_in_events?
   end

--- a/app/views/canonical_pending_transaction_mailer/_attach_receipt.html.erb
+++ b/app/views/canonical_pending_transaction_mailer/_attach_receipt.html.erb
@@ -1,7 +1,7 @@
 <% if hcb_code.receipt_required? %>
 
   <%= link_to upload_url do %>
-    <img style="display: block; margin-top: 10px;" src="<%= receipt_status_hcb_code_url(id: @cpt.local_hcb_code.hashid, format: :svg, s: @cpt.local_hcb_code.signed_id(purpose: :receipt_status)) %>" alt="Click to upload your receipt">
+    <img style="display: block; margin-top: 10px;" src="<%= receipt_status_hcb_codes_url(format: :svg, s: @cpt.local_hcb_code.signed_id(purpose: :receipt_status)) %>" alt="Click to upload your receipt">
   <% end %>
   <p><em>This link can be used by anyone for two weeks to upload a receipt for this charge.</em></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -482,7 +482,6 @@ Rails.application.routes.draw do
       get "attach_receipt"
       get "memo_frame"
       get "dispute"
-      get "receipt_status"
       post "invoice_as_personal_transaction"
       post "pin"
       post "toggle_tag/:tag_id", to: "hcb_codes#toggle_tag", as: :toggle_tag
@@ -491,6 +490,10 @@ Rails.application.routes.draw do
       scope module: "hcb_code" do
         get "subscriptions/transactions", to: "subscriptions#transactions"
       end
+    end
+
+    collection do
+      get "receipt_status"
     end
   end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/GBXBFEED9/p1759940792433679
In Gmail, a broken image is displayed where it should be a button to upload the receipt.
Originally, we thought this was due to Gmail not rendering SVGs correctly. However, it seems that we were actually requiring a signed in user to fetch the image, which would not be sent when viewing from any email client, but it would exist when viewing from hcb.hackclub.com, letter opener, or previews in development.

It's still possible that SVGs could not work in Gmail, but I'll test to see if it works after this PR is merged and deployed.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Bypass requiring a signed in user for the receipt status action.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

