### PR TITLE
Handle check errors cleaner in reimbursements

### DIFF
--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -75,7 +75,8 @@ module Reimbursement
                   payout_holding.mark_sent!
                 rescue Faraday::Error => e
                   check.mark_rejected!
-                  Rails.error.unexpected "[reimbursements / check issuing] #{e.response_body["message"]}. report ID: #{payout_holding.report.id}"
+                  message = e.response_body&.dig("message") || e.message
+                  Rails.error.unexpected "[reimbursements / check issuing] #{message}. report ID: #{payout_holding.report.id}"
                 end
               end
             when User::PayoutMethod::AchTransfer


### PR DESCRIPTION
We're over creating checks and its bad. For all other transfers, if there's an error, we reject the transfer. Not for checks though until now. Also gives better errors for engineers to debug (aka me oof).