### PR TITLE
Fix typo

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -194,9 +194,8 @@ module Reimbursement
         end
 
         flash[:success] = {
-          text: "You report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.payout_method.name}.",
-          link: settings_payouts_path,
-          link_text: "If needed, you can still edit your payout settings."
+          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.payout_method.name}.",
+          link: settings_payouts_path
         }
       rescue => e
         flash[:error] = e.message

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -197,6 +197,9 @@ module Reimbursement
           text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.payout_method.name}.",
           link: settings_payouts_path
         }
+        if @report.user.can_update_payout_method?
+          flash[:success][:link_text] = "If needed, you can still edit your payout settings."
+        end
       rescue => e
         flash[:error] = e.message
       end


### PR DESCRIPTION
## Summary of the problem

> bug: when you send a wise reimbursement to review to ops, it says you can still edit your payout while it's pending. you, in fact, can not.

bug report: https://hackclub.slack.com/archives/GBXBFEED9/p1769311946789589

<img width="181" height="173" alt="image" src="https://github.com/user-attachments/assets/7a710311-60a3-4ef1-ae30-6d57f861a82f" />

<img width="720" height="107" alt="image" src="https://github.com/user-attachments/assets/3a756c73-d187-440e-9e0f-5f356b1b44c0" />


## Describe your changes

1. Fix typo ("You" → "Your")
2. Conditionally render "If needed, you can still edit your payout settings."