### PR TITLE
[v4] Standardize error message field

### DIFF
--- a/app/controllers/concerns/api/v4/error_handling.rb
+++ b/app/controllers/concerns/api/v4/error_handling.rb
@@ -11,7 +11,7 @@ module Api
         end
 
         rescue_from ActiveRecord::RecordNotFound do |e|
-          render json: { error: "resource_not_found", message: ("Couldn't locate that #{e.model.constantize.model_name.human}." if e.model) }.compact_blank, status: :not_found
+          render json: { error: "resource_not_found", messages: [("Couldn't locate that #{e.model.constantize.model_name.human}." if e.model)] }.compact_blank, status: :not_found
         end
 
         rescue_from ActiveRecord::RecordInvalid do |e|


### PR DESCRIPTION
## Summary of the problem
This is the only field where we use `message` instead of an array of `messages`. We should be consistent


## Describe your changes
Changed it


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

