### PR TITLE
Add a 24 hour buffer for card locking

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -90,7 +90,7 @@ class MyController < ApplicationController
 
   def inbox
     @count = current_user.transactions_missing_receipt.count
-    @locking_count = current_user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
+    @locking_count = current_user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE, to: 24.hours.ago).count
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
 

--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -38,8 +38,9 @@ class StripeController < ActionController::Base
 
     if approved
       user = service.card.user
-      ::User::UpdateCardLockingJob.perform_later(user:)
+      ::User::UpdateCardLockingJob.set(wait: 24.hours).perform_later(user:)
       ::User::SendCardLockingNotificationJob.perform_later(user:, event: service.card.event)
+      ::User::SendCardLockingNotificationJob.set(wait: 24.hours).perform_later(user:, event: service.card.event)
     end
 
     response.set_header "Stripe-Version", "2022-08-01"

--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -38,7 +38,7 @@ class StripeController < ActionController::Base
 
     if approved
       user = service.card.user
-      ::User::UpdateCardLockingJob.set(wait: 24.hours).perform_later(user:)
+      ::User::UpdateCardLockingJob.set(wait: 24.hours + 1.minute).perform_later(user:)
       ::User::SendCardLockingNotificationJob.perform_later(user:, event: service.card.event)
       ::User::SendCardLockingNotificationJob.set(wait: 24.hours).perform_later(user:, event: service.card.event)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,16 +359,17 @@ class User < ApplicationRecord
     end
   end
 
-  memo_wise def transactions_missing_receipt(since: nil)
+  memo_wise def transactions_missing_receipt(from: nil, to: nil)
     return HcbCode.none unless hcb_code_ids_missing_receipt.any?
 
     user_hcb_codes = HcbCode.where(id: hcb_code_ids_missing_receipt)
-    user_hcb_codes = user_hcb_codes.where("created_at >= ?", since) if since
+    user_hcb_codes = user_hcb_codes.where("created_at >= ?", from) if from
+    user_hcb_codes = user_hcb_codes.where("created_at <= ?", to) if to
     user_hcb_codes.order(created_at: :desc)
   end
 
-  memo_wise def transactions_missing_receipt_count(since: nil)
-    transactions_missing_receipt(since:).size
+  memo_wise def transactions_missing_receipt_count(from: nil, to: nil)
+    transactions_missing_receipt(from:, to:).size
   end
 
   def build_payout_method(params)

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -12,18 +12,18 @@ module UserService
       current_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE, to: 24.hours.ago).count
       future_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE).count
 
-      if count.in?([5, 7, 9])
+      if current_count.in?([5, 7, 9])
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later
 
         if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You now have #{count} transactions missing receipts from more than a day ago. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          message = "You now have #{current_count} transactions missing receipts from more than a day ago. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
           TwilioMessageService::Send.new(@user, message).run!
         end
 
       elsif future_count >= 10
         if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You have more than ten transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
         
           TwilioMessageService::Send.new(@user, message).run!
         end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -24,7 +24,7 @@ module UserService
       elsif future_count >= 10
         if @user.phone_number.present? && @user.phone_number_verified?
           message = "You have more than ten transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
-        
+
           TwilioMessageService::Send.new(@user, message).run!
         end
       end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -9,17 +9,24 @@ module UserService
     def run
       return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
 
-      count = @user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
+      current_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE, to: 24.hours.ago).count
+      future_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE).count
 
       if count.in?([5, 7, 9])
         CardLockingMailer.warning(email: @user.email, missing_receipts: count).deliver_later
 
         if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You now have #{count} transactions missing receipts. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          message = "You now have #{count} transactions missing receipts from more than a day ago. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
           TwilioMessageService::Send.new(@user, message).run!
         end
 
+      elsif future_count >= 10
+        if @user.phone_number.present? && @user.phone_number_verified?
+          message = "You have more than ten transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+        
+          TwilioMessageService::Send.new(@user, message).run!
+        end
       end
     end
 

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -9,7 +9,7 @@ module UserService
     def run
       return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
 
-      count = @user.transactions_missing_receipt(since: Receipt::CARD_LOCKING_START_DATE).count
+      count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE, to: 24.hours.ago).count
 
       cards_should_lock = count >= 10
       if cards_should_lock && !@user.cards_locked?


### PR DESCRIPTION
This means that cards won't be locked until 24 hours after the 10 transactions have been made. Plus we'll still send a warning. Closes https://github.com/hackclub/hcb/issues/12421.