### PR TITLE
Fix event charts loading race condition for signed-out users

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,15 @@
 import $ from 'jquery'
 import ReactRailsUJS from 'react_ujs'
 
+// Initialize Intl polyfill globally before any components load
+// This prevents "IntlPolyfill is not defined" errors
+import 'intl'
+import 'intl/locale-data/jsonp/en-US'
+
+// Explicitly import home components to ensure they're in the bundle
+// This prevents race conditions when loading via turbo frames
+import './components/home'
+
 // Support component names relative to this directory:
 var componentRequireContext = require.context('./components', true)
 ReactRailsUJS.useContext(componentRequireContext)

--- a/app/javascript/components/command_bar/search/results.js
+++ b/app/javascript/components/command_bar/search/results.js
@@ -3,8 +3,6 @@
 import React from 'react'
 import Icon from '@hackclub/icons'
 import { Priority } from 'kbar'
-import Intl from 'intl'
-import 'intl/locale-data/jsonp/en-US'
 
 export const USDollar = new Intl.NumberFormat('en-US', {
   style: 'currency',

--- a/app/javascript/components/home/Categories.js
+++ b/app/javascript/components/home/Categories.js
@@ -1,4 +1,3 @@
-import 'intl/locale-data/jsonp/en-US'
 import PropTypes from 'prop-types'
 import React from 'react'
 import {

--- a/app/javascript/components/home/index.js
+++ b/app/javascript/components/home/index.js
@@ -1,0 +1,8 @@
+// Explicitly import all home components to ensure they're in the webpack bundle
+// This prevents "home is not defined" errors when loading via turbo frames
+import Categories from './Categories'
+import Merchants from './Merchants'
+import Tags from './Tags'
+import Users from './Users'
+
+export { Categories, Merchants, Tags, Users }

--- a/app/javascript/components/home/utils.js
+++ b/app/javascript/components/home/utils.js
@@ -1,5 +1,3 @@
-import Intl from 'intl'
-import 'intl/locale-data/jsonp/en-US'
 import { useEffect, useState } from 'react'
 
 export const generateColor = (index, length, isDark) => {


### PR DESCRIPTION
Fixes intermittent chart loading failures on event home pages when users are signed out viewing transparent orgs. The issue was a race condition between deferred JavaScript bundle loading and turbo frames trying to mount React components.

Changes:
- Initialize Intl polyfill globally in application.js before any components load to prevent "IntlPolyfill is not defined" errors
- Explicitly import home components in application.js to ensure they're in the webpack bundle and prevent "home is not defined" errors when ReactRailsUJS tries to mount them via turbo frames
- Remove redundant Intl imports from individual components (Categories.js, utils.js, command_bar/search/results.js) now that it's loaded globally
- Create home/index.js to explicitly export all home components

This ensures that when turbo frames lazy-load chart content, all required dependencies are already available, preventing the random chart loading failures that occurred when the bundle hadn't fully loaded yet.

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

