### PR TITLE
[V4 API] Revoken' some tokens

### DIFF
--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -3,13 +3,22 @@
 module Api
   module V4
     class UsersController < ApplicationController
-      skip_after_action :verify_authorized, only: [:available_icons, :beacon_config]
+      skip_after_action :verify_authorized, only: [:available_icons, :beacon_config, :revoke]
       before_action :require_admin!, only: [:show, :by_email]
       before_action :require_trusted_oauth_app!, only: [:beacon_config]
 
       def me
         @user = authorize current_user, :show?
         render :show
+      end
+
+      def revoke
+        @current_token.update(revoked_at: Time.now)
+        render json: {
+          success: true,
+          owner_email: current_user.email,
+          key_name: @current_token.application&.name
+        }
       end
 
       def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -644,6 +644,7 @@ Rails.application.routes.draw do
       defaults format: :json do
         resource :user, only: [] do
           get "/", to: "users#me", as: "user"
+          post :revoke
           resources :events, path: "organizations", only: [:index]
           resources :stripe_cards, path: "cards", only: [:index]
           resources :card_grants, only: [:index]


### PR DESCRIPTION
sometimes people leak their tokens! 
spending all their money shouldn't be the only thing a finder can do with them...
this PR adds a `POST /api/v4/user/revoke` endpoint for [hackclub/revoker](https://github.com/hackclub/revoker) that nukes the current token from orbit.