### PR TITLE
Fix welcome popup alignment on mobile

### DIFF
--- a/app/assets/stylesheets/components/_welcome.scss
+++ b/app/assets/stylesheets/components/_welcome.scss
@@ -87,7 +87,6 @@
 
 @media (max-width: 48em) {
   .welcome {
-    justify-content: flex-start;
     padding: 8px;
     padding-top: 36px;
     overflow-y: scroll;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
               <%= image_tag "logo-production-dark.svg", width: 100, class: "logo-dark" %>
               <%= image_tag "logo-production.svg", width: 100, class: "logo" %>
             </div>
-            <h1 class="border-0 mt-0">Welcome to <%= @event.name %></h1>
+            <h1 class="border-0 mt-0 text-center">Welcome to <%= @event.name %></h1>
             <div class="mb2">
               <button class="btn" data-action="welcome#tour">Show me around</button>
             </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The welcome popup was not aligned well on mobile screens (left-aligned text and justify start)

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Center align the welcome popup text and items.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="377" height="642" alt="image" src="https://github.com/user-attachments/assets/ec250c8e-d1f6-491d-9ae2-0016ade890af" />
