### PR TITLE
[Emburse Cards] Fix random </main> tag

### DIFF
--- a/app/views/events/emburse_card_overview.html.erb
+++ b/app/views/events/emburse_card_overview.html.erb
@@ -140,12 +140,10 @@ West Hollywood, CA 90069</pre>
 <% end %>
 
 <% if @emburse_transactions.any? %>
-</main>
-<main class="container">
-  <h2 class="mt3 mb2">
-    Emburse card transactions
-  </h2>
-  <div class="table-container">
+<h2 class="mt3 mb2">
+  Emburse card transactions
+</h2>
+<div class="table-container">
   <table>
     <thead>
       <tr>
@@ -165,5 +163,5 @@ West Hollywood, CA 90069</pre>
                locals: { show_running_sum: true, show_card: true } %>
     </tbody>
   </table>
-  </div>
+</div>
 <% end %>


### PR DESCRIPTION
why do we have a random `</main>` tag. this removes the random container added as well so it fixes this bug

<img width="1899" height="599" alt="image" src="https://github.com/user-attachments/assets/993f30d8-6f5a-45ec-81ce-46218829e592" />
