### PR TITLE
Disable Rails session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :disabled


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Rails' session store was adding a new cookie to every request that we don't use or need.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Configures the session store to be disabled so that we don't have an unnecessary cookie

WIP: testing

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

