### PR TITLE
Return early if `@event.discord_channel_id` is blank

### DIFF
--- a/app/jobs/discord/process_notification_job.rb
+++ b/app/jobs/discord/process_notification_job.rb
@@ -11,6 +11,8 @@ module Discord
     def perform(public_activity_id)
       @activity = PublicActivity::Activity.find(public_activity_id)
       @event = @activity.event
+      return if @event.discord_channel_id.blank?
+
       @user = @activity.owner || User.system_user
 
       discord_scrubber = Loofah::Scrubber.new do |node|


### PR DESCRIPTION
No more resolve id errors!