### PR TITLE
[Admin] Add transfer approval limits

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class AdminController < Admin::BaseController
+  rescue_from Governance::Admin::InsufficientApprovalLimitError do |e|
+    redirect_back fallback_location: root_path, flash: { error: e.message }
+  end
+
   def task_size
     starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     size = pending_task params[:task_name].to_sym

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,6 +90,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from Governance::Admin::InsufficientApprovalLimitError do |e|
+    redirect_back fallback_location: root_path, flash: { error: e.message }
+  end
+
+
   def find_current_auditor
     current_user if auditor_signed_in?
   end

--- a/app/controllers/increase_checks_controller.rb
+++ b/app/controllers/increase_checks_controller.rb
@@ -45,6 +45,7 @@ class IncreaseChecksController < ApplicationController
   def approve
     authorize @check
 
+    Governance::Admin.ensure_may_approve_transfer!(current_user, @check.amount)
     @check.send_check!
 
     redirect_to increase_check_process_admin_path(@check), flash: { success: "Check has been sent!" }

--- a/app/controllers/paypal_transfers_controller.rb
+++ b/app/controllers/paypal_transfers_controller.rb
@@ -34,6 +34,7 @@ class PaypalTransfersController < ApplicationController
 
   def approve
     authorize @paypal_transfer
+    Governance::Admin.ensure_may_approve_transfer!(current_user, @paypal_transfer.amount_cents)
 
     @paypal_transfer.mark_approved!
 

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -201,6 +201,8 @@ module Reimbursement
 
     def admin_approve
       authorize @report
+      # TODO: This does NOT consider currency
+      Governance::Admin.ensure_may_approve_transfer!(current_user, @report.amount_to_reimburse_cents)
 
       begin
         @report.with_lock do

--- a/app/controllers/wires_controller.rb
+++ b/app/controllers/wires_controller.rb
@@ -41,6 +41,7 @@ class WiresController < ApplicationController
 
   def approve
     authorize @wire
+    Governance::Admin.ensure_may_approve_transfer!(current_user, @wire.usd_amount_cents)
 
     @wire.mark_approved!
 
@@ -69,6 +70,7 @@ class WiresController < ApplicationController
   def send_wire
     authorize @wire
 
+    Governance::Admin.ensure_may_approve_transfer!(current_user, @wire.usd_amount_cents)
     @wire.send_wire!
 
     if params[:charge_fee] == "1"

--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -47,6 +47,7 @@ class WiseTransfersController < ApplicationController
 
   def approve
     authorize @wise_transfer
+    Governance::Admin.ensure_may_approve_transfer!(current_user, @wise_transfer.quoted_usd_amount_cents)
 
     @wise_transfer.mark_approved!
 

--- a/app/models/ach_transfer.rb
+++ b/app/models/ach_transfer.rb
@@ -271,6 +271,8 @@ class AchTransfer < ApplicationRecord
   end
 
   def approve!(processed_by = nil, send_realtime: false)
+    Governance::Admin.ensure_may_approve_transfer!(processed_by, amount)
+
     if scheduled_on.present?
       mark_scheduled!
     elsif send_realtime

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -188,6 +188,8 @@ class Disbursement < ApplicationRecord
   end
 
   def approve_by_admin(user)
+    Governance::Admin.ensure_may_approve_transfer!(user, amount)
+
     if scheduled_on.present?
       mark_scheduled!(user)
     else

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -188,7 +188,11 @@ class Disbursement < ApplicationRecord
   end
 
   def approve_by_admin(user)
-    Governance::Admin.ensure_may_approve_transfer!(user, amount)
+    # Don't check admin transfer limits for card grants. This method is also
+    # used to auto-approve card grants; even ones NOT sent by admins.
+    unless source_event == destination_event
+      Governance::Admin.ensure_may_approve_transfer!(user, amount)
+    end
 
     if scheduled_on.present?
       mark_scheduled!(user)

--- a/app/models/governance.rb
+++ b/app/models/governance.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Governance
+  class Error < StandardError; end
+end

--- a/app/models/governance/admin.rb
+++ b/app/models/governance/admin.rb
@@ -4,8 +4,7 @@ module Governance
   module Admin
     TRANSFER_APPROVAL_LIMITS = {
       admin: Money.new(5_000_00), # $5k USD
-      # superadmin: Money.new(200_000_00) # $200k USD
-      superadmin: Money.new(200) # TODO: teseting
+      superadmin: Money.new(200_000_00) # $200k USD
     }.freeze
 
     class InsufficientApprovalLimitError < Governance::Error; end

