### PR TITLE
Upgrade strong_migrations to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,9 +108,7 @@ gem "reverse_markdown" # public activity to discord
 gem "namae" # multi-cultural human name parser
 gem "premailer-rails" # css to inline styles for emails
 gem "safely_block"
-gem "strong_migrations", "~> 1" # protects against risky migrations
-# [@garyhtou] ^ We still use Postgres 11 in dev (not in prod). Strong Migrations
-#               2.x is incompatible with Postgres 11.
+gem "strong_migrations", "~> 2" # protects against risky migrations
 gem "xxhash" # fast hashing
 gem "memo_wise"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -825,8 +825,8 @@ GEM
     statsd-instrument (3.9.9)
     stringio (3.1.7)
     stripe (11.7.0)
-    strong_migrations (1.8.0)
-      activerecord (>= 5.2)
+    strong_migrations (2.5.1)
+      activerecord (>= 7.1)
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.4.0)
@@ -1030,7 +1030,7 @@ DEPENDENCIES
   stackprof
   statsd-instrument (~> 3.9)
   stripe (= 11.7.0)
-  strong_migrations (~> 1)
+  strong_migrations (~> 2)
   suo!
   terser (~> 1.2)
   turbo-rails (~> 2.0.17)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
After our migration to Rails 8 started (#11976), we started seeing that `rails db:migrate` was no longer working as expected - it did not detect new migrations to run. This was caused by our old version of the `strong_migrations` gem, which had been held back to major version 1 because we still used Postgres 11 in development. Now that we use Postgres 15 in development, we can safely upgrade `strong_migrations` to the latest version.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Upgrades `strong_migrations` to version 2.5.1.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

