### PR TITLE
[Ledger] Disable filtering in transparency

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1198,7 +1198,7 @@ class EventsController < ApplicationController
       @merchant_name = merchant.present? ? merchant[:name] : "Merchant #{@merchant}"
     end
 
-    @ledger_filters_disabled = !(organizer_signed_in? || auditor_signed_in?) && @event.slug == "hq"
+    @ledger_filters_disabled = !(organizer_signed_in? || auditor_signed_in?)
     has_filters = @tag || @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @missing_receipts || @merchant || @direction || @category
     if @ledger_filters_disabled && has_filters
       render plain: "Invalid parameters. Please try again", status: :bad_request


### PR DESCRIPTION
## Summary of the problem

See https://github.com/hackclub/hcb/pull/12403 for reasoning. It's causing major performance issues on HCB.

## Describe your changes

Disable filtering for all ledgers in transparency mode. Not just HQ. Note that all transactions are still visible. If you want to filter, download the CSV and filter in Excel. Organizers will have access to filters in HCB UI.