### PR TITLE
[Stats] Update correct stats metric

### DIFF
--- a/app/jobs/metric/calculate_stats_job.rb
+++ b/app/jobs/metric/calculate_stats_job.rb
@@ -5,7 +5,7 @@ class Metric
     queue_as :metrics
 
     def perform
-      stats = Metric::Hcb::Stats.first_or_initialize
+      stats = Metric::Hcb::Stats.instance
 
       stats.populate!
     end


### PR DESCRIPTION
## Summary of the problem

`/stats` endpoint hasn't updated since December 2025. `first_or_initialize` doesn't choose the metric from the current year. This means we've been updating the wrong record.

## Describe your changes

 So, we use `instance`, which handles that.