### PR TITLE
Fix bug in `CardGrantPolicy` (Pass event into event)

### DIFF
--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -106,7 +106,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def user_in_event?
-    OrganizerPosition.role_at_least?(user, record, :reader)
+    OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def authorized_to_activate?


### PR DESCRIPTION
## Summary of the problem

`OrganizerPosition.role_at_least?` asks for an event, but we give it a card grant


## Describe your changes

Give it an event