### PR TITLE
[Wise] Validate USD <$50,000, not foreign currency

### DIFF
--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -148,7 +148,7 @@ class WiseTransfer < ApplicationRecord
   end
 
   validates :amount_cents, numericality: { greater_than: 0, message: "must be positive!" }
-  validates :amount_cents, numericality: { less_than: 50_000_00, message: "must be less than $50,000" }
+  validates :usd_amount_cents, numericality: { less_than: 50_000_00, message: "must be less than $50,000" }, allow_nil: true
 
   alias_attribute :name, :recipient_name
 


### PR DESCRIPTION
## Summary of the problem

Wise transfers are broken because we're validating that the local currency is less than $50,000, not the USD amount.

This causes issues when creating a Wise transfer for, say, $50,001 CAD (which is under $50,000 USD).

## Describe your changes

Validate `usd_amount_cents`, not `amount_cents`, and allow for `nil` values