### PR TITLE
Fix Turbo Stream support for email invite form and error handling

### DIFF
--- a/app/controllers/organizer_position_invite/links_controller.rb
+++ b/app/controllers/organizer_position_invite/links_controller.rb
@@ -77,7 +77,16 @@ class OrganizerPositionInvite
           }
         end
       else
-        redirect_to event_team_path(event_id: @link.event.id), flash: { error: "Failed to deactivate invite link." }
+        @event = @link.event
+        @invite_links = @event.organizer_position_invite_links.active
+
+        respond_to do |format|
+          format.html { redirect_to event_team_path(event_id: @event.id), flash: { error: "Failed to deactivate invite link." } }
+          format.turbo_stream {
+            flash.now[:error] = "Failed to deactivate invite link."
+            render turbo_stream: turbo_stream.replace("invite_links_section", partial: "events/invite_links_section", locals: { event: @event, invite_links: @invite_links }), status: :unprocessable_entity
+          }
+        end
       end
     end
 

--- a/app/views/organizer_position_invites/_form.html.erb
+++ b/app/views/organizer_position_invites/_form.html.erb
@@ -1,25 +1,27 @@
-<%= form_with(model: invite, local: true, url: event_organizer_position_invites_path(event_id: @event.slug), html: { "x-data": "{ role: 'member', spendingControls: 'true' }" }) do |form| %>
-  <%= form_errors invite, "user" %>
+<%= turbo_frame_tag "invite_member_form" do %>
+  <%= form_with(model: invite, url: event_organizer_position_invites_path(event_id: @event.slug), html: { "x-data": "{ role: 'member' }" }) do |form| %>
+    <%= form_errors invite, "user" %>
 
-  <div class="border rounded-xl overflow-hidden banner shadow-none p-0 text-left">
-    <div class="field" x-data="{ email: '' }">
-      <div class="flex items-center !border-gray-200 dark:border-neutral-700 pr-2" style="border-bottom:1px solid">
-        <%= form.email_field :email, class: "!max-w-full w-full !border-0 bg-transparent !rounded-none !h-[50px] !px-4 font-bold !text-lg", "x-model": "email", placeholder: "Email address" %>
-        <button type="submit" class="btn btn-small">
-          Send
-          <%= inline_icon "send", class: "!ml-1 !-mr-1" %>
-        </button>
-      </div>
-      <template x-if="/(team|webmaster|marketing|admin|info|about|support|sales|hello)/.test(email)">
-        <div class="warning mt-5 px-3 text-center">⚠️ For security, we discourage team emails on
-          HCB. We recommend individual emails such as <em>ben@hackclub.com</em>!
+    <div class="border rounded-xl overflow-hidden banner shadow-none p-0 text-left">
+      <div class="field" x-data="{ email: '' }">
+        <div class="flex items-center !border-gray-200 dark:border-neutral-700 pr-2" style="border-bottom:1px solid">
+          <%= form.email_field :email, class: "!max-w-full w-full !border-0 bg-transparent !rounded-none !h-[50px] !px-4 font-bold !text-lg", "x-model": "email", placeholder: "Email address" %>
+          <button type="submit" class="btn btn-small">
+            Send
+            <%= inline_icon "send", class: "!ml-1 !-mr-1" %>
+          </button>
         </div>
-      </template>
-    </div>
+        <template x-if="/(team|webmaster|marketing|admin|info|about|support|sales|hello)/.test(email)">
+          <div class="warning mt-5 px-3 text-center">⚠️ For security, we discourage team emails on
+            HCB. We recommend individual emails such as <em>ben@hackclub.com</em>!
+          </div>
+        </template>
+      </div>
 
-    <%= render "organizer_position_invites/role_and_control_form", form: form %>
-    <% admin_tool("rounded-t-none rounded-b-xl") do %>
-      <%= render "organizer_position_invites/admin_signee_check", form: form, default_selected: false %>
-    <% end %>
-  </div>
+      <%= render "organizer_position_invites/role_and_control_form", form: form %>
+      <% admin_tool("rounded-t-none rounded-b-xl") do %>
+        <%= render "organizer_position_invites/admin_signee_check", form: form, default_selected: false %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This commit addresses a bug where the email invite form submission was breaking the modal flow by performing full-page navigation instead of updating inline.

Changes:
1. Added Turbo Stream response handling to OrganizerPositionInvitesController#create
   - On success: Re-renders the form with a fresh model instance
   - On error: Re-renders the form with validation errors
   - Maintains backward compatibility with HTML format responses

2. Updated email invite form partial
   - Wrapped form in turbo_frame_tag "invite_member_form" for proper targeting
   - Removed `local: true` to allow Turbo interception
   - Cleaned up unused `spendingControls` state from Alpine.js x-data

3. Fixed error handling in LinksController#deactivate
   - Added proper Turbo Stream response for deactivation failures
   - Prevents redirect attempts when Turbo Stream format is requested

These changes ensure the modal remains open during form submission, displaying success feedback and resetting the form on success, or showing validation errors inline on failure.

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

