### PR TITLE
[Stripe Card] Add safe navigation operator to `_freeze.html.erb:27`

### DIFF
--- a/app/views/stripe_cards/actions/_freeze.html.erb
+++ b/app/views/stripe_cards/actions/_freeze.html.erb
@@ -24,7 +24,7 @@
       <p class="text-sm opacity-60"><%= policy(stripe_card).freeze? ? freeze_tooltip : "You don't have permission to perform this action" %></p>
     </div>
   <% end %>
-<% elsif !stripe_card.canceled? %>
+<% elsif !stripe_card&.canceled? %>
   <%= link_to "#",
               method: :post,
               class: "btn btn--list-item",


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Loading this partial would fail if the card did not exist on a card grant, causing the page to break.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Add a safe navigation operator which evaluates to nil and prevents erroring from `NoMethodError` on `nil` on subsequent method calls.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

