### PR TITLE
Redirect form unauthorized outgoing disbursements to incoming disbursements

### DIFF
--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -54,7 +54,7 @@ class HcbCodesController < ApplicationController
       render :show
     end
   rescue Pundit::NotAuthorizedError => e
-    if @hcb_code.stripe_card.card_grant.present? && current_user == @hcb_code.stripe_card.card_grant.user
+    if @hcb_code.stripe_card&.card_grant.present? && current_user == @hcb_code.stripe_card.card_grant.user
       redirect_to card_grant_path(@hcb_code.stripe_card.card_grant, frame: params[:frame])
     else
       if @hcb_code.outgoing_disbursement?

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -59,7 +59,7 @@ class HcbCodesController < ApplicationController
     elsif @hcb_code.outgoing_disbursement?
       incoming_hcb_code = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement.local_hcb_code
       if HcbCodePolicy.new(current_user, incoming_hcb_code).show?
-         redirect_to hcb_code_path(incoming_hcb_code.hashid)
+        redirect_to hcb_code_path(incoming_hcb_code.hashid)
       end
     else
       raise unless @event.is_public? && !params[:redirect_to_sign_in]

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -58,9 +58,9 @@ class HcbCodesController < ApplicationController
       redirect_to card_grant_path(@hcb_code.stripe_card.card_grant, frame: params[:frame])
     else
       if @hcb_code.outgoing_disbursement?
-        incoming_disbursement = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement
-        if incoming_disbursement.event.users.include?(current_user)
-          return redirect_to hcb_code_path(incoming_disbursement.local_hcb_code.hashid)
+        incoming_hcb_code = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement.local_hcb_code
+        if HcbCodePolicy.new(current_user, incoming_hcb_code).show?
+          return redirect_to hcb_code_path(incoming_hcb_code.hashid)
         end
       end
 

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -57,6 +57,13 @@ class HcbCodesController < ApplicationController
     if @hcb_code.stripe_card.card_grant.present? && current_user == @hcb_code.stripe_card.card_grant.user
       redirect_to card_grant_path(@hcb_code.stripe_card.card_grant, frame: params[:frame])
     else
+      if @hcb_code.outgoing_disbursement?
+        incoming_disbursement = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement
+        if incoming_disbursement.event.users.include?(current_user)
+          return redirect_to hcb_code_path(incoming_disbursement.local_hcb_code.hashid)
+        end
+      end
+
       raise unless @event.is_public? && !params[:redirect_to_sign_in]
 
       if @hcb_code.canonical_transactions.any?

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -56,14 +56,12 @@ class HcbCodesController < ApplicationController
   rescue Pundit::NotAuthorizedError => e
     if @hcb_code.stripe_card&.card_grant.present? && current_user == @hcb_code.stripe_card.card_grant.user
       redirect_to card_grant_path(@hcb_code.stripe_card.card_grant, frame: params[:frame])
-    else
-      if @hcb_code.outgoing_disbursement?
-        incoming_hcb_code = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement.local_hcb_code
-        if HcbCodePolicy.new(current_user, incoming_hcb_code).show?
-          return redirect_to hcb_code_path(incoming_hcb_code.hashid)
-        end
+    elsif @hcb_code.outgoing_disbursement?
+      incoming_hcb_code = @hcb_code.outgoing_disbursement.disbursement.incoming_disbursement.local_hcb_code
+      if HcbCodePolicy.new(current_user, incoming_hcb_code).show?
+         redirect_to hcb_code_path(incoming_hcb_code.hashid)
       end
-
+    else
       raise unless @event.is_public? && !params[:redirect_to_sign_in]
 
       if @hcb_code.canonical_transactions.any?


### PR DESCRIPTION
Note: this needs to merge after #12792

## Summary of the problem

Once we split disbursement HCB codes, we'll need to handle the case where someone accesses the source HCB code but only has permission to view the destination.


## Describe your changes

When a policy check on HCB code fails, but it's an outgoing disbursement and the user has access to the incoming disbursement, redirect there.