### PR TITLE
Improve minimalistic ledger

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,11 @@ module ApplicationHelper
   end
 
   def render_transaction_amount(amount)
-    render_money amount
+    if(Flipper.enabled?(:transactions_background_2024_06_05, current_user))
+      content_tag :div, render_money(amount), class: "badge bg-#{amount.positive? ? 'success' : 'error'}"
+    else
+      render_money amount
+    end
   end
 
   def render_percentage(decimal, params = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def render_transaction_amount(amount)
-    if(Flipper.enabled?(:transactions_background_2024_06_05, current_user))
+    if Flipper.enabled?(:transactions_background_2024_06_05, current_user)
       content_tag :div, render_money(amount), class: "badge bg-#{amount.positive? ? 'success' : 'error'}"
     else
       render_money amount


### PR DESCRIPTION
one of the main complaints of the minimalistic ledger is that positive/negative transactions are hard to read. 

this little experiment improves this flipper flag

<img width="1010" height="682" alt="image" src="https://github.com/user-attachments/assets/19242264-85c4-473d-a60c-6f0302521291" />
