### PR TITLE
Vertically align HCB code headings

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -82,6 +82,7 @@
   @apply pb-0 mb-1 mt-3 shadow-none;
   border: 1px solid rgba(200, 200, 200, 0.3);
   box-shadow: var(--shadow-sm);
+  padding-top: 0px;
 }
 
 .hcb-code--info {

--- a/app/views/hcb_codes/_heading.html.erb
+++ b/app/views/hcb_codes/_heading.html.erb
@@ -17,7 +17,7 @@
     <div class="flex-1"></div>
     <%= pop_icon_to "edit",
         edit_hcb_code_path(hcb_code),
-        class: "align-middle tooltipped tooltipped--s -mt-1", "aria-label": "Rename",
+        class: "align-middle tooltipped tooltipped--s", "aria-label": "Rename",
         data: { turbo: true } if organizer_signed_in?(as: :member) %>
     <%= render partial: "hcb_codes/meatballs", locals: { hcb_code: } %>
   <% end %>

--- a/app/views/hcb_codes/_heading.html.erb
+++ b/app/views/hcb_codes/_heading.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (hcb_code:, render_memo: false) %>
 
-<h2 class="h2 mt0 border-none flex items-center justify-between hcb-code--heading" style="gap: 1ch">
-  <%= turbo_frame_tag hcb_code, class: "flex items-start gap-2 flex-grow" do %>
+<h2 class="h2 mt0 border-none flex items-center justify-between hcb-code--heading mb-0" style="gap: 1ch">
+  <%= turbo_frame_tag hcb_code, class: "flex items-center py-3 gap-2 flex-grow" do %>
     <% if hcb_code.custom_memo.nil? && !render_memo %>
       <%= yield %>
     <% else %>

--- a/app/views/hcb_codes/_meatballs.html.erb
+++ b/app/views/hcb_codes/_meatballs.html.erb
@@ -10,7 +10,7 @@
 <% allowable_on_event = merchant_not_allowed && EventPolicy.new(current_user, hcb_code.stripe_card.card_grant.event).permit_merchant? && !hcb_code.stripe_card.card_grant.event.card_grant_setting.merchant_lock.include?(hcb_code.stripe_merchant["network_id"]) %>
 
 <% if (disputable || flagable || pinnable || open_invoice || reversible_disbursement || allowable_on_card || allowable_on_event) && organizer_signed_in?(as: :member) %>
-  <div data-controller="menu" data-menu-placement-value="bottom-end" class="-mt-1">
+  <div data-controller="menu" data-menu-placement-value="bottom-end">
     <%= pop_icon_to "more",
         "#",
         class: "align-middle", "aria-label": "More Options",


### PR DESCRIPTION
## Summary of the problem

The HCB code heading isn't aligned vertically


## Describe your changes

<img width="834" height="245" alt="image" src="https://github.com/user-attachments/assets/27e4acbf-0704-47dd-962d-9c6624d22278" />
