### PR TITLE
[Admin] Send AdminMailers to Lucy's personal email as well

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -5,7 +5,7 @@ class AdminMailer < ApplicationMailer
   default to: -> do
     [
       Credentials.fetch(:SLACK_NOTIFICATIONS_EMAIL),
-      User.find_by_public_id("usr_MVtap3") # Lucy
+      User.find_by_public_id("usr_MVtap3")&.email_address_with_name # Lucy
     ].compact
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -2,7 +2,12 @@
 
 class AdminMailer < ApplicationMailer
   include Rails.application.routes.url_helpers
-  default to: -> { Credentials.fetch(:SLACK_NOTIFICATIONS_EMAIL) }
+  default to: -> do
+    [
+      Credentials.fetch(:SLACK_NOTIFICATIONS_EMAIL),
+      User.find_by_public_id("usr_MVtap3") # Lucy
+    ].compact
+  end
 
   def cash_withdrawal_notification
     @hcb_code = params[:hcb_code]


### PR DESCRIPTION
## Summary of the problem

Currently, the admin mailers have low visibility since it's sent into a spamy slack channel

## Describe your changes

Lucy wants to keep an eye on negative events, so we're sending them to her personal email too.