### PR TITLE
[Disbursement] Support eventless `new` page

### DIFF
--- a/app/views/disbursements/new.html.erb
+++ b/app/views/disbursements/new.html.erb
@@ -1,5 +1,5 @@
 <% title "Initiate a disbursement" %>
-<% @back_url = event_transfers_path(@source_event) %>
+<% @back_url = @source_event ? event_transfers_path(@source_event) : nil %>
 
 <% content_for :sidebar_footer do %>
   <% if @allowed_destination_events.empty? %>

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -2,11 +2,13 @@
 <% @no_app_shell = true %>
 
 <nav class="border-b px-6 flex items-center gap-4 fixed top-0 left-0 backdrop-blur-xl h-20 md:h-24 w-full z-10">
-  <%= link_to inline_icon("view-back"), @back_url || event_transfers_path, class: "pop" %>
+  <% unless defined?(@back_url) && @back_url.nil? %>
+    <%= link_to inline_icon("view-back"), @back_url || event_transfers_path, class: "pop" %>
+  <% end %>
   <div class="min-w-0">
     <h1 class="border-0 m-0 p-0 h2 truncate"><%= yield(:title) %></h1>
     <%# For disbursements %>
-    <% unless @source_event.present? %>
+    <% if !@source_event.present? && @event.present? %>
       <p class="text-sm text-muted m-0 truncate">From <%= @event.name %></p>
     <% end %>
   </div>


### PR DESCRIPTION
## Summary of the problem

The disbursement new page was erroring because it expected the page to have an event (e.g. `@event` or `@source_event`). However, in some cases, it's possible to load the page with no event defined (and then select the source event on the page).


## Describe your changes

This is a semi-hacky fix to get the page working again. @manuthecoder, we should maybe explore `yield`ing this section of the page so that each individual page (e.g. ach, check, disbursement, etc.) can easily define its own nav section. The `transfers` layout should not rely on `@event` or `@source_event` being defined.