### PR TITLE
[Migration] Fix 20260204193727_allow_null_in_affiliation_event.rb

### DIFF
--- a/db/migrate/20260204193727_allow_null_in_affiliation_event.rb
+++ b/db/migrate/20260204193727_allow_null_in_affiliation_event.rb
@@ -1,5 +1,14 @@
 class AllowNullInAffiliationEvent < ActiveRecord::Migration[8.0]
   def change
-    change_column_null :event_affiliations, :event_id, true
+    # Only change column if it exists (may have been removed by an earlier migration)
+    #
+    # In production, this migration ran before
+    # 20260203031519_remove_event_id_from_affiliations due to PR merge order.
+    #
+    # This migration:    https://github.com/hackclub/hcb/pull/12884
+    # Earlier migration: https://github.com/hackclub/hcb/pull/12864
+    if column_exists?(:event_affiliations, :event_id)
+      change_column_null :event_affiliations, :event_id, true
+    end
   end
 end


### PR DESCRIPTION
## Summary of the problem

Intended migration order:
1. 20260204193727_allow_null_in_affiliation_event.rb
2. 20260203031519_remove_event_id_from_affiliations.rb

In production, the migrations _did_ run in the intended order due to PR merge order.

However, due to timestamp order, 20260204193727_allow_null_in_affiliation_event is now causing errors because it attempts to change a column that was previously removed.


## Describe your changes

Only run migration is the column still exists