### PR TITLE
[Stripe Personalization] Fix Stripe overwriting backfilled personalization IDs

### DIFF
--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -63,7 +63,7 @@ module Api
           stripe_shipping_address_line2: card[:shipping_address_line2],
           stripe_shipping_address_postal_code: card[:shipping_address_postal_code],
           stripe_shipping_address_country: card[:shipping_address_country],
-          stripe_card_personalization_design_id: card[:card_personalization_design_id] || StripeCard::PersonalizationDesign.common.first&.id
+          stripe_card_personalization_design_id: card[:card_personalization_design_id] || StripeCard::PersonalizationDesign.default&.id
         ).run
 
         return render json: { error: "internal_server_error" }, status: :internal_server_error if @stripe_card.nil?

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -123,7 +123,7 @@ class StripeCardsController < ApplicationController
       stripe_shipping_address_line2: sc[:stripe_shipping_address_line2],
       stripe_shipping_address_postal_code: sc[:stripe_shipping_address_postal_code],
       stripe_shipping_address_country: sc[:stripe_shipping_address_country],
-      stripe_card_personalization_design_id: sc[:stripe_card_personalization_design_id] || StripeCard::PersonalizationDesign.common.first&.id
+      stripe_card_personalization_design_id: sc[:stripe_card_personalization_design_id] || StripeCard::PersonalizationDesign.default&.id
     ).run
 
     redirect_to new_card, flash: { success: "Card was successfully created." }

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -303,7 +303,14 @@ class StripeCard < ApplicationRecord
     self.last4 = stripe_obj[:last4]
     self.stripe_status = stripe_obj[:status]
     self.card_type = stripe_obj[:type]
-    self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: stripe_obj[:personalization_design])&.id
+    # On ~2024-03-26, Stripe introduced personalization designs for physical cards
+    # This resulted in older cards not having a personalization design ID.
+    # This fix checks if its an old card without a personalization design ID and sets it to the default black design ID (311).
+    if self.created_at < Time.utc(2024, 3, 26) && stripe_obj[:personalization_design].nil?
+      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: 311)&.id
+    else
+      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: stripe_obj[:personalization_design])&.id
+    end
 
     if stripe_obj[:status] == "active"
       self.initially_activated = true

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -63,6 +63,8 @@ class StripeCard < ApplicationRecord
 
   has_paper_trail
 
+  DEFAULT_BLACK_PERSONALIZATION_DESIGN_ID = 311
+
   validate :within_card_limit, on: :create
 
   after_create_commit :notify_user, unless: :skip_notify_user
@@ -306,8 +308,8 @@ class StripeCard < ApplicationRecord
     # On ~2024-03-26, Stripe introduced personalization designs for physical cards
     # This resulted in older cards not having a personalization design ID.
     # This fix checks if its an old card without a personalization design ID and sets it to the default black design ID (311).
-    if self.created_at < Time.utc(2024, 3, 26) && stripe_obj[:personalization_design].nil?
-      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: 311)&.id
+    if self.created_at < Time.utc(2024, 3, 27) && stripe_obj[:personalization_design].nil?
+      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: DEFAULT_BLACK_PERSONALIZATION_DESIGN_ID)&.id
     else
       self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: stripe_obj[:personalization_design])&.id
     end

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -63,8 +63,6 @@ class StripeCard < ApplicationRecord
 
   has_paper_trail
 
-  DEFAULT_BLACK_PERSONALIZATION_DESIGN_ID = 311
-
   validate :within_card_limit, on: :create
 
   after_create_commit :notify_user, unless: :skip_notify_user
@@ -307,9 +305,9 @@ class StripeCard < ApplicationRecord
     self.card_type = stripe_obj[:type]
     # On ~2024-03-26, Stripe introduced personalization designs for physical cards
     # This resulted in older cards not having a personalization design ID.
-    # This fix checks if its an old card without a personalization design ID and sets it to the default black design ID (311).
+    # This fix checks if its an old card without a personalization design ID and sets it to the default black design.
     if self.created_at < Time.utc(2024, 3, 27) && stripe_obj[:personalization_design].nil?
-      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: DEFAULT_BLACK_PERSONALIZATION_DESIGN_ID)&.id
+      self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.default&.id
     else
       self.stripe_card_personalization_design_id = StripeCard::PersonalizationDesign.find_by(stripe_id: stripe_obj[:personalization_design])&.id
     end

--- a/app/models/stripe_card/personalization_design.rb
+++ b/app/models/stripe_card/personalization_design.rb
@@ -27,7 +27,13 @@
 #
 class StripeCard
   class PersonalizationDesign < ApplicationRecord
+    DEFAULT_STRIPE_ID = "311"
+
     has_paper_trail
+
+    def self.default
+      find_by(id: DEFAULT_STRIPE_ID)
+    end
 
     include HasStripeDashboardUrl
     has_stripe_dashboard_url "issuing/personalization-designs", :stripe_id


### PR DESCRIPTION
## Summary of the problem
Old cards before personalization was a thing are getting their backfilled stripe personalization ID overwritten because anytime we sync from stripe (e.g freeze) it changes it to stripe's value (which is nil cuz it wasnt a thing then) 


## Describe your changes
If its before the specific date that we found and its nil we should set it to our default design which has an ID of 311


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

