### PR TITLE
[Governance ApprovalAttempt] Handle redundant approvals

### DIFF
--- a/app/models/governance/admin/transfer/approval_attempt.rb
+++ b/app/models/governance/admin/transfer/approval_attempt.rb
@@ -60,7 +60,7 @@ module Governance
         validates :attempted_amount_cents, numericality: { greater_than: 0 }
         validate :one_successful_approval_per_transfer, on: :create
 
-        SUCCESS_STATES = %i[approved redundantly_approved].freeze
+        SUCCESSFUL_RESULTS = %i[approved redundantly_approved].freeze
         enum :result, {
           approved: "approved",
           redundantly_approved: "redundantly_approved",
@@ -100,7 +100,7 @@ module Governance
         delegate :impersonator, :impersonated?, to: :request_context, allow_nil: true
 
         def successful?
-          SUCCESS_STATES.include?(result.to_sym)
+          SUCCESSFUL_RESULTS.include?(result.to_sym)
         end
 
         def previously_approved_attempt

--- a/app/models/governance/admin/transfer/approval_attempt.rb
+++ b/app/models/governance/admin/transfer/approval_attempt.rb
@@ -60,8 +60,10 @@ module Governance
         validates :attempted_amount_cents, numericality: { greater_than: 0 }
         validate :one_successful_approval_per_transfer, on: :create
 
+        SUCCESS_STATES = %i[approved redundantly_approved].freeze
         enum :result, {
           approved: "approved",
+          redundantly_approved: "redundantly_approved",
           denied: "denied"
         }
         DENIAL_REASONS = {
@@ -97,6 +99,19 @@ module Governance
 
         delegate :impersonator, :impersonated?, to: :request_context, allow_nil: true
 
+        def successful?
+          SUCCESS_STATES.include?(result.to_sym)
+        end
+
+        def previously_approved_attempt
+          # There theoretically could only be one
+          ApprovalAttempt.find_by(transfer:, user:, result: :approved)
+        end
+
+        def previously_approved?
+          previously_approved_attempt.present?
+        end
+
         private
 
         def user_matches_limit_user
@@ -108,9 +123,15 @@ module Governance
         def one_successful_approval_per_transfer
           # The goal here is to prevent users from eating up their transfer
           # limits by approving the same transfer multiple times.
-          return if ApprovalAttempt.where(transfer:, result: :approved).none?
-
-          errors.add(:transfer, "was already approved!")
+          #
+          # Different users should be able to approve the same transfer
+          # independently; we do this primarily for logging purposes. This may
+          # happen if the first approval succeeds, but transfer isn't sent due
+          # to validation/network errors. Then, a second person attempts it.
+          if previously_approved? && approved?
+            Rails.error.unexpected("Detected multiple successful approval attempts for the same transfer. Ensure second approvals are marked as `redundantly_approved`.")
+            errors.add(:transfer, "was already approved! Report this issue to an engineer.")
+          end
         end
 
       end

--- a/app/models/governance/admin/transfer/approval_attempt/decision.rb
+++ b/app/models/governance/admin/transfer/approval_attempt/decision.rb
@@ -17,7 +17,22 @@ module Governance
               # 1. Take a snapshot of the limit right before the decision
               snapshot_limit
 
-              # 2. Based on the snapshot, find reasons to deny the attempt
+              # 2. Handle case where transfer was previously successfully
+              #    approved by this user; in this case, we auto-approve the
+              #    attempt.
+              #
+              #    We use pessimistic locking here to prevent race conditions.
+              #    If there isn't a previously approved attempt, it is nil and
+              #    the `if` condition is skipped. If there was a previously
+              #    approved attempt and the lock is acquired, then it returns
+              #    the record which is truthy.
+              #    The lock on `previously_approved_attempt` is held until the
+              #    wrapping transaction on the `limit` is committed (`limit.with_lock`).
+              if previously_approved_attempt&.lock!
+                return self.result = :redundantly_approved
+              end
+
+              # 3. Based on the snapshot, find reasons to deny the attempt
               if request_context&.impersonated?
                 return deny_for :impersonation
               end
@@ -26,7 +41,7 @@ module Governance
                 return deny_for :insufficient_limit
               end
 
-              # 3. Approve if no denial reasons were found
+              # 4. Approve if no denial reasons were found
               self.result ||= :approved
             end
 
@@ -35,6 +50,8 @@ module Governance
           def deny_for(denial_reason)
             self.result = :denied
             self.denial_reason = denial_reason
+
+            self.result # return result
           end
         end
 

--- a/app/services/governance_service/admin/transfer/approval.rb
+++ b/app/services/governance_service/admin/transfer/approval.rb
@@ -28,7 +28,7 @@ module GovernanceService
             @approval_attempt.save!
           end
 
-          unless @approval_attempt.approved?
+          unless @approval_attempt.successful?
             raise Governance::Admin::Transfer::ApprovalAttempt::DeniedError.new(@approval_attempt.denial_message)
           end
 


### PR DESCRIPTION
## Summary of the problem

At the moment, when the admin attempts to approve a transfer a second time, it errors on them, blocking the transfer from being processed.

See `one_successful_approval_per_transfer` validation for explanation on why redundant approvals happen.

## Describe your changes

Instead of erroring when an admin attempts to approve a second time, we record the redundant approval.

