### PR TITLE
Extract set_event method to SetEvent concern

### DIFF
--- a/app/controllers/donation/tiers_controller.rb
+++ b/app/controllers/donation/tiers_controller.rb
@@ -2,6 +2,7 @@
 
 class Donation
   class TiersController < ApplicationController
+    include SetEvent
     include DonationPageSetup
 
     before_action :set_event, except: [:set_index]
@@ -94,13 +95,6 @@ class Donation
       redirect_back fallback_location: edit_event_path(@event.slug), flash: { success: "Donation tiers updated successfully." }
     rescue ActiveRecord::RecordInvalid => e
       redirect_back fallback_location: edit_event_path(@event.slug), flash: { error: e.message }
-    end
-
-    private
-
-    def set_event
-      @event = Event.where(slug: params[:event_name] || params[:event_id]).first
-      render json: { error: "Event not found" }, status: :not_found unless @event
     end
 
   end


### PR DESCRIPTION
## Summary of the problem
The `set_event` method was duplicated across multiple controllers, violating the DRY principle and making maintenance harder. This change extracts the shared logic into a reusable concern.

## Describe your changes
- Created a `SetEvent` concern to encapsulate the `set_event` method
- Updated `Donation::TiersController` to include the `SetEvent` concern instead of defining the method locally
- Removed the private `set_event` method from `Donation::TiersController`

This refactoring allows other controllers to reuse the same event-finding logic by simply including the `SetEvent` concern, reducing code duplication and improving maintainability.