### PR TITLE
[Card Grants] Block suspected pre-authorization fraud

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -23,7 +23,10 @@ class CardGrantsController < ApplicationController
     card_grants_page = (params[:page] || 1).to_i
     card_grants_per_page = (params[:per] || 20).to_i
 
-    @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :subledger).order(created_at: :desc)
+    @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger).order(
+      @event.card_grant_setting.block_suspected_fraud? ? Arel.sql("card_grant_pre_authorizations.aasm_state='fraudulent' DESC") : nil,
+      "card_grants.created_at DESC"
+    )
     # we allow searching by purpose but sometimes the purpose shown in the table is actually the memo
     @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?
     @paginated_card_grants = @card_grants.page(card_grants_page).per(card_grants_per_page)

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -103,7 +103,9 @@ class CardGrant < ApplicationRecord
   delegate :name, to: :user
 
   def state
-    if canceled? || expired?
+    if suspected_fraud?
+      "error"
+    elsif suspected_fraud? || canceled? || expired?
       "muted"
     elsif pending_invite?
       "info"
@@ -115,7 +117,9 @@ class CardGrant < ApplicationRecord
   end
 
   def state_text
-    if canceled?
+    if suspected_fraud?
+      "Fraudulent"
+    elsif canceled?
       "Canceled"
     elsif expired?
       "Expired"
@@ -131,10 +135,14 @@ class CardGrant < ApplicationRecord
   def status_badge_type
     s = state.to_sym
     return :success if s == :success
-    return :error if s == :muted
+    return :error if s == :muted || s == :error
     return :warning if s == :info
 
     :muted
+  end
+
+  def suspected_fraud?
+    pre_authorization.present? && card_grant_setting.block_suspected_fraud? && pre_authorization.fraudulent?
   end
 
   def pending_invite?

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -135,7 +135,7 @@ class CardGrant < ApplicationRecord
   def status_badge_type
     s = state.to_sym
     return :success if s == :success
-    return :error if s == :muted || s == :error
+    return :error if [:muted, :error].include?(s)
     return :warning if s == :info
 
     :muted

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -34,6 +34,7 @@ class CardGrant
 
     belongs_to :card_grant
     has_one :event, through: :card_grant
+    has_one :card_grant_setting, through: :card_grant
     has_one :user, through: :card_grant
 
     include Turbo::Broadcastable
@@ -195,11 +196,11 @@ class CardGrant
     end
 
     def unauthorized?
-      draft? || submitted? || rejected?
+      draft? || submitted? || rejected? || (card_grant_setting.block_suspected_fraud? && fraudulent?)
     end
 
     def authorized?
-      approved? || fraudulent?
+      approved? || (!card_grant_setting.block_suspected_fraud? && fraudulent?)
     end
 
   end

--- a/app/models/card_grant_setting.rb
+++ b/app/models/card_grant_setting.rb
@@ -7,6 +7,7 @@
 #  id                                :bigint           not null, primary key
 #  banned_categories                 :string
 #  banned_merchants                  :string
+#  block_suspected_fraud             :boolean          default(TRUE), not null
 #  category_lock                     :string
 #  expiration_preference             :integer          default("1 year"), not null
 #  invite_message                    :string

--- a/app/views/events/settings/_card_grants.html.erb
+++ b/app/views/events/settings/_card_grants.html.erb
@@ -48,7 +48,7 @@
           </div>
         </div>
 
-        <div class="field field--checkbox mb-0 flex flex-row items-center justify-between">
+        <div class="field field--checkbox flex flex-row items-center justify-between">
           <div>
             <span style="font-weight: 700">Enable pre-authorization on new cards by default</span>
             <p class="h5 muted m-0">
@@ -58,6 +58,26 @@
           <div class="field--checkbox--switch" style="flex-shrink:0">
             <%= card_grant_setting_fields.label :pre_authorization_required do %>
               <%= card_grant_setting_fields.check_box :pre_authorization_required,
+                disabled:,
+                switch: true %>
+              <span class="slider"></span>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="field field--checkbox mb-0 flex flex-row items-center justify-between">
+          <div>
+            <span style="font-weight: 700">
+              <%= inline_icon "rep", class: "purple m-[-6px] pr-1 align-sub" %>
+              Block suspected fraud on pre-authorizations
+            </span>
+            <p class="h5 muted m-0">
+              When HCB suspects a fraudulent pre-authorization submission, automatically block the grant
+            </p>
+          </div>
+          <div class="field--checkbox--switch" style="flex-shrink:0">
+            <%= card_grant_setting_fields.label :block_suspected_fraud do %>
+              <%= card_grant_setting_fields.check_box :block_suspected_fraud,
                 disabled:,
                 switch: true %>
               <span class="slider"></span>

--- a/db/migrate/20260114004848_add_block_suspected_fraud_to_card_grant_setting.rb
+++ b/db/migrate/20260114004848_add_block_suspected_fraud_to_card_grant_setting.rb
@@ -1,0 +1,5 @@
+class AddBlockSuspectedFraudToCardGrantSetting < ActiveRecord::Migration[8.0]
+  def change
+    add_column :card_grant_settings, :block_suspected_fraud, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_05_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_14_004848) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -457,6 +457,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_05_000001) do
   create_table "card_grant_settings", force: :cascade do |t|
     t.string "banned_categories"
     t.string "banned_merchants"
+    t.boolean "block_suspected_fraud", default: true, null: false
     t.string "category_lock"
     t.bigint "event_id", null: false
     t.integer "expiration_preference", default: 365, null: false


### PR DESCRIPTION
## Summary of the problem

Pre-authorizations don't currently lock cards when fraud is suspected


## Describe your changes

Add a toggle for locking cards when fraud is suspected

<img width="929" height="257" alt="image" src="https://github.com/user-attachments/assets/efdcf0b4-de36-4efe-b975-0acc48329c63" />
