### PR TITLE
Disallow bots following links on HCB pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,8 +31,8 @@ class ApplicationController < ActionController::Base
   end
 
   before_action do
-    # Disallow indexing
-    response.set_header("X-Robots-Tag", "noindex")
+    # Disallow indexing and following
+    response.set_header("X-Robots-Tag", "none")
   end
 
   before_action do


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We seem to be getting a lot of traffic from bots on HCB, which is expensive when they load the ledger and follow all of the links on that page. We don't really need search engines or other bots to be indexing our pages or following those links.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change the `X-Robots-Tag` header value that we send on all requests from `noindex` to `none`, which will prevent them from indexing that page and following any links on that page.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

