### PR TITLE
Don't check `reimbursement_expense_payout.present?` for `#receipts`

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -526,7 +526,7 @@ class HcbCode < ApplicationRecord
   end
 
   def receipts
-    return reimbursement_expense_payout.expense.receipts if reimbursement_expense_payout.present?
+    return reimbursement_expense_payout.expense.receipts if reimbursement_expense_payout? && reimbursement_expense_payout.present?
 
     super
   end


### PR DESCRIPTION
`reimbursement_expense_payout?` does 0 SQL calls because its just based on the HCB code. `reimbursement_expense_payout.present?` does 1 because it looks for the association. 