### PR TITLE
[Announcements] Improve announcement explanations

### DIFF
--- a/app/views/announcement_mailer/_explanation.html.erb
+++ b/app/views/announcement_mailer/_explanation.html.erb
@@ -1,4 +1,5 @@
 <p>
   Announcements are a feature where you can send out updates to users following your organization.
   You are receiving this message because you have auto-scheduled monthly announcements enabled in your organization settings.
+  For more information on monthly announcements, check out <%= link_to "our blog post", "https://blog.hcb.hackclub.com/posts/monthly-announcements" %>!
 </p>

--- a/app/views/announcement_mailer/canceled.html.erb
+++ b/app/views/announcement_mailer/canceled.html.erb
@@ -6,12 +6,14 @@
 
 <p>
   Your monthly announcement that was scheduled to send on <%= scheduled_for_string %>
-  has been canceled since blocks contained in this announcement have no data.
+  has been canceled since there is no recent activity to show in this announcement.
 </p>
 
 <p>
   If you would like, you can keep this monthly announcement to be sent on <%= scheduled_for_string %> by <%= link_to "editing it on HCB", edit_announcement_url(@announcement) %>.
 </p>
+
+<%= render "announcement_mailer/explanation" %>
 
 <p>
   Sincerely,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
There was some confusion about monthly announcements when the canceled emails got sent out a couple days ago.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds the announcement explanation partial to the canceled email and adds a link to the new monthly announcement blog post in the explanation partial.

This PR should not be merged until https://github.com/hackclub/hcb-engr/pull/108 is merged and deployed.

