### PR TITLE
Fix application policy to allow users to resend the cosigner contract

### DIFF
--- a/app/policies/event/application_policy.rb
+++ b/app/policies/event/application_policy.rb
@@ -34,7 +34,7 @@ class Event
       return true if user.admin?
       # Cosigner email is the only field we want to let users update once they've submitted,
       # but not after they've been activated
-      return record.user == user if record.draft? || (record.changed == ["cosigner_email"] && record.event.nil?)
+      return record.user == user if record.draft? || record.changed.empty? || (record.changed == ["cosigner_email"] && record.event.nil?)
 
       false
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The cosigner manage modal works by sending an update to the application with the cosigner email, and triggers a resend if not changed. However, the policy currently does not authorize the update if there are no changes and the application is not a draft.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Authorize application updates that have no changes after submission.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

