### PR TITLE
[Announcements] Unlink transparency mode and monthly announcements

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -451,7 +451,6 @@ class Event < ApplicationRecord
   after_validation :move_friendly_id_error_to_slug
 
   after_update :generate_stripe_card_designs, if: -> { attachment_changes["stripe_card_logo"].present? && stripe_card_logo.attached? && !Rails.env.test? }
-  before_save :enable_monthly_announcements
 
   # We can't do this through a normal dependent: :destroy since ActiveRecord does not support deleting records through indirect has_many associations
   # https://github.com/rails/rails/commit/05bcb8cecc8573f28ad080839233b4bb9ace07be
@@ -966,13 +965,6 @@ class Event < ApplicationRecord
 
     unless eligible_for_indexing?
       self.is_indexable = false
-    end
-  end
-
-  def enable_monthly_announcements
-    # We'll enable monthly announcements when transparency mode is turned on
-    if is_public_changed?(to: true)
-      config.update(generate_monthly_announcement: true)
     end
   end
 

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -29,14 +29,9 @@ class Event
     normalizes :contact_email, with: ->(contact_email) { contact_email.strip.downcase }
     validates :subevent_plan, inclusion: { in: -> { Event::Plan.available_plans.map(&:name) } }, allow_blank: true
 
-    before_create :set_defaults
     after_save :create_or_destroy_monthly_announcement
 
     private
-
-    def set_defaults
-      self.generate_monthly_announcement = event.is_public if self.generate_monthly_announcement.nil?
-    end
 
     def create_or_destroy_monthly_announcement
       if self.generate_monthly_announcement_previously_changed?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
See #11944 for context - for now, we've decided to not automatically link transparency mode to enabling monthly announcements as it doesn't give the event managers any chance to get context on what monthly announcements are.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove the callbacks on `Event::Configuration` and `Event` that automatically enabled monthly announcements if the event was/became transparent.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

