### PR TITLE
[Stripe Card] Remove empty card when no actions are available

### DIFF
--- a/app/views/stripe_cards/_actions.html.erb
+++ b/app/views/stripe_cards/_actions.html.erb
@@ -1,34 +1,39 @@
 <%# locals: (stripe_card:) %>
+<% if !stripe_card.canceled? %>
+  <div class="mt-3 mb-2 flex flex-col justify-center flex-wrap card card--homepage p-2">
+    <% if !stripe_card.initially_activated? %>
+      <%= render "stripe_cards/actions/activate", stripe_card: %>
+    <% else %>
+      <%= render "stripe_cards/actions/rename", stripe_card: %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: %>
+    <% end %>
+    <%= render "stripe_cards/actions/cancel", stripe_card: %>
 
-<div class="mt-3 mb-2 flex flex-col justify-center flex-wrap card card--homepage p-2">
-  <% if !stripe_card.initially_activated? %>
-    <%= render "stripe_cards/actions/activate", stripe_card: %>
-  <% else %>
-    <%= render "stripe_cards/actions/rename", stripe_card: %>
-    <%= render "stripe_cards/actions/freeze", stripe_card: %>
-  <% end %>
-  <%= render "stripe_cards/actions/cancel", stripe_card: %>
-
-  <% if stripe_card.virtual? && Flipper.enabled?(:onepass_cc_save_2024_04_29, current_user) && params["show_details"] == "true" %>
-    <onepassword-save-button
-      data-controller="1pass"
-      data-action="click->1pass#click"
-      data-onepassword-type="credit-card"
-      lang="en"
-      class="white"
-      padding="compact"
-      data-cc-title="<%= stripe_card.name.presence || "HCB card for #{stripe_card.event.name}" %>"
-      data-cc-name="<%= stripe_card.stripe_cardholder.stripe_name %>"
-      data-cc-number="<%= stripe_card.full_card_number %>"
-      data-cc-exp="<%= stripe_card.stripe_exp_year %><%= stripe_card.stripe_exp_month.to_s.rjust(2, "0") %>"
-      data-cc-csc="<%= stripe_card.cvc %>"
-      data-cc-type="<%= stripe_card.stripe_brand %>"
-      data-cc-address-street-address="<%= stripe_card.stripe_cardholder.stripe_billing_address_line1 %>"
-      data-cc-address-city="<%= stripe_card.stripe_cardholder.stripe_billing_address_city %>"
-      data-cc-address-state="<%= stripe_card.stripe_cardholder.stripe_billing_address_state %>"
-      data-cc-address-postal-code="<%= stripe_card.stripe_cardholder.stripe_billing_address_postal_code %>"
-      data-cc-address-country="<%= stripe_card.stripe_cardholder.stripe_billing_address_country %>"
-      data-organization-name="<%= stripe_card.event.name %>">
-    </onepassword-save-button>
-  <% end %>
-</div>
+    <% if stripe_card.virtual? && Flipper.enabled?(:onepass_cc_save_2024_04_29, current_user) && params["show_details"] == "true" %>
+      <onepassword-save-button
+        data-controller="1pass"
+        data-action="click->1pass#click"
+        data-onepassword-type="credit-card"
+        lang="en"
+        class="white"
+        padding="compact"
+        data-cc-title="<%= stripe_card.name.presence || "HCB card for #{stripe_card.event.name}" %>"
+        data-cc-name="<%= stripe_card.stripe_cardholder.stripe_name %>"
+        data-cc-number="<%= stripe_card.full_card_number %>"
+        data-cc-exp="<%= stripe_card.stripe_exp_year %><%= stripe_card.stripe_exp_month.to_s.rjust(2, "0") %>"
+        data-cc-csc="<%= stripe_card.cvc %>"
+        data-cc-type="<%= stripe_card.stripe_brand %>"
+        data-cc-address-street-address="<%= stripe_card.stripe_cardholder.stripe_billing_address_line1 %>"
+        data-cc-address-city="<%= stripe_card.stripe_cardholder.stripe_billing_address_city %>"
+        data-cc-address-state="<%= stripe_card.stripe_cardholder.stripe_billing_address_state %>"
+        data-cc-address-postal-code="<%= stripe_card.stripe_cardholder.stripe_billing_address_postal_code %>"
+        data-cc-address-country="<%= stripe_card.stripe_cardholder.stripe_billing_address_country %>"
+        data-organization-name="<%= stripe_card.event.name %>">
+      </onepassword-save-button>
+    <% end %>
+  </div>
+<% else %>
+  <div class="my-3 mx-0 flex flex-col justify-center flex-wrap px-2">
+    <%= blankslate "This card is canceled. No actions are available." %>
+  </div>
+<% end %>

--- a/app/views/stripe_cards/_actions.html.erb
+++ b/app/views/stripe_cards/_actions.html.erb
@@ -32,8 +32,4 @@
       </onepassword-save-button>
     <% end %>
   </div>
-<% else %>
-  <div class="my-3 mx-0 flex flex-col justify-center flex-wrap px-2">
-    <%= blankslate "This card is canceled. No actions are available." %>
-  </div>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Previously there was a blank area if a card was canceled

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Add a blankslate so the box is not empty.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
Previous:

<img width="339" height="387" alt="Screenshot 2026-01-08 at 1 22 31 PM" src="https://github.com/user-attachments/assets/1278a79b-df2b-4ccb-8e80-172ff52e85d1" />

New:

<img width="319" height="495" alt="Screenshot 2026-01-08 at 1 49 21 PM" src="https://github.com/user-attachments/assets/1f5b45a5-eb95-4963-8605-1afe5b34318a" />

---

EDIT: we decided to just remove the card entirely if no actions are available.