### PR TITLE
[FullStory] Render FS javascript at most once

### DIFF
--- a/app/views/application/_fullstory.html.erb
+++ b/app/views/application/_fullstory.html.erb
@@ -1,33 +1,38 @@
-<% if Rails.env.production? && (current_user&.sessions_reported || @force_fullstory.present?) && !(current_user&.sessions_reported == false) %>
-  <script defer>
-    window['_fs_debug'] = false;
-    window['_fs_host'] = 'fullstory.com';
-    window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
-    window['_fs_org'] = 'ARN0J';
-    window['_fs_namespace'] = 'FS';
-    (function(m,n,e,t,l,o,g,y){
-        if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
-        g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
-        o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
-        y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
-        g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
-        g.anonymize=function(){g.identify(!!0)};
-        g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
-        g.log = function(a,b){g("log",[a,b])};
-        g.consent=function(a){g("consent",!arguments.length||a)};
-        g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
-        g.clearUserCookie=function(){};
-        g.setVars=function(n, p){g(n, p);};
-        g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
-        if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
-        g._v="1.3.0";
-    })(window,document,window['_fs_namespace'],'script','user');
+<%# We want to make sure FullStory is only rendered at most once %>
+<% unless @_rendered_fullstory %>
+  <% if Rails.env.production? && (current_user&.sessions_reported || @force_fullstory.present?) && !(current_user&.sessions_reported == false) %>
+    <% @_rendered_fullstory = true %>
 
-    FS.identify(<%= current_user&.id&.to_s.to_json.html_safe %>, {
-      displayName: <%= current_user&.full_name.to_json.html_safe %>,
-      email: <%= current_user&.email.to_json.html_safe %>,
-      admin_bool: <%= admin_signed_in?.to_json.html_safe %>,
-      auditor_bool: <%= auditor_signed_in?.to_json.html_safe %>
-    });
-  </script>
+    <script defer>
+      window['_fs_debug'] = false;
+      window['_fs_host'] = 'fullstory.com';
+      window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+      window['_fs_org'] = 'ARN0J';
+      window['_fs_namespace'] = 'FS';
+      (function(m,n,e,t,l,o,g,y){
+          if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+          g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+          o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+          y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+          g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+          g.anonymize=function(){g.identify(!!0)};
+          g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+          g.log = function(a,b){g("log",[a,b])};
+          g.consent=function(a){g("consent",!arguments.length||a)};
+          g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+          g.clearUserCookie=function(){};
+          g.setVars=function(n, p){g(n, p);};
+          g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+          if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
+          g._v="1.3.0";
+      })(window,document,window['_fs_namespace'],'script','user');
+
+      FS.identify(<%= current_user&.id&.to_s.to_json.html_safe %>, {
+        displayName: <%= current_user&.full_name.to_json.html_safe %>,
+        email: <%= current_user&.email.to_json.html_safe %>,
+        admin_bool: <%= admin_signed_in?.to_json.html_safe %>,
+        auditor_bool: <%= auditor_signed_in?.to_json.html_safe %>
+      });
+    </script>
+  <% end %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem

Sometimes the FullStory partial is double rendered, causing JavaScript to attempt redefining the `FS` namespace/constant.

Reported here: https://news.ycombinator.com/item?id=46141420

## Describe your changes

Enforce that the FullStory partial is rendered at most once.