### PR TITLE
[Gemfile] Bump `prosemirror_to_html` to patch XSS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,7 +589,7 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     prism (1.4.0)
-    prosemirror_to_html (0.2.0)
+    prosemirror_to_html (0.2.1)
       nokogiri
     pry (0.15.2)
       coderay (~> 1.1)


### PR DESCRIPTION
## Summary of the problem

A user found a stored XSS vulnerability within our HCB Announcements feature. @polypixeldev and @Luke-Oldenburg discovered it was an issue within https://github.com/etaminstudio/prosemirror_to_html.

## Describe your changes

Vulnerability was [fixed](https://github.com/etaminstudio/prosemirror_to_html/commit/4d59f94f550bcabeec30d298791bbdd883298ad8) within the gem by @spone and [released](https://rubygems.org/gems/prosemirror_to_html/versions/0.2.1) as [v0.2.1](https://github.com/etaminstudio/prosemirror_to_html/releases/tag/v0.2.1). Thank you for the quick response @spone!