### PR TITLE
Fix earmuffed mail error and include cc and bcc recipients

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -43,7 +43,7 @@ class ApplicationMailer < ActionMailer::Base
 
       all_recipients = new_to + new_cc + new_bcc
 
-      unless all_recipients.empty?
+      unless all_recipients.empty? || Rails.env.development?
         msg.to = new_to
         msg.cc = new_cc
         msg.bcc = new_bcc

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -35,8 +35,8 @@ class ApplicationMailer < ActionMailer::Base
     end
   end
 
-  def mail(headers = {}, &block)
-    super(headers, &block).tap do |msg|
+  def mail(...)
+    super(...).tap do |msg|
       new_to = (msg.to || []) - self.class.earmuffed_recipients
       new_cc = (msg.cc || []) - self.class.earmuffed_recipients
       new_bcc = (msg.bcc || []) - self.class.earmuffed_recipients

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -45,7 +45,7 @@ class ApplicationMailer < ActionMailer::Base
 
       unless all_recipients.empty?
         msg.to = new_to
-        msg.cc = new_bcc
+        msg.cc = new_cc
         msg.bcc = new_bcc
       end
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -37,9 +37,17 @@ class ApplicationMailer < ActionMailer::Base
 
   def mail(headers = {}, &block)
     super(headers, &block).tap do |msg|
-      msg.to = msg.to - self.class.earmuffed_recipients if msg.to.present?
-      msg.cc = msg.cc - self.class.earmuffed_recipients if msg.cc.present?
-      msg.bcc = msg.bcc - self.class.earmuffed_recipients if msg.bcc.present?
+      new_to = (msg.to || []) - self.class.earmuffed_recipients
+      new_cc = (msg.cc || []) - self.class.earmuffed_recipients
+      new_bcc = (msg.bcc || []) - self.class.earmuffed_recipients
+
+      all_recipients = new_to + new_cc + new_bcc
+
+      unless all_recipients.empty?
+        msg.to = new_to
+        msg.cc = new_bcc
+        msg.bcc = new_bcc
+      end
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,8 +9,6 @@ class ApplicationMailer < ActionMailer::Base
   default from: "HCB <hcb@#{DOMAIN}>"
   layout "mailer/default"
 
-  after_action :prevent_noisy_delivery
-
   # allow usage of application helper
   helper :application
 
@@ -37,6 +35,14 @@ class ApplicationMailer < ActionMailer::Base
     end
   end
 
+  def mail(headers = {}, &block)
+    super(headers, &block).tap do |msg|
+      msg.to = msg.to - self.class.earmuffed_recipients if msg.to.present?
+      msg.cc = msg.cc - self.class.earmuffed_recipients if msg.cc.present?
+      msg.bcc = msg.bcc - self.class.earmuffed_recipients if msg.bcc.present?
+    end
+  end
+
   protected
 
   def hcb_email_with_name_of(object)
@@ -52,20 +58,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def no_recipients?
     mail.recipients.compact.empty?
-  end
-
-  def prevent_noisy_delivery
-    return if mail.to.nil? # This may happen if `mail` was never called.
-
-    remaining_recipients = mail.to - self.class.earmuffed_recipients
-
-    if remaining_recipients.blank?
-      # If there are no recipients left (e.g. direct email to earmuffed recipient,
-      # or all recipients are earmuffed), then send the email normally.
-      return
-    end
-
-    mail.to = remaining_recipients
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We've been seeing a ton of https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2520/samples/timestamp/2025-12-04T21:24:48Z lately, which is caused by the new earmuffed mail feature. In short, the `after_action` method was constructing the mail object to see if it contained recipients, but this sometimes caused errors when `mail` is not called in the mailer and the default mail object would not be valid.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Changes earmuffed recipients to work by overriding the `mail` method itself to remove earmuffed recipients from the to, cc, and bcc headers of the mail object (currently, this only acts on the to header, but comment emails only use bcc). This prevents constructing a mail object when `mail` is never called.

