### PR TITLE
[DX] Remove outdated info from dev-docs

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,6 +1,6 @@
 # All About HCB
 
-HCB is a tool for hackers to hack on the real world, like GitHub, but for building with atoms and people, not bits and cycles. Thank you so much for contributing to the HCB database.
+HCB is a tool for hackers to hack on the real world, like GitHub, but for building with atoms and people, not bits and cycles. Thank you so much for contributing to the HCB codebase.
 
 ## Table of Contents
 - [Home](#)
@@ -93,7 +93,7 @@ HCB's operations team perform their work through the admin dashboard on HCB and 
 
 ### Deployment & Monitoring
 
-HCB is deployed on [Heroku](https://www.heroku.com/). We have two dynos, one for Rails and one for our [Sidekiq](https://github.com/sidekiq/sidekiq) workers. We handle errors using [AppSignal](https://www.appsignal.com/). We also run [status.hackclub.com](https://status.hackclub.com/) using [Checkly](https://www.checklyhq.com/).
+HCB is deployed on [Hetzner](https://www.hetzner.com/). We have two dynos, one for Rails and one for our [Sidekiq](https://github.com/sidekiq/sidekiq) workers. We handle errors using [AppSignal](https://www.appsignal.com/). We also run [status.hackclub.com](https://status.hackclub.com/) using [Checkly](https://www.checklyhq.com/).
 
 ***
 

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -93,7 +93,7 @@ HCB's operations team perform their work through the admin dashboard on HCB and 
 
 ### Deployment & Monitoring
 
-HCB is deployed on [Hetzner](https://www.hetzner.com/). We have two dynos, one for Rails and one for our [Sidekiq](https://github.com/sidekiq/sidekiq) workers. We handle errors using [AppSignal](https://www.appsignal.com/). We also run [status.hackclub.com](https://status.hackclub.com/) using [Checkly](https://www.checklyhq.com/).
+HCB is deployed on [Hetzner](https://www.hetzner.com/). We handle errors using [AppSignal](https://www.appsignal.com/). We also run [status.hackclub.com](https://status.hackclub.com/) using [Checkly](https://www.checklyhq.com/).
 
 ***
 

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-We recommend using Docker to get an instance running locally. It should work out-of-the-box and is how most contributors work on HCB.
+We recommend using GitHub Codespaces to get an instance running. It should work out-of-the-box and is how most contributors work on HCB.
 
 - [Running HCB locally](#running-hcb-locally)
   - [Quickstart with GitHub Codespaces](#quickstart-with-github-codespaces)
@@ -164,10 +164,6 @@ HCB has a limited set of tests created using [RSpec](https://rspec.info/). Run t
 ```bash
 bundle exec rspec
 ```
-
-### Staging access
-
-All PRs are deployed in a staging enviroment using Heroku. Login using the email `staging@bank.engineering`. Visit [`#hcb-staging`](https://hackclub.slack.com/archives/C07KLU4B0M7) on the [Hack Club Slack](https://hackclub.com/slack) for the code.
 
 ## Credentials
 


### PR DESCRIPTION
- rename heroku to hetzner
- remove staging info
- update most commonly used environment to codespaces