### PR TITLE
[Schema] Swap order of `subledger_id` for `hcb_codes` table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1347,9 +1347,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_01_234218) do
     t.datetime "created_at", null: false
     t.bigint "event_id"
     t.text "hcb_code", null: false
-    t.bigint "subledger_id"
     t.datetime "marked_no_or_lost_receipt_at", precision: nil
     t.text "short_code"
+    t.bigint "subledger_id"
     t.datetime "updated_at", null: false
     t.index ["hcb_code"], name: "index_hcb_codes_on_hcb_code", unique: true
     t.check_constraint "short_code = upper(short_code)", name: "constraint_hcb_codes_on_short_code_to_uppercase"


### PR DESCRIPTION
Running `db:migrate` does this for @sampoder and I
