### PR TITLE
[Discord] Remove button from `/ping` command

### DIFF
--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -82,22 +82,6 @@ module Discord
       @generate_discord_unlink_server_url ||= url_helpers.discord_unlink_server_url(signed_guild_id: Discord.generate_signed(@guild_id, purpose: :unlink_server))
     end
 
-    def ping_component
-      {
-        "type": 9,
-        "data": {
-          "custom_id": "ping_modal",
-          "title": "Ping",
-          "components": [
-            {
-              "type": 10,
-              "content": "Pong! 🏓",
-            },
-          ]
-        }
-      }
-    end
-
     def attach_receipt_component
       discord_message = Discord::Message.find_by(discord_message_id: @interaction.dig(:message, :id))
       activity = PublicActivity::Activity.find_by(id: discord_message&.activity_id)
@@ -178,19 +162,7 @@ module Discord
     end
 
     def ping_command
-      respond content: "Pong! 🏓", components: [
-        {
-          type: 1,
-          components: [
-            {
-              type: 2,
-              label: "Ping",
-              style: 1,
-              custom_id: "ping"
-            }
-          ]
-        }
-      ]
+      respond content: "Pong! 🏓"
     end
 
     def link_command


### PR DESCRIPTION
## Summary of the problem

#11834


## Describe your changes

Fixes #11834 by removing the broken button from the `/ping` command