### PR TITLE
Revert "Update `receipt_required?` to consider amounts"

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -503,14 +503,6 @@ class HcbCode < ApplicationRecord
   # HCB-600: Stripe card charges (always required)
   # @sampoder
 
-  # receipt_required (the scope) diverges from receipt_required?
-  # in a couple of ways:
-  #
-  # 1) it doesn't consider event plan
-  # 2) it doesn't consider the amount of the HCB code
-  #
-  # this is because these two things are expensive to compute on a HCB code.
-
   scope :receipt_required, -> {
     joins("LEFT JOIN canonical_pending_transactions ON canonical_pending_transactions.hcb_code = hcb_codes.hcb_code")
       .joins("LEFT JOIN canonical_pending_declined_mappings ON canonical_pending_declined_mappings.canonical_pending_transaction_id = canonical_pending_transactions.id")
@@ -528,8 +520,6 @@ class HcbCode < ApplicationRecord
   # load the event once on the ledger and never again
   def receipt_required?(event = self.event, type = self.type)
     return false if pt&.declined?
-
-    return false if amount_cents_by_event(event) >= 0
 
     return false unless event&.plan&.receipts_required?
 


### PR DESCRIPTION
Reverts hackclub/hcb#12471

`amount_cents_by_event` appears to return the wrong polarity (positive number for a typical card charge), causing all receipts to not be required

https://github.com/hackclub/hcb/blob/4ad21a9ee19219c7a53cc1170182f06f04064e32/app/models/hcb_code.rb#L533-L534