### PR TITLE
[Discord] Update integration card header background

### DIFF
--- a/app/assets/stylesheets/components/_integrations.scss
+++ b/app/assets/stylesheets/components/_integrations.scss
@@ -2,7 +2,11 @@
   color: white;
 
   background: #32406e;
-  background: linear-gradient(33deg, rgba(50, 64, 110, 1) 0%, rgba(88, 101, 242, 1) 100%);
+  background: linear-gradient(
+    33deg,
+    rgba(50, 64, 110, 1) 0%,
+    rgba(88, 101, 242, 1) 100%
+  );
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;

--- a/app/assets/stylesheets/components/_integrations.scss
+++ b/app/assets/stylesheets/components/_integrations.scss
@@ -1,14 +1,8 @@
 .integration-discord {
   color: white;
 
-  background-color: #f5f5f5;
-  background-image:
-    linear-gradient(
-      to right,
-      rgba(245, 246, 252, 0.25),
-      rgba(248, 248, 248, 0.05)
-    ),
-    url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/03659550ddee837a06c9c3281fba0f02aadbcb8a_discord-banner.png');
+  background: #32406e;
+  background: linear-gradient(33deg, rgba(50, 64, 110, 1) 0%, rgba(88, 101, 242, 1) 100%);
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;

--- a/app/views/integrations/_discord_integration.html.erb
+++ b/app/views/integrations/_discord_integration.html.erb
@@ -2,7 +2,10 @@
 
 <div class="card pb0 mb3">
   <div class="card__banner card__banner--top flex justify-between items-center integration-discord">
-    <h3 class="h1 pt2 pb2 my0">Discord</h3>
+    <div class="flex gap-4 items-center">
+      <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/33b33ecc0ada9fe45d62f01e3511bbe3f5a0b195_Discord-Symbol-White.png" alt="Discord logo" class="h-10">
+      <h3 class="h1 pt2 pb2 my0">Discord</h3>
+    </div>
     <% if active %>
       <%= link_to(
             "Unlink",


### PR DESCRIPTION
## Summary of the problem

Updates the Discord integration card background.
<img width="1852" height="408" alt="image" src="https://github.com/user-attachments/assets/23d267e8-f91d-499a-81cd-a524ffbe1c6b" />



## Describe your changes

This commit was intended to be a part of https://github.com/hackclub/hcb/pull/11839, but I forgot to push; whoops.