### PR TITLE
[Rack::Attack] Configure more precise rate limits for HQ ledger

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -107,8 +107,14 @@ class Rack::Attack
     end
   end
 
-  throttle("/hq/transactions/ip", limit: 15, period: 20.seconds) do |req|
-    if (req.path.start_with?("/hq/transactions") || req.path.start_with?("/hq/ledger")) && req.cookies[:session_token].nil?
+  throttle("/hq/transactions/ip", limit: 25, period: 1.minute) do |req|
+    if req.path.start_with?("/hq/transactions") && req.cookies[:session_token].nil?
+      req.ip
+    end
+  end
+
+  throttle("/hq/ledger/ip", limit: 40, period: 1.minute) do |req|
+    if req.path.start_with?("/hq/ledger") && req.cookies[:session_token].nil?
       req.ip
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -113,7 +113,7 @@ class Rack::Attack
     end
   end
 
-  throttle("/hq/ledger/ip", limit: 40, period: 1.minute) do |req|
+  throttle("/hq/ledger/ip", limit: 30, period: 1.minute) do |req|
     if req.path.start_with?("/hq/ledger") && req.cookies[:session_token].nil?
       req.ip
     end


### PR DESCRIPTION
## Summary of the problem

We're getting bot traffic on the HQ ledger and it's affecting us.


## Describe your changes

Split the rate limit for the transactions and ledger page.