### PR TITLE
[ApplicationMailer#prevent_noisy_delivery] Ignore skipped mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -55,6 +55,8 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def prevent_noisy_delivery
+    return if mail.to.nil? # This may happen if `mail` was never called.
+
     remaining_recipients = mail.to - self.class.earmuffed_recipients
 
     if remaining_recipients.blank?


### PR DESCRIPTION
## Summary of the problem

```
undefined method '-' for nil
```
likely because the `mail` method was never called— such as due to an early return.

## Describe your changes

skip the callback if `mail.to` is `nil`.