### PR TITLE
Made acronym expansions show to all teenagers

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -5,7 +5,7 @@
 
 <h1 class="heading items-center sm:items-start justify-center sm:justify-between center sm:text-left w-auto m-0">
   <div>
-    <% if current_user.hack_clubber? %>
+    <% if current_user.hack_clubber? || current_user.teenager? %>
       <a
         class="text-base caps muted block no-underline"
         href="https://github.com/hackclub/hcb-expansions/tree/main#hcb-what-does-it-stand-for"


### PR DESCRIPTION

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The acronym expansions only showed to users defined as hack_clubber, but not everyone in Hack Club is tagged as a Hack Clubber in the HCB backend (seemingly only tagged if you are a member of an HCB org tagged as organized by Hack Clubbers), so not every Hack Clubber can see the expansions. Noticed this when some people saw the expansions and some people didn't.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
I updated it to show if they're a Hack Clubber or if they're a teenager, so that it shows to everyone except for adults who might find it weird. Literally just changed `<% if current_user.hack_clubber? %>` to `<% if current_user.hack_clubber? || current_user.teenager? %>`.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

