### PR TITLE
[Event::ScopedTag] Use `muted` background

### DIFF
--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -55,7 +55,7 @@
 
         <% if policy(event).toggle_scoped_tag? %>
           <div data-controller="menu" class="inline">
-            <button class="badge m-0 menu__toggle menu__toggle--arrowless border-none" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
+            <button class="badge m-0 menu__toggle menu__toggle--arrowless border-none bg-muted" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
             <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
               <% event.parent.subevent_scoped_tags.each do |scoped_tag| %>
                 <div class="flex items-center" data-scoped-tag="<%= scoped_tag.id %>">

--- a/app/views/events/scoped_tags/_scoped_tag.html.erb
+++ b/app/views/events/scoped_tags/_scoped_tag.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (scoped_tag:, subevent:, streamed: false) %>
 
-<span class="badge m-0 mb-1" data-scoped-tag="<%= scoped_tag.id %>">
+<span class="badge m-0 mb-1 bg-muted" data-scoped-tag="<%= scoped_tag.id %>">
   <%= scoped_tag.name %>
 
   <% if local_assigns[:streamed] || policy(scoped_tag).toggle_tag? %>


### PR DESCRIPTION
## Summary of the problem

It currently shows as red in lightmode. See image below.

<img width="367" height="174" alt="image" src="https://github.com/user-attachments/assets/2951994e-683c-4647-95d9-67c6e38016b6" />


## Describe your changes

Add `bg-muted` CSS class. See the "Tag A" in screenshot above for how it looks. I applied the CSS class to all scoped tags including the Add Tag button (not reflected in the screenshot).