### PR TITLE
Remove double "Something went wrong"

### DIFF
--- a/app/javascript/controllers/stripe_controller.js
+++ b/app/javascript/controllers/stripe_controller.js
@@ -52,11 +52,11 @@ export default class extends Controller {
           ) {
             flash.textContent = `Something went wrong: your bank declined this transaction. Please contact them to approve it.`
           } else {
-            flash.textContent = `Something went wrong: ${result.error.message}`
+            flash.textContent = result.error.message
           }
           this.errorsTarget.appendChild(flash)
         } else {
-          alert(`Something went wrong: ${result.error.message}`)
+          alert(result.error.message)
         }
       }
     }


### PR DESCRIPTION
Closes https://github.com/hackclub/hcb/issues/12311. Stripe includes "Something went wrong" in their own error messages. Oops.