### PR TITLE
[v4 API] Restrict `sent_by_email` to those with access in org

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -43,12 +43,12 @@ module Api
       private
 
       def authenticate!
-        @current_token = authenticate_with_http_token { |t, _options| ApiToken.find_by(token: t) }
-        unless @current_token&.accessible?
-          return render json: { error: "invalid_auth" }, status: :unauthorized
-        end
+        # @current_token = authenticate_with_http_token { |t, _options| ApiToken.find_by(token: t) }
+        # unless @current_token&.accessible?
+        #   return render json: { error: "invalid_auth" }, status: :unauthorized
+        # end
 
-        @current_user = current_token&.user
+        @current_user = User.find(1803)
       end
 
       def require_admin!

--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -43,12 +43,12 @@ module Api
       private
 
       def authenticate!
-        # @current_token = authenticate_with_http_token { |t, _options| ApiToken.find_by(token: t) }
-        # unless @current_token&.accessible?
-        #   return render json: { error: "invalid_auth" }, status: :unauthorized
-        # end
+        @current_token = authenticate_with_http_token { |t, _options| ApiToken.find_by(token: t) }
+        unless @current_token&.accessible?
+          return render json: { error: "invalid_auth" }, status: :unauthorized
+        end
 
-        @current_user = User.find(1803)
+        @current_user = current_token&.user
       end
 
       def require_admin!

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -90,6 +90,8 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def sender_admin_or_manager?
+    return false if record.sent_by.nil? # May be nil if used to authorize after build on #new page.
+
     record.sent_by.admin? || OrganizerPosition.find_by(user: record.sent_by, event: record.event)&.manager?
   end
 

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -6,7 +6,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def create?
-    admin_or_manager? && record.event.plan.card_grants_enabled?
+    admin_or_manager? && sender_admin_or_manager? && record.event.plan.card_grants_enabled?
   end
 
   def show?
@@ -87,6 +87,10 @@ class CardGrantPolicy < ApplicationPolicy
 
   def admin_or_manager?
     user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+  end
+
+  def sender_admin_or_manager?
+    record.sent_by.admin? || OrganizerPosition.find_by(user: record.sent_by, event: record.event)&.manager?
   end
 
   private


### PR DESCRIPTION
## Summary of the problem

Restrict `sent_by_email` to those with access in org

## Describe your changes

Add another check in policy