### PR TITLE
Try loading credentials before appsignal plugin for puma.rb

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,9 +42,9 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
-# Report stats to AppSignal
-plugin :appsignal
-
+# Report stats to AppSignal, pull credentials before loading plugin
 require_relative "../app/lib/credentials"
 
 Credentials.load if ENV["DOPPLER_TOKEN"]
+
+plugin :appsignal


### PR DESCRIPTION
This is contrary to the order suggested in https://docs.appsignal.com/ruby/integrations/puma.html#secrets
but seems logical. Also pre Rails 7, `preload_app!` happened before adding `plugin :appsignal`
