### PR TITLE
Use preloaded receipts count or cache

### DIFF
--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -124,7 +124,12 @@
       <% end %>
       <% if pt.local_hcb_code %>
         <%= list_badge_for auditor_signed_in? ? pt.local_hcb_code.comments.size : pt.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
-        <%= list_badge_for pt.local_hcb_code.receipts.size, "receipt", "payment-docs", optional: pt.local_hcb_code.receipt_optional?(event, type), required: pt.local_hcb_code.missing_receipt?(event, type) %>
+        <% receipts_count = if pt.local_hcb_code.reimbursement_expense_payout?
+                              Rails.cache.fetch("pt_#{pt.hcb_code}/receipts_count", expires_in: 12.hours) { pt.local_hcb_code.receipts.size }
+                            else
+                              pt.local_hcb_code.association(:receipts).reader.size
+                            end %>
+        <%= list_badge_for receipts_count, "receipt", "payment-docs", optional: pt.local_hcb_code.receipt_optional?(event, type), required: pt.local_hcb_code.missing_receipt?(event, type) %>
       <% end %>
     </div>
   </td>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -133,7 +133,12 @@
       <% end %>
       <% if ct.local_hcb_code %>
         <%= list_badge_for auditor_signed_in? ? ct.local_hcb_code.comments.size : ct.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
-        <%= list_badge_for ct.local_hcb_code.receipts.size, "receipt", "payment-docs", optional: ct.local_hcb_code.receipt_optional?(event, type), required: ct.local_hcb_code.missing_receipt?(event, type) %>
+        <% receipts_count = if ct.local_hcb_code.reimbursement_expense_payout?
+                              Rails.cache.fetch("ct_#{ct.hcb_code}/receipts_count", expires_in: 12.hours) { ct.local_hcb_code.receipts.size }
+                            else
+                              ct.local_hcb_code.association(:receipts).reader.size
+                            end %>
+        <%= list_badge_for receipts_count, "receipt", "payment-docs", optional: ct.local_hcb_code.receipt_optional?(event, type), required: ct.local_hcb_code.missing_receipt?(event, type) %>
       <% end %>
     </div>
   </td>


### PR DESCRIPTION
You can't upload new receipts for a reimbursement expense. And if it isn't a reimbursement expense we can directly get the count from the association which is preloaded.