### PR TITLE
Add current_user fallback for common activity ERB

### DIFF
--- a/app/views/public_activity/_common.html.erb
+++ b/app/views/public_activity/_common.html.erb
@@ -1,3 +1,5 @@
+<% current_user ||= local_assigns[:p][:current_user] %>
+
 <li class="mb1 text-sm">
   <div class="flex flex-row gap-2">
     <% if defined?(icon) && defined?(color) %>


### PR DESCRIPTION
## Summary of the problem

We're running into issues where `current_user` isn't defined in PublicActivity activities


## Describe your changes

Adds current_user fallback to `app/views/public_activity/_common.html.erb`

```
<% current_user ||= local_assigns[:p][:current_user] %>
```
