### PR TITLE
[Announcements] Update notice email to clarify monthly announcements

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -31,18 +31,7 @@ class AnnouncementMailer < ApplicationMailer
 
     @cancellation_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement has been canceled").first
 
-    subject = "[#{@event.name}] Explaining monthly announcements"
-
-    unless @cancellation_email.present?
-      scheduled_for = Date.today.next_month.beginning_of_month
-      @warning_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{scheduled_for.strftime("%B #{scheduled_for.day.ordinalize}")}").first
-
-      if @warning_email.nil?
-        subject = "[#{@event.name}] Monthly announcements are enabled for your organization"
-      end
-    end
-
-    mail to: @emails, subject:
+    mail to: @emails, subject: "[#{@event.name}] #{@cancellation_email.present? ? "Explaining monthly announcements" : "Monthly announcements are enabled for your organization"}"
   end
 
   def set_warning_variables

--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -29,7 +29,13 @@ class AnnouncementMailer < ApplicationMailer
     @monthly_announcement = params[:monthly_announcement]
     @scheduled_for = Date.today.next_month.beginning_of_month
 
-    mail to: @emails, subject: "[#{@event.name}] Monthly announcements have been enabled for your organization"
+    @cancellation_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement has been canceled").first
+
+    if @cancellation_email.present?
+      mail to: @emails, subject: "[#{@event.name}] Explaining monthly announcements"
+    else
+      mail to: @emails, subject: "[#{@event.name}] Monthly announcements are enabled for your organization"
+    end
   end
 
   def set_warning_variables

--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -31,11 +31,18 @@ class AnnouncementMailer < ApplicationMailer
 
     @cancellation_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement has been canceled").first
 
-    if @cancellation_email.present?
-      mail to: @emails, subject: "[#{@event.name}] Explaining monthly announcements"
-    else
-      mail to: @emails, subject: "[#{@event.name}] Monthly announcements are enabled for your organization"
+    subject = "[#{@event.name}] Explaining monthly announcements"
+
+    unless @cancellation_email.present?
+      scheduled_for = Date.today.next_month.beginning_of_month
+      @warning_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement will be delivered on #{scheduled_for.strftime("%B #{scheduled_for.day.ordinalize}")}").first
+
+      if @warning_email.nil?
+        subject = "[#{@event.name}] Monthly announcements are enabled for your organization"
+      end
     end
+
+    mail to: @emails, subject:
   end
 
   def set_warning_variables

--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -31,7 +31,14 @@ class AnnouncementMailer < ApplicationMailer
 
     @cancellation_email = Ahoy::Message.where(sent_at: Date.today.beginning_of_month.., subject: "[#{@event.name}] Your scheduled monthly announcement has been canceled").first
 
-    mail to: @emails, subject: "[#{@event.name}] #{@cancellation_email.present? ? "Explaining monthly announcements" : "Monthly announcements are enabled for your organization"}"
+    if @cancellation_email.present?
+      email = Mail.read_from_string(@cancellation_email.content)
+      message_id = email.message_id
+
+      mail to: @emails, subject: "[#{@event.name}] Explaining monthly announcements", in_reply_to: message_id, references: message_id
+    else
+      mail to: @emails, subject: "[#{@event.name}] Monthly announcements are enabled for your organization"
+    end
   end
 
   def set_warning_variables

--- a/app/views/announcement_mailer/notice.html.erb
+++ b/app/views/announcement_mailer/notice.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <% if @cancellation_email.present? || @warning_email.present? %>
-  <p> 
+  <p>
     You recently received an email from HCB saying that your scheduled monthly announcement <%= @cancellation_email.present? ? "has been canceled" : "will go out in 7 days" %>.
     This is related to a new feature on HCB, organization announcements, which will help you send out announcements on HCB to people who follow your organization.
   </p>

--- a/app/views/announcement_mailer/notice.html.erb
+++ b/app/views/announcement_mailer/notice.html.erb
@@ -2,9 +2,9 @@
   Hey<%= " all" if @emails.size > 1 %>,
 </p>
 
-<% if @cancellation_email.present? %>
+<% if @cancellation_email.present? || @warning_email.present? %>
   <p> 
-    You recently received an email from HCB saying that your scheduled monthly announcement has been canceled.
+    You recently received an email from HCB saying that your scheduled monthly announcement <%= @cancellation_email.present? ? "has been canceled" : "will go out in 7 days" %>.
     This is related to a new feature on HCB, organization announcements, which will help you send out announcements on HCB to people who follow your organization.
   </p>
 
@@ -15,7 +15,9 @@
 
   <p>
     This feature was automatically enabled for <%= @event.name %>, which is why you were sent the email about your scheduled monthly announcement.
-    HCB will cancel sending monthly announcements if they are not edited or if there is no recent activity to include in the announcement.
+    <% if @cancellation_email.present? %>
+      HCB will cancel sending monthly announcements if they are not edited or if there is no recent activity to include in the announcement.
+    <% end %>
   </p>
 <% else %>
   <p>

--- a/app/views/announcement_mailer/notice.html.erb
+++ b/app/views/announcement_mailer/notice.html.erb
@@ -2,9 +2,9 @@
   Hey<%= " all" if @emails.size > 1 %>,
 </p>
 
-<% if @cancellation_email.present? || @warning_email.present? %>
+<% if @cancellation_email.present? %>
   <p>
-    You recently received an email from HCB saying that your scheduled monthly announcement <%= @cancellation_email.present? ? "has been canceled" : "will go out in 7 days" %>.
+    You recently received an email from HCB saying that your scheduled monthly announcement has been cancelled.
     This is related to a new feature on HCB, organization announcements, which will help you send out announcements on HCB to people who follow your organization.
   </p>
 
