### PR TITLE
Use consistent colours for `hcb-code--footer`

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -127,19 +127,16 @@
 }
 
 .hcb-code--footer {
-  border-top: 1px solid rgba(200, 200, 200, 0.3);
-  background: rgba(200, 200, 200, 0.2);
   padding: 0.75rem 1rem;
   font-style: italic;
   text-align: center;
   font-size: 0.875rem;
-  color: rgba(100, 100, 100, 0.85);
   margin-left: -16px !important;
   margin-right: -16px !important;
-
+  border-top: 1px solid rgba(200, 200, 200, 0.3);
+  background-color: rgba(245, 245, 245, 0.75);
   html[data-dark='true'] & {
-    color: rgba(150, 150, 150, 0.85);
-    border-top-color: rgba(80, 80, 85, 0.3);
+    background-color: rgba(50, 50, 55, 0.5);
   }
 }
 


### PR DESCRIPTION
<img width="911" height="426" alt="Screenshot 2026-01-21 at 11 48 01 PM" src="https://github.com/user-attachments/assets/5873ee6b-537f-457e-8261-787af5286ff7" />
