### PR TITLE
[Discord] Add support for PDF receipts

### DIFF
--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -118,7 +118,7 @@ module Discord
 
       attachments = @interaction.dig(:data, :resolved, :attachments)
       file = attachments&.values&.first
-      content_type = file[:content_type] if file.present?
+      content_type = file&.[](:content_type)
 
       unless file.present? && (content_type == "application/pdf" || content_type&.start_with?("image/"))
         return respond(embeds: [{

--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -120,7 +120,7 @@ module Discord
       file = attachments&.values&.first
       content_type = file[:content_type] if file.present?
 
-      unless file.nil? || content_type == "application/pdf" || content_type&.start_with?("image/")
+      unless file.present? && (content_type == "application/pdf" || content_type&.start_with?("image/"))
         return respond(embeds: [{
                          title: "There was a problem with your receipt",
                          description: "Only images and PDF files are supported. Please try again.",
@@ -129,7 +129,6 @@ module Discord
       end
 
       filename = file[:filename]
-      content_type = file[:content_type]
       io = URI(file[:url]).open
 
       ActiveRecord::Base.transaction do

--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -117,9 +117,10 @@ module Discord
       return respond(content: "This Discord server is not currently linked to the same HCB organization") unless hcb_code.event.id == @current_event&.id
 
       attachments = @interaction.dig(:data, :resolved, :attachments)
-      content_type = attachments.values.first[:content_type] if attachments.present?
+      file = attachments&.values&.first
+      content_type = file[:content_type] if file.present?
 
-      unless content_type == "application/pdf" || content_type&.start_with?("image/")
+      unless file.nil? || content_type == "application/pdf" || content_type&.start_with?("image/")
         return respond(embeds: [{
                          title: "There was a problem with your receipt",
                          description: "Only images and PDF files are supported. Please try again.",
@@ -127,7 +128,6 @@ module Discord
                        }])
       end
 
-      file = attachments.values.first
       url = file[:url]
       filename = file[:filename]
       content_type = file[:content_type]

--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -128,10 +128,8 @@ module Discord
                        }])
       end
 
-      url = file[:url]
       filename = file[:filename]
       content_type = file[:content_type]
-
       io = URI(file[:url]).open
 
       ActiveRecord::Base.transaction do


### PR DESCRIPTION
## Summary of the problem

#12568

PDF receipts don't currently  work.


## Describe your changes

Fixes #12568

- Accepts PDF receipts
- Now provides a message for invalid file types
- Refactors modal handling code to be cleaner