### PR TITLE
[v4] Prevent ephemeral key generation on unauthorized card grants

### DIFF
--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -45,6 +45,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def ephemeral_keys?
+    return false if record.card_grant&.pre_authorization&.unauthorized?
     cardholder?
   end
 

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -46,6 +46,7 @@ class StripeCardPolicy < ApplicationPolicy
 
   def ephemeral_keys?
     return false if record.card_grant&.pre_authorization&.unauthorized?
+
     cardholder?
   end
 


### PR DESCRIPTION
## Summary of the problem
Currently, if card grants have preauth and they fail it they can still use the card grant by getting an ephemeral key to access stripe card details


## Describe your changes
Prevents it via policy change


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

