### PR TITLE
[Wise] Fix ample balance calculation to factor in pending amount

### DIFF
--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -176,7 +176,7 @@
         <% end %>
       </fieldset>
 
-      <fieldset class="px-6 py-3" x-data="{ amount: null, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
+      <fieldset class="px-6 py-3" x-data="{ amount: null, pending_amount: <%= @wise_transfer.quoted_usd_amount_cents %>, balance: <%= @wise_transfer.event.balance_available_v2_cents %> }">
         <legend class="py-0 px-2">Send</legend>
 
         <%= form_with(model: @wise_transfer, local: true, url: wise_transfer_path(@wise_transfer), method: :patch) do |form| %>
@@ -190,11 +190,11 @@
               "@keyup": "amount = +$event.target.value * 100",
               data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
           </div>
-          <p x-show="amount && balance >= amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
+          <p x-show="amount && balance >= (amount - pending_amount)" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
             <%= inline_icon "checkmark", class: "text-green" %>
             Sufficient funds available
           </p>
-          <p x-show="amount && balance < amount" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
+          <p x-show="amount && balance < (amount - pending_amount)" class="mx-0 bold flex flex-row justify-start items-center gap-2 my-2">
             <%= inline_icon "important", class: "text-red" %>
             Insufficient funds, please reject this transfer
           </p>


### PR DESCRIPTION
## Summary of the problem

Currently, if an organization has enough funds to cover a transfer, but not enough money to cover 2x that amount, the transfer can't be sent. This is because we create a pending transaction when a Wise transfer is created, but this reduces the organization's balance when it comes time for the ample balance check.

For example, the following situation would block an admin from approving a Wise transfer:
- DevHacks has $30.00
- DevHacks submits a Wise transfer and is quoted $20.00
- Even if the amount is still $20.00 when ops sends the transfer, DevHacks' new balance is $10.00, which is flagged as insufficient


## Describe your changes

This PR applies the original transfer amount to the new transfer amount when checking ample balance. This results in only the difference (change in amount since the time the quote was generated) being compared to the organization's balance.