### PR TITLE
[Wise] Swap out name for name on account

### DIFF
--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -13,9 +13,9 @@
       </tr>
     <% end %>
     <tr>
-      <td>Name:</td>
+      <td>Name on account:</td>
       <td>
-        <%= report.user.name %>
+        <%= report.user.payout_method.account_holder %>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary of the problem

We're currently showing the user's preferred name, not the name on the bank account.


## Describe your changes

Swap it out for the name on the bank account.