### PR TITLE
[v4 API] Prevent admins from obtaining stripe card ephemeral keys

### DIFF
--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -45,7 +45,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def ephemeral_keys?
-    cardholder? || user&.auditor?
+    cardholder?
   end
 
   def enable_cash_withdrawal?


### PR DESCRIPTION
## Summary of the problem

It was reported by @thedev132 that admins can add other people's cards to Apple Wallet via the mobile app


## Describe your changes

Disallow admins from obtaining someone else's stripe card ephemeral key