### PR TITLE
Fix mismatching Ruby version in codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,19 @@
-ARG VARIANT="3.4-bookworm"
-FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+# Install Ruby
+ARG RUBY_VERSION="3.4"
+RUN su vscode -c "gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+RUN su vscode -c "curl -sSL https://get.rvm.io | bash -s stable"
+RUN su vscode -c "/bin/bash -l -c \"rvm install ${RUBY_VERSION}\""
+RUN su vscode -c "/bin/bash -l -c \"rvm --default use ${RUBY_VERSION}\""
+
 # Install Rails
-RUN su vscode -c "gem install rails webdrivers"
-RUN su vscode -c "/usr/local/rvm/bin/rvm fix-permissions"
+RUN su vscode -c "/bin/bash -l -c \"gem install rails webdrivers\""
+RUN su vscode -c "/bin/bash -l -c \"rvm fix-permissions\""
 
 ARG NODE_VERSION="22"
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
+RUN su vscode -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
+RUN su vscode -c "source /home/vscode/.nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
 # The value is a comma-separated list of allowed domains 
@@ -16,6 +24,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
 		# These libraries are used by rails or helpful for development
     postgresql-client \
+    libpq-dev \
     poppler-utils \
     gir1.2-freedesktop \
     gir1.2-glib-2.0 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,14 +16,6 @@
 		}
 	},
 
-	"build": {
-		"args": {
-			// Update 'VARIANT' to pick a Ruby version
-			"VARIANT": "3.4.7-bookworm",
-			"NODE_VERSION": "22"  // Node version installed by nvm (https://github.com/devcontainers/images/tree/main/src/ruby#installing-nodejs)
-		}
-	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
 	"forwardPorts": [3000, 5432],
@@ -53,7 +45,7 @@
 				"Shopify.ruby-lsp"
 			]
 		}
-	},
+	}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      args:
+        RUBY_VERSION: 3.4.7
+        NODE_VERSION: 22
 
     volumes:
       - ../..:/workspaces:cached


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, we're using the Ruby devcontainer image provided by Microsoft in our devcontainer configuration for codespaces. However, patch versioned images are not provided, so when containers are rebuilt they will automatically install the latest patch version instead of what's in `.ruby-version`, causing the build to fail.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change the codespace configuration to use the base Debian Bookworm image instead of the provided Ruby image, and install Ruby using rvm according to the version specified in `docker-compose.yml`. This does increase the initial build time as rvm compiles Ruby, which took a few minutes on a base-level codespace.

Going forward, updating the Ruby version will just require updating `.ruby-version` and `docker-compose.yml`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

