### PR TITLE
Calculate the `Current.session` once in a before action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   include SetGovernanceRequestContext
 
   protect_from_forgery
-  
+
   # set Current.session
   before_action do
     Current.session ||= begin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,7 @@ class ApplicationController < ActionController::Base
     Current.session = begin
       # Find a valid session (not expired) using the session token
       session_token = cookies.encrypted[:session_token]
-      next nil if session_token.nil?
-
-      User::Session.not_expired.find_by(session_token:)
+      session_token.present? ? User::Session.not_expired.find_by(session_token:) : nil
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  include Pundit::Authorization
-  include SessionsHelper
-  include ToursHelper
-  include PublicActivity::StoreController
-  include SetGovernanceRequestContext
-
-  protect_from_forgery
-
-  # set Current.session
+  # set Current.session - this should come first as
+  # a large portion of the code below this depends on this
   before_action do
     Current.session ||= begin
       # Find a valid session (not expired) using the session token
@@ -19,6 +12,14 @@ class ApplicationController < ActionController::Base
       User::Session.not_expired.find_by(session_token:)
     end
   end
+
+  include Pundit::Authorization
+  include SessionsHelper
+  include ToursHelper
+  include PublicActivity::StoreController
+  include SetGovernanceRequestContext
+
+  protect_from_forgery
 
   # Ensure users are signed in. Create one-off exceptions to this on routes
   # that you want to be unauthenticated with skip_before_action.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   # set Current.session - this should come first as
   # a large portion of the code below this depends on this
   before_action do
-    Current.session ||= begin
+    Current.session = begin
       # Find a valid session (not expired) using the session token
       session_token = cookies.encrypted[:session_token]
       return nil if session_token.nil?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,17 @@ class ApplicationController < ActionController::Base
   include SetGovernanceRequestContext
 
   protect_from_forgery
+  
+  # set Current.session
+  before_action do
+    Current.session ||= begin
+      # Find a valid session (not expired) using the session token
+      session_token = cookies.encrypted[:session_token]
+      return nil if session_token.nil?
+
+      User::Session.not_expired.find_by(session_token:)
+    end
+  end
 
   # Ensure users are signed in. Create one-off exceptions to this on routes
   # that you want to be unauthenticated with skip_before_action.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
     Current.session = begin
       # Find a valid session (not expired) using the session token
       session_token = cookies.encrypted[:session_token]
-      return nil if session_token.nil?
+      next nil if session_token.nil?
 
       User::Session.not_expired.find_by(session_token:)
     end
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_to_onboarding
 
   # update the current session's last_seen_at
-  before_action { current_session&.update_session_timestamps }
+  before_action { Current.session&.update_session_timestamps }
 
   before_action do
     # Disallow indexing and following

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -117,13 +117,7 @@ module SessionsHelper
   end
 
   def current_session
-    Current.session ||= begin
-      # Find a valid session (not expired) using the session token
-      session_token = cookies.encrypted[:session_token]
-      return nil if session_token.nil?
-
-      User::Session.not_expired.find_by(session_token:)
-    end
+    Current.session
   end
 
   def signed_in_user


### PR DESCRIPTION
Previously `current_session` was doing this calculation a bunch if `Current.session` was `nil`. Also this will let us remove `#current_session` eventually.