### PR TITLE
[Event::Application] Fix broken `accessibility_notes` usage

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -286,7 +286,7 @@ class Event
       app["Address Country"] = address_country
       app["Event Location"] = address_country
       app["How did you hear about HCB?"] = referrer
-      app["Accommodations"] = notes
+      app["Accommodations"] = accessibility_notes
       app["(Adults) Political Activity"] = political_description
       app["Referral Code"] = referral_code
       app["HCB Status"] = aasm_state.humanize unless draft?


### PR DESCRIPTION
## Summary of the problem

We're accessing `notes`, which doesn't exist.


## Describe your changes

Access `accessibility_notes` instead.
