### PR TITLE
Fix transparency mode bugs

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -44,13 +44,15 @@ module EventsHelper
       selected: selected == :transactions,
     }
 
-    items << {
-      name: "Account numbers",
-      path: account_number_event_path(@event),
-      tooltip: "View account numbers",
-      icon: "hashtag",
-      selected: selected == :account_number,
-    }
+    if policy(@event).account_number?
+      items << {
+        name: "Account numbers",
+        path: account_number_event_path(@event),
+        tooltip: "View account numbers",
+        icon: "hashtag",
+        selected: selected == :account_number,
+      }
+  end
 
     if policy(@event).donation_overview? || ( @event.approved? && @event.plan.invoices_enabled? ) || policy(@event).account_number? || policy(@event.check_deposits.build).index?
       items << { section: "Receive" }
@@ -77,13 +79,15 @@ module EventsHelper
       }
     end
 
-    items << {
-      name: "Check deposits",
-      path: event_check_deposits_path(@event),
-      tooltip: "Deposit a check",
-      icon: "cheque",
-      selected: selected == :deposit_check,
-    }
+    if policy(@event.check_deposits.build).index?
+      items << {
+        name: "Check deposits",
+        path: event_check_deposits_path(@event),
+        tooltip: "Deposit a check",
+        icon: "cheque",
+        selected: selected == :deposit_check,
+      }
+    end
 
     if policy(@event).transfers? || policy(@event).reimbursements? || policy(@event).card_overview?
       items << { section: "Spend" }
@@ -127,7 +131,7 @@ module EventsHelper
         selected: selected == :reimbursements
       }
     end
-    if Flipper.enabled?(:payroll_2025_02_13, @event)
+    if Flipper.enabled?(:payroll_2025_02_13, @event) && policy(@event).employees?
       items << {
         name: "Contractors",
         path: event_employees_path(event_id: @event.slug),
@@ -147,7 +151,7 @@ module EventsHelper
         icon: "people-2",
         selected: selected == :team,
       }
-    if event.approved?
+    if event.approved? && policy(event).promotions?
       items << {
         name: "Perks",
         path: event_promotions_path(event_id: event.slug),

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -52,7 +52,7 @@ module EventsHelper
         icon: "hashtag",
         selected: selected == :account_number,
       }
-  end
+    end
 
     if policy(@event).donation_overview? || ( @event.approved? && @event.plan.invoices_enabled? ) || policy(@event).account_number? || policy(@event.check_deposits.build).index?
       items << { section: "Receive" }

--- a/app/views/events/_card_grant_actions.html.erb
+++ b/app/views/events/_card_grant_actions.html.erb
@@ -8,17 +8,17 @@
     <%= link_to card_grant do %>
       <%= inline_icon "card", size: 20 %> View transactions
     <% end if card_grant.stripe_card.present? %>
-    <% if card_grant.active? && card_grant.stripe_card&.active? %>
+    <% if card_grant.active? && card_grant.stripe_card&.active? && policy(card_grant.stripe_card).freeze? %>
       <%= link_to freeze_stripe_card_path(card_grant.stripe_card), method: :post do %>
-        <%= inline_icon "freeze", size: 20 %> Freeze card
+      <%= inline_icon "freeze", size: 20 %> Freeze card
       <% end %>
-    <% elsif card_grant.active? && card_grant.stripe_card&.frozen? %>
+    <% elsif card_grant.active? && card_grant.stripe_card&.frozen? && policy(card_grant.stripe_card).defrost? %>
       <%= link_to defrost_stripe_card_path(card_grant.stripe_card), method: :post do %>
         <%= inline_icon "freeze", size: 20 %> Defrost
       <% end %>
     <% end %>
     <%= link_to cancel_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug), data: { confirm: "Are you sure? This will irreversibly transfer the remaining balance on this grant BACK to your account." }, method: :post do %>
-      <%= inline_icon "reply", size: 20 %> Cancel grant...
-    <% end if card_grant.active? %>
+      <%= inline_icon "reply", size: 20 %> Cancel grant
+    <% end if card_grant.active? && policy(card_grant).cancel? %>
   </div>
 </div>

--- a/app/views/events/home/_money_movement.html.erb
+++ b/app/views/events/home/_money_movement.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <% if @money_in.empty? %>
-        <div class="text-gray-500 text-center bg-zinc-100 dark:bg-zinc-700 rounded-xl mx-4 flex-1 flex items-center text-center justify-center">
+        <div class="text-gray-500 bg-zinc-100 dark:bg-zinc-700 rounded-xl mx-4 flex-1 flex items-center text-center justify-center">
           You haven't received any money yet.
         </div>
       <% end %>
@@ -18,7 +18,7 @@
       <% @money_in.each do |transaction| %>
         <% rendered_transaction = capture do %>
           <div style="min-width:0;flex:1">
-            <span class="truncate block truncate"><%= transaction_memo(transaction) %></span>
+            <span class="truncate block"><%= transaction_memo(transaction) %></span>
             <div class="text-sm text-gray-500">
               <% if transaction.is_a?(CanonicalPendingTransaction) %>
                 Pending &bull;
