### PR TITLE
[Card Overview] Only show 18 cards

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -485,7 +485,7 @@ class EventsController < ApplicationController
     authorize @event
 
     page = (params[:page] || 1).to_i
-    per_page = (params[:per] || 20).to_i
+    per_page = (params[:per] || 18).to_i
 
     display_cards = [
       @user_stripe_cards.active,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
20 / 3 is not evenly divisible resulting in a missing card at the bottom of the page when tiling 3 across and there is >= 20 cards on the org.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

