### PR TITLE
Preserve signup param when redirecting to login page

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -21,6 +21,8 @@ class LoginsController < ApplicationController
 
     @prefill_email = params[:email] if params[:email].present?
     @referral_program = Referral::Program.find_by_hashid(params[:referral]) if params[:referral].present?
+
+    @signup = params[:signup] == "true"
   end
 
   # when you submit your email

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -136,7 +136,7 @@ module SessionsHelper
       if request.fullpath == "/"
         redirect_to auth_users_path(require_reload: true)
       else
-        redirect_to auth_users_path(return_to: request.original_url, require_reload: true)
+        redirect_to auth_users_path(return_to: request.original_url, require_reload: true, signup: params[:signup])
       end
     end
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -134,7 +134,7 @@ module SessionsHelper
   def signed_in_user
     unless signed_in?
       if request.fullpath == "/"
-        redirect_to auth_users_path(require_reload: true)
+        redirect_to auth_users_path(require_reload: true, signup: params[:signup])
       else
         redirect_to auth_users_path(return_to: request.original_url, require_reload: true, signup: params[:signup])
       end

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -1,10 +1,10 @@
 <% turbo_page_requires_reload if params[:require_reload].present? %>
-<% title "Sign #{params[:signup] ? "up" : "in"}" %>
+<% title "Sign #{@signup ? "up" : "in"}" %>
 
 <div class="flex flex-col flex-1 justify-center max-w-md w-full">
   <div class="my-auto">
     <%= render "logins/header", label: "Hack Club" do %>
-      Sign <%= params[:signup] ? "up for" : "in to" %> HCB
+      Sign <%= @signup ? "up for" : "in to" %> HCB
     <% end %>
     <%= form_tag logins_path, class: "mt-1", 'data-action': "webauthn-auth#submit", 'data-webauthn-auth-target': "authForm" do %>
       <div data-webauthn-auth-target="error" class="mb2 display-none">
@@ -14,7 +14,7 @@
       <%= hidden_field_tag :referral_program_id, @referral_program.hashid if @referral_program %>
       <%= email_field_tag :email, @prefill_email, placeholder: "Enter your email...", autofocus: true, autocomplete: "username", class: "!max-w-full w-full", style: "padding: 12px 15px", required: true, "data-webauthn-auth-target" => "loginEmailInput" %>
       <div class="flex justify-between items-center gap-4">
-        <% if params[:signup] %>
+        <% if @signup %>
           <%= link_to "Sign in", auth_users_path(return_to: @return_to), class: "mt-3" %>
         <% else %>
           <%= link_to "Sign up", auth_users_path(signup: true, return_to: @return_to), class: "mt-3" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
On HCB Mobile, there's a login button and signup button that each initially try to start an OAuth authorize flow. When clicking on sign up, the app will direct to the OAuth authorize page with `signup=true`. This needs to be preserved in the redirect to the login page for the signup text to show on that page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Refactored the signup param check into an instance variable (that checks for `true`, not just the parameter's presence) and changed the redirects to copy the signup parameter if present.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

