### PR TITLE
[Donation Tiers] Fix donations only being charged once

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -80,7 +80,7 @@ class DonationsController < ApplicationController
 
     authorize @donation
 
-    @monthly = params[:monthly].present?
+    @monthly = params[:monthly].present? || params[:tier_id].present?
 
     if @monthly
       @recurring_donation = @event.recurring_donations.build(


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
> Hi! We've been having an issue reported with the donation tiers that have been set up where folks are not being signed up on a recurring basis, but rather as one-time donors.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check for presence of tier id.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

