### PR TITLE
[User] Disallow SMS enrollment for fresh users

### DIFF
--- a/app/services/user_service/enroll_sms_auth.rb
+++ b/app/services/user_service/enroll_sms_auth.rb
@@ -12,11 +12,15 @@ module UserService
       # doing this here to be safe.
       raise ArgumentError.new("phone number for user: #{@user.id} not in E.164 format") unless @user.phone_number =~ /\A\+[1-9]\d{1,14}\z/
 
+      disallow_fresh_users
+
       TwilioVerificationService.new.send_verification_request(@user.phone_number)
     end
 
     # Completing the phone number verification by checking that exchanging code works
     def complete_verification(verification_code)
+      disallow_fresh_users
+
       begin
         verified = TwilioVerificationService.new.check_verification_token(@user.phone_number, verification_code)
       rescue Twilio::REST::RestError
@@ -33,6 +37,8 @@ module UserService
       raise SMSEnrollmentError("user has no phone number") if @user.phone_number.blank?
       raise SMSEnrollmentError("user has not verified phone number") unless @user.phone_number_verified
 
+      disallow_fresh_users
+
       @user.use_sms_auth = true
       @user.save!
     end
@@ -45,6 +51,12 @@ module UserService
     private
 
     class SMSEnrollmentError < StandardError
+    end
+
+    def disallow_fresh_users
+      return if user.created_at < 1.day.ago
+
+      raise SMSEnrollmentError("Please wait at least 24 hours after creating your account before enrolling in SMS authentication.")
     end
 
   end

--- a/app/services/user_service/enroll_sms_auth.rb
+++ b/app/services/user_service/enroll_sms_auth.rb
@@ -54,7 +54,7 @@ module UserService
     end
 
     def disallow_fresh_users
-      return if user.created_at < 1.day.ago
+      return if @user.created_at < 1.day.ago
 
       raise SMSEnrollmentError("Please wait at least 24 hours after creating your account before enrolling in SMS authentication.")
     end


### PR DESCRIPTION
## Summary of the problem

We're seeing increased traffic of new spam accounts attempting SMS verification

## Describe your changes

Disallow SMS auth for brand new users