### PR TITLE
Revert standard DocuSeal template ID change

### DIFF
--- a/app/models/event/plan/standard.rb
+++ b/app/models/event/plan/standard.rb
@@ -84,7 +84,7 @@ class Event
       end
 
       def contract_docuseal_template_id
-        2532762
+        487784
       end
 
       def contract_skip_prefills


### PR DESCRIPTION
Accidentally changed this in the applications PR