### PR TITLE
Redirect to privacy policy instead of hack.club

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -592,7 +592,7 @@ Rails.application.routes.draw do
   get "mobile", to: "static_pages#mobile"
   get "branding", to: "static_pages#branding"
   get "security", to: "static_pages#security"
-  get "privacy", to: redirect("https://hack.club/hcb-privacy-policy")
+  get "privacy", to: redirect("https://hackclub.com/privacy-and-terms/")
   get "faq", to: redirect("https://help.hcb.hackclub.com")
   get "roles", to: "static_pages#roles"
   get "admin_tools", to: "static_pages#admin_tools"


### PR DESCRIPTION
This cuts out the middle man as https://hack.club/hcb-privacy-policy redirects to https://hackclub.com/privacy-and-terms/ so 2 redirects isnt good. 