### PR TITLE
[Receipts] Respect inline attachments in receipt mailbox

### DIFF
--- a/app/mailboxes/concerns/has_attachments.rb
+++ b/app/mailboxes/concerns/has_attachments.rb
@@ -7,7 +7,7 @@ module HasAttachments
     private
 
     def set_attachments(include_body: true, convert_emls: true)
-      files = mail.attachments.select { |a| valid_content_type(a.content_type) }.map do |atta|
+      files = mail.attachments.select { |a| valid_content_type(a.content_type) && a.content_disposition.starts_with?("attachment") }.map do |atta|
         {
           io: StringIO.new(atta.decoded),
           content_type: atta.content_type,


### PR DESCRIPTION
## Summary of the problem

#12595

> The receipt mailbox treats any attachment (inline or not) as the entire receipt, causing a simple logo to break the entire email forward.

## Describe your changes

Fixes #12595

> If someone adds an attachment, we don't want the presence of an email signature to cause the non-empty body to be converted to a PDF—we want to take the attachment. We should only take attachments with a Content-Disposition header of attachment, though, not inline.

