### PR TITLE
[CT] Make account verification deposit detection more laxed

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -350,7 +350,12 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def likely_account_verification_related?
-    hcb_code.starts_with?("HCB-000-") && memo.downcase.include?("acctverify") && amount_cents.abs < 100
+    # Substring match (case-insensitive) for any of these identifiers in the
+    # memo indicating an account verification transaction. The majority use
+    # "ACCTVERIFY", however, it appears a few companies use other variants.
+    memo_matches = %w[acctverify verify validation sdv-vrfy].any? { |s| memo.downcase.include?(s) }
+
+    hcb_code.starts_with?("HCB-000-") && amount_cents.abs < 100 && memo_matches
   end
 
   def short_code


### PR DESCRIPTION
## Summary of the problem

`cirrus3` on Hacker News [reported](https://news.ycombinator.com/item?id=46168821) that we weren't hiding a account verification deposit.

We currently have logic for the typical "ACCTVERIFY" transactions. However, it appears that Expensify and a few other companies don't follow that standard.

<img width="1057" height="411" alt="image" src="https://github.com/user-attachments/assets/45d429b9-1232-4d63-ba85-58a71298367c" />

^ How it should look

## Describe your changes

I'm allowing these additional substrings to be detected as an account verification transaction:
- `verify`
- `validation`
- `sdv-vrfy`
- (in addition to `acctverify`)
