### PR TITLE
[v4] fix render action for card grant creation

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -65,7 +65,7 @@ module Api
           return
         end
 
-        render :show, status: :created, location: api_v4_card_grant_path(@card_grant)
+        render :create, status: :created, location: api_v4_card_grant_path(@card_grant)
       end
 
       require_oauth2_scope "card_grants:write", :create


### PR DESCRIPTION
https://github.com/hackclub/hcb/commit/166a8e163380fd3e1de82aebae5fba61300b34d8 was a breaking change - previously it implicitly rendered [create](https://github.com/hackclub/hcb/blob/main/app/views/api/v4/card_grants/create.json.jbuilder), now it renders show, which doesn't expand disbursements by default!