### PR TITLE
Enable Rails 8 strict_freshness default

### DIFF
--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -24,7 +24,7 @@
 # only consider `If-None-Match` as specified by RFC 7232 Section 6.
 # If set to `false` both conditions need to be satisfied.
 #++
-# Rails.application.config.action_dispatch.strict_freshness = true
+Rails.application.config.action_dispatch.strict_freshness = true
 
 ###
 # Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.


### PR DESCRIPTION
This should be pretty safe as it's more standards compliant behavior.

The first of 3 PRs to flip rails 8 framework defaults one by one
