### PR TITLE
[v4] Preload only the paginated event transactions

### DIFF
--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -31,7 +31,7 @@ module Api
 
         if @transactions.any?
 
-          page_settled = @transactions.select { |tx| tx.is_a?(::CanonicalTransactionGrouped) }
+          page_settled = @transactions.select { |tx| tx.is_a?(CanonicalTransactionGrouped) }
           page_pending = @transactions.select { |tx| tx.is_a?(CanonicalPendingTransaction) }
 
           if page_settled.any?

--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -20,10 +20,7 @@ module Api
         authorize @event, :show_in_v4?
 
         @settled_transactions = TransactionGroupingEngine::Transaction::All.new(event_id: @event.id).run
-        TransactionGroupingEngine::Transaction::AssociationPreloader.new(transactions: @settled_transactions, event: @event).run!
-
         @pending_transactions = PendingTransactionEngine::PendingTransaction::All.new(event_id: @event.id).run
-        PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions: @pending_transactions, event: @event).run!
 
         type_results = ::EventsController.filter_transaction_type(params[:type], settled_transactions: @settled_transactions, pending_transactions: @pending_transactions)
         @settled_transactions = type_results[:settled_transactions]
@@ -31,6 +28,20 @@ module Api
 
         @total_count = @pending_transactions.count + @settled_transactions.count
         @transactions = paginate_transactions(@pending_transactions + @settled_transactions)
+
+        if @transactions.any?
+
+          page_settled = @transactions.select { |tx| tx.is_a?(::CanonicalTransactionGrouped) }
+          page_pending = @transactions.select { |tx| tx.is_a?(CanonicalPendingTransaction) }
+
+          if page_settled.any?
+            TransactionGroupingEngine::Transaction::AssociationPreloader.new(transactions: page_settled, event: @event).run!
+          end
+
+          if page_pending.any?
+            PendingTransactionEngine::PendingTransaction::AssociationPreloader.new(pending_transactions: page_pending, event: @event).run!
+          end
+        end
       end
 
       def followers


### PR DESCRIPTION
## Summary of the problem
API times to load big orgs like HQ or HCB Ops is wayyyyyy longer than ledger. Why? The code is preloading associations for ALL transactions, and we're only showing 25 of them.

## Describe your changes
This moves the association preloader logic after we have paginated them, so only preloads the 25 or whatever transactions instead of all. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

