### PR TITLE
Replace Shiba with Accelerate because Shiba is not accepting new signups

### DIFF
--- a/app/views/static_pages/index/_explore.html.erb
+++ b/app/views/static_pages/index/_explore.html.erb
@@ -12,16 +12,16 @@
   </div>
 
   <ul class="grid grid--medium-narrow left-align w-100 mt0">
-    <%= link_to "https://shiba.hackclub.com/?sentby=hcb", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
-      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/ce3bc442bb3af98cf381032025350a757b3ca34e_Shiba_final_splash_art_1__1_.png')">
+    <%= link_to "https://accelerate.hackclub.com/?sentby=hcb", style: "max-width: calc(100vw - 2rem)", class: "draggable no-underline" do %>
+      <li class="card card--hover flex flex-col h-full mx-auto card--background-image" style="--bg-image: url('https://hc-cdn.hel1.your-objectstorage.com/s/v3/5a4ae386cef3858637ac0a7dcaeb0ed3ccbfdadc_background.png')">
         <div class="flex gap-2 items-center">
-          <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/d11ea0ca365fd8acb594125bc3b9909457b31ec4_icon.png" height="24" weight="24" class="rounded align-bottom" alt="Shiba logo">
+          <img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/4f866555fa86a77e48331365c438942c4d856c48_orpheus-note.png" height="24" weight="24" class="rounded align-bottom" alt="Shiba logo">
           <strong class="text-xl leading-tight">
-            Shiba
+            Accelerate
           </strong>
         </div>
         <p>
-          Make a game for 2 months, then fly to Tokyo and build an arcade with us from November 5th - 12th.
+          Ship a simulation every fortnight, get it judged, see how it stacks up, and get cool prizes!
         </p>
       </li>
     <% end %>


### PR DESCRIPTION
Shiba is not taking signups anymore, ended 20th. "shiba has begun and will end on october 20. then, we'll build an arcade in tokyo from november 5-12th." https://shiba.hackclub.com/ Updated link and content for the Accelerate project.

Please do not merge until I've gotten permission from Thomas to take Shiba's spot.

- AVD
