### PR TITLE
Fix yarn install in codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,13 @@ RUN su vscode -c "/bin/bash -l -c \"rvm fix-permissions\""
 
 ARG NODE_VERSION="22"
 RUN su vscode -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
-RUN su vscode -c "source /home/vscode/.nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
+RUN su vscode -c "\
+  export NVM_DIR=/home/vscode/.nvm && \
+  source \$NVM_DIR/nvm.sh && \
+  nvm install ${NODE_VERSION} && \
+  nvm alias default ${NODE_VERSION} && \
+  corepack enable \
+"
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
 # The value is a comma-separated list of allowed domains 

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,5 +1,5 @@
 bundle install
-yarn install
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install
 yarn build
 
 sudo chown -R vscode:vscode /usr/local/bundle


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#12582 changed the devcontainer Dockerfile to pull from the debian base and install node manually. However, this caused an error with the yarn installation, as corepack needed to be enabled.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Enable corepack and disable the interactive download prompt when running yarn for the first time.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

