### PR TITLE
Use `OrganizerPosition.role_at_least?` in `CardGrantPolicy`

### DIFF
--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -106,7 +106,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def user_in_event?
-    record.event.users.include?(user)
+    OrganizerPosition.role_at_least?(user, record, :reader)
   end
 
   def authorized_to_activate?


### PR DESCRIPTION
## Summary of the problem

`user_in_event?` currently needs the user to explicitly be in the event and doesn't factor in parent events


## Describe your changes

Using `OrganizerPosition.role_at_least?` fixes this