### PR TITLE
Handle nil scoped tags in EventService::Create

### DIFF
--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -37,7 +37,7 @@ module EventService
       @invited_by = invited_by
       @cosigner_email = cosigner_email
       @include_onboarding_videos = include_onboarding_videos
-      @scoped_tags = scoped_tags
+      @scoped_tags = scoped_tags || []
     end
 
     def run


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#11907 introduced a new scoped tags parameter to `EventService::Create`, but if `nil` is explicitly passed to this (which happens when creating a subevent without any scoped tags), it errors as it expects an array to map.

https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2397/samples/timestamp/2025-10-23T09:35:51Z

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add an extra fallback in the `initialize` method to ensure that `@scoped_tags` is an empty array if no tags are passed in.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

