### PR TITLE
Use fork of suo to work around dalli log message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "redis", "~> 5.4" # for caching, jobs, etc.
 gem "sidekiq", "~> 7.3.8" # background jobs
 gem "sidekiq-cron", "~> 2.3" # run Sidekiq jobs at scheduled intervals
 gem "activejob-traffic_control" # throttle jobs
+gem "suo", github: "instacart/suo" # suo is a transitive dependency of activejob-traffic_control
+# explicitly use instacart fork here to work around dalli log in upstream https://github.com/nickelser/suo/pull/21
 
 gem "image_processing", "~> 1.2"
 gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,15 @@ GIT
   specs:
     yellow_pages (0.4.0)
 
+GIT
+  remote: https://github.com/instacart/suo.git
+  revision: e93ab4a6b5e19ed0ba915092a1a8fcab6d306258
+  specs:
+    suo (0.4.0)
+      dalli
+      msgpack
+      redis
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -817,10 +826,6 @@ GEM
     stripe (11.7.0)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
-    suo (0.4.0)
-      dalli
-      msgpack
-      redis
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.4.0)
@@ -1023,6 +1028,7 @@ DEPENDENCIES
   statsd-instrument (~> 3.9)
   stripe (= 11.7.0)
   strong_migrations (~> 1)
+  suo!
   terser (~> 1.2)
   turbo-rails (~> 2.0.17)
   twilio-ruby


### PR DESCRIPTION
suo is a transitive dependency of activejob-traffic_control, but explicitly use instacart's fork here to work around dalli log message

https://github.com/nickelser/suo/pull/21

Closes https://github.com/hackclub/hcb/issues/11755
