### PR TITLE
Fix select menu options on dark mode

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -70,6 +70,10 @@ textarea {
   }
 }
 
+[data-dark='true'] option {
+  background-color: $darkless;
+}
+
 select {
   min-height: 2.5rem;
   padding: 0.25rem 0.5rem;


### PR DESCRIPTION
Fixes select menu `<option>` appearance in dark mode


<img width="595" height="626" alt="image" src="https://github.com/user-attachments/assets/7ecb0b07-ade2-451d-8afe-67c5697218f6" />
