### PR TITLE
Add back event relation to affiliations

### DIFF
--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -26,6 +26,7 @@ class Event
   class Affiliation < ApplicationRecord
     include Hashid::Rails
 
+    belongs_to :event
     belongs_to :affiliable, polymorphic: true
 
     store_accessor :metadata, :league, :team_number, :size, :venue_name


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Migration failed because I tried to do `affiliation.event` after removing the `belongs_to :event`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add back the `belongs_to`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

