### PR TITLE
[Ledger] Add declined filter and paginate PTs with CTs

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -120,6 +120,12 @@ class CanonicalPendingTransaction < ApplicationRecord
       .includes(:canonical_pending_declined_mapping)
       .where(canonical_pending_declined_mapping: { canonical_pending_transaction_id: nil })
   }
+  scope :declined, -> {
+    includes(:canonical_pending_settled_mappings)
+      .where(canonical_pending_settled_mappings: { canonical_pending_transaction_id: nil })
+      .includes(:canonical_pending_declined_mapping)
+      .where.not(canonical_pending_declined_mapping: { canonical_pending_transaction_id: nil })
+  }
   scope :missing_hcb_code, -> { where(hcb_code: nil) }
   scope :missing_or_unknown_hcb_code, -> { where("hcb_code is null or hcb_code ilike 'HCB-000%'") }
   scope :invoice_hcb_code, -> { where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::INVOICE_CODE}%'") }

--- a/app/views/events/_filter.html.erb
+++ b/app/views/events/_filter.html.erb
@@ -1,4 +1,4 @@
-<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @direction || @category || @merchant %>
+<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @direction || @category || @merchant || @declined_or_reversed %>
 
 <div class="flex flex-row justify-between items-center width-100 gap-2 mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
@@ -189,6 +189,14 @@
         <div class="badge badge-large bg-muted">
           Missing receipts
           <%= link_to event_ledger_path(@event, upsert_query_params(missing_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+            <%= inline_icon "view-close", size: 20 %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if @declined_or_reversed %>
+        <div class="badge badge-large bg-muted">
+          Declined or reversed
+          <%= link_to event_ledger_path(@event, upsert_query_params(declined_or_reversed: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>

--- a/app/views/events/_filter_menu.html.erb
+++ b/app/views/events/_filter_menu.html.erb
@@ -22,6 +22,7 @@
         <button id="category" data-tabs-target="btn" data-action="click->tabs#select">Category</button>
         <button id="merchant" data-tabs-target="btn" data-action="click->tabs#select">Merchant</button>
         <button id="receipts" data-tabs-target="btn" data-action="click->tabs#select">Receipts</button>
+        <button id="declined" data-tabs-target="btn" data-action="click->tabs#select">Declined</button>
       </div>
 
       <div class="col-span-2 p-2 overflow-y-scroll">
@@ -132,6 +133,14 @@
           </div>
           <div>
             <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params(missing_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          </div>
+        </div>
+        <div data-tabs-target="tab" id="declined">
+          <div class="flex items-center">
+            <%= link_to("Declined or reversed", event_ledger_path(@event, upsert_query_params(declined_or_reversed: true, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @declined_or_reversed}", data: { turbo_prefetch: "false" }) %>
+          </div>
+          <div>
+            <%= link_to("All other transactions", event_ledger_path(@event, upsert_query_params(declined_or_reversed: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @declined_or_reversed}", data: { turbo_prefetch: "false" }) %>
           </div>
         </div>
       </div>

--- a/app/views/events/ledger.html.erb
+++ b/app/views/events/ledger.html.erb
@@ -19,9 +19,9 @@
           <tbody data-behavior="transactions">
           <%= render "events/pending_fee_transaction" unless @event.fronted_fee_balance_v2_cents <= 0 || @direction == "revenue" || params[:subledger] %>
 
-          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @pending_transactions, as: :pt, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
+          <%= render partial: "canonical_pending_transactions/canonical_pending_transaction", collection: @transactions.select { |t| t.is_a?(CanonicalPendingTransaction) }, as: :pt, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
 
-          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions, as: :ct, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
+          <%= render partial: "canonical_transactions/canonical_transaction", collection: @transactions.reject { |t| t.is_a?(CanonicalPendingTransaction) }, as: :ct, locals: { event: @event, show_amount: true, selectable: @event.tags.size > 0, show_author_column: true, show_tags: true } %>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary of the problem

#12735

Right now, we exclude declined transactions from the ledger. However, there are some cases where it would be nice to have declined transactions visible, like card grants, for example.


## Describe your changes

Implements #12735

This PR adds a new filter to show declined and reversed transactions (CPTs and CTs). As a side effect, it also combines the transaction pagination to include CPTs, too. This is because HCB assumes that there are only a few PTs and puts them at the very top on page 1. However, when filtering by declined transactions, it's easy to get over 100 CPTs included, necessitating pagination.

<table>
<tr>
 <td><img width="368" height="422" alt="image" src="https://github.com/user-attachments/assets/35a8a730-f29d-4ab3-97f8-2e7400dfa7f2" /><br>The filter menu</td>
 <td><img width="1126" height="760" alt="image" src="https://github.com/user-attachments/assets/bba80282-d885-461b-acaf-8cb6b54c5e13" /><br>The ledger with the filter (blurred for good measure—this data is all public but I'm not sure if it's been aggregated this way before)<td>
</table>



