### PR TITLE
[CI] Only rollback once to test all migrations are reversible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,14 +298,20 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/bank_test
           RAILS_ENV: test
         run: |
-          for VERSION in ${{ steps.migrations.outputs.versions }}; do
-            echo "Testing migration $VERSION..."
-            echo "  Rolling back..."
-            bundle exec rails db:migrate:down VERSION=$VERSION
-            echo "  Migrating up..."
-            bundle exec rails db:migrate:up VERSION=$VERSION
-            echo "  Migration $VERSION is reversible!"
-          done
+          # Get the oldest new migration version
+          VERSIONS="${{ steps.migrations.outputs.versions }}"
+          OLDEST_VERSION=$(echo "$VERSIONS" | awk '{print $NF}')
+
+          echo "========================================="
+          echo "Rolling back all new migrations..."
+          bundle exec rails db:migrate VERSION=$((OLDEST_VERSION - 1))
+
+          echo "========================================="
+          echo "Re-applying all migrations..."
+          bundle exec rails db:migrate
+
+          echo "========================================="
+          echo "✅ All migrations are reversible!"
   brakeman:
     name: Brakeman
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of the problem

We do not need all migrations to be _independently_ reversible. We only need a migration to be reversible after newer migrations have already rolledback. This means the current test implementation fails excessively and is slower than necessary.

**Example:**

If we created new migrations A, B, and C...

Before (redundant):
1. down C, up C
2. down C, down B, up B, up C
3. down C, down B, down A, up A, up B, up C

After (efficient):
1. down C, down B, down A
2. up A, up B, up C

## Describe your changes

Just rollback from the oldest migration added by the PR, then migrate back up.