### PR TITLE
Disable send grant button according to card grant policy

### DIFF
--- a/app/views/card_grants/index.html.erb
+++ b/app/views/card_grants/index.html.erb
@@ -10,7 +10,7 @@
   </span>
 
   <% if organizer_signed_in?(as: :member) %>
-    <%= link_to new_event_card_grant_path(@event), class: "btn bg-success", data: { behavior: "modal_trigger", modal: "create_card_grant" }, disabled: !policy(@event).create_transfer? do %>
+    <%= link_to new_event_card_grant_path(@event), class: "btn bg-success", data: { behavior: "modal_trigger", modal: "create_card_grant" }, disabled: !policy(@event.card_grants.build).create? do %>
       <%= inline_icon "card-add" %>
       Send a grant
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, the send grant button on the new card grants overview page checks the transfer create policy for if it is disabled. However, this policy differs from the card grant create policy because it does not check if the event plan has card grants enabled.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changes the disabled attribute on the send grant button to check the card grant policy instead of the transfer create policy.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

