### PR TITLE
Allow auditors to get layout on event ledger

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -242,7 +242,7 @@ class EventsController < ApplicationController
       @mock_total = @transactions.sum(&:amount_cents)
     end
 
-    render layout: !turbo_frame_request? && admin_signed_in?
+    render layout: !turbo_frame_request? && auditor_signed_in?
   end
 
   def balance_by_date


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#12195 allowed admins to see the layout on the ledger page, allowing them to analyze performance of the ledger with flamegraph, but not auditors.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Allow auditors!