### PR TITLE
Add back preload_app! to hopefully fix puma reporting to appsignal

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,6 +42,9 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
+# this shouldn't be needed anymore once we upgrade to Puma 7
+preload_app! unless ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Report stats to AppSignal
 plugin :appsignal
 


### PR DESCRIPTION
We removed this during Rails 8 upgrade because it was removed from defaults, but it might be necessary for appsignal to report puma metrics
