### PR TITLE
Allow commentable authors to comment on transactions

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -45,15 +45,27 @@ class CommentPolicy < ApplicationPolicy
   private
 
   def users
+    user_list = []
+
     if record.commentable.respond_to?(:events)
-      record.commentable.events.collect(&:users).flatten
+      user_list = record.commentable.events.collect(&:users).flatten
     elsif record.commentable.is_a?(Reimbursement::Report)
-      [record.commentable.user] + (record.commentable.event&.users || [])
+      user_list = [record.commentable.user]
+
+      unless record.commentable.event&.users&.empty?
+        user_list += record.commentable.event&.users
+      end
     elsif record.commentable.is_a?(Event)
-      record.commentable.users
+      user_list = record.commentable.users
     else
-      record.commentable.event.users
+      user_list = record.commentable.event.users
     end
+
+    if record.commentable.respond_to?(:author) && record.commentable.author.present?
+      user_list += [record.commentable.author]
+    end
+
+    user_list
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, transactions on an event (such as through grant cards) can be made by users that are not in the event. However, these users should still be able to comment on their own transactions.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Edits `CommentPolicy` to allow creating comments on `Commentable`s that define an `author` method, such as `HcbCode`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

