### PR TITLE
Add margin at the bottom of the transaction component

### DIFF
--- a/app/views/card_grants/_transactions.html.erb
+++ b/app/views/card_grants/_transactions.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:hcb_codes].present? %>
   <h2 class="heading h2 leading-[1.5] mt0 ml0 pt1 pb1 pr2">Transactions on this card</h2>
 
-  <div style="overflow-x: auto;">
+  <div style="overflow-x: auto;" class="mb4">
     <table>
       <tbody data-behavior="transactions">
         <% local_assigns[:hcb_codes].each do |hcb_code| %>

--- a/app/views/card_grants/_transactions.html.erb
+++ b/app/views/card_grants/_transactions.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:hcb_codes].present? %>
   <h2 class="heading h2 leading-[1.5] mt0 ml0 pt1 pb1 pr2">Transactions on this card</h2>
 
-  <div style="overflow-x: auto;" class="mb4">
+  <div style="overflow-x: auto;" class="mb-16">
     <table>
       <tbody data-behavior="transactions">
         <% local_assigns[:hcb_codes].each do |hcb_code| %>


### PR DESCRIPTION
## Summary of the problem

<img width="1390" height="239" alt="Screenshot 2025-12-25 at 18 47 07" src="https://github.com/user-attachments/assets/3c6a49a4-47cd-4d57-890f-de9eb0b30624" />
there isn't any margin under the transactions box, that makes dragging receipts annoying and feels strange

## Describe your changes

adds a mb4 class to the transactions container, should fix the issue?
I didn't bother to setup a dev env as this is a single line change so no screenshot :(