### PR TITLE
Only pass-through query parameters for signed in users

### DIFF
--- a/app/views/events/transactions.html.erb
+++ b/app/views/events/transactions.html.erb
@@ -141,7 +141,7 @@
 
   <%= render "pinned_transactions" %>
 
-  <%= turbo_frame_tag [dom_id(@event), :ledger], src: event_ledger_path(@event, request.query_parameters) do %>
+  <%= turbo_frame_tag [dom_id(@event), :ledger], src: event_ledger_path(@event, current_user.present? ? request.query_parameters : {}) do %>
     <%= render partial: "filter" %>
 
     <%= render "application/loading_container", klass: "mt-8" %>


### PR DESCRIPTION
This is clogging up our requests because these are not cached. Non-signed in users can still filter through the UI but not through query parameters. We never document / advertise filtering through query params so this is largely bots. I think this regression is fine.