--- a/app/models/governance/admin.rb
+++ b/app/models/governance/admin.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Governance
+  module Admin
+    TRANSFER_APPROVAL_LIMITS = {
+      admin: Money.new(5_000_00), # $5k USD
+      # superadmin: Money.new(200_000_00) # $200k USD
+      superadmin: Money.new(200) # TODO: teseting
+    }.freeze
+
+    class InsufficientApprovalLimitError < Governance::Error; end
+
+    def self.ensure_may_approve_transfer!(user, amount_cents)
+      unless may_approve_transfer?(user, amount_cents)
+        amount = Money.new(amount_cents)
+        role_required = role_required_to_approve_transfer(amount_cents)
+        raise InsufficientApprovalLimitError, <<~MSG.squish
+          You do not have sufficient permissions to approve a transfer of #{amount.format}.
+          Please contact #{role_required} for help.
+        MSG
+      end
+    end
+
+    def self.may_approve_transfer?(user, amount_cents)
+      return false unless user&.admin?
+
+      amount = amount_cents.is_a?(Money) ? amount_cents : Money.from_cents(amount_cents)
+      amount <= transfer_approval_limit(user)
+    rescue KeyError
+      Rails.error.unexpected("Unknown access level '#{user.access_level}' for user ID #{user.id} when checking transfer approval limit")
+
+      false
+    end
+
+    def self.transfer_approval_limit(user)
+      return ArgumentsError.new("User must be an admin") unless user&.admin?
+
+      TRANSFER_APPROVAL_LIMITS.fetch(user.access_level.to_sym)
+    end
+
+    def self.role_required_to_approve_transfer(amount_cents)
+      amount = amount_cents.is_a?(Money) ? amount_cents : Money.from_cents(amount_cents)
+
+      role, _limit = TRANSFER_APPROVAL_LIMITS.sort_by { |_role, limit| limit }.find { |_role, limit| amount <= limit }
+
+      case role
+      when :admin
+        "an admin"
+      when :superadmin
+        "a superadmin"
+      when nil
+        # Well, no one can approve this transfer! Contact Gary for help.
+        "Gary"
+      else
+        role.to_s.humanize
+      end
+    end
+
+  end
+end

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -78,7 +78,7 @@ module DisbursementService
           i_cpt.update(fronted: @fronted)
         end
 
-        if requested_by_admin? || disbursement.source_event == disbursement.destination_event # Auto-fulfill disbursements between subledgers in the same event
+        if requested_by_admin_with_approval_permission? || disbursement.source_event == disbursement.destination_event # Auto-fulfill disbursements between subledgers in the same event
           disbursement.approve_by_admin(requested_by)
         end
 
@@ -110,6 +110,10 @@ module DisbursementService
 
     def requested_by_admin?
       !@skip_auto_approve && requested_by&.admin?
+    end
+
+    def requested_by_admin_with_approval_permission?
+      requested_by_admin? && Governance::Admin.may_approve_transfer?(requested_by, amount_cents)
     end
 
     def amount_cents

--- a/app/services/invoice_service/mark_paid.rb
+++ b/app/services/invoice_service/mark_paid.rb
@@ -14,6 +14,8 @@ module InvoiceService
     end
 
     def run
+      Governance::Admin.ensure_may_approve_transfer!(@user, invoice.item_amount)
+
       raise ArgumentError, "reason is required" if @reason.blank?
       if remote_invoice.paid? && !remote_invoice.paid_out_of_band
         raise ArgumentError, "can not manually mark an invoice as paid when it was already paid through Stripe"


### PR DESCRIPTION
## Summary of the problem

For security, we want to implement transfer approval limits for admins. All users (including admins) should still be able to request transfers of any amount. However, only certain individuals can approve larger amounts.

## Describe your changes

- Admins can approve <= $5k
- Superadmins can approve <= $200k
- If anyone needs >= $200k, talk to me! (@garyhtou)

This applies to all external transfers that require human review.

<img width="528" height="122" alt="image" src="https://github.com/user-attachments/assets/de40af66-a5e6-4ac6-a3d2-eb48aba44761" />
