### PR TITLE
[Ledger] Add missing cache invalidation params

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1355,6 +1355,9 @@ class EventsController < ApplicationController
         @end_date.blank? &&
         @minimum_amount.nil? &&
         @maximum_amount.nil? &&
+        @direction.nil? &&
+        @category.nil? &&
+        @merchant.nil? &&
         !@missing_receipts
     )
 


### PR DESCRIPTION
Adds new ledger params to `set_cacheable`
closes #12057