### PR TITLE
[Org home] Clarify copy for transparency mode

### DIFF
--- a/app/views/events/home/_categories_chart.html.erb
+++ b/app/views/events/home/_categories_chart.html.erb
@@ -11,7 +11,9 @@
         It's quiet here...
       </h3>
       <p class="text-gray-500 my-1 mb-8">
-        Categories will appear here<br>as you spend more money
+        Categories will appear here<br>as
+        <%= organizer_signed_in? ? "you" : "they" %>
+        spend more money
       </p>
     </div>
   <% end %>

--- a/app/views/events/home/_merchants_chart.html.erb
+++ b/app/views/events/home/_merchants_chart.html.erb
@@ -12,7 +12,9 @@
         It's quiet here...
       </h3>
       <p class="text-gray-500 my-1 mb-8">
-        Merchants will appear here<br>as you spend more money
+        Merchants will appear here<br>as
+        <%= organizer_signed_in? ? "you" : "they" %>
+        spend more money
       </p>
     </div>
   <% end %>

--- a/app/views/events/home/_recent_activity.html.erb
+++ b/app/views/events/home/_recent_activity.html.erb
@@ -4,9 +4,11 @@
       <div style="position: absolute; bottom: 0; left: 0; height: 100px; width: 100%; background: linear-gradient(transparent, var(--card-bg)); pointer-events: none; z-index: 1"></div>
       <div class="flex items-center p-4 mt-auto justify-between">
         <h3 class="m-0">Recent activity</h3>
-        <%= link_to edit_event_path(@event, tab: "audit_log"), class: "flex items-center shrink-0 no-underline" do %>
-          See all
-          <%= inline_icon "view-forward" %>
+        <% if organizer_signed_in? %>
+          <%= link_to edit_event_path(@event, tab: "audit_log"), class: "flex items-center shrink-0 no-underline" do %>
+            See all
+            <%= inline_icon "view-forward" %>
+          <% end %>
         <% end %>
       </div>
 

--- a/app/views/events/home/_tags_chart.html.erb
+++ b/app/views/events/home/_tags_chart.html.erb
@@ -7,7 +7,8 @@
             It's quiet here...
           </h3>
           <p class="text-gray-500 my-1 max-w-sm">
-            Either you don't have any tags, or you haven't categorized any transactions yet.
+            <%= organizer_signed_in? ? "You" : "They" %>
+            haven't tagged any transactions yet.
           </p>
         </div>
       </div>

--- a/app/views/events/home/_users_chart.html.erb
+++ b/app/views/events/home/_users_chart.html.erb
@@ -7,10 +7,14 @@
             Not enough data
           </h3>
           <p class="text-gray-500 my-1">
-            To see users here, make sure they have at least one transaction. If not, invite team members to get
-            started!
+            Spending by user is available when users have at least one transaction.
+            <% if organizer_signed_in? %>
+              Invite some team members to get started!
+            <% end %>
           </p>
-          <%= link_to "Invite", event_team_path(event), class: "btn mt-4", target: "_top" %>
+          <% if organizer_signed_in? %>
+            <%= link_to "Invite", event_team_path(event), class: "btn mt-4", target: "_top" %>
+          <% end %>
         </div>
       </div>
     <% else %>


### PR DESCRIPTION
## Summary of the problem

The org home can be very confusing in transparency mode when there is not enough data to be displayed.


## Describe your changes

Make the copy a bit conditional based on whether you're viewing in transparency mode.

When signed in (not much has changed):

<img width="1007" height="454" alt="image" src="https://github.com/user-attachments/assets/c32d01fc-c36b-47b4-9f9c-ab14bf1dfb45" />


In transparency:
<img width="1018" height="444" alt="image" src="https://github.com/user-attachments/assets/057d8eb8-6c36-416b-9ee3-95865de21fd7" />


Also, in transparency, the "show all" button for activities is now hidden because transparency mode users don't have access.
<img width="515" height="77" alt="image" src="https://github.com/user-attachments/assets/74edecdb-fe5b-4d90-9c92-4a4a627df713" />

Before:
<img width="504" height="64" alt="image" src="https://github.com/user-attachments/assets/7196c1cd-3f2a-4f15-98c4-51d96cccdeb3" />
