### PR TITLE
[Wise] Add admin status filter and highlight approved transfers

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -717,15 +717,18 @@ class AdminController < Admin::BaseController
     @per = params[:per] || 20
     @q = params[:q].presence
     @event_id = params[:event_id].presence
+    @status = WiseTransfer.aasm.states.collect(&:name).include?(params[:status]&.to_sym) ? params[:status] : nil
 
     @wise_transfers = WiseTransfer.all
 
     @wise_transfers = @wise_transfers.search_recipient(@q) if @q
 
-    @wise_transfers.where(event_id: @event_id) if @event_id
+    @wise_transfers = @wise_transfers.where(event_id: @event_id) if @event_id
+    @wise_transfers = @wise_transfers.where(aasm_state: @status) if @status
 
     @wise_transfers = @wise_transfers.page(@page).per(@per).order(
       Arel.sql("aasm_state = 'pending' DESC"),
+      Arel.sql("aasm_state = 'approved' DESC"),
       "created_at desc"
     )
   end

--- a/app/views/admin/wise_transfers.html.erb
+++ b/app/views/admin/wise_transfers.html.erb
@@ -3,6 +3,7 @@
 <%= form_with local: true, url: wise_transfers_admin_index_path, method: :get do |form| %>
   <%= form.text_field :q, value: params[:q], placeholder: "Search" %>
   <%= form.collection_select(:event_id, Event.reorder(Event::CUSTOM_SORT), :id, :admin_dropdown_description, { include_blank: "Select An Event", selected: @event_id }, { width: 250, style: "max-width: 250px" }) %>
+  <%= form.collection_select(:status, WiseTransfer.aasm.states, :name, :human_name, { include_blank: "Filter by status", selected: @status }, { width: 250, style: "max-width: 250px" }) %>
   <%= form.submit "Search" %>
 <% end %>
 

--- a/app/views/admin/wise_transfers.html.erb
+++ b/app/views/admin/wise_transfers.html.erb
@@ -27,7 +27,7 @@
   </thead>
   <tbody>
     <% @wise_transfers.each do |wise_transfer| %>
-      <tr class="<%= "admin-bg-pending" if wise_transfer.pending? %>">
+      <tr class="<%= "admin-bg-pending" if wise_transfer.pending? %> <%= "admin-bg-transit" if wise_transfer.approved? %>">
         <td><%= wise_transfer.id %></td>
         <td><%= wise_transfer.created_at.strftime("%Y-%m-%d") %></td>
         <td><%= wise_transfer.event.name %></td>


### PR DESCRIPTION
Fixes #11829

## Summary of the problem

- It can be difficult to easily spot approved transfers (only sent transfers are highlighted)
- There's no way to filter Wise transfers by status
- The event select field doesn't work


## Describe your changes

Fixes the aforementioned problems by
- Highlighting approved transfers
- Adding a Wise transfer status filter
- Fixing the event select filter

<img width="1414" height="511" alt="image" src="https://github.com/user-attachments/assets/8979f787-9208-485b-aa4f-eb68336a09f7" />
