### PR TITLE
[Webauthn] Configure `origins` and `rp_id` via Ruby

### DIFF
--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 WebAuthn.configure do |config|
-  if Rails.env.staging?
-    # Use the Heroku review app's origin
-    heroku_app_name = ENV["HEROKU_APP_NAME"]
-    config.origin = "https://#{heroku_app_name}.herokuapp.com"
-  elsif Rails.env.production?
+  if Rails.env.production?
     config.origin = "https://#{Credentials.fetch(:LIVE_URL_HOST)}"
+
+    config.allowed_origins = %w[https://hcb.hackclub.com https://ui3.hcb.hackclub.com]
+    config.rp_id = "https://hcb.hackclub.com"
   else
     config.origin = "http://#{Credentials.fetch(:TEST_URL_HOST)}"
   end

--- a/public/.well-known/webauthn
+++ b/public/.well-known/webauthn
@@ -1,5 +1,0 @@
-{
-  "origins": [
-    "https://ui3.hcb.hackclub.com"
-  ]
-}


### PR DESCRIPTION
## Summary of the problem

https://github.com/hackclub/hcb/pull/12219 didn't work

## Describe your changes

Configure these attributes via the `webauthn` gem. Drop config for heroku staging because we don't have that anymore