### PR TITLE
form_with model: false because model: nil is deprecated

### DIFF
--- a/app/views/my/reimbursements.html.erb
+++ b/app/views/my/reimbursements.html.erb
@@ -85,7 +85,7 @@
   <%= blankslate "No reports found!" %>
 <% else %>
   <h2 class="mb2">Reports created</h2>
-  <%= form_with(model: nil, local: true, method: :get) do |form| %>
+  <%= form_with(model: false, local: true, method: :get) do |form| %>
     <div class="flex items-center width-100 mb2">
       <%= form.text_field :q, placeholder: "Search…", class: "flex-auto", style: "width auto; max-width: none;", value: params[:q] %>
     </div>


### PR DESCRIPTION
Resolves https://github.com/hackclub/hcb/issues/12000

Same reason as https://github.com/hackclub/hcb/pull/11310
