### PR TITLE
[Mailers] Add EARMUFFED_RECIPIENTS

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -24,6 +24,19 @@ class ApplicationMailer < ActionMailer::Base
     super(mail)
   end
 
+  EARMUFFED_USER_IDS = [
+    "usr_b9YtZb", # Zach
+    "usr_b6mtLG", # Christina
+    "usr_N4tk5d", # Rachel A (personal)
+    "usr_ZBt5g5", # Rachel A (Hack Club)
+  ].freeze
+
+  def self.earmuffed_recipients
+    @earmuffed_recipients ||= EARMUFFED_USER_IDS.filter_map do |id|
+      User.find_by_public_id(id)&.email
+    end
+  end
+
   protected
 
   def hcb_email_with_name_of(object)
@@ -39,19 +52,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def no_recipients?
     mail.recipients.compact.empty?
-  end
-
-  EARMUFFED_USER_IDS = [
-    "usr_b9YtZb", # Zach
-    "usr_b6mtLG", # Christina
-    "usr_N4tk5d", # Rachel A (personal)
-    "usr_ZBt5g5", # Rachel A (Hack Club)
-  ].freeze
-
-  def self.earmuffed_recipients
-    @earmuffed_recipients ||= EARMUFFED_USER_IDS.filter_map do |id|
-      User.find_by_public_id(id)&.email
-    end
   end
 
   def prevent_noisy_delivery

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -41,17 +41,21 @@ class ApplicationMailer < ActionMailer::Base
     mail.recipients.compact.empty?
   end
 
-  EARMUFFED_RECIPIENTS = [
+  EARMUFFED_USER_IDS = [
     "usr_b9YtZb", # Zach
     "usr_b6mtLG", # Christina
     "usr_N4tk5d", # Rachel A (personal)
     "usr_ZBt5g5", # Rachel A (Hack Club)
-  ].filter_map do |id|
-    User.find_by_public_id(id)&.email
+  ].freeze
+
+  def self.earmuffed_recipients
+    @earmuffed_recipients ||= EARMUFFED_USER_IDS.filter_map do |id|
+      User.find_by_public_id(id)&.email
+    end
   end
 
   def prevent_noisy_delivery
-    remaining_recipients = mail.to - EARMUFFED_RECIPIENTS
+    remaining_recipients = mail.to - self.class.earmuffed_recipients
 
     if remaining_recipients.blank?
       # If there are no recipients left (e.g. direct email to earmuffed recipient,

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,6 +9,8 @@ class ApplicationMailer < ActionMailer::Base
   default from: "HCB <hcb@#{DOMAIN}>"
   layout "mailer/default"
 
+  after_action :prevent_noisy_delivery
+
   # allow usage of application helper
   helper :application
 
@@ -37,6 +39,27 @@ class ApplicationMailer < ActionMailer::Base
 
   def no_recipients?
     mail.recipients.compact.empty?
+  end
+
+  EARMUFFED_RECIPIENTS = [
+    "usr_b9YtZb", # Zach
+    "usr_b6mtLG", # Christina
+    "usr_N4tk5d", # Rachel A (personal)
+    "usr_ZBt5g5", # Rachel A (Hack Club)
+  ].filter_map do |id|
+    User.find_by_public_id(id)&.email
+  end
+
+  def prevent_noisy_delivery
+    remaining_recipients = mail.to - EARMUFFED_RECIPIENTS
+
+    if remaining_recipients.blank?
+      # If there are no recipients left (e.g. direct email to earmuffed recipient,
+      # or all recipients are earmuffed), then send the email normally.
+      return
+    end
+
+    mail.to = remaining_recipients
   end
 
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -3,18 +3,18 @@
 require "rails_helper"
 
 RSpec.describe ApplicationMailer, type: :mailer do
-  # Create a test mailer class to test the prevent_noisy_delivery callback
-  class TestMailer < ApplicationMailer
-    def test_email(recipients:)
-      mail(to: recipients, subject: "Test Subject") do |format|
-        format.text { render plain: "Test body" }
-        format.html { render html: "<p>Test body</p>".html_safe }
+  describe "#prevent_noisy_delivery" do
+    # Create a test mailer class to test the prevent_noisy_delivery callback
+    let(:test_mailer_class) do
+      Class.new(ApplicationMailer) do
+        def test_email(recipients:)
+          mail(to: recipients, subject: "Test Subject") do |format|
+            format.text { render plain: "Test body" }
+            format.html { render html: "<p>Test body</p>".html_safe }
+          end
+        end
       end
     end
