### PR TITLE
[Wise] Show reimbursements with incomplete processing at the top of admin page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -487,15 +487,15 @@ class AdminController < Admin::BaseController
 
     relation = relation.reimbursement_requested if @pending
 
-    @unprocessed_wise_reports = Reimbursement::Report
-                                .where(id: Reimbursement::PayoutHolding.settled.select(:reimbursement_reports_id))
-                                .where(user_id: User.where(payout_method_type: "User::PayoutMethod::WiseTransfer").select(:id))
-                                .select(:id)
-                                .pluck(:id)
+    @unprocessed_wise_report_ids = Reimbursement::Report
+                                   .where(id: Reimbursement::PayoutHolding.settled.select(:reimbursement_reports_id))
+                                   .where(user_id: User.where(payout_method_type: "User::PayoutMethod::WiseTransfer").select(:id))
+                                   .select(:id)
+                                   .pluck(:id)
 
     @count = relation.count
     @reports = relation.page(@page).per(@per).order(
-      @unprocessed_wise_reports.any? ? Arel.sql("CASE WHEN reimbursement_reports.id IN (#{@unprocessed_wise_reports.join(',')}) THEN 1 ELSE 0 END DESC") : nil,
+      @unprocessed_wise_report_ids.any? ? Arel.sql("CASE WHEN reimbursement_reports.id IN (#{@unprocessed_wise_report_ids.join(',')}) THEN 1 ELSE 0 END DESC") : nil,
       Arel.sql("reimbursement_reports.aasm_state = 'reimbursement_requested' DESC"),
       # Arel.sql("aasm_state = 'draft' ASC"),
       "reimbursement_reports.created_at desc"

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -487,9 +487,16 @@ class AdminController < Admin::BaseController
 
     relation = relation.reimbursement_requested if @pending
 
+    @unprocessed_wise_reports = Reimbursement::Report
+                                .where(id: Reimbursement::PayoutHolding.settled.select(:reimbursement_reports_id))
+                                .where(user_id: User.where(payout_method_type: "User::PayoutMethod::WiseTransfer").select(:id))
+                                .select(:id)
+                                .pluck(:id)
+
     @count = relation.count
     @reports = relation.page(@page).per(@per).order(
-      Arel.sql("aasm_state = 'reimbursement_requested' DESC"),
+      @unprocessed_wise_reports.any? ? Arel.sql("CASE WHEN reimbursement_reports.id IN (#{@unprocessed_wise_reports.join(',')}) THEN 1 ELSE 0 END DESC") : nil,
+      Arel.sql("reimbursement_reports.aasm_state = 'reimbursement_requested' DESC"),
       # Arel.sql("aasm_state = 'draft' ASC"),
       "reimbursement_reports.created_at desc"
     )

--- a/app/views/admin/reimbursements.html.erb
+++ b/app/views/admin/reimbursements.html.erb
@@ -34,7 +34,7 @@
   </thead>
   <tbody>
     <% @reports.each do |report| %>
-      <tr class="<%= "admin-bg-pending" if report.reimbursement_requested? %>">
+      <tr class="<%= "admin-bg-pending" if report.reimbursement_requested? %> <%= "admin-bg-orange" if report.id.in?(@unprocessed_wise_reports) %>">
         <td class="w-16"><%= report.id %></td>
         <td class="w-32"><%= report.created_at.strftime("%Y-%m-%d") %></td>
         <td>

--- a/app/views/admin/reimbursements.html.erb
+++ b/app/views/admin/reimbursements.html.erb
@@ -34,7 +34,7 @@
   </thead>
   <tbody>
     <% @reports.each do |report| %>
-      <tr class="<%= "admin-bg-pending" if report.reimbursement_requested? %> <%= "admin-bg-orange" if report.id.in?(@unprocessed_wise_reports) %>">
+      <tr class="<%= "admin-bg-pending" if report.reimbursement_requested? %> <%= "admin-bg-orange" if report.id.in?(@unprocessed_wise_report_ids) %>">
         <td class="w-16"><%= report.id %></td>
         <td class="w-32"><%= report.created_at.strftime("%Y-%m-%d") %></td>
         <td>


### PR DESCRIPTION
## Summary of the problem

It's bad when Wise reimbursement reports aren't fully processed, but it can be tricky to keep track of which ones need to be followed up on.

## Describe your changes

This PR highlights unfinished Wise reimbursement reports by placing them at the top of the admin page in orange. In theory, reports are never in this `settled` payout holding state for more than a few minutes while being processed. Any reports shown at the top should be looked into immediately.