### PR TITLE
[Ledger] Add proper tests for creation on CardGrant after_create

### DIFF
--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -4,15 +4,28 @@ require "rails_helper"
 
 RSpec.describe CardGrant, type: :model do
   describe "ledger association" do
+    # CardGrant has an after_create :transfer_money callback that triggers
+    # DisbursementService::Create, which requires the source event to have
+    # sufficient balance and creates actual disbursement records. We stub
+    # this callback to test ledger creation in isolation without needing
+    # to set up a full funded event with transactions.
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+    end
+
     it "automatically creates a primary ledger after creation" do
-      # Skip - CardGrant creation triggers complex disbursement logic
-      skip "Requires actual card_grant which triggers disbursement logic"
+      card_grant = create(:card_grant)
+
+      expect(card_grant.ledger).to be_present
+      expect(card_grant.ledger.primary?).to be true
+      expect(card_grant.ledger.card_grant).to eq(card_grant)
     end
 
     it "has a primary ledger association" do
-      card_grant = CardGrant.new
+      card_grant = create(:card_grant)
 
       expect(card_grant).to respond_to(:ledger)
+      expect(card_grant.ledger).to be_a(Ledger)
     end
   end
 end


### PR DESCRIPTION
## Summary of the problem

These tests were skipped because it's complicated to set up the right states to get a CardGrant created.

## Describe your changes

Stub out the `transfer_money ` method to make it easier to test just the specific behavior: "Does a primary ledger get created when a card grant is created?"