### PR TITLE
Try using preload instead of includes

### DIFF
--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -43,8 +43,8 @@ module PendingTransactionEngine
             included_local_hcb_code_associations = [:receipts, :comments, :canonical_transactions, { canonical_pending_transactions: [:canonical_pending_declined_mapping] }]
             included_local_hcb_code_associations << :tags
             cpts = CanonicalPendingTransaction.preload([:raw_pending_stripe_transaction,
-                                                         order_by_mapped_at ? :canonical_pending_event_mapping : nil,
-                                                         { local_hcb_code: included_local_hcb_code_associations }])
+                                                        order_by_mapped_at ? :canonical_pending_event_mapping : nil,
+                                                        { local_hcb_code: included_local_hcb_code_associations }])
                                               .unsettled
                                               .where(id: canonical_pending_event_mappings.pluck(:canonical_pending_transaction_id))
                                               .order("#{order_by_mapped_at ? "canonical_pending_event_mappings.created_at" : "canonical_pending_transactions.date"} desc, canonical_pending_transactions.id desc")

--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -42,7 +42,7 @@ module PendingTransactionEngine
           begin
             included_local_hcb_code_associations = [:receipts, :comments, :canonical_transactions, { canonical_pending_transactions: [:canonical_pending_declined_mapping] }]
             included_local_hcb_code_associations << :tags
-            cpts = CanonicalPendingTransaction.includes([:raw_pending_stripe_transaction,
+            cpts = CanonicalPendingTransaction.preload([:raw_pending_stripe_transaction,
                                                          order_by_mapped_at ? :canonical_pending_event_mapping : nil,
                                                          { local_hcb_code: included_local_hcb_code_associations }])
                                               .unsettled


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

includes does a massive join which is possibly causing timeout issues in postgres, preload splits it out into multiple queries

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

