### PR TITLE
Improve "Attach receipt" button on Discord

### DIFF
--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -152,6 +152,7 @@ module Discord
 
         respond(embeds: [{
                   title: "Your receipt has been uploaded!",
+                  description: "<@#{@user_id}>, your receipt for #{link_to("#{Money.from_cents(hcb_code.amount_cents.abs).format} at #{hcb_code.memo}", url_helpers.hcb_code_url(hcb_code))} has been uploaded successfully.",
                   color:
                 }], components: button_to("View receipt", url_helpers.hcb_code_url(hcb_code)))
       end

--- a/app/models/discord/support.rb
+++ b/app/models/discord/support.rb
@@ -55,5 +55,13 @@ module Discord
         0xec3750
       end
     end
+
+    def emoji_icon(name)
+      {
+        id: {
+          payment_docs: "1428571025804890245"
+        }[name]
+      }
+    end
   end
 end

--- a/app/models/discord/support.rb
+++ b/app/models/discord/support.rb
@@ -56,11 +56,13 @@ module Discord
       end
     end
 
+    DISCORD_EMOJI_IDS = {
+      payment_docs: "1428571025804890245"
+    }.freeze
+
     def emoji_icon(name)
       {
-        id: {
-          payment_docs: "1428571025804890245"
-        }[name]
+        id: DISCORD_EMOJI_IDS[name]
       }
     end
   end

--- a/app/views/public_activity/raw_pending_stripe_transaction/_create_discord.json.jbuilder
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create_discord.json.jbuilder
@@ -21,4 +21,4 @@ json.embed do
 
 end
 
-json.components Discord.button_to("Attach receipt", "attach_receipt:#{hcb_code.hashid}")
+json.components Discord.button_to("Attach receipt", "attach_receipt:#{hcb_code.hashid}", style: 3, emoji: Discord.emoji_icon(:payment_docs)) if hcb_code.present?


### PR DESCRIPTION
## Summary of the problem

This "Attach receipt" button is a little bit bland.


## Describe your changes

<img width="461" height="176" alt="image" src="https://github.com/user-attachments/assets/2fb7d5ad-643a-43a5-9d34-50029e92653f" />
