### PR TITLE
[Webauthn] Attempt to allow UI3 to use primary domain's webauthn

### DIFF
--- a/public/.well-known/webauthn
+++ b/public/.well-known/webauthn
@@ -1,0 +1,5 @@
+{
+  "origins": [
+    "https://ui3.hcb.hackclub.com"
+  ]
+}


### PR DESCRIPTION
## Summary of the problem

Because UI3 is on a different domain, the webauthns previously set up on HCB (e.g. passkeys) do NOT work on the UI3 domain.

## Describe your changes

According to https://web.dev/articles/webauthn-related-origin-requests, we can define related origin requests for webauthn. We'll see if this allows webauthn to work on UI3.