### PR TITLE
Only load `ledger` if `turbo_frame_request?`

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -175,6 +175,10 @@ class EventsController < ApplicationController
   end
 
   def ledger
+    unless turbo_frame_request?
+      return redirect_to event_transactions_path(@event)
+    end
+
     begin
       authorize @event
     rescue Pundit::NotAuthorizedError


### PR DESCRIPTION
This might reduce the load on our servers as bots are directly accessing this page.