@@ -43,7 +43,7 @@
             <%= rendered_transaction %>
           </a>
         <% else %>
-          <div class="homepage-transaction">
+          <div class="homepage-transaction cursor-[unset]">
             <%= rendered_transaction %>
           </div>
         <% end %>
@@ -68,7 +68,7 @@
         <% end %>
       </div>
       <% if @money_out.empty? %>
-        <div class="text-gray-500 text-center bg-zinc-100 dark:bg-zinc-700 rounded-xl mx-4 flex-1 flex items-center text-center justify-center">
+        <div class="text-gray-500 bg-zinc-100 dark:bg-zinc-700 rounded-xl mx-4 flex-1 flex items-center text-center justify-center">
           You haven't spent any money yet.
         </div>
       <% end %>
@@ -76,7 +76,7 @@
       <% @money_out.each do |transaction| %>
         <% rendered_transaction = capture do %>
           <div style="min-width:0;flex:1">
-            <span class="truncate block truncate"><%= transaction_memo(transaction) %></span>
+            <span class="truncate block"><%= transaction_memo(transaction) %></span>
             <div class="text-sm text-gray-500">
               <% if transaction.is_a?(CanonicalPendingTransaction) %>
                 Pending &bull;
@@ -101,7 +101,7 @@
             <%= rendered_transaction %>
           </a>
         <% else %>
-          <div class="homepage-transaction">
+          <div class="homepage-transaction cursor-[unset]">
             <%= rendered_transaction %>
           </div>
         <% end %>

--- a/app/views/events/home/_number_stats.erb
+++ b/app/views/events/home/_number_stats.erb
@@ -4,22 +4,26 @@
       <span class="muted uppercase text-sm" style="font-weight: 700">Total revenue</span>
       <span class="stat__value -mb-2"><%= render_money_amount @event.total_raised %></span>
     </div>
-    <%= link_to event_transactions_path(@event, direction: "revenue"), class: "flex items-center shrink-0 no-underline -mr-2" do %>
-      See transactions
-      <%= inline_icon "view-forward" %>
+    <% if organizer_signed_in? %>
+      <%= link_to event_transactions_path(@event, direction: "revenue"), class: "flex items-center shrink-0 no-underline -mr-2" do %>
+        See transactions
+        <%= inline_icon "view-forward" %>
+      <% end %>
     <% end %>
   </div>
 
   <div class="menu__divider w-full my-2"></div>
 
-  <div class="gap-4 flex flex-1 flex-col items-center justify-center">
+  <div class="gap-4 flex flex-1 flex-col items-center justify-center pb-3">
     <div class="stat stat--small flex flex-col items-center" style="flex:unset">
       <span class="muted uppercase text-sm" style="font-weight: 700">Total expenses</span>
       <span class="stat__value -mb-2"><%= render_money_amount @event.total_spent_cents %></span>
     </div>
-    <%= link_to event_transactions_path(@event, direction: "expenses"), class: "flex items-center shrink-0 no-underline -mr-2" do %>
-      See transactions
-      <%= inline_icon "view-forward" %>
+    <% if organizer_signed_in? %>
+      <%= link_to event_transactions_path(@event, direction: "expenses"), class: "flex items-center shrink-0 no-underline -mr-2" do %>
+        See transactions
+        <%= inline_icon "view-forward" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/home/_transactions.html.erb
+++ b/app/views/events/home/_transactions.html.erb
@@ -36,7 +36,7 @@
           <%= rendered_transaction %>
         </a>
       <% else %>
-        <div class="homepage-transaction" style="height:60px">
+        <div class="homepage-transaction cursor-[unset]" style="height:60px">
           <%= rendered_transaction %>
         </div>
       <% end %>

--- a/app/views/organizer_positions/_organizer_position_row.html.erb
+++ b/app/views/organizer_positions/_organizer_position_row.html.erb
@@ -18,7 +18,7 @@
   </td>
   <td><%= organizer_position.role.humanize %></td>
   <td>
-    <%= copy_to_clipboard(organizer_signed_in? ? organizer_position.user.email : "user@example.com", class: "inline-flex items-center g1 line-height-0") do %>
+    <%= copy_to_clipboard(organizer_signed_in? ? organizer_position.user.email : "user@example.com", class: "#{organizer_signed_in? ? "" : "pointer-events-none"} inline-flex items-center g1 line-height-0") do %>
       <%= inline_icon("email", size: 20) %>
       <%= organizer_signed_in? ? organizer_position.user.email : "Hidden" %>
     <% end %>


### PR DESCRIPTION
This PR provides various fixes to button visibility on transparency mode. 

## Changes
* Account numbers, check deposit, payroll, and perks are now hidden from sidebar
* Hidden organization position contact emails are not clickable anymore
* Card grant actions (frost/defrost, cancel) are now hidden
* Removes duplicate `.truncate` and `.text-center` class names
* Makes cursor default on homepage transactions (instead of previously `pointer`)
* Hides "See transactions" button, since clicking on this redirects to an errored page saying "Invalid parameters. Please try again"