### PR TITLE
[Card Grant Pre-Auth] Use `after_commit` in `pre_authorization.rb` AASM `mark_submitted` event

### DIFF
--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -52,7 +52,7 @@ class CardGrant
 
       event :mark_submitted do
         transitions from: :draft, to: :submitted
-        after do
+        after_commit do
           ::CardGrant::PreAuthorization::AnalyzeJob.perform_later(pre_authorization: self)
         end
       end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

race condition in `AnalyzeJob` running while AASM's `mark_submitted` event still has the DB lock. When it attempts to update to another state, this fails due to not being able to acquire the lock. It does retry later though.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Uses `after_commit` to only queue `AnalyzeJob` after commit.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

