### PR TITLE
Add one-time job to `BackfillTeenagerOnSeenAtHistories`

### DIFF
--- a/app/jobs/one_time_jobs/backfill_teenager_on_seen_at_histories.rb
+++ b/app/jobs/one_time_jobs/backfill_teenager_on_seen_at_histories.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillTeenagerOnSeenAtHistories < ApplicationJob
+    def perform
+      User.where.not(birthday_ciphertext: nil).find_each do |user|
+        histories = User::SeenAtHistory.where(user_id: user.id)
+        next if histories.empty?
+
+        if user.teenager?
+          # User is currently a teenager so they've always been a teenager
+          histories.update_all(teenager: true)
+        else
+          # User is 18+, calculate when they turned 18
+          eighteenth_birthday = user.birthday.to_date + 18.years
+
+          # Records before their 18th birthday: teenager = true
+          histories.where(period_end_at: ...eighteenth_birthday).update_all(teenager: true)
+
+          # Records on or after their 18th birthday: teenager = false
+          histories.where(period_end_at: eighteenth_birthday..).update_all(teenager: false)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/hackclub/hcb/pull/12542.

After running this locally:

<img width="495" height="126" alt="Screenshot 2026-01-07 at 7 46 42 PM" src="https://github.com/user-attachments/assets/1cf784e2-b141-43cf-b387-8f183681255f" />

None of the non-backfilled users have birthdays:

<img width="509" height="98" alt="Screenshot 2026-01-07 at 7 48 57 PM" src="https://github.com/user-attachments/assets/80865d7a-d504-41e0-a33c-b96c84278a2f" />
