### PR TITLE
[Discord] Rescue `ActionView::Template::Error` errors, too

### DIFF
--- a/app/jobs/discord/process_notification_job.rb
+++ b/app/jobs/discord/process_notification_job.rb
@@ -42,7 +42,7 @@ module Discord
         }.merge(json["embed"] || {})
 
         components = format_components(json["components"])
-      rescue ActionView::MissingTemplate # fallback to HTML (which already exists for all activities)
+      rescue ActionView::MissingTemplate, ActionView::Template::Error # fallback to HTML (which already exists for all activities)
         html = ApplicationController.renderer.render(partial: "public_activity/activity", locals:)
         html = Loofah.scrub_html5_fragment(html, discord_scrubber)
 


### PR DESCRIPTION
## Summary of the problem
We aren't handling `ActionView::Template::Error` errors


## Describe your changes
Handle `ActionView::Template::Error` errors

Fixes #11929 