### PR TITLE
[User Settings] Only render billing address tab if stripe cardholder exists

### DIFF
--- a/app/views/users/_settings_dropdown.html.erb
+++ b/app/views/users/_settings_dropdown.html.erb
@@ -13,9 +13,11 @@
   <%= dock_item "Notifications",
                 use_my_path ? settings_notifications_path : notifications_user_path(@user || current_user),
                 selected: local_assigns[:selected] == :settings_notifications && local_assigns[:open] %>
-  <%= dock_item "Billing address",
-                use_my_path ? settings_address_path : address_user_path(@user || current_user),
-                selected: local_assigns[:selected] == :settings_billing_address && local_assigns[:open] %>
+  <% if (@user || current_user)&.stripe_cardholder.present? %>
+    <%= dock_item "Billing address",
+                  use_my_path ? settings_address_path : address_user_path(@user || current_user),
+                  selected: local_assigns[:selected] == :settings_billing_address && local_assigns[:open] %>
+  <% end %>
   <%= dock_item "Reimbursement payouts",
                 use_my_path ? settings_payouts_path : payouts_user_path(@user || current_user),
                 selected: local_assigns[:selected] == :settings_reimbursement_payouts && local_assigns[:open] %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This page can't load if there is no stripe cardholder and there isn't a reason to create one from opening this page as the user has no cards yet.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

