### PR TITLE
[Wise] Collect additional information to handle edge cases

### DIFF
--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -29,7 +29,8 @@ module HasWiseRecipient
           type: :text_field,
           key: "account_holder",
           placeholder: "Fiona Hackworth",
-          label: "Account holder's name"
+          label: "Account holder's full name",
+          description: "Must match the name on the bank account exactly"
         }
       end
 

--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -32,6 +32,13 @@ module HasWiseRecipient
           label: "Account holder's full name",
           description: "Must match the name on the bank account exactly"
         }
+
+        fields << {
+          type: :text_field,
+          key: "bank_name",
+          placeholder: "Silicon Valley Bank",
+          label: "Name of financial institution"
+        }
       end
 
       if currency.in?(%w[AED BGN CHF CZK DKK EGP EUR GBP GEL HUF ILS NOK PKR PLN RON SEK TRY UAH])


### PR DESCRIPTION
## Summary of the problem

In certain cases, additional information is required. Not having this information on hand when it's needed can cause operational bottlenecks.

## Describe your changes

- Reword account holder name field to reduce ambiguity
- Start collecting name of financial institution

These two fields now show up regardless of selected currency:

<img width="464" height="210" alt="image" src="https://github.com/user-attachments/assets/eaa445de-f3a1-465f-9f9e-1ccd94623116" />
