### PR TITLE
Use Turbo Stream to update comments list on deletion

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -48,14 +48,21 @@ class CommentsController < ApplicationController
 
   def destroy
     authorize @comment
+    commentable = @comment.commentable
     @comment.destroy!
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.remove(@comment)
+        render turbo_stream: turbo_stream.replace(
+          "comments",
+          partial: "comments/list",
+          locals: {
+            comments: commentable.comments,
+            show_blankslate: commentable.comments.empty? }
+        )
       end
 
-      format.any { redirect_back_or_to @comment.commentable }
+      format.any { redirect_back_or_to commentable }
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -58,7 +58,8 @@ class CommentsController < ApplicationController
           partial: "comments/list",
           locals: {
             comments: commentable.comments,
-            show_blankslate: commentable.comments.empty? }
+            show_blankslate: commentable.comments.empty?
+          }
         )
       end
 

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,8 +1,7 @@
-<section class="comments">
-
-  <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file.order(created_at: :asc), as: :comment %>
-
+<section class="comments" id="comments">
   <% if policy_scope(comments).empty? && defined?(show_blankslate) %>
     <%= blankslate "No comments yet." %>
+  <% else %>
+    <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file.order(created_at: :asc), as: :comment %>
   <% end %>
 </section>


### PR DESCRIPTION
When a comment is destroyed, replace the entire comments section with the updated list partial instead of just removing the DOM element. This ensures the UI properly reflects the current state and handles edge cases like empty state rendering.

Fixes #11601

