### PR TITLE
Handle nil signee party on the home page

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -174,11 +174,12 @@
 
     <%= render "static_pages/index/explore" %>
 
-    <% if current_user.contracts.sent.any? %>
+    <% valid_contracts = current_user.contracts.sent.select { |contract| contract.party(:signee).present? } %>
+    <% if valid_contracts.any? %>
       <h2 class="w-full text-left mt-4 pb-0 border-none">Your pending forms</h2>
       <p class="text-left my0 w-100 muted">Forms are sent to your HCB email, currently set to <%= mail_to current_user.email %>.</p>
       <ul class="grid grid--narrow grid-cols-1 text-left w-full mt-2">
-        <% current_user.contracts.sent.each do |contract| %>
+        <% valid_contracts.each do |contract| %>
           <%= link_to contract_party_path(contract.party(:signee)), target: "_blank" do %>
             <li class="card card--item flex" style="gap: 4.5px; align-items: baseline">
               <%= status_badge "info" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
While we shouldn't have any sent contracts that don't have an associated signee party, we seem to have missed some in the backfill (see https://hcb.hackclub.com/blazer/queries/1051-sent-contracts-without-a-signee-role). This is causing the HCB home page to 500 for anyone who has one of these contracts.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
While we work on sorting out this data, this PR adds a check to make sure we don't try to render any contracts that don't have a signee party.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

