### PR TITLE
[v4] Add reversed field to transactions

### DIFF
--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -3,6 +3,7 @@
 # This partial is capable of rendering `HcbCode`, `CanonicalPendingTransaction`, and `CanonicalTransactionGrouped` instances
 
 hcb_code = tx.is_a?(HcbCode) ? tx : tx.local_hcb_code
+is_cpt = tx.is_a?(CanonicalPendingTransaction)
 amount = transaction_amount(tx, event: @event)
 
 json.id hcb_code.public_id
@@ -10,8 +11,9 @@ json.date tx.date
 json.amount_cents amount
 json.memo hcb_code.memo(event: @event)
 json.has_custom_memo hcb_code.custom_memo.present?
-json.pending (tx.is_a?(CanonicalPendingTransaction) && tx.unsettled?) || (tx.is_a?(HcbCode) && !tx.pt&.fronted? && tx.pt&.unsettled?)
-json.declined (tx.is_a?(CanonicalPendingTransaction) && tx.declined?) || (tx.is_a?(HcbCode) && tx.pt&.declined?)
+json.pending (is_cpt && tx.unsettled?) || (tx.is_a?(HcbCode) && !tx.pt&.fronted? && tx.pt&.unsettled?)
+json.declined (is_cpt && tx.declined?) || (tx.is_a?(HcbCode) && tx.pt&.declined?)
+json.reversed (is_cpt && tx.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") == "reversed") || (tx.is_a?(HcbCode) && tx.stripe_reversed_by_merchant?)
 json.tags hcb_code.tags do |tag|
   json.id tag.public_id
   json.label tag.label

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -11,9 +11,9 @@ json.date tx.date
 json.amount_cents amount
 json.memo hcb_code.memo(event: @event)
 json.has_custom_memo hcb_code.custom_memo.present?
-json.pending (is_cpt && tx.unsettled?) || (tx.is_a?(HcbCode) && !tx.pt&.fronted? && tx.pt&.unsettled?)
-json.declined (is_cpt && tx.declined?) || (tx.is_a?(HcbCode) && tx.pt&.declined?)
-json.reversed (is_cpt && tx.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") == "reversed") || (tx.is_a?(HcbCode) && tx.stripe_reversed_by_merchant?)
+json.pending (is_cpt && tx.unsettled?) || (is_hcb_code && !tx.pt&.fronted? && tx.pt&.unsettled?)
+json.declined (is_cpt && tx.declined?) || (is_hcb_code && tx.pt&.declined?)
+json.reversed (is_cpt && tx.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") == "reversed") || (is_hcb_code && tx.stripe_reversed_by_merchant?)
 json.tags hcb_code.tags do |tag|
   json.id tag.public_id
   json.label tag.label

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -4,6 +4,7 @@
 
 hcb_code = tx.is_a?(HcbCode) ? tx : tx.local_hcb_code
 is_cpt = tx.is_a?(CanonicalPendingTransaction)
+is_hcb_code = tx.is_a?(HcbCode)
 amount = transaction_amount(tx, event: @event)
 
 json.id hcb_code.public_id


### PR DESCRIPTION
## Summary of the problem
The app currently is showing reversed transactions as declined so we need someway to check if the transaction is reversed


## Describe your changes
added a reversed field


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

