### PR TITLE
Claude/Test POST request functionality

### DIFF
--- a/app/controllers/concerns/redirect_to_ui3.rb
+++ b/app/controllers/concerns/redirect_to_ui3.rb
@@ -11,8 +11,10 @@ module RedirectToUI3
 
   def redirect_to_ui3_if_needed
     return if current_user.nil?
+    # Only redirect GET and HEAD requests - POST/PUT/DELETE should reach the backend
+    return unless request.get? || request.head?
 
-    if Flipper.enabled?(:redirect_to_ui3_2025_11_03, current_user) && request.domain == "hcb.hackclub.com"
+    if Flipper.enabled?(:redirect_to_ui3_2025_11_03, current_user) && request.host == "hcb.hackclub.com"
       redirect_to "https://ui3.hcb.hackclub.com#{request.fullpath}", allow_other_host: true
     end
   end


### PR DESCRIPTION
Issue 1: Domain check was broken ❌

Problem: Used request.domain == "hcb.hackclub.com"

    In Rails, request.domain returns the domain WITHOUT subdomain
    For hcb.hackclub.com, it returns just hackclub.com
    The redirect would NEVER trigger!

Fix: Changed to request.host == "hcb.hackclub.com" ✅
Issue 2: POST requests would break ❌

Problem: Redirected ALL HTTP methods (GET, POST, PUT, DELETE, etc.)

    Browsers convert redirected POST requests to GET requests
    All form data would be lost!
    This breaks forms, API calls, and any POST submissions

Fix: Only redirect GET and HEAD requests ✅

    POST/PUT/DELETE requests now properly reach the backend
    Aligns with the PR description stating "UI3 only contains UI changes"

Issue 3: Infinite redirects ✅

Result: No infinite redirect issues

    Once the domain check is fixed, it only matches hcb.hackclub.com
    Requests to ui3.hcb.hackclub.com won't redirect back

The fixes have been committed and pushed to claude/check-post-requests-011CUzWJXBEXUwAnbZHiGHsg.

File changed: app/controllers/concerns/redirect_to_ui3.rb:12-19

See #12016