### PR TITLE
[Rack::Attack] Rate limit HQ ledger

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -107,8 +107,8 @@ class Rack::Attack
     end
   end
 
-  throttle("/hq/transactions/ip", limit: 5, period: 20.seconds) do |req|
-    if req.path.start_with?("/hq/transactions") && req.cookies[:session_token].nil?
+  throttle("/hq/transactions/ip", limit: 15, period: 20.seconds) do |req|
+    if (req.path.start_with?("/hq/transactions") || req.path.start_with?("/hq/ledger")) && req.cookies[:session_token].nil?
       req.ip
     end
   end


### PR DESCRIPTION
## Summary of the problem

The HQ ledger is getting hit especially hard 


## Describe your changes

We had already rate limited `/hq/transactions`, but since we split the actual transactions off to `/hq/ledger`, we didn't update the rate limit to include it.
