### PR TITLE
Add index on event_tags.name

### DIFF
--- a/app/models/event/scoped_tags_event.rb
+++ b/app/models/event/scoped_tags_event.rb
@@ -6,8 +6,8 @@
 #
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  event_id            :bigint           not null
-#  event_scoped_tag_id :bigint           not null
+#  event_id            :bigint           not null, primary key
+#  event_scoped_tag_id :bigint           not null, primary key
 #
 # Indexes
 #

--- a/app/models/event_tag.rb
+++ b/app/models/event_tag.rb
@@ -11,6 +11,10 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
+# Indexes
+#
+#  index_event_tags_on_name_and_purpose  (name,purpose) UNIQUE
+#
 class EventTag < ApplicationRecord
   include ActionView::Helpers::TextHelper # for `pluralize`
 

--- a/db/migrate/20251115104532_add_event_tags_index_by_name.rb
+++ b/db/migrate/20251115104532_add_event_tags_index_by_name.rb
@@ -1,0 +1,7 @@
+class AddEventTagsIndexByName < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:event_tags, [:name, :purpose], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,13 +12,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_15_001440) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_15_104532) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "ach_transfers", force: :cascade do |t|
     t.bigint "event_id"
@@ -1001,6 +1001,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_15_001440) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "purpose"
+    t.index ["name", "purpose"], name: "index_event_tags_on_name_and_purpose", unique: true
   end
 
   create_table "event_tags_events", id: false, force: :cascade do |t|


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

There is a unique validation on the model, so I made the index unique too (EDIT: scoped on purpose so added that to the index, but after name since more queries are on name only)

There are only 32 rows but 1348843462 seq_scans since last reboot
