### PR TITLE
Allow auditors to access receipt link modal

### DIFF
--- a/app/policies/receiptable_policy.rb
+++ b/app/policies/receiptable_policy.rb
@@ -10,7 +10,7 @@ class ReceiptablePolicy < ApplicationPolicy
   end
 
   def link_modal?
-    upload?
+    upload? || user&.auditor?
   end
 
   def mark_no_or_lost?


### PR DESCRIPTION
## Summary of the problem
I was seeing an infinite request loop as an auditor when viewing HcbCodes that I did not have access to as a normal user. This seems to be caused by auditors not having authorization to access the `link_modal` for receipt uploading, which results in a 302 being returned, which starts the cycle over again. This would eventually result in me getting ratelimited by Rack Attack for 5 minutes.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Allow auditors to access receipt link modal - this is just a GET route that shows the receipt link picker.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

