### PR TITLE
[Settings] Fix scrollbar on audit log

### DIFF
--- a/app/views/events/settings/_audit_log.html.erb
+++ b/app/views/events/settings/_audit_log.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (event:, activities:, activities_before:) %>
 
-<ul class="list-reset comments w-100 my-0 pb-2 overflow-y-scroll">
+<ul class="list-reset comments w-100 my-0 pb-2">
   <%= turbo_stream_from current_user, event, "activities" %>
   <turbo-frame id="activities-<%= activities.current_page %>" target="_top">
     <%= render_activities(activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>


### PR DESCRIPTION
## Summary of the problem

There's a persistent unused scrollbar on the audit log because we're forcing `overflow-y: scroll`


## Describe your changes

Stop forcing `overflow-y: scroll`