### PR TITLE
Revert "[Webauthn] Configure `origins` and `rp_id` via Ruby"

### DIFF
--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 WebAuthn.configure do |config|
-  if Rails.env.production?
+  if Rails.env.staging?
+    # Use the Heroku review app's origin
+    heroku_app_name = ENV["HEROKU_APP_NAME"]
+    config.origin = "https://#{heroku_app_name}.herokuapp.com"
+  elsif Rails.env.production?
     config.origin = "https://#{Credentials.fetch(:LIVE_URL_HOST)}"
-
-    config.allowed_origins = %w[https://hcb.hackclub.com https://ui3.hcb.hackclub.com]
-    config.rp_id = "https://hcb.hackclub.com"
   else
     config.origin = "http://#{Credentials.fetch(:TEST_URL_HOST)}"
   end

--- a/public/.well-known/webauthn
+++ b/public/.well-known/webauthn
@@ -1,0 +1,5 @@
+{
+  "origins": [
+    "https://ui3.hcb.hackclub.com"
+  ]
+}


### PR DESCRIPTION
Reverts hackclub/hcb#12226. Reverting because both prod + ui3 failed to deploy after this.