### PR TITLE
[Reimbursements] Account for non-USD reports in totals

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -683,6 +683,11 @@ class EventsController < ApplicationController
 
   def reimbursements
     authorize @event
+    @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:amount_cents)
+    @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed.where.not(currency: "USD")).sum(&:amount_cents)
+    @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)
+    @pending = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.pending.reimbursed).sum(&:amount_cents)
+
     @reports = @event.reimbursement_reports.visible
     @reports = @reports.draft if params[:status] == "draft"
     @reports = @reports.submitted if params[:status] == "review_required"

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -685,6 +685,7 @@ class EventsController < ApplicationController
     authorize @event
     @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:amount_cents)
     @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed.where.not(currency: "USD")).sum(&:amount_cents)
+    @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.pending.where.not(currency: "USD")).sum(&:cached_wise_transfer_quote_amount)
     @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)
     @pending = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.pending.reimbursed).sum(&:amount_cents)
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -685,9 +685,9 @@ class EventsController < ApplicationController
     authorize @event
     @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:amount_cents)
     @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed.where.not(currency: "USD")).sum(&:amount_cents)
-    @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.pending.where.not(currency: "USD")).sum(&:cached_wise_transfer_quote_amount)
+    @total += @event.reimbursement_reports.pending.where.not(currency: "USD").sum(&:cached_wise_transfer_quote_amount)
     @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)
-    @pending = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.pending.reimbursed).sum(&:amount_cents)
+    @pending = @total - @reimbursed
 
     @reports = @event.reimbursement_reports.visible
     @reports = @reports.draft if params[:status] == "draft"

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -344,6 +344,12 @@ module Reimbursement
       Money.from_cents(0)
     end
 
+    def cached_wise_transfer_quote_amount
+      Rails.cache.fetch("cached_wise_transfer_quote_amount_#{id}", expires_in: 3.days) do
+        wise_transfer_quote_amount
+      end
+    end
+
     def wise_transfer_quote_without_fees_amount
       @wise_transfer_quote_without_fees_amount ||= WiseTransfer.generate_detailed_quote(amount)[:without_fees_usd_amount]
     rescue

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -35,16 +35,21 @@
 
 <div class="statset mb-2">
   <div class="stat">
-    <span class="stat__label">Total</span>
-    <span class="stat__value" style="text-wrap: nowrap"><%= render_money_amount(@event.reimbursement_reports.to_calculate_total.sum(&:amount_cents)) %></span>
+    <span class="stat__label">
+      Total
+      <a class="tooltipped tooltipped--w link--ignore flex" aria-label='This figure excludes foreign currency reimbursement reports that have not yet settled to USD.' tabindex="0">
+        <%= inline_icon "info", width: 24 %>
+      </a>
+    </span>
+    <span class="stat__value" style="text-wrap: nowrap"><%= render_money_amount(@total) %></span>
   </div>
   <div class="stat stat--small">
     <span class="stat__label">Reimbursed</span>
-    <span class="stat__value"><%= render_money_amount(@event.reimbursement_reports.reimbursed.sum(&:amount_cents)) %></span>
+    <span class="stat__value"><%= render_money_amount(@reimbursed) %></span>
   </div>
   <div class="stat stat--small">
     <span class="stat__label">Pending</span>
-    <span class="stat__value"><%= render_money_amount(@event.reimbursement_reports.pending.reimbursed.sum(&:amount_cents)) %></span>
+    <span class="stat__value"><%= render_money_amount(@pending) %></span>
   </div>
 </div>
 

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -37,9 +37,11 @@
   <div class="stat">
     <span class="stat__label">
       Total
-      <a class="tooltipped tooltipped--w link--ignore flex" aria-label='This figure excludes foreign currency reimbursement reports that have not yet settled to USD.' tabindex="0">
-        <%= inline_icon "info", width: 24 %>
-      </a>
+      <% if @event.reimbursement_reports.reimbursed.where.not(currency: "USD").exists? %>
+        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='This figure excludes foreign currency reimbursement reports that have not yet settled to USD.' tabindex="0">
+          <%= inline_icon "info", width: 24 %>
+        </a>
+      <% end %>
     </span>
     <span class="stat__value" style="text-wrap: nowrap"><%= render_money_amount(@total) %></span>
   </div>

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -37,11 +37,6 @@
   <div class="stat">
     <span class="stat__label">
       Total
-      <% if @event.reimbursement_reports.reimbursed.where.not(currency: "USD").exists? %>
-        <a class="tooltipped tooltipped--e link--ignore inline-flex h-6 overflow-clip items-center justify-center align-bottom" aria-label='Excludes pending foreign currency reimbursement reports' tabindex="0">
-          <%= inline_icon "info", width: 24 %>
-        </a>
-      <% end %>
     </span>
     <span class="stat__value" style="text-wrap: nowrap"><%= render_money_amount(@total) %></span>
   </div>

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -38,7 +38,7 @@
     <span class="stat__label">
       Total
       <% if @event.reimbursement_reports.reimbursed.where.not(currency: "USD").exists? %>
-        <a class="tooltipped tooltipped--w link--ignore flex" aria-label='This figure excludes foreign currency reimbursement reports that have not yet settled to USD.' tabindex="0">
+        <a class="tooltipped tooltipped--e link--ignore inline-flex h-6 overflow-clip items-center justify-center align-bottom" aria-label='Excludes pending foreign currency reimbursement reports' tabindex="0">
           <%= inline_icon "info", width: 24 %>
         </a>
       <% end %>


### PR DESCRIPTION
## Summary of the problem

The current totals include non-USD values


## Describe your changes

Excludes non-USD values from the totals

<img width="909" height="608" alt="image" src="https://github.com/user-attachments/assets/18e5322d-6f9e-4182-8596-5d835e52a7ea" />

Also adds a tooltip for applicable totals