### PR TITLE
[Discord] Don't rely on HCB code being passed through `custom_id`

### DIFF
--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -99,9 +99,9 @@ module Discord
     end
 
     def attach_receipt_component
-      hcb_code = HcbCode.find_by_hashid!(@params)
       discord_message = Discord::Message.find_by(discord_message_id: @interaction.dig(:message, :id))
       activity = PublicActivity::Activity.find_by(id: discord_message&.activity_id)
+      hcb_code = activity.trackable&.canonical_pending_transaction&.local_hcb_code
 
       return respond(content: "Could not find the transaction to attach a receipt to.") unless activity&.key == "raw_pending_stripe_transaction.create"
 

--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -101,7 +101,7 @@ module Discord
     def attach_receipt_component
       discord_message = Discord::Message.find_by(discord_message_id: @interaction.dig(:message, :id))
       activity = PublicActivity::Activity.find_by(id: discord_message&.activity_id)
-      hcb_code = activity.trackable&.canonical_pending_transaction&.local_hcb_code
+      hcb_code = activity&.trackable&.canonical_pending_transaction&.local_hcb_code
 
       return respond(content: "Could not find the transaction to attach a receipt to.") unless activity&.key == "raw_pending_stripe_transaction.create"
 

--- a/app/views/public_activity/raw_pending_stripe_transaction/_create_discord.json.jbuilder
+++ b/app/views/public_activity/raw_pending_stripe_transaction/_create_discord.json.jbuilder
@@ -21,4 +21,4 @@ json.embed do
 
 end
 
-json.components Discord.button_to("Attach receipt", "attach_receipt:#{hcb_code.hashid}", style: 3, emoji: Discord.emoji_icon(:payment_docs)) if hcb_code.present?
+json.components Discord.button_to("Attach receipt", "attach_receipt", style: 3, emoji: Discord.emoji_icon(:payment_docs))


### PR DESCRIPTION
## Summary of the problem

We're requiring that the HCB code exists at the time of activity sending (which isn't always the case), and we're also relying on the HCB passed through Discord.


## Describe your changes

By computing the HCB code from the Discord message ID, we're able to rely less on the custom ID given by Discord. And, by removing this dependency, we can skip passing in an HCB code when sending the public activity notification, and we're less susceptible to race conditions where the HCB code doesn't yet exist.