### PR TITLE
[v4 BREAKING CHANGE] Remove unused transaction_id from disbursement

### DIFF
--- a/app/views/api/v4/transactions/_disbursement.json.jbuilder
+++ b/app/views/api/v4/transactions/_disbursement.json.jbuilder
@@ -3,7 +3,6 @@
 json.id disbursement.public_id
 json.memo disbursement.local_hcb_code.memo
 json.status disbursement.v4_api_state
-json.transaction_id disbursement.local_hcb_code.public_id
 json.amount_cents disbursement.amount
 
 json.from do

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -73,15 +73,14 @@ RSpec.describe Api::V4::CardGrantsController do
           "expires_on"                 => card_grant.expires_on.iso8601(3),
           "disbursements"              => [
             {
-              "id"             => disbursement.public_id,
-              "memo"           => "Grant to recipient",
-              "status"         => "completed",
-              "transaction_id" => disbursement.local_hcb_code.public_id,
-              "amount_cents"   => 123_45,
-              "card_grant_id"  => card_grant.public_id,
-              "from"           => serialized_event,
-              "to"             => serialized_event,
-              "sender"         => {
+              "id"            => disbursement.public_id,
+              "memo"          => "Grant to recipient",
+              "status"        => "completed",
+              "amount_cents"  => 123_45,
+              "card_grant_id" => card_grant.public_id,
+              "from"          => serialized_event,
+              "to"            => serialized_event,
+              "sender"        => {
                 "id"       => user.public_id,
                 "name"     => "Orpheus D",
                 "email"    => "orpheus@hackclub.com",


### PR DESCRIPTION
Removed transaction_id from disbursement JSON response. Value is unused by mobile app and complicates logic