### PR TITLE
Hide tooltips on frame load

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -192,6 +192,7 @@ window.attachTooltipListener = () => {
   // on unload turbo
   $(document).on('turbo:before-visit', removeTooltips);
   $(document).on('beforeunload', removeTooltips)
+  $(document).on('turbo:frame-load', removeTooltips);
 }
 
 $(document).on('turbo:frame-load', window.attachTooltipListener)


### PR DESCRIPTION
<img width="751" height="583" alt="image" src="https://github.com/user-attachments/assets/e53f34a1-7807-440f-8e4b-e56b9a58c66c" />


fixes the annoying tooltip bug aaah