### PR TITLE
Fix `OneTimeJobs::BackfillColumnTransferOnRawColumnTransactions`

### DIFF
--- a/app/jobs/one_time_jobs/backfill_column_transfer_on_raw_column_transactions.rb
+++ b/app/jobs/one_time_jobs/backfill_column_transfer_on_raw_column_transactions.rb
@@ -4,9 +4,9 @@ module OneTimeJobs
   class BackfillColumnTransferOnRawColumnTransactions < ApplicationJob
     extend Limiter::Mixin
 
-    limit_method :perform, rate: 180 # 3 requests per second
+    limit_method :process, rate: 180 # 3 requests per second
 
-    def self.perform
+    def perform
       raw_column_transactions = RawColumnTransaction.where(id: CanonicalTransaction.where(transaction_source_type: "RawColumnTransaction", hcb_code: HcbCode.where("hcb_code ILIKE 'HCB-000%'").select(:hcb_code)).select(:transaction_source_id), column_transfer: nil)
 
       raw_column_transactions.find_each(batch_size: 100) do |rct|
@@ -14,7 +14,7 @@ module OneTimeJobs
       end
     end
 
-    def self.process(raw_column_transaction)
+    def process(raw_column_transaction)
       raw_column_transaction.extract_remote_object
     end
 


### PR DESCRIPTION
## Summary of the problem

These should be instance methods, not class methods. We also want to be limiting the process method, not the perform method.

