### PR TITLE
Fix `inverse_of` on `WiseTransfer`

### DIFF
--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -61,7 +61,7 @@ class WiseTransfer < ApplicationRecord
 
   has_one :canonical_pending_transaction
 
-  has_one :reimbursement_payout_holding, class_name: "Reimbursement::PayoutHolding", inverse_of: :wire, required: false
+  has_one :reimbursement_payout_holding, class_name: "Reimbursement::PayoutHolding", inverse_of: :wise_transfer, required: false
 
   monetize :amount_cents, as: "amount", with_model_currency: :currency
   monetize :usd_amount_cents, as: "usd_amount", allow_nil: true


### PR DESCRIPTION
making reimbursements buggy