### PR TITLE
[Admin] Add Fee Revenue index page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -813,6 +813,15 @@ class AdminController < Admin::BaseController
     @page = params[:page] || 1
     @per = params[:per] || 20
 
+    # Pending fees that haven't been converted to FeeRevenue yet
+    # Pre-calculate fee balances to avoid calling fee_balance_v2_cents multiple times per event
+    events_with_balances = Event.pending_fees_v2.map do |event|
+      { event: event, balance: event.fee_balance_v2_cents }
+    end
+
+    @uncharged_fees_events = events_with_balances.sort_by { |item| -item[:balance] }
+    @total_pending_fees = @uncharged_fees_events.sum { |item| item[:balance] }
+
     relation = FeeRevenue.all
 
     @count = relation.count

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -809,6 +809,16 @@ class AdminController < Admin::BaseController
 
   end
 
+  def fee_revenues
+    @page = params[:page] || 1
+    @per = params[:per] || 20
+
+    relation = FeeRevenue.all
+
+    @count = relation.count
+    @fee_revenues = relation.page(@page).per(@per).order("created_at desc")
+  end
+
   def disbursements
     @page = params[:page] || 1
     @per = params[:per] || 20

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -123,6 +123,12 @@ module Admin
             count_type: :records
           ),
           make_item(
+            name: "Fee Revenues",
+            path: fee_revenues_admin_index_path,
+            count: FeeRevenue.count,
+            count_type: :records
+          ),
+          make_item(
             name: "Column Statements",
             path: admin_column_statements_path,
             count: Column::Statement.count,

--- a/app/views/admin/fee_revenues.html.erb
+++ b/app/views/admin/fee_revenues.html.erb
@@ -1,5 +1,32 @@
 <% title "Fee Revenues" %>
 
+<div class="mb3">
+  <h3>Uncharged Fee Balance: <%= render_money @total_pending_fees %></h3>
+
+  <details>
+    <summary>View breakdown by organization (<%= @uncharged_fees_events.count %> organizations)</summary>
+
+    <table class="mt2">
+      <thead>
+        <tr>
+          <th>Organization</th>
+          <th>Fee Balance</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @uncharged_fees_events.each do |item| %>
+          <tr>
+            <td><%= link_to item[:event].name, event_path(item[:event]) %></td>
+            <td><%= render_money item[:balance] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </details>
+</div>
+
+<hr class="mb3">
+
 <div class="flex items-center mb2 flex-col sm:flex-row">
   <div class="flex-grow">
     <%= page_entries_info @fee_revenues, entry_name: "fee revenues" %>

--- a/app/views/admin/fee_revenues.html.erb
+++ b/app/views/admin/fee_revenues.html.erb
@@ -1,0 +1,37 @@
+<% title "Fee Revenues" %>
+
+<div class="flex items-center mb2 flex-col sm:flex-row">
+  <div class="flex-grow">
+    <%= page_entries_info @fee_revenues, entry_name: "fee revenues" %>
+  </div>
+  <%= paginate @fee_revenues %>
+</div>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Created</th>
+      <th>Status</th>
+      <th>Start Date</th>
+      <th>End Date</th>
+      <th>Amount</th>
+      <th>HCB Code</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @fee_revenues.each do |fee_revenue| %>
+      <tr>
+        <td><%= fee_revenue.id %></td>
+        <td><%= fee_revenue.created_at.strftime("%Y-%m-%d") %></td>
+        <td><%= fee_revenue.aasm_state %></td>
+        <td><%= fee_revenue.start&.strftime("%Y-%m-%d") %></td>
+        <td><%= fee_revenue.end&.strftime("%Y-%m-%d") %></td>
+        <td><%= render_money_amount(fee_revenue.amount_cents) %></td>
+        <td><%= link_to fee_revenue.hcb_code, hcb_code_path(fee_revenue.hcb_code) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @fee_revenues %>

--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -77,6 +77,7 @@
       <h2>Accounting</h2>
       <ul class="grid text-left w-100 mt0" id="accounting-grid">
         <%= card_to "Bank fees", bank_fees_admin_index_path, badge: BankFee.in_transit_or_pending.count %>
+        <%= card_to "Fee revenues", fee_revenues_admin_index_path %>
         <%= card_to "Ledger audits", admin_ledger_audits_path, badge: Admin::LedgerAudit.pending.count %>
         <%= render partial: "static_pages/card", locals: { task_path: balances_admin_index_path, human_name: "Organization balances" } %>
         <%= render partial: "static_pages/card", locals: { task_path: blazer_path, human_name: "Blazer" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,7 @@ Rails.application.routes.draw do
       get "bank_accounts", to: "admin#bank_accounts"
       get "hcb_codes", to: "admin#hcb_codes"
       get "bank_fees", to: "admin#bank_fees"
+      get "fee_revenues", to: "admin#fee_revenues"
       get "users", to: "admin#users"
       get "raw_transactions", to: "admin#raw_transactions"
       get "raw_transaction_new", to: "admin#raw_transaction_new"


### PR DESCRIPTION
## Summary of the problem

It's difficult for Mel to know how much fee revenue we're about to bring in throughout the week. She has to wait for the weekly job to run/for it to hit the ledger.

## Describe your changes

This PR adds a Fee Revenue index admin page so Mel can get an estimate of our fee revenue mid-week. It shows all previous fee revenues with their amount and states. At the top of the page, there's a sum and breakdown of uncharged fee balances.

<img width="1416" height="332" alt="image" src="https://github.com/user-attachments/assets/9f3886e8-76dd-424b-85b1-9f56358042a0" />
<img width="1412" height="202" alt="image" src="https://github.com/user-attachments/assets/e0d4fb08-960e-40d7-a5b2-f322b4b9be52" />
