### PR TITLE
[Event::Plan] Clarify Internal is for transaction engine use only

### DIFF
--- a/app/models/event/plan/internal.rb
+++ b/app/models/event/plan/internal.rb
@@ -28,7 +28,7 @@ class Event
       end
 
       def description
-        "👻 oo scary! you're looking at the internal workings of HCB. shield your eyes, you may not like what you see."
+        "FOR ENGINEERING/TRANSACTION ENGINE USE ONLY. 👻 oo scary! you're looking at the internal workings of HCB. shield your eyes, you may not like what you see."
       end
 
       def features


### PR DESCRIPTION
## Summary of the problem

I'm finding HCB Ops' orgs in `Internal `, when it should only be used for transaction engine stuff.


## Describe your changes

Clarify in the Event::Plan description.