### PR TITLE
Only show user avatars if `organizer_signed_in?`

### DIFF
--- a/app/views/events/ledger.html.erb
+++ b/app/views/events/ledger.html.erb
@@ -14,15 +14,17 @@
             <% if @show_running_balance %>
               <th>Running Balance</th>
             <% end %>
-            <th><%# user avatar %></th>
+            <% if organizer_signed_in? %>
+              <th><%# user avatar %></th>
+            <% end %>
           </tr>
           </thead>
           <tbody data-behavior="transactions">
           <%= render "pending_fee_transaction" unless @event.fronted_fee_balance_v2_cents <= 0 || @direction == "revenue" %>
 
-          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
+          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: organizer_signed_in?, show_tags: true } %>
 
-          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions, as: :ct, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
+          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions, as: :ct, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: organizer_signed_in?, show_tags: true } %>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
I think this will reduce the amount of requests we get as each image is a new request