### PR TITLE
Add not_voided scope to contracts

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -96,6 +96,8 @@ class Contract < ApplicationRecord
     manual: 999 # used to backfill contracts
   }, prefix: :sent_with
 
+  scope :not_voided, -> { where.not(aasm_state: :voided) }
+
   def docuseal_document
     docuseal_client.get("submissions/#{external_id}").body
   end
@@ -175,7 +177,7 @@ class Contract < ApplicationRecord
   end
 
   def one_non_void_contract
-    if contractable.contracts.where.not(aasm_state: :voided).excluding(self).any?
+    if contractable.contracts.not_voided.excluding(self).any?
       self.errors.add(:base, "source already has a contract!")
     end
   end

--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -98,7 +98,7 @@ class OrganizerPositionInvite < ApplicationRecord
   end
 
   def contract
-    contracts.where.not(aasm_state: :voided).last
+    contracts.not_voided.last
   end
 
   def pending_signature?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
`contracts.where.not(aasm_state: :voided)` isn't great, let's clean that up and make it a scope

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Factor it out into the `not_voided` scope!

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

