### PR TITLE
[Twilio] Report errors from `TwilioVerificationService`

### DIFF
--- a/app/services/twilio_verification_service.rb
+++ b/app/services/twilio_verification_service.rb
@@ -16,6 +16,9 @@ class TwilioVerificationService
           .services(VERIFY_SERVICE_ID)
           .verifications
           .create(to: phone_number, channel: "sms")
+  rescue => e
+    Rails.error.report(e)
+    raise
   end
 
   def check_verification_token(phone_number, code)
@@ -24,6 +27,9 @@ class TwilioVerificationService
                          .verification_checks
                          .create(to: phone_number, code:)
     verification.status == "approved"
+  rescue => e
+    Rails.error.report(e)
+    raise
   end
 
 end


### PR DESCRIPTION
## Summary of the problem

We knew Twilio was down due to the AWS outage, but I didn't see any AppSignal errors about it. I discovered that in the controller, we're rescuing the error without reporting.

https://github.com/hackclub/hcb/blob/d9c491d29a35d617c7474701dea9d913a5d60f82/app/services/login_code_service/request.rb#L25-L30


## Describe your changes

Rescue errors in service, report, and then reraise.