### PR TITLE
[Verification Deposit] Add `AMTS:` to detector

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -353,7 +353,7 @@ class CanonicalTransaction < ApplicationRecord
     # Substring match (case-insensitive) for any of these identifiers in the
     # memo indicating an account verification transaction. The majority use
     # "ACCTVERIFY", however, it appears a few companies use other variants.
-    memo_matches = %w[acctverify verify validation sdv-vrfy].any? { |s| memo.downcase.include?(s) }
+    memo_matches = %w[acctverify verify validation sdv-vrfy amts:].any? { |s| memo.downcase.include?(s) }
 
     hcb_code.starts_with?("HCB-000-") && amount_cents.abs < 100 && memo_matches
   end


### PR DESCRIPTION
## Summary of the problem

Related to https://github.com/hackclub/hcb/pull/12336. `AMTS:` deposits were visible. There are only 9 instances of these in prod.

## Describe your changes

Add `AMTS:` to memo detector.