### PR TITLE
Add external_id to Contract::Party

### DIFF
--- a/app/jobs/one_time_jobs/backfill_party_external_ids.rb
+++ b/app/jobs/one_time_jobs/backfill_party_external_ids.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillPartyExternalIds < ApplicationJob
+    def perform
+      Contract.where(external_service: 0).find_each do |contract|
+        submitters = contract.docuseal_document["submitters"]
+
+        next if submitters.nil?
+
+        contract.parties.each do |party|
+          slug = submitters.select { |s| s["role"] == party.docuseal_role }&.[](0)&.[]("slug")
+
+          party.update!(external_id: slug) if slug.present?
+        end
+
+      end
+    end
+
+  end
+
+end

--- a/app/jobs/one_time_jobs/backfill_party_external_ids.rb
+++ b/app/jobs/one_time_jobs/backfill_party_external_ids.rb
@@ -3,7 +3,7 @@
 module OneTimeJobs
   class BackfillPartyExternalIds < ApplicationJob
     def perform
-      Contract.where(external_service: 0).find_each do |contract|
+      Contract.where(external_service: 0).find_each(order: :desc) do |contract|
         submitters = contract.docuseal_document["submitters"]
 
         next if submitters.nil?

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -168,6 +168,14 @@ class Contract < ApplicationRecord
     end
 
     update(external_service: :docuseal, external_id: response.body.first["submission_id"])
+
+    submitters = docuseal_document["submitters"]
+
+    parties.each do |party|
+      slug = submitters.select { |s| s["role"] == party.docuseal_role }&.[](0)&.[]("slug")
+
+      party.update!(external_id: slug) if slug.present?
+    end
   end
 
   def archive_on_docuseal!

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -174,7 +174,11 @@ class Contract < ApplicationRecord
     parties.each do |party|
       slug = submitters.select { |s| s["role"] == party.docuseal_role }&.[](0)&.[]("slug")
 
-      party.update!(external_id: slug) if slug.present?
+      if slug.present?
+        party.update!(external_id: slug)
+      else
+        Rails.error.unexpected("Contract Party (#{party.id}) role and/or slug missing in DocuSeal.")
+      end
     end
   end
 

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -13,6 +13,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  contract_id    :bigint           not null
+#  external_id    :string
 #  user_id        :bigint
 #
 # Indexes

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -66,7 +66,7 @@ class Contract
     end
 
     def docuseal_signature_url
-      "https://docuseal.co/s/#{contract.docuseal_document["submitters"].select { |s| s["role"] == docuseal_role }[0]["slug"]}"
+      "https://docuseal.co/s/#{external_id}"
     end
 
     def docuseal_role

--- a/db/migrate/20260126192011_add_external_id_to_contract_parties.rb
+++ b/db/migrate/20260126192011_add_external_id_to_contract_parties.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToContractParties < ActiveRecord::Migration[8.0]
+  def up
+    add_column :contract_parties, :external_id, :string
+  end
+end

--- a/db/migrate/20260126192011_add_external_id_to_contract_parties.rb
+++ b/db/migrate/20260126192011_add_external_id_to_contract_parties.rb
@@ -1,5 +1,5 @@
 class AddExternalIdToContractParties < ActiveRecord::Migration[8.0]
-  def up
+  def change
     add_column :contract_parties, :external_id, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_17_193703) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_26_192011) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -631,6 +631,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_17_193703) do
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.string "external_email"
+    t.string "external_id"
     t.string "role", null: false
     t.datetime "signed_at"
     t.datetime "updated_at", null: false

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -53,11 +53,18 @@ RSpec.describe OrganizerPositionInvitesController do
           .and_return([])
           .twice
       )
-      docuseal_request =
+      create_docuseal_request =
         stub_request(:post, "https://api.docuseal.co/submissions")
         .to_return(
           status: 201,
           body: [{ submission_id: "STUBBED" }].to_json,
+          headers: { content_type: "application/json" }
+        )
+      fetch_docuseal_request =
+        stub_request(:get, "https://api.docuseal.co/submissions/STUBBED")
+        .to_return(
+          status: 200,
+          body: { submitters: [{ role: "HCB", slug: "STUBBED" }, { role: "Contract Signee", slug: "STUBBED" }] }.to_json,
           headers: { content_type: "application/json" }
         )
 
@@ -78,7 +85,8 @@ RSpec.describe OrganizerPositionInvitesController do
         }
       )
 
-      expect(docuseal_request).to(have_been_made.once)
+      expect(create_docuseal_request).to(have_been_made.once)
+      expect(fetch_docuseal_request).to(have_been_made.once)
 
       expect(response).to redirect_to(event_team_path(event))
       expect(flash[:success]).to eq("Invite successfully sent to orpheus@hackclub.com")
@@ -92,6 +100,7 @@ RSpec.describe OrganizerPositionInvitesController do
       expect(contract.include_videos).to eq(true)
       expect(contract.external_service).to eq("docuseal")
       expect(contract.external_id).to eq("STUBBED")
+      expect(contract.party(:signee)&.external_id).to eq("STUBBED")
     end
   end
 end

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe OrganizerPositionInvitesController do
         stub_request(:get, "https://api.docuseal.co/submissions/STUBBED")
         .to_return(
           status: 200,
-          body: { submitters: [{ role: "HCB", slug: "STUBBED" }, { role: "Contract Signee", slug: "STUBBED" }] }.to_json,
+          body: { submitters: [{ role: "HCB", slug: "STUBBED" }, { role: "Contract Signee", slug: "STUBBED" }, { role: "Cosigner", slug: "STUBBED" }] }.to_json,
           headers: { content_type: "application/json" }
         )
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We currently have to fetch the DocuSeal document every time we need the slug for a party submission. Since this slug doesn't change once we create the document, we can just store it in the database to avoid all of these requests.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds `external_id` to `Contract::Party`, use it instead of looking up the slug, and backfill and set it for all contracts sent with DocuSeal.

After deploy, make sure to run `OneTimeJobs::BackfillPartyExternalIds.perform_now`, which will backfill slugs in most recent order.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

