### PR TITLE
Use accessibility_notes when syncing applications to airtable

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -286,7 +286,7 @@ class Event
       app["Address Country"] = address_country
       app["Event Location"] = address_country
       app["How did you hear about HCB?"] = referrer
-      app["Accommodations"] = notes
+      app["Accommodations"] = accessibility_notes
       app["(Adults) Political Activity"] = political_description
       app["Referral Code"] = referral_code
       app["HCB Status"] = aasm_state.humanize unless draft?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2701/samples/timestamp/2026-02-04T23:03:14Z - I renamed the column before merging #12188, but forgot to rename this reference.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
`notes` -> `accessibility_notes`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

