### PR TITLE
[Admin] Prevent IDV downtime from affecting HCB

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1556,6 +1556,9 @@ class AdminController < Admin::BaseController
     end
 
     client.get("https://identity.hackclub.com/api/v1/hcb").body["pending"] || 0
+  rescue => e
+    Rails.error.report(e)
+    9999 # return something invalidly high to get the ops team to report it
   end
 
   def hackathons_task_size


### PR DESCRIPTION
## Summary of the problem

IDV has some minor downtime, which caused the HCB home page to error for admins (when it attempted to fetch IDV task size).


## Describe your changes

Prevent IDV downtime from taking down the home page for admins by rescuing API call to IDV.