### PR TITLE
[Card Grants] Fix bug with card grants controller

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -24,7 +24,7 @@ class CardGrantsController < ApplicationController
     card_grants_per_page = (params[:per] || 20).to_i
 
     @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger).order(
-      @event.card_grant_setting.block_suspected_fraud? ? Arel.sql("card_grant_pre_authorizations.aasm_state='fraudulent' DESC") : nil,
+      Arel.sql("card_grant_pre_authorizations.aasm_state='fraudulent' DESC"),
       "card_grants.created_at DESC"
     )
     # we allow searching by purpose but sometimes the purpose shown in the table is actually the memo

--- a/app/views/my/_activities.html.erb
+++ b/app/views/my/_activities.html.erb
@@ -1,7 +1,7 @@
 <ul class="list-reset comments w-100 my-0 p-3 activity overflow-y-visible overflow-x-hidden">
   <%= turbo_stream_from current_user, "activities" %>
   <turbo-frame id="activities-<%= @activities.current_page %>" target="_top">
-    <%# render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
+    <%= render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
     <% if @activities.next_page %>
       <%= turbo_frame_tag(
             "activities-#{@activities.next_page}",

--- a/app/views/my/_activities.html.erb
+++ b/app/views/my/_activities.html.erb
@@ -1,7 +1,7 @@
 <ul class="list-reset comments w-100 my-0 p-3 activity overflow-y-visible overflow-x-hidden">
   <%= turbo_stream_from current_user, "activities" %>
   <turbo-frame id="activities-<%= @activities.current_page %>" target="_top">
-    <%= render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
+    <%# render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
     <% if @activities.next_page %>
       <%= turbo_frame_tag(
             "activities-#{@activities.next_page}",


### PR DESCRIPTION
## Summary of the problem

We're not using safe navigation, so if an organization's `card_grant_setting` is `nil`, we encounter an error.


## Describe your changes

We actually don't need to be checking the card grant setting here, so I've removed the ternary entirely.