### PR TITLE
[v4] Include application helper in controllers

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V4
     class StripeCardsController < ApplicationController
       include SetEvent
+      include ApplicationHelper
 
       def index
         if params[:event_id].present?

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V4
     class TransactionsController < ApplicationController
       include SetEvent
+      include ApplicationHelper
 
       before_action :set_api_event, only: [:update, :memo_suggestions]
       skip_after_action :verify_authorized, only: [:missing_receipt]


### PR DESCRIPTION
## Summary of the problem
Stripe cards and transaction controller can't access paginate_hcb_codes because we're not including the helper in the controller


## Describe your changes
Included the helper in those controllers. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

