### PR TITLE
Update appsignal gem to see if it fixes puma reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     api-pagination (6.0.0)
-    appsignal (4.5.4)
+    appsignal (4.7.5)
       logger
       rack (>= 2.0.0)
     argon2-kdf (0.3.0)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Not seeing puma metrics in appsignal for past few days (possibly because of Rails 8?), so try updating the gem

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

`bundle update appsignal --conservative`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

