### PR TITLE
[v4] Card Designs

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -159,7 +159,7 @@ module Api
       def card_designs
         if params[:event_id].present?
           set_api_event
-          authorize @event, :create_stripe_card?
+          authorize @event, :create_stripe_card?, policy_class: EventPolicy
 
           @designs = [event.stripe_card_personalization_designs&.available, StripeCard::PersonalizationDesign.common.available].flatten.compact
         else

--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -156,6 +156,20 @@ module Api
 
       end
 
+      def card_designs
+        if params[:event_id].present?
+          set_api_event
+          authorize @event, :create_stripe_card?
+
+          @designs = [event.stripe_card_personalization_designs&.available, StripeCard::PersonalizationDesign.common.available].flatten.compact
+        else
+          skip_authorization
+          @designs = StripeCard::PersonalizationDesign.common.available
+        end
+
+        @designs += StripeCard::PersonalizationDesign.unlisted.available if current_user.auditor?
+      end
+
     end
   end
 end

--- a/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
@@ -5,6 +5,7 @@ json.array! @designs do |design|
   json.name design.name_without_id
   json.color design.color
   json.status design.stripe_status
+  json.unlisted design.unlisted?
   json.common design.common
   json.logo_url rails_blob_url(design.logo) if design.logo.attached?
 end

--- a/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 json.array! @designs do |design|
-  json.id design.id
   json.name design.name_without_id
   json.color design.color
   json.status design.stripe_status

--- a/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+json.array! @designs do |design|
+  json.id design.id
+  json.name design.name_without_id
+  json.color design.color
+  json.status design.stripe_status
+  json.common design.common
+  json.logo_url rails_blob_url(design.logo) if design.logo.attached?
+end

--- a/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/card_designs.json.jbuilder
@@ -6,5 +6,5 @@ json.array! @designs do |design|
   json.status design.stripe_status
   json.unlisted design.unlisted?
   json.common design.common
-  json.logo_url rails_blob_url(design.logo) if design.logo.attached?
+  json.logo_url design.logo.attached? ? rails_blob_url(design.logo) : nil
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -677,6 +677,10 @@ Rails.application.routes.draw do
         resources :receipts, only: [:create, :index, :destroy]
 
         resources :stripe_cards, path: "cards", only: [:show, :update, :create] do
+          collection do
+            get "card_designs"
+          end
+
           member do
             get "transactions"
             get "ephemeral_keys"


### PR DESCRIPTION
## Summary of the problem
@Luke-Oldenburg already made a create cards endpoint that takes in a stripe personalization ID but we dont know what they are. This gives users more flexibility as they can choose their design. 


## Describe your changes
Create a card designs method to fetch designs for either specifically an event or in general if event id not provided. 
Endpoint would be /api/v4/card/card_designs


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

