### PR TITLE
[v4] Add card grant transactions

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -129,7 +129,7 @@ module Api
       end
 
       def transactions
-        authorize @card_grant, :show?
+        authorize @card_grant
 
         @hcb_codes = @card_grant.visible_hcb_codes
 

--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V4
     class CardGrantsController < ApplicationController
       include SetEvent
+      include ApplicationHelper
 
       before_action :set_api_event, only: [:create]
       before_action :set_card_grant, except: [:index, :create]
@@ -125,6 +126,15 @@ module Api
         return render json: { error: "invalid_operation", messages: ["This card could not be activated: #{e.message}"] }, status: :bad_request
       rescue Errors::StripeInvalidNameError => e
         return render json: { error: "invalid_operation", messages: [e.message] }, status: :bad_request
+      end
+
+      def transactions
+        authorize @card_grant, :show?
+
+        @hcb_codes = @card_grant.visible_hcb_codes
+
+        @total_count = @hcb_codes.size
+        @hcb_codes = paginate_hcb_codes(@hcb_codes)
       end
 
       private

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -85,6 +85,8 @@ class CardGrantPolicy < ApplicationPolicy
     admin_or_manager? && record.active?
   end
 
+  private
+
   def admin_or_user?
     user&.admin? || record.event.users.include?(user)
   end
@@ -98,8 +100,6 @@ class CardGrantPolicy < ApplicationPolicy
 
     record.sent_by.admin? || OrganizerPosition.find_by(user: record.sent_by, event: record.event)&.manager?
   end
-
-  private
 
   def user_in_event?
     record.event.users.include?(user)

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -13,6 +13,10 @@ class CardGrantPolicy < ApplicationPolicy
     user&.auditor? || record.user == user || user_in_event?
   end
 
+  def transactions?
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || cardholder?
+  end
+
   def spending?
     record.event.is_public? || user&.auditor? || user_in_event?
   end
@@ -46,15 +50,15 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def activate?
-    user&.admin? || (record.user == user && authorized_to_activate?)
+    user&.admin? || (cardholder? && authorized_to_activate?)
   end
 
   def cancel?
-    (admin_or_manager? || record.user == user) && record.active?
+    (admin_or_manager? || cardholder?) && record.active?
   end
 
   def convert_to_reimbursement_report?
-    (admin_or_manager? || record.user == user) && record.active? && record.card_grant_setting.reimbursement_conversions_enabled?
+    (admin_or_manager? || cardholder?) && record.active? && record.card_grant_setting.reimbursement_conversions_enabled?
   end
 
   def edit?
@@ -103,6 +107,10 @@ class CardGrantPolicy < ApplicationPolicy
 
   def authorized_to_activate?
     record.pre_authorization.nil? || record.pre_authorization.approved? || record.pre_authorization.fraudulent?
+  end
+
+  def cardholder?
+    record.user == user
   end
 
 end

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -10,11 +10,11 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || record.user == user || user_in_event?
+    user&.auditor? || cardholder? || user_in_event?
   end
 
   def transactions?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || cardholder?
+    user&.auditor? || cardholder? || user_in_event?
   end
 
   def spending?

--- a/app/views/api/v4/card_grants/transactions.json.jbuilder
+++ b/app/views/api/v4/card_grants/transactions.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+pagination_metadata(json)
+
+json.data @hcb_codes do |hcb_code|
+  if hcb_code.canonical_transactions.any?
+    json.partial! "api/v4/transactions/transaction", tx: hcb_code
+  else
+    json.partial! "api/v4/transactions/transaction", tx: hcb_code.pt
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -706,6 +706,7 @@ Rails.application.routes.draw do
             post "topup"
             post "withdraw"
             post "cancel"
+            get "transactions"
           end
         end
 


### PR DESCRIPTION
## Summary of the problem
Currently on the mobile app we are only showing the stripe card transactions of grant cards. This doesn't include critical information such as top ups, withdraws, cancels and other grant card specific transactions


## Describe your changes
Add a transaction endpoint to our card grants (/api/v4/card_grants/xxxxxx/transactions) with very similar implementation as stripe card transactions


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

