### PR TITLE
Ignore event_id on affiliations before removing

### DIFF
--- a/app/controllers/event/affiliations_controller.rb
+++ b/app/controllers/event/affiliations_controller.rb
@@ -13,7 +13,6 @@ class Event
           name: params[:type],
           metadata: @metadata,
           affiliable: @affiliable,
-          event_id: @affiliable.id # since this is non-null, remove later
         }
       )
 

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -27,7 +27,6 @@ class Event
     self.ignored_columns += ["event_id"]
     include Hashid::Rails
 
-    belongs_to :event
     belongs_to :affiliable, polymorphic: true
 
     store_accessor :metadata, :league, :team_number, :size, :venue_name

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -24,6 +24,7 @@
 #
 class Event
   class Affiliation < ApplicationRecord
+    self.ignored_columns += ["event_id"]
     include Hashid::Rails
 
     belongs_to :event


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We're now using the `affiliable` polymorphic relation, and have backfilled it. Following `strong_migrations`, we should ignore the column before dropping it.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Ignore the `event_id` column and remove references to it.

**Merge #12884 first, then this PR, and lastly #12864**

