### PR TITLE
[Flipper] Always render unlisted features for admins

### DIFF
--- a/app/views/events/settings/_features.html.erb
+++ b/app/views/events/settings/_features.html.erb
@@ -1,13 +1,15 @@
 <%# locals: (event:) %>
 
-<%= render partial: "features/preview", locals: {
-      id: "home-page-redesign",
-      classes: ["feature-home-page-redesign"],
-      feature_flag: :event_home_page_redesign_2024_09_21,
-      name: "Home Page Redesign",
-      description: "A fresh new look for your event's home page!",
-      event:
-    } if Flipper.enabled?(:event_home_page_redesign_2024_09_21, event) %>
+<% admin_tool("mb3") do %>
+  <%= render partial: "features/preview", locals: {
+        id: "home-page-redesign",
+        classes: ["feature-home-page-redesign", "pb2"],
+        feature_flag: :event_home_page_redesign_2024_09_21,
+        name: "Home Page Redesign",
+        description: "A fresh new look for your event's home page!",
+        event:
+      } %>
+<% end %>
 
 <details>
   <summary class="mb2">Past feature previews</summary>

--- a/app/views/events/settings/_features.html.erb
+++ b/app/views/events/settings/_features.html.erb
@@ -3,7 +3,7 @@
 <% admin_tool("mb3") do %>
   <%= render partial: "features/preview", locals: {
         id: "home-page-redesign",
-        classes: ["feature-home-page-redesign", "pb2"],
+        classes: ["feature-home-page-redesign"],
         feature_flag: :event_home_page_redesign_2024_09_21,
         name: "Home Page Redesign",
         description: "A fresh new look for your event's home page!",

--- a/app/views/events/settings/_features.html.erb
+++ b/app/views/events/settings/_features.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (event:) %>
 
-<% admin_tool("mb3") do %>
+<% admin_tool_if(!Flipper.enabled?(:event_home_page_redesign_2024_09_21, @event), "mb3") do %>
   <%= render partial: "features/preview", locals: {
         id: "home-page-redesign",
         classes: ["feature-home-page-redesign"],

--- a/app/views/users/edit_featurepreviews.html.erb
+++ b/app/views/users/edit_featurepreviews.html.erb
@@ -7,6 +7,15 @@
 <turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
   <%= render "settings_nav", active: "previews" %>
   <section>
+    <% admin_tool("mb3") do %>
+      <%= render partial: "features/preview", locals: {
+            id: "minimalistic-ledger",
+            feature_flag: :transactions_background_2024_06_05,
+            name: "Minimalistic Ledger",
+            description: "This feature flag makes the ledger more minimalistic by removing the colored backgrounds from transactions.",
+            user: @user
+          } %>
+    <% end %>
 
     <%= render partial: "features/preview", locals: {
           id: "transaction-popovers",
@@ -15,14 +24,6 @@
           description: "This feature flag enables a popover allowing quick and easy access to transaction details, card information, and more!",
           user: @user
         } %>
-
-    <%= render partial: "features/preview", locals: {
-          id: "minimalistic-ledger",
-          feature_flag: :transactions_background_2024_06_05,
-          name: "Minimalistic Ledger",
-          description: "This feature flag makes the ledger more minimalistic by removing the colored backgrounds from transactions.",
-          user: @user
-        } if Flipper.enabled?(:transactions_background_2024_06_05, @user) %>
 
     <%= render partial: "features/preview", locals: {
           id: "sudo-mode",

--- a/app/views/users/edit_featurepreviews.html.erb
+++ b/app/views/users/edit_featurepreviews.html.erb
@@ -7,7 +7,7 @@
 <turbo-frame id="settings" autoscroll data-autoscroll-behavior="smooth">
   <%= render "settings_nav", active: "previews" %>
   <section>
-    <% admin_tool("mb3") do %>
+    <% admin_tool_if(!Flipper.enabled?(:transactions_background_2024_06_05, @event), "mb3") do %>
       <%= render partial: "features/preview", locals: {
             id: "minimalistic-ledger",
             feature_flag: :transactions_background_2024_06_05,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This way admins don't need to go into the Flipper UI to enable them.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

