### PR TITLE
[Governance::Admin::Transfer] Add support for non-USD reimbursements

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -221,7 +221,8 @@ module Reimbursement
 
     def admin_approve
       authorize @report
-      ensure_admin_may_approve!(@report, amount_cents: currency == "USD" ? @report.amount_to_reimburse_cents : params[:wise_total_including_fees])
+      wise_amount_cents = (params[:wise_total_including_fees] * 100).to_i if currency != "USD" && params[:wise_total_including_fees].present?
+      ensure_admin_may_approve!(@report, amount_cents: wise_amount_cents || @report.amount_to_reimburse_cents)
 
       begin
         @report.with_lock do

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -221,8 +221,7 @@ module Reimbursement
 
     def admin_approve
       authorize @report
-      # TODO: This does NOT consider currency
-      ensure_admin_may_approve!(@report, amount_cents: @report.amount_to_reimburse_cents)
+      ensure_admin_may_approve!(@report, amount_cents: currency == "USD" ? @report.amount_to_reimburse_cents : params[:wise_total_including_fees])
 
       begin
         @report.with_lock do

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -221,6 +221,8 @@ module Reimbursement
 
     def admin_approve
       authorize @report
+      # For Wise, the amount stored on the report is not in USD. By using the passed in :wise_total_including_fees parameter,
+      # we're able to track admin transfer amounts based on the amounts used in the reimbursement processing flow.
       wise_amount_cents = (params[:wise_total_including_fees] * 100).to_i if @report.currency != "USD" && params[:wise_total_including_fees].present?
       ensure_admin_may_approve!(@report, amount_cents: wise_amount_cents || @report.amount_to_reimburse_cents)
 

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -221,7 +221,7 @@ module Reimbursement
 
     def admin_approve
       authorize @report
-      wise_amount_cents = (params[:wise_total_including_fees] * 100).to_i if currency != "USD" && params[:wise_total_including_fees].present?
+      wise_amount_cents = (params[:wise_total_including_fees] * 100).to_i if @report.currency != "USD" && params[:wise_total_including_fees].present?
       ensure_admin_may_approve!(@report, amount_cents: wise_amount_cents || @report.amount_to_reimburse_cents)
 
       begin


### PR DESCRIPTION
## Summary of the problem

Non-USD reimbursements count the local currency towards an admin's transfer limits


## Describe your changes

Use the provided Wise amount in USD instead of the local amount