### PR TITLE
[v4] Update shipping address validation for cards

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -49,7 +49,7 @@ module Api
         )
 
         return render json: { error: "Birthday must be set before creating a card." }, status: :bad_request if current_user.birthday.nil?
-        return render json: { error: "Cards can only be shipped to the US." }, status: :bad_request unless card[:shipping_address_country] == "US"
+        return render json: { error: "Cards can only be shipped to the US." }, status: :bad_request if card[:card_type] == "physical" && card[:shipping_address_country] != "US"
 
         @stripe_card = ::StripeCardService::Create.new(
           current_user:,


### PR DESCRIPTION
## Summary of the problem
We shouldn't pass in any shipping details for virtual cards but currently that returns 404 cuz we're checking if the country is US for all card types.


## Describe your changes
Only check if card is physical


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

