### PR TITLE
Deprecate the /transactions route

### DIFF
--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -101,6 +101,7 @@ FriendlyId.defaults do |config|
     404
     500
     mobile
+    deprecated
   ]
 
   # This adds an option to to treat reserved words as conflicts rather than exceptions.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -543,7 +543,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :transactions, only: [:index, :show, :edit, :update]
+  resources :transactions, only: [:index, :show, :edit, :update], path: "deprecated/transactions"
+  get "/transactions/*path", to: redirect("/deprecated/transactions/%{path}", status: 302)
+
 
   namespace :reimbursement do
     resources :reports, only: [:show, :create, :edit, :update, :destroy] do


### PR DESCRIPTION
## Summary of the problem

The routing scheme `/transactions/<transaction>` is already in use, but we'd like to steal it back for the new ledger items.


## Describe your changes

Redirect `/transactions/<transaction>` to `/deprecated/transactions/<transaction>`