### PR TITLE
[v4] Allow other org members to see stripe card last 4

### DIFF
--- a/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
@@ -6,7 +6,7 @@ json.type stripe_card.card_type
 json.status stripe_card.status_text.parameterize(separator: "_")
 json.name stripe_card.name
 
-if stripe_card.user == @current_user && stripe_card.initially_activated?
+if stripe_card.initially_activated?
   json.last4 stripe_card.last4
   json.exp_month stripe_card.stripe_exp_month
   json.exp_year stripe_card.stripe_exp_year


### PR DESCRIPTION
This is safe as last4 and expiration is already shown in the web and the only people who can access this are people in this policy which is same as in frontend. 

https://github.com/hackclub/hcb/blob/c08dbc05f98f2a1d1dbdc9c505ac2fdd896cabf3/app/policies/stripe_card_policy.rb#L31-L33