### PR TITLE
Move project description to a contract signee field

### DIFF
--- a/app/models/contract/fiscal_sponsorship.rb
+++ b/app/models/contract/fiscal_sponsorship.rb
@@ -88,6 +88,11 @@ class Contract
                 name: "Organization",
                 default_value: prefills["name"],
                 readonly: true
+              },
+              {
+                name: "The Project",
+                default_value: prefills["description"],
+                readonly: false
               }
             ]
           },
@@ -110,11 +115,6 @@ class Contract
               {
                 name: "Signature",
                 default_value: ActionController::Base.helpers.asset_url("zach_signature.png", host: "https://hcb.hackclub.com"),
-                readonly: false
-              },
-              {
-                name: "The Project",
-                default_value: prefills["description"],
                 readonly: false
               }
             ]


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C026RKHLPNJ/p1768576643482079 - the project description should be something that the signee signs. Some people are also confused by Exhibit A being empty when they sign.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Move the field from HCB to contract signee. All the signee will have to do is confirm, as this field is prefilled by us.

**WHEN MERGING, ALL DOCUSEAL TEMPLATES USED BY HCB (487784, 1766872, 1711777) MUST BE UPDATED ACCORDINGLY BY CHANGING THIS FIELD TO BE FOR THE SIGNEE.**
Contracts with mismatched fields will error when sent to DocuSeal!

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

