### PR TITLE
[Reimbursements] Add Wise to list of payout methods for approved email

### DIFF
--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -16,6 +16,8 @@
     You'll receive an PayPal transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
   <% elsif @report.user&.payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
+  <% elsif @report.user&.payout_method&.kind == "wise_transfer" %>
+    You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.currency.iso_code %> from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>
     to receive the <%= render_money @report.amount_to_reimburse %> reimbursement.


### PR DESCRIPTION
## Summary of the problem

https://hackclub.slack.com/archives/CN523HLKW/p1762284278868209

Wise payouts aren't handled in the email we send out when reimbursement reports are approved.


## Describe your changes

Add new condition for when a user's payout method is Wise.
