### PR TITLE
[IntraFi Transactions] Auto-map after importing

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -313,6 +313,9 @@ class AdminController < Admin::BaseController
       end
     end
 
+    # Auto mapp the transactions
+    ::EventMappingEngine::Nightly.new.run
+
     duplicates = transactions.count - raw_intrafi_transactions.count
 
     redirect_to raw_intrafi_transactions_admin_index_path, flash: {


### PR DESCRIPTION
## Summary of the problem

There is code to auto-map IntraFi transactions, however, it's ran once a day: https://github.com/hackclub/hcb/blob/8444870912091589304cce75a733c926e0145585/app/jobs/transaction_engine/nightly_job.rb#L10-L9




## Describe your changes

To speed things, we explicitly run the mapping engine after we import new IntraFi transactions.