### PR TITLE
[Wise] Show more descriptive error message & fix CAD payout settings

### DIFF
--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -48,11 +48,10 @@ module HasWiseRecipient
         fields << { type: :select, key: "account_type", label: "Account type", options: { "Checking": "checking", "Savings": "savings" } }
       elsif currency == "CAD"
         fields << { type: :select, key: "account_type", label: "Account type", options: { "Bank Account": "bank_account", "Interac": "interac" } }
-        fields << { type: :text_field, key: "institution_number", placeholder: "123", label: "Institution number", conditional: "account_type == 'bank_account'" }
-        fields << { type: :text_field, key: "branch_number", placeholder: "45678", label: "Branch number", conditional: "account_type == 'bank_account'" }
-        fields << { type: :text_field, key: "account_number", placeholder: "123456789", label: "Account number", conditional: "account_type == 'bank_account'" }
-        fields << { type: :check_box, key: "use_same_email_for_interac", required: false, label_options: { "x-text": "email ? `Use '${email}' for Interac?` : 'Use the same email for Interac?'" }, conditional: "account_type == 'interac'" }
-        fields << { type: :text_field, key: "interac_email", placeholder: "fionah@gmail.com", label: "Or, enter your Interac email", conditional: "account_type == 'interac' && !use_same_email_for_interac" }
+        fields << { type: :text_field, key: "institution_number", placeholder: "123", label: "Institution number", conditional: "account_type != 'interac'" }
+        fields << { type: :text_field, key: "branch_number", placeholder: "45678", label: "Branch number", conditional: "account_type != 'interac'" }
+        fields << { type: :text_field, key: "account_number", placeholder: "123456789", label: "Account number", conditional: "account_type != 'interac'" }
+        fields << { type: :text_field, key: "interac_email", placeholder: "fionah@gmail.com", label: "Interac email", conditional: "account_type == 'interac'" }
       elsif currency == "CLP"
         fields << ACCOUNT_NUMBER_FIELD
         fields << { type: :text_field, key: "rut_number", placeholder: "12345678-9", label: "RUT number" }

--- a/app/services/reimbursement/payout_holding_service/process_single.rb
+++ b/app/services/reimbursement/payout_holding_service/process_single.rb
@@ -43,7 +43,7 @@ module Reimbursement
       end
 
       def payout_holding
-        @payout_holding ||= Reimbursement::PayoutHolding.pending.find(@payout_holding_id)
+        @payout_holding ||= Reimbursement::PayoutHolding.find(@payout_holding_id)
       end
 
     end


### PR DESCRIPTION
## Summary of the problem

We don't want to re-process payout holdings that are no longer pending, however we're currently filtering out pending payout holdings with a scope, even though there's already code to filter them out in the job.

We're also not storing the Interac email, which can be ambiguous on the operations side and mess up our data if their HCB email address changes.

## Describe your changes

This PR removes the `.pending` scope (which prevents `ActiveRecord::RecordNotFound` errors causing a 404) and does away with the "Use the same email for Interac?" checkbox.


<img width="497" height="491" alt="image" src="https://github.com/user-attachments/assets/437def81-cf9c-4770-8885-b3a32051ebe6" />
