### PR TITLE
Remove 140 char limit on payment_for for Wise

### DIFF
--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -48,8 +48,6 @@ class WiseTransfer < ApplicationRecord
 
   has_encrypted :recipient_information, type: :json
 
-  validates_length_of :payment_for, maximum: 140
-
   include AASM
   include Freezable
 


### PR DESCRIPTION
causing lots of issues with reimbursements, eg. https://hcb.hackclub.com/reimbursement/reports/EzSEol.

fyi @YodaLightsabr 