### PR TITLE
[Perks] Remove period from robotics printer raffle tooltip

### DIFF
--- a/app/views/events/perks/_robotics_printer_raffle.html.erb
+++ b/app/views/events/perks/_robotics_printer_raffle.html.erb
@@ -11,7 +11,7 @@
         <% if event.robotics_team? || event.affiliations.robotics.any? || @is_argosy %>
           <span class="btn disabled bg-clip-padding"><%= pluralize(active_teenagers_count, "ticket") %></span>
         <% else %>
-          <div class="tooltipped tooltipped--w inline-block" aria-label="Must be tagged as a robotics team or have a robotics affiliation.">
+          <div class="tooltipped tooltipped--w inline-block" aria-label="Must be tagged as a robotics team or have a robotics affiliation">
             <span class="btn disabled bg-clip-padding">Ineligible</span>
           </div>
         <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
None of the other perks have periods in their tooltips.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

