### PR TITLE
[Card Grants] Add missing permit merchant routes after #12752

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -964,6 +964,7 @@ Rails.application.routes.draw do
         post "convert_to_reimbursement_report"
         post "toggle_one_time_use"
         post "disable_pre_authorization"
+        post "permit_merchant"
 
         get "edit/overview", to: "card_grants#edit_overview"
         get "edit/usage_restrictions", to: "card_grants#edit_usage_restrictions"
@@ -1005,6 +1006,7 @@ Rails.application.routes.draw do
       get "audit_log"
       post "validate_slug"
       get "termination"
+      post "permit_merchant"
 
       get "settings(/:tab)", to: "events#edit", as: :edit
     end


### PR DESCRIPTION
## Summary of the problem

Routes are missing after #12643 


## Describe your changes

Add in the necessary routes to `routes.rb`