-
-  end
-
-  describe "#prevent_noisy_delivery" do
     let(:normal_recipient) { "normal@example.com" }
     let(:another_normal_recipient) { "another@example.com" }
     let(:earmuffed_recipient) { "earmuffed@example.com" }
@@ -26,14 +26,14 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
     context "when there are no earmuffed recipients" do
       it "delivers to all recipients" do
-        mail = TestMailer.test_email(recipients: [normal_recipient, another_normal_recipient])
+        mail = test_mailer_class.test_email(recipients: [normal_recipient, another_normal_recipient])
         expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
       end
     end
 
     context "when there are earmuffed recipients among other recipients" do
       it "filters out earmuffed recipients" do
-        mail = TestMailer.test_email(recipients: [normal_recipient, earmuffed_recipient, another_normal_recipient])
+        mail = test_mailer_class.test_email(recipients: [normal_recipient, earmuffed_recipient, another_normal_recipient])
         expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
         expect(mail.to).not_to include(earmuffed_recipient)
       end
@@ -41,28 +41,28 @@ RSpec.describe ApplicationMailer, type: :mailer do
 
     context "when all recipients are earmuffed" do
       it "sends the email normally without filtering" do
-        mail = TestMailer.test_email(recipients: [earmuffed_recipient, another_earmuffed_recipient])
+        mail = test_mailer_class.test_email(recipients: [earmuffed_recipient, another_earmuffed_recipient])
         expect(mail.to).to contain_exactly(earmuffed_recipient, another_earmuffed_recipient)
       end
     end
 
     context "when the only recipient is earmuffed" do
       it "sends the email normally without filtering" do
-        mail = TestMailer.test_email(recipients: [earmuffed_recipient])
+        mail = test_mailer_class.test_email(recipients: [earmuffed_recipient])
         expect(mail.to).to contain_exactly(earmuffed_recipient)
       end
     end
 
     context "when recipients list is empty" do
       it "keeps the recipients list empty" do
-        mail = TestMailer.test_email(recipients: [])
+        mail = test_mailer_class.test_email(recipients: [])
         expect(mail.to).to be_empty
       end
     end
 
     context "with multiple earmuffed recipients and one normal recipient" do
       it "only keeps the normal recipient" do
-        mail = TestMailer.test_email(recipients: [normal_recipient, earmuffed_recipient, another_earmuffed_recipient])
+        mail = test_mailer_class.test_email(recipients: [normal_recipient, earmuffed_recipient, another_earmuffed_recipient])
         expect(mail.to).to contain_exactly(normal_recipient)
         expect(mail.to).not_to include(earmuffed_recipient)
         expect(mail.to).not_to include(another_earmuffed_recipient)
@@ -74,7 +74,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
         earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
         normal_with_name = "Normal User <#{normal_recipient}>"
 
-        mail = TestMailer.test_email(recipients: [normal_with_name, earmuffed_with_name])
+        mail = test_mailer_class.test_email(recipients: [normal_with_name, earmuffed_with_name])
         expect(mail.to).to contain_exactly(normal_recipient)
         expect(mail.to).not_to include(earmuffed_recipient)
       end
@@ -82,7 +82,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
       it "sends normally when only earmuffed recipient with name format" do
         earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
 
-        mail = TestMailer.test_email(recipients: [earmuffed_with_name])
+        mail = test_mailer_class.test_email(recipients: [earmuffed_with_name])
         expect(mail.to).to contain_exactly(earmuffed_recipient)
       end
 
@@ -90,7 +90,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
         earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
         normal_with_name = "Normal User <#{normal_recipient}>"
 
-        mail = TestMailer.test_email(recipients: [normal_with_name, another_earmuffed_recipient, earmuffed_with_name, another_normal_recipient])
+        mail = test_mailer_class.test_email(recipients: [normal_with_name, another_earmuffed_recipient, earmuffed_with_name, another_normal_recipient])
         expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
         expect(mail.to).not_to include(earmuffed_recipient)
         expect(mail.to).not_to include(another_earmuffed_recipient)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
     let(:another_earmuffed_recipient) { "another_earmuffed@example.com" }
 
     before do
