### PR TITLE
Refactor `first_login` email to `onboarded`

### DIFF
--- a/app/mailers/user/session_mailer.rb
+++ b/app/mailers/user/session_mailer.rb
@@ -9,12 +9,6 @@ class User
       mail to: @user.email, subject: "New login to your HCB account"
     end
 
-    def first_login(user:)
-      @user = user
-
-      mail to: @user.email, subject: "Welcome to HCB!"
-    end
-
   end
 
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserMailer < ApplicationMailer
+  def onboarded(user:)
+    @user = user
+
+    mail to: @user.email, subject: "Welcome to HCB!"
+  end
+
+end

--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -56,11 +56,12 @@ class User
     scope :recently_expired_within, ->(date) { expired.where("expiration_at >= ?", date) }
 
     after_create_commit do
-      if user.user_sessions.size == 1
-        User::SessionMailer.first_login(user:).deliver_later
-      elsif fingerprint.present? && user.user_sessions.excluding(self).where(fingerprint:).none?
-        User::SessionMailer.new_login(user_session: self).deliver_later
-      end
+      return if impersonated?
+      return unless user.user_sessions.size > 1
+      return unless fingerprint.present?
+      return unless user.user_sessions.excluding(self).where(fingerprint:).none?
+
+      UserSessionMailer.new_login(user_session: self).deliver_later
     end
 
     extend Geocoder::Model::ActiveRecord

--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -56,10 +56,10 @@ class User
     scope :recently_expired_within, ->(date) { expired.where("expiration_at >= ?", date) }
 
     after_create_commit do
-      return if impersonated?
-      return unless user.user_sessions.size > 1
-      return unless fingerprint.present?
-      return unless user.user_sessions.excluding(self).where(fingerprint:).none?
+      next if impersonated?
+      next unless user.user_sessions.size > 1
+      next unless fingerprint.present?
+      next unless user.user_sessions.excluding(self).where(fingerprint:).none?
 
       UserSessionMailer.new_login(user_session: self).deliver_later
     end

--- a/app/views/user_mailer/onboarded.html.erb
+++ b/app/views/user_mailer/onboarded.html.erb
@@ -1,0 +1,20 @@
+<p>
+  Hey <%= @user.first_name %>,
+</p>
+
+<p>Welcome to HCB! We're glad you've joined us.</p>
+<p>From serving your local community to running global events and more, we're here to help you on your nonprofit journey.</p>
+
+<p>Here's just a few things you can do on HCB:</p>
+<ul>
+  <li><%= link_to "Apply to start an organization", "https://hackclub.com/fiscal-sponsorship/apply/" %></li>
+  <li><%= link_to "Follow other nonprofit organizations", "https://hackclub.com/fiscal-sponsorship/directory/?utm_source=hcb&utm_medium=email&utm_campaign=welcome" %>
+  <li><%= link_to "Check out what's new", "https://blog.hcb.hackclub.com/" %>
+</ul>
+
+<p>Feel free to reach out to <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %> if you have any questions!</p>
+
+<p>
+  Best,<br>
+  The HCB Team
+</p>

--- a/bin/dev
+++ b/bin/dev
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+bundle install
 if [[ $* == *--with-stripe* ]]
 then
     bundle exec foreman start -f Procfile.dev $@

--- a/bin/dev
+++ b/bin/dev
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-bundle install
+
 if [[ $* == *--with-stripe* ]]
 then
     bundle exec foreman start -f Procfile.dev $@

--- a/spec/mailers/previews/user/session_mailer_preview.rb
+++ b/spec/mailers/previews/user/session_mailer_preview.rb
@@ -8,12 +8,6 @@ class User
       User::SessionMailer.new_login(user_session:)
     end
 
-    def first_login
-      user = User.last
-
-      User::SessionMailer.first_login(user:)
-    end
-
   end
 
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserMailerPreview < ActionMailer::Preview
+  def onboarded
+    user = User.where.not(full_name: [nil, ""]).last
+
+    UserMailer.onboarded(user:)
+  end
+
+end


### PR DESCRIPTION
Closes https://github.com/hackclub/hcb/issues/11708 by refactoring this email to only go out when a user is "onboarded" which we define as the user having a full name.