### PR TITLE
Only validate duplicate invites on creation

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -84,7 +84,7 @@ class OrganizerPositionInvite < ApplicationRecord
 
   belongs_to :organizer_position, optional: true
 
-  validate :not_already_organizer, if: -> { event_changed? || user_changed? }
+  validate :not_already_organizer, on: :create
   validate :not_already_invited, on: :create
   validates :accepted_at, absence: true, if: -> { rejected_at.present? }
   validates :rejected_at, absence: true, if: -> { accepted_at.present? }


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We only need to be checking if an invite is not to a current organizer when the invite is created - the invite user and event should never change.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Clean up the validation to only run on create

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