-      stub_const("ApplicationMailer::EARMUFFED_RECIPIENTS", [earmuffed_recipient, another_earmuffed_recipient])
+      allow(ApplicationMailer).to receive(:earmuffed_recipients).and_return([earmuffed_recipient, another_earmuffed_recipient])
     end
 
     context "when there are no earmuffed recipients" do

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  # Create a test mailer class to test the prevent_noisy_delivery callback
+  class TestMailer < ApplicationMailer
+    def test_email(recipients:)
+      mail(to: recipients, subject: "Test Subject") do |format|
+        format.text { render plain: "Test body" }
+        format.html { render html: "<p>Test body</p>".html_safe }
+      end
+    end
+
+  end
+
+  describe "#prevent_noisy_delivery" do
+    let(:normal_recipient) { "normal@example.com" }
+    let(:another_normal_recipient) { "another@example.com" }
+    let(:earmuffed_recipient) { "earmuffed@example.com" }
+    let(:another_earmuffed_recipient) { "another_earmuffed@example.com" }
+
+    before do
+      stub_const("ApplicationMailer::EARMUFFED_RECIPIENTS", [earmuffed_recipient, another_earmuffed_recipient])
+    end
+
+    context "when there are no earmuffed recipients" do
+      it "delivers to all recipients" do
+        mail = TestMailer.test_email(recipients: [normal_recipient, another_normal_recipient])
+        expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
+      end
+    end
+
+    context "when there are earmuffed recipients among other recipients" do
+      it "filters out earmuffed recipients" do
+        mail = TestMailer.test_email(recipients: [normal_recipient, earmuffed_recipient, another_normal_recipient])
+        expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
+        expect(mail.to).not_to include(earmuffed_recipient)
+      end
+    end
+
+    context "when all recipients are earmuffed" do
+      it "sends the email normally without filtering" do
+        mail = TestMailer.test_email(recipients: [earmuffed_recipient, another_earmuffed_recipient])
+        expect(mail.to).to contain_exactly(earmuffed_recipient, another_earmuffed_recipient)
+      end
+    end
+
+    context "when the only recipient is earmuffed" do
+      it "sends the email normally without filtering" do
+        mail = TestMailer.test_email(recipients: [earmuffed_recipient])
+        expect(mail.to).to contain_exactly(earmuffed_recipient)
+      end
+    end
+
+    context "when recipients list is empty" do
+      it "keeps the recipients list empty" do
+        mail = TestMailer.test_email(recipients: [])
+        expect(mail.to).to be_empty
+      end
+    end
+
+    context "with multiple earmuffed recipients and one normal recipient" do
+      it "only keeps the normal recipient" do
+        mail = TestMailer.test_email(recipients: [normal_recipient, earmuffed_recipient, another_earmuffed_recipient])
+        expect(mail.to).to contain_exactly(normal_recipient)
+        expect(mail.to).not_to include(earmuffed_recipient)
+        expect(mail.to).not_to include(another_earmuffed_recipient)
+      end
+    end
+
+    context "when recipients are in 'Name <email>' format" do
+      it "filters out earmuffed recipients by email address" do
+        earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
+        normal_with_name = "Normal User <#{normal_recipient}>"
+
+        mail = TestMailer.test_email(recipients: [normal_with_name, earmuffed_with_name])
+        expect(mail.to).to contain_exactly(normal_recipient)
+        expect(mail.to).not_to include(earmuffed_recipient)
+      end
+
+      it "sends normally when only earmuffed recipient with name format" do
+        earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
+
+        mail = TestMailer.test_email(recipients: [earmuffed_with_name])
+        expect(mail.to).to contain_exactly(earmuffed_recipient)
+      end
+
+      it "handles mixed formats (with and without names)" do
+        earmuffed_with_name = "Earmuffed User <#{earmuffed_recipient}>"
+        normal_with_name = "Normal User <#{normal_recipient}>"
+
+        mail = TestMailer.test_email(recipients: [normal_with_name, another_earmuffed_recipient, earmuffed_with_name, another_normal_recipient])
+        expect(mail.to).to contain_exactly(normal_recipient, another_normal_recipient)
+        expect(mail.to).not_to include(earmuffed_recipient)
+        expect(mail.to).not_to include(another_earmuffed_recipient)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Some HQ staff are getting spammed too much by HCB. This is a temporary fix.

## Describe your changes

There's this new concept of `EARMUFFED_RECIPIENTS`. These are people who have opted in to receive fewer emails from HCB. Earmuffed recipients will NOT receive deliveries when at least one NON-earmuffed recipient will receive the same email.