### PR TITLE
Try fixing puma reporting to appsignal by loading credentials earlier

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -44,3 +44,7 @@ pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
 # Report stats to AppSignal
 plugin :appsignal
+
+require_relative "../app/lib/credentials"
+
+Credentials.load if ENV["DOPPLER_TOKEN"]


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

HCB is not reporting puma to appsignal


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

This might be lighter weight than a full preload_app or require "rails"



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

