### PR TITLE
Fix invoice min of $1.00

### DIFF
--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -246,7 +246,7 @@ class HcbCodesController < ApplicationController
 
     authorize hcb_code
 
-    if hcb_code.amount_cents >= -100
+    if hcb_code.amount_cents > -100
       flash[:error] = "Invoices can only be generated for charges of $1.00 or more."
       return redirect_to hcb_code
     end


### PR DESCRIPTION
## Summary of the problem
HelpScout Ticket #49269

When flagging a reimbursement as a personal transaction, for a charge of $1.00 (⁠-100), the condition ⁠-100 >= -100 is ⁠true, so we incorrectly show an error.