### PR TITLE
Fix issues for HCB's contract party notification

### DIFF
--- a/app/mailers/contract/party_mailer.rb
+++ b/app/mailers/contract/party_mailer.rb
@@ -7,7 +7,7 @@ class Contract
       @contract = @party.contract
 
       mail to: @party.email,
-           subject: "You've been invited to sign an agreement for #{@contract.event.name} on HCB 📝",
+           subject: @party.notify_email_subject,
            template_name: "notify_#{@party.role}"
     end
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -71,7 +71,7 @@ class Contract < ApplicationRecord
     event :mark_sent do
       transitions from: :pending, to: :sent
       after do
-        parties.each(&:notify)
+        parties.not_hcb.each(&:notify)
       end
     end
 
@@ -138,6 +138,8 @@ class Contract < ApplicationRecord
   def on_party_signed
     if parties.all?(&:signed?)
       mark_signed!
+    elsif parties.not_hcb.all?(&:signed?)
+      party(:hcb).notify
     end
   end
 

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -83,6 +83,14 @@ class Contract
       end
     end
 
+    def notify_email_subject
+      if hcb?
+        "Sign the agreement as HCB Operations for #{contract.event.name}"
+      else
+        "You've been invited to sign an agreement for #{contract.event.name} on HCB 📝"
+      end
+    end
+
     private
 
     def signee_is_user

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -83,7 +83,7 @@ class Contract
 
     def notify_email_subject
       if hcb?
-        "Sign the agreement as HCB Operations for #{contract.event.name}"
+        "Sign the #{contract.event.name}'s agreement as HCB Operations"
       else
         "You've been invited to sign an agreement for #{contract.event.name} on HCB 📝"
       end

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -34,8 +34,6 @@ class Contract
 
     enum :role, { signee: "signee", cosigner: "cosigner", hcb: "hcb" }
 
-    scope :not_hcb, -> { where.not(role: :hcb) }
-
     attr_accessor :skip_pending_validation
 
     validates :role, uniqueness: { scope: :contract }

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -34,6 +34,8 @@ class Contract
 
     enum :role, { signee: "signee", cosigner: "cosigner", hcb: "hcb" }
 
+    scope :not_hcb, -> { where.not(role: :hcb) }
+
     attr_accessor :skip_pending_validation
 
     validates :role, uniqueness: { scope: :contract }

--- a/app/views/contract/party_mailer/notify_hcb.html.erb
+++ b/app/views/contract/party_mailer/notify_hcb.html.erb
@@ -1,7 +1,7 @@
 <p>Hi there! 👋</p>
 
 <p>
-  <%= @contract.party(:signee).email %> from <%= @contract.event.name %> is ready for you (HCB operations) to sign the fiscal sponsorship agreement!
+  <%= @contract.party(:signee).email %> from <%= @contract.event.name %> is ready for you (HCB Operations) to sign the fiscal sponsorship agreement!
 </p>
 
 <p>

--- a/app/views/contract/party_mailer/notify_hcb.html.erb
+++ b/app/views/contract/party_mailer/notify_hcb.html.erb
@@ -1,7 +1,7 @@
 <p>Hi there! 👋</p>
 
 <p>
-  <%= @contract.party(:signee).email %> from <%= @contract.event.name %> is ready for you to sign the fiscal sponsorship agreement!
+  <%= @contract.party(:signee).email %> from <%= @contract.event.name %> is ready for you (HCB operations) to sign the fiscal sponsorship agreement!
 </p>
 
 <p>
@@ -9,6 +9,6 @@
 </p>
 
 <p>
-  Best,<br>
-  The <%= link_to "HCB", "https://hackclub.com/hcb?utm_source=hcb&utm_medium=email" %> Team
+  Thanks!<br>
+  Here's a cookie 🍪
 </p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
HCB Operations was getting notiifed to sign the fiscal sponsorship agreement before other parties had signed their part. The email we sent to them was also unclear that it was for them to sign as operations and not as the contract signee.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Waits to notify HCB's party until all other parties have signed, and edits the email subject and body for HCB's notification. Includes giving them back their cookies - they deserve it 🍪

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

