### PR TITLE
[Admin] Fix `user_mention` layout shift

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -91,16 +91,16 @@ module UsersHelper
     klass = klasses.uniq.join(" ")
 
     aria_label = if options[:aria_label]
-                  options[:aria_label]
-                elsif user.nil?
-                  "No user found"
-                elsif user.id == viewer&.id
-                  current_user_flavor_text.sample
-                elsif user.admin?
-                  "#{user.name} is an admin"
-                elsif user.auditor?
-                  "#{user.name} is an auditor"
-                end
+                   options[:aria_label]
+                 elsif user.nil?
+                   "No user found"
+                 elsif user.id == viewer&.id
+                   current_user_flavor_text.sample
+                 elsif user.admin?
+                   "#{user.name} is an admin"
+                 elsif user.auditor?
+                   "#{user.name} is an auditor"
+                 end
 
     content = if user&.auditor? && !options[:hide_avatar]
                 bolt = inline_icon "admin-badge", size: 20
@@ -124,19 +124,19 @@ module UsersHelper
 
       # Menu content items
       menu_items = safe_join([
-        link_to(
-          safe_join([inline_icon("email", size: 16), content_tag(:span, "Email", class: "ml1")]),
-          "mailto:#{user.email}",
-          target: "_blank",
-          class: "menu__item menu__item--icon"
-        ),
-        link_to(
-          safe_join([inline_icon("link", size: 16), content_tag(:span, "Open in Admin", class: "ml1")]),
-          admin_user_url(user),
-          target: "_blank",
-          class: "menu__item menu__item--icon"
-        )
-      ])
+                               link_to(
+                                 safe_join([inline_icon("email", size: 16), content_tag(:span, "Email", class: "ml1")]),
+                                 "mailto:#{user.email}",
+                                 target: "_blank",
+                                 class: "menu__item menu__item--icon", rel: "noopener"
+                               ),
+                               link_to(
+                                 safe_join([inline_icon("link", size: 16), content_tag(:span, "Open in Admin", class: "ml1")]),
+                                 admin_user_url(user),
+                                 target: "_blank",
+                                 class: "menu__item menu__item--icon", rel: "noopener"
+                               )
+                             ])
 
       menu_content = content_tag(
         :div,

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -131,7 +131,7 @@ module UsersHelper
                                  class: "menu__item menu__item--icon", rel: "noopener"
                                ),
                                link_to(
-                                 safe_join([inline_icon("link", size: 16), content_tag(:span, "Open in Admin", class: "ml1")]),
+                                 safe_join([inline_icon("settings", size: 16), content_tag(:span, "Settings", class: "ml1")]),
                                  admin_user_url(user),
                                  target: "_blank",
                                  class: "menu__item menu__item--icon", rel: "noopener"

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -114,8 +114,8 @@ module UsersHelper
     if user && viewer&.auditor?
       button = content_tag(
         :a,
-        content + inline_icon("down-caret", size: 18, style: "vertical-align: middle"),
-        class: "menu__toggle menu__toggle--arrowless overflow-visible mention__menu-btn",
+        content + inline_icon("down-caret", size: 18, class: "ml-0 -mr-1"),
+        class: "*:align-middle menu__toggle menu__toggle--arrowless overflow-visible mention__menu-btn",
         data: {
           "menu-target": "toggle",
           action: "menu#toggle click@document->menu#close keydown@document->menu#keydown"


### PR DESCRIPTION
This PR fixes the layout shift for user mentions when in admin mode, fixing #11943

https://github.com/user-attachments/assets/9f8f10ee-b4ea-457f-8dd6-2f5c49212eee