### PR TITLE
[Gemfile] Upgrade Public Activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,7 +200,8 @@ gem "rtesseract"
 
 gem "sprockets-rails", "~> 3.5"
 
-gem "public_activity"
+# We are waiting for a new `public_activity` release that includes https://github.com/public-activity/public_activity/pull/387
+gem "public_activity", github: "public-activity/public_activity", ref: "29bbd6e788950b5528c512bb8361071f187f3230"
 
 gem "console1984"
 gem "audits1984"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,17 @@ GIT
       msgpack
       redis
 
+GIT
+  remote: https://github.com/public-activity/public_activity.git
+  revision: 29bbd6e788950b5528c512bb8361071f187f3230
+  ref: 29bbd6e788950b5528c512bb8361071f187f3230
+  specs:
+    public_activity (3.0.1)
+      actionpack (>= 6.1.0)
+      activerecord (>= 6.1)
+      i18n (>= 0.5.0)
+      railties (>= 6.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -610,11 +621,6 @@ GEM
     psych (5.2.6)
       date
       stringio
-    public_activity (3.0.1)
-      actionpack (>= 6.1.0)
-      activerecord (>= 6.1)
-      i18n (>= 0.5.0)
-      railties (>= 6.1.0)
     public_suffix (6.0.2)
     puma (6.6.1)
       nio4r (~> 2.0)
@@ -1005,7 +1011,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   pstore
-  public_activity
+  public_activity!
   puma (~> 6.6)
   pundit
   query_count


### PR DESCRIPTION
## Summary of the problem

@YodaLightsabr and I were running into the bug described in https://github.com/public-activity/public_activity/pull/387

## Describe your changes

While we're waiting for a new release that includes https://github.com/public-activity/public_activity/pull/387, we're sourcing directly from GitHub.

At the time of writing, the latest version available on RubyGems.org is 3.0.1 (which is the version we had installed).