### PR TITLE
[Org Home] Only show anonymous donors to organizers in public activity

### DIFF
--- a/app/views/public_activity/donation/_paid.html.erb
+++ b/app/views/public_activity/donation/_paid.html.erb
@@ -1,5 +1,5 @@
 <% current_user ||= local_assigns[:p][:current_user] %>
 
 <%= render layout: "/public_activity/common", locals: { activity:, current_user:, icon: "support", color: "purple", hide_owner: true } do %>
-  <%= activity.trackable.name(show_anonymous: true) %> donated <%= render_money activity.trackable.amount %> to <%= link_to activity.trackable.event.name, activity.trackable.event %>
+  <%= activity.trackable.name(show_anonymous: organizer_signed_in?) %> donated <%= render_money activity.trackable.amount %> to <%= link_to activity.trackable.event.name, activity.trackable.event %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem

We want to make sure anonymous donors listed in the "recent activities" section are only visible to organizers.


## Describe your changes

Show anonymous names based on `organizer_signed_in?`