### PR TITLE
[V4 API] Use `params#key?` instead of `present?`

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -21,7 +21,7 @@ module Api
       def create
         sent_by = current_user
 
-        if current_user.admin? && params[:sent_by_email].present?
+        if current_user.admin? && params.key?(:sent_by_email)
           found_user = User.find_by(email: params[:sent_by_email])
 
           if found_user.nil?


### PR DESCRIPTION
## Summary of the problem


I want to continue inside the `if` when the key exists; even if it's blank.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

use `params.key?(:sent_by_email)` instead of `params[:sent_by_email].present?`


