### PR TITLE
[stats] Fix HCB Mobile user installs stat

### DIFF
--- a/app/models/metric/hcb/stats.rb
+++ b/app/models/metric/hcb/stats.rb
@@ -83,7 +83,7 @@ class Metric
           # users
 
           currently_online: ::User.currently_online.count,
-          mobile_installs: ::ApiToken.joins("INNER JOIN oauth_applications ON api_tokens.application_id = oauth_applications.id").where(oauth_applications: { name: "HCB Mobile" }).where(revoked_at: nil).distinct.count(:user_id)
+          mobile_installs: ::ApiToken.joins("INNER JOIN oauth_applications ON api_tokens.application_id = oauth_applications.id").where(oauth_applications: { name: "HCB Mobile" }).distinct.count(:user_id)
         }
       end
 


### PR DESCRIPTION
## Summary of the problem
We shouldn't care whether or not an API Token is revoked as long as there was an API token for a user on oauth application for HCB Mobile it should be counted.


## Describe your changes
removed `revoked_at`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

