### PR TITLE
[v4] Use public user ID for Intercom JWT

### DIFF
--- a/app/controllers/api/v4/intercom_controller.rb
+++ b/app/controllers/api/v4/intercom_controller.rb
@@ -8,7 +8,7 @@ module Api
 
       def token
         payload = {
-          user_id: current_user.id,
+          user_id: current_user.public_id,
           email: current_user.email,
           exp: 1.hour.from_now.to_i
         }


### PR DESCRIPTION
We should be using public ID as app can't login with internal ID as it doesnt have that 