### PR TITLE
[Governance] Allow admins w/o transfer limits to request disbursements

### DIFF
--- a/app/services/governance_service/admin/transfer/approval.rb
+++ b/app/services/governance_service/admin/transfer/approval.rb
@@ -40,6 +40,8 @@ module GovernanceService
           @approval_attempt.make_decision
           # Don't save to DB. We just want to check if it would be approved
           @approval_attempt.approved?
+        rescue Governance::Admin::Transfer::Limit::MissingApprovalLimitError
+          false
         end
 
         private


### PR DESCRIPTION
## Summary of the problem

Admins without transfer limits will get an error if they attempt to request a disbursement.


## Describe your changes

Allow them to request— but they still can't approve.