### PR TITLE
[Ledger] Allow signed in users to filter

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1230,7 +1230,7 @@ class EventsController < ApplicationController
       @merchant_name = merchant.present? ? merchant[:name] : "Merchant #{@merchant}"
     end
 
-    @ledger_filters_disabled = !(organizer_signed_in? || auditor_signed_in?)
+    @ledger_filters_disabled = !signed_in?
     has_filters = @tag || @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @missing_receipts || @merchant || @direction || @category
     if @ledger_filters_disabled && has_filters
       render plain: "Invalid parameters. Please try again", status: :bad_request


### PR DESCRIPTION
## Summary of the problem

Shipwrecked is running into an issue where they would allow a non-organizer to filter their ledger.


## Describe your changes


Relax restrictions to allow signed in users to filter. Previously, it was only organizers who could filter ledgers.