### PR TITLE
Add ScGoogleGrant plan

### DIFF
--- a/app/models/contract/fiscal_sponsorship.rb
+++ b/app/models/contract/fiscal_sponsorship.rb
@@ -60,7 +60,7 @@ class Contract
       cosigner = party :cosigner
       hcb = party :hcb
 
-      {
+      payload = {
         template_id: external_template_id,
         send_email: false,
         order: "preserved",
@@ -121,6 +121,21 @@ class Contract
           }
         ].compact
       }
+
+      if contractable.is_a?(OrganizerPositionInvite)
+        skip_prefills = contractable.event.plan.contract_skip_prefills
+        payload[:submitters] = payload[:submitters].map do |submitter|
+          skip_prefill_party = skip_prefills.find { |role, list| role == submitter[:role] }&.second
+          next submitter if skip_prefill_party.nil?
+
+          submitter[:fields] = submitter[:fields].reject do |field|
+            skip_prefill_party.include? field[:name]
+          end
+          submitter
+        end
+      end
+
+      payload
     end
 
     def required_roles

--- a/app/models/event/plan/sc_google_grant.rb
+++ b/app/models/event/plan/sc_google_grant.rb
@@ -33,7 +33,7 @@ class Event
 
       def contract_skip_prefills
         {
-          "Contract Signee" => ["The Project", "Organization"],
+          "Contract Signee" => ["The Project"],
           "HCB"             => ["HCB ID", "Signature"]
         }
       end

--- a/app/models/event/plan/sc_google_grant.rb
+++ b/app/models/event/plan/sc_google_grant.rb
@@ -23,8 +23,19 @@
 class Event
   class Plan
     class ScGoogleGrant < Standard
+      def label
+        "South Carolina Google Grant"
+      end
+
       def contract_docuseal_template_id
         2672920
+      end
+
+      def contract_skip_prefills
+        {
+          "Contract Signee" => ["The Project", "Organization"],
+          "HCB"             => ["HCB ID", "Signature"]
+        }
       end
 
     end

--- a/app/models/event/plan/sc_google_grant.rb
+++ b/app/models/event/plan/sc_google_grant.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: event_plans
+#
+#  id          :bigint           not null, primary key
+#  aasm_state  :string
+#  inactive_at :datetime
+#  type        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  event_id    :bigint           not null
+#
+# Indexes
+#
+#  index_event_plans_on_event_id  (event_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#
+class Event
+  class Plan
+    class ScGoogleGrant < Standard
+      def contract_docuseal_template_id
+        2672920
+      end
+
+    end
+
+  end
+
+end

--- a/app/models/event/plan/standard.rb
+++ b/app/models/event/plan/standard.rb
@@ -87,6 +87,10 @@ class Event
         487784
       end
 
+      def contract_skip_prefills
+        {}
+      end
+
     end
 
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
New grant program with a new contract template, so we're adding a new plan!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds new plan that inherits from standard and overrides contract template ID.

This PR also adds a new plan method to skip certain prefilled fields on the fiscal sponsorship contract, and implements it in `Contract::FiscalSponsorship`. While this is not the best way to do this, it'll work for now since we need to get these contracts out. In the future, we can improve this by creating `Contract::Template` and storing prefills along with those.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

