### PR TITLE
[HQ] Temporarily disable filtering of HQ ledger in transparency mode

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1177,6 +1177,9 @@ class EventsController < ApplicationController
     # to `q`. This following line retains backwards compatibility.
     params[:q] ||= params[:search]
 
+    @ledger_filters_disabled = !organizer_signed_in? && @event.slug == "hq"
+    return if @ledger_filters_disabled
+
     if params[:tag]
       @tag = Tag.find_by(event_id: @event.id, label: params[:tag])
     end

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   <% end %>
 
-  <%= render partial: "events/filter_menu" unless filter_applied %>
+  <%= render partial: "events/filter_menu" unless filter_applied || @ledger_filters_disabled %>
 
   <% if @event.canonical_transactions.any? %>
     <div data-controller="menu" data-menu-placement-value="bottom-end" class="-mb-1">


### PR DESCRIPTION
## Summary of the problem

We are seeing 16x more traffic due to people web scraping/crawling the HQ ledger. Unfortunately, this is so much more traffic than we're used to and is causing performance issues for normal users.

<img width="2200" height="1435" alt="image" src="https://github.com/user-attachments/assets/201514c7-992e-48a3-9c69-8fd93a311af8" />

Logs show them crawling every filter variation on the ledger.

## Describe your changes

To counteract this, I'm temporarily disabling all filters (except search) for the HQ ledger in transparency mode. It's important to note that **all transactions are still accessible in transparency mode**. If you want to filter, I'd suggest just downloading a CSV and filtering in Excel.







