### PR TITLE
Fix currency code reference in Wise transfer message

### DIFF
--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -17,7 +17,7 @@
   <% elsif @report.user&.payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% elsif @report.user&.payout_method&.kind == "wise_transfer" %>
-    You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.currency.iso_code %> from us in approximately 2-3 business days.
+    You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.amount.currency.iso_code %> from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>
     to receive the <%= render_money @report.amount_to_reimburse %> reimbursement.


### PR DESCRIPTION
## Summary of the problem

We were calling a `Currency` method on a currency string

## Describe your changes

Fix the currency code reference