### PR TITLE
Test reversible migrations in reverse order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
             echo "New migrations found:"
             echo "$NEW_MIGRATIONS"
             # Extract versions (timestamps) from filenames
-            VERSIONS=$(echo "$NEW_MIGRATIONS" | sed 's/.*\/\([0-9]*\)_.*/\1/' | tr '\n' ' ')
+            VERSIONS=$(echo "$NEW_MIGRATIONS" | sed 's/.*\/\([0-9]*\)_.*/\1/' | tac | tr '\n' ' ')
             echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
           fi
       - name: Setup database


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
In https://github.com/hackclub/hcb/actions/runs/20934979891/job/60155176895?pr=12188, there are 2 new migrations created, with the 2nd depending on the 1st. The reversible migrations CI currently tests migrations in ascending order. This causes an error as when the first migration (creates table) is tested, it removes any changes to that table done by future migrations, so reverting those migrations fails.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Reverse the order in which migrations are tested. No prior migration can depend on a future migration, so this should fix this issue.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

