### PR TITLE
Fix flash layout on mobile

### DIFF
--- a/app/views/layouts/apply.html.erb
+++ b/app/views/layouts/apply.html.erb
@@ -166,7 +166,7 @@
                 <h3 class="text-sm muted m-0">Turn your ideas into reality</h3>
               </div>
             </div>
-            <div class="flex flex-row justify-center">
+            <div class="flex-row justify-center hidden md:flex">
               <div class="w-max">
                 <%= render "application/flash" unless @hide_flash %>
               </div>
@@ -192,6 +192,11 @@
                   </p>
                 </div>
               </div>
+            </div>
+          </div>
+          <div class="flex-row justify-center flex md:hidden bg-snow dark:bg-darkless">
+            <div class="w-max">
+              <%= render "application/flash", klass: "mb-2" unless @hide_flash %>
             </div>
           </div>
           <% if content_for?(:progress).present? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Any flashes were displaying in the horizontal flex in the top bar, which did not look good.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moves flash messages to below the top bar on mobile

<img width="750" height="1334" alt="Screen Shot 2026-02-04 at 12 27 12" src="https://github.com/user-attachments/assets/ef28ca44-aaf8-45ab-b96f-8b378ea32352" />



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

