### PR TITLE
[Card Grants] Permit the param `block_suspected_fraud` on event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1096,7 +1096,8 @@ class EventsController < ApplicationController
           :banned_categories,
           :expiration_preference,
           :reimbursement_conversions_enabled,
-          :pre_authorization_required
+          :pre_authorization_required,
+          :block_suspected_fraud
         ],
         config_attributes: [
           :id,
@@ -1156,7 +1157,8 @@ class EventsController < ApplicationController
         :banned_categories,
         :expiration_preference,
         :reimbursement_conversions_enabled,
-        :pre_authorization_required
+        :pre_authorization_required,
+        :block_suspected_fraud
       ],
       config_attributes: [
         :id,


### PR DESCRIPTION
## Summary of the problem

You currently can't save the block suspected fraud toggle


## Describe your changes

Permit the parameter in the EventsController