### PR TITLE
[OrganizerPositionInvite] Hint when accepting invite with wrong user

### DIFF
--- a/app/controllers/organizer_position_invites_controller.rb
+++ b/app/controllers/organizer_position_invites_controller.rb
@@ -59,6 +59,13 @@ class OrganizerPositionInvitesController < ApplicationController
     elsif @invite.rejected?
       redirect_to root_path, flash: { error: "You’ve already rejected this invitation." }
     end
+  rescue Pundit::NotAuthorizedError
+    if @invite.user != current_user
+      flash[:error] = "This invitation was sent to #{@invite.user.redacted_email}, but you are currently logged in as #{current_user.email }."
+      redirect_to root_path and return
+    end
+
+    raise
   end
 
   def accept

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,6 +288,20 @@ class User < ApplicationRecord
     words.any? ? words.map(&:first).join.upcase : name
   end
 
+  # gary@hackclub.com → g***y@hackclub.com
+  # gt@hackclub.com → g*@hackclub.com
+  # g@hackclub.com → g@hackclub.com
+  def redacted_email
+    handle, domain = email.split("@")
+    redacted_handle =
+      if handle.length <= 2
+        handle[0] + "*" * (handle.length - 1)
+      else
+        "#{handle[0]}***#{handle[-1]}"
+      end
+    "#{redacted_handle}@#{domain}"
+  end
+
   def pretty_phone_number
     Phonelib.parse(self.phone_number).national
   end


### PR DESCRIPTION
## Summary of the problem

A user ran into a confusing moment when they attempted to accept an invite with another email address. They were unaware they were using the wrong account because all HCB says is "You are not authorized to perform this action."


## Describe your changes

🥁 Introducing.... a helpful hint!

<img width="308" height="232" alt="image" src="https://github.com/user-attachments/assets/1e3999c9-a165-400b-b830-9759ff79a87a" />
