### PR TITLE
[Performance] Restructure `gte_member_in_events?`

### DIFF
--- a/app/policies/hcb_code_policy.rb
+++ b/app/policies/hcb_code_policy.rb
@@ -63,8 +63,11 @@ class HcbCodePolicy < ApplicationPolicy
 
   # if users have permissions greater than or equal to member in events
   def gte_member_in_events?
-    user&.admin? || record.events.any? do |e|
-      e.try(:users).try(:include?, user) && OrganizerPosition.role_at_least?(user, e, :member)
+    return false if user.nil? # dont run checks if the user isnt signed in
+    return true if user&.admin?
+
+    record.events.any? do |e|
+      OrganizerPosition.role_at_least?(user, e, :member)
     end
   end
 


### PR DESCRIPTION
- return early if not signed in
- move admin check out of or
- just rely on `role_at_least?`