### PR TITLE
[v4] Fix validation for anonymous param of donation API

### DIFF
--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -20,7 +20,7 @@ module Api
                                    in_person: true,
                                    name: params[:name].presence,
                                    email: params[:email].presence,
-                                   anonymous: params[:anonymous].presence,
+                                   anonymous: !!params[:anonymous],
                                    tax_deductible: params[:tax_deductible].nil? || params[:tax_deductible],
                                    fee_covered: params[:fee_covered].presence && @event.config.cover_donation_fees
                                  })


### PR DESCRIPTION
## Summary of the problem
Currently donation v4 API can't handle a value of nil for the anon param


## Describe your changes
Improves validation


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

