### PR TITLE
Use project-based OpenAI API keys

### DIFF
--- a/app/controllers/extraction_controller.rb
+++ b/app/controllers/extraction_controller.rb
@@ -35,7 +35,7 @@ class ExtractionController < ApplicationController
 
     conn = Faraday.new url: "https://api.openai.com" do |f|
       f.request :json
-      f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+      f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :INVOICE_EXTRACTION) }
       f.response :raise_error
       f.response :json
     end

--- a/app/models/card_grant/pre_authorization.rb
+++ b/app/models/card_grant/pre_authorization.rb
@@ -105,7 +105,7 @@ class CardGrant
     def analyze!
       conn = Faraday.new url: "https://api.openai.com" do |c|
         c.request :json
-        c.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+        c.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :PRE_AUTHORIZATION) }
         c.response :json
         c.response :raise_error
       end

--- a/app/services/hcb_code_service/generate/suggested_tags.rb
+++ b/app/services/hcb_code_service/generate/suggested_tags.rb
@@ -33,7 +33,7 @@ module HcbCodeService
 
         conn = Faraday.new url: "https://api.openai.com" do |f|
           f.request :json
-          f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+          f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :SUGGESTED_TAGS) }
           f.response :raise_error
           f.response :json
         end

--- a/app/services/receipt_service/extract.rb
+++ b/app/services/receipt_service/extract.rb
@@ -38,7 +38,7 @@ module ReceiptService
 
       conn = Faraday.new url: "https://api.openai.com" do |f|
         f.request :json
-        f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI_API_KEY) }
+        f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :RECEIPT_EXTRACTION) }
         f.response :raise_error
         f.response :json
       end


### PR DESCRIPTION
## Summary of the problem

Our OpenAI spend has gone up slightly over time. It would be beneficial to have project-based insights into where we're spending money to help us optimize our usage.


## Describe your changes

This PR uses a different project-based API key for each place we use OpenAI.