### PR TITLE
[v4] Don't require receipts for salary accounts and other edge cases

### DIFF
--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -19,7 +19,7 @@ json.tags hcb_code.tags do |tag|
   json.emoji tag.emoji
 end
 json.code hcb_code.hcb_i1
-json.missing_receipt hcb_code.missing_receipt?
+json.missing_receipt hcb_code.missing_receipt?(@event)
 json.lost_receipt hcb_code.no_or_lost_receipt?
 json.appearance hcb_code.disbursement.special_appearance_name if hcb_code.disbursement&.special_appearance? && amount.positive?
 


### PR DESCRIPTION
## Summary of the problem
We aren't checking the cases where missing receipts aren't required


## Describe your changes
passed in `@event` into missing_receipt so we can account for these cases 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

