### PR TITLE
[Governance] Handle transfer models without `local_hcb_code` method

### DIFF
--- a/app/views/governance/admin/transfer/approval_attempt_mailer/report_denial.html.erb
+++ b/app/views/governance/admin/transfer/approval_attempt_mailer/report_denial.html.erb
@@ -5,7 +5,7 @@
 
 <%= link_to @approval_attempt.user.name, admin_user_url(@approval_attempt.user) %>
 (<%= @approval_attempt.user.email %>) attempted to approve a
-<%= link_to "#{@approval_attempt.attempted_amount.format} #{@approval_attempt.transfer_type}", @approval_attempt.transfer.local_hcb_code %>
+<%= link_to "#{@approval_attempt.attempted_amount.format} #{@approval_attempt.transfer_type}", @approval_attempt.transfer.try(:local_hcb_code) || @approval_attempt.transfer %>
 but was denied for the following reason:
 
 <blockquote>


### PR DESCRIPTION
## Summary of the problem

Closes https://github.com/hackclub/hcb/issues/11980


## Describe your changes

We try to link to `local_hcb_code`. Otherwise, just link directly to the transfer.

I think ideally we'd just link to the transfer's show page, but not all models (e.g. `IncreaseCheck` have a show page). Most models just redirect to the HcbCode anyways.