### PR TITLE
Enable Rails 8 Regexp.timeout default for ReDoS

### DIFF
--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -29,4 +29,4 @@ Rails.application.config.action_dispatch.strict_freshness = true
 ###
 # Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.
 #++
-# Regexp.timeout = 1
+Regexp.timeout = 1

--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -24,7 +24,7 @@
 # only consider `If-None-Match` as specified by RFC 7232 Section 6.
 # If set to `false` both conditions need to be satisfied.
 #++
-# Rails.application.config.action_dispatch.strict_freshness = true
+Rails.application.config.action_dispatch.strict_freshness = true
 
 ###
 # Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.


### PR DESCRIPTION
## Summary of the problem

Protect against ReDoS with a timeout

The second of 3 PRs to flip rails 8 framework defaults
