### PR TITLE
[Card Grant] Enable form

### DIFF
--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -90,7 +90,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def sender_admin_or_manager?
-    return false if record.sent_by.nil? # May be nil if used to authorize after build on #new page.
+    return true if record.sent_by.nil? # May be nil if used to authorize after build on #new page.
 
     record.sent_by.admin? || OrganizerPosition.find_by(user: record.sent_by, event: record.event)&.manager?
   end


### PR DESCRIPTION
## Summary of the problem

card grant create form is currently disabled for everyone.. whoops

<img width="608" height="645" alt="image" src="https://github.com/user-attachments/assets/758695da-24a0-4283-881b-e2af5e89b879" />


## Describe your changes

We check the create policy to determine whether to disable the form. Because `sent_by` isn't set on an empty form, we can ignore this check by returning true.