### PR TITLE
[v3] Fix optimized images erroring due to `saver` transform

### DIFF
--- a/app/api/api/entities/base.rb
+++ b/app/api/api/entities/base.rb
@@ -50,10 +50,17 @@ module Api
 
       private
 
-      def url_for_attached(attachment)
+      def url_for_attached(attachment, transformations = nil)
         return nil unless attachment&.attached?
 
-        Rails.application.routes.url_helpers.url_for attachment
+        if transformations.nil? || !attachment.variable?
+          # Serve original attachment
+          return Rails.application.routes.url_helpers.url_for attachment
+        end
+
+        Rails.application.routes.url_helpers.url_for(
+          attachment.variant(transformations)
+        )
       end
 
     end

--- a/app/api/api/entities/directory_organization.rb
+++ b/app/api/api/entities/directory_organization.rb
@@ -74,10 +74,10 @@ module Api
       end
 
       expose :logo do |organization|
-        url_for_attached organization.logo, resize_to_limit: [200, 200], saver: { quality: 80 }
+        url_for_attached organization.logo, resize_to_limit: [200, 200]
       end
       expose :background_image do |organization|
-        url_for_attached organization.background_image, resize_to_limit: [800, 800], saver: { quality: 80 }
+        url_for_attached organization.background_image, resize_to_limit: [800, 800]
       end
       expose :donation_link do |organization|
         if organization.donation_page_available?

--- a/app/api/api/entities/directory_organization.rb
+++ b/app/api/api/entities/directory_organization.rb
@@ -74,22 +74,10 @@ module Api
       end
 
       expose :logo do |organization|
-        if organization.logo.attached? && organization.logo.variable?
-          Rails.application.routes.url_helpers.url_for(
-            organization.logo.variant(resize_to_limit: [200, 200], saver: { quality: 80 })
-          )
-        elsif organization.logo.attached?
-          url_for_attached organization.logo
-        end
+        url_for_attached organization.logo, resize_to_limit: [200, 200], saver: { quality: 80 }
       end
       expose :background_image do |organization|
-        if organization.background_image.attached? && organization.background_image.variable?
-          Rails.application.routes.url_helpers.url_for(
-            organization.background_image.variant(resize_to_limit: [800, 800], saver: { quality: 80 })
-          )
-        else
-          url_for_attached organization.background_image
-        end
+        url_for_attached organization.background_image, resize_to_limit: [800, 800], saver: { quality: 80 }
       end
       expose :donation_link do |organization|
         if organization.donation_page_available?


### PR DESCRIPTION
## Summary of the problem

Closes https://github.com/hackclub/hcb/issues/12501. Continuation of https://github.com/hackclub/hcb/pull/12476

Our server doesn't support the `saver` transformation.


## Describe your changes

We'll remove it for now. I also DRY'ed up the code a bit.