@@ -15,9 +15,7 @@
 
   <p>
     This feature was automatically enabled for <%= @event.name %>, which is why you were sent the email about your scheduled monthly announcement.
-    <% if @cancellation_email.present? %>
-      HCB will cancel sending monthly announcements if they are not edited or if there is no recent activity to include in the announcement.
-    <% end %>
+    HCB will cancel sending monthly announcements if they are not edited or if there is no recent activity to include in the announcement.
   </p>
 <% else %>
   <p>

--- a/app/views/announcement_mailer/notice.html.erb
+++ b/app/views/announcement_mailer/notice.html.erb
@@ -2,22 +2,40 @@
   Hey<%= " all" if @emails.size > 1 %>,
 </p>
 
+<% if @cancellation_email.present? %>
+  <p> 
+    You recently received an email from HCB saying that your scheduled monthly announcement has been canceled.
+    This is related to a new feature on HCB, organization announcements, which will help you send out announcements on HCB to people who follow your organization.
+  </p>
+
+  <p>
+    Monthly announcements are an optional feature that automatically generates an announcement each month to send out to your followers.
+    By default, they will include a short message and public data about your organization from the past month such as donation and spending summaries, but you can edit the announcement to include whatever you'd like.
+  </p>
+
+  <p>
+    This feature was automatically enabled for <%= @event.name %>, which is why you were sent the email about your scheduled monthly announcement.
+    HCB will cancel sending monthly announcements if they are not edited or if there is no recent activity to include in the announcement.
+  </p>
+<% else %>
+  <p>
+    We recently launched a new feature on HCB - organization announcements! This will help you send out announcements on HCB to people who follow your organization.
+  </p>
+
+  <p>
+    Your organization also has monthly announcements enabled!
+    This is a feature that automatically generates an announcement each month to send out to your followers.
+  </p>
+
+  <p>
+    By default, they will include a short message and public data about your organization from the past month such as donation and spending summaries, but you can edit the announcement to include whatever you'd like.
+  </p>
+<% end %>
+
 <p>
-  We recently launched a new feature on HCB - organization announcements! This will help you send out announcements on HCB to people who follow your organization.
   For more details, check out <%= link_to "our blog post", "https://blog.hcb.hackclub.com/posts/organization-announcements" %> and the new Announcements page on any of your organizations.
+  If you would like to disable monthly announcements, you can do so in <%= link_to "your organization settings", edit_event_url(@event) %>.
 </p>
-
-<p>
-  Your organization also has monthly announcements enabled!
-  This is a feature that automatically generates an announcement each month to send out to your followers.
-</p>
-
-<p>
-  By default, they will include a short message and public data about your organization from the past month such as donation and spending summaries, but you can edit the announcement to include whatever you'd like.
-  We've already generated your first monthly announcement to be sent on <%= @scheduled_for.strftime("%B #{@scheduled_for.day.ordinalize}") %> - <%= link_to "view or edit it on HCB", announcement_url(@monthly_announcement) %>!
-</p>
-
-<p>If you would like to disable monthly announcements, you can do so in <%= link_to "your organization settings", edit_event_url(@event) %>.</p>
 
 <p>
   Sincerely,

--- a/app/views/announcement_mailer/notice.html.erb
+++ b/app/views/announcement_mailer/notice.html.erb
@@ -5,7 +5,7 @@
 <% if @cancellation_email.present? %>
   <p>
     You recently received an email from HCB saying that your scheduled monthly announcement has been cancelled.
-    This is related to a new feature on HCB, organization announcements, which will help you send out announcements on HCB to people who follow your organization.
+    This is related to a new feature on HCB, organization announcements, which will help you send out announcements to people who follow your organization on HCB.
   </p>
 
   <p>
@@ -19,7 +19,7 @@
   </p>
 <% else %>
   <p>
-    We recently launched a new feature on HCB - organization announcements! This will help you send out announcements on HCB to people who follow your organization.
+    We recently launched a new feature on HCB: organization announcements! This will help you send announcements to people who follow your organization on HCB.
   </p>
 
   <p>

--- a/spec/mailers/previews/announcement_mailer_preview.rb
+++ b/spec/mailers/previews/announcement_mailer_preview.rb
@@ -15,7 +15,7 @@ class AnnouncementMailerPreview < ActionMailer::Preview
   end
 
   def notice
-    AnnouncementMailer.with(event: Event.last, monthly_announcement: Announcement.monthly.last).notice
+    AnnouncementMailer.with(event: Announcement.monthly.last.event, monthly_announcement: Announcement.monthly.last).notice
   end
 
   def canceled


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
On October 25th, emails were sent to many managers of organizations with monthly announcements enabled with the subject "Your scheduled monthly announcement has been canceled". This was confusing and surprising since this was the first time most of these organizations had heard of monthly announcements.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The announcement notice mailer was never sent out, so it has been updated to include a clarification for the events that got the cancellation email. For events with monthly announcements enabled that did not get the cancellation email, the notice mailer will just contain an overview of announcements and monthly announcements.

`OneTimeJobs::SendAnnouncementNotice.perform_now` should be run in the console to send this email after this PR has been merged and deployed.

For events that got the cancellation email:
<img width="1897" height="935" alt="image" src="https://github.com/user-attachments/assets/822fa0d0-701c-455a-9600-3c2ba1b585aa" />

For events that did not get the cancellation email:
<img width="1897" height="935" alt="image" src="https://github.com/user-attachments/assets/054a65d1-3d3f-48c8-9b1d-5215f43ffc3a" />