### PR TITLE
[Admin] Add Public ID lookup tool

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1456,8 +1456,9 @@ class AdminController < Admin::BaseController
     @public_id = params[:public_id]&.strip
     return unless @public_id.present?
 
-    # Return if record is found
-    return if (@record = PublicIdentifiable.find_by_public_id(@public_id))
+    @record = PublicIdentifiable.find_by_public_id(@public_id)
+
+    return if @record.present?
 
     # Handle error
     components = PublicIdentifiable.parse_components(@public_id)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1452,6 +1452,25 @@ class AdminController < Admin::BaseController
     @link_creators = User.where(id: Referral::Link.select(:creator_id).map(&:creator_id).uniq).includes(:referral_links)
   end
 
+  def public_id_lookup
+    @public_id = params[:public_id]&.strip
+    return unless @public_id.present?
+
+    # Return if record is found
+    return if (@record = PublicIdentifiable.find_by_public_id(@public_id))
+
+    # Handle error
+    components = PublicIdentifiable.parse_components(@public_id)
+
+    if components.nil?
+      @error = "Invalid public ID format. Expected format: org_abc123, usr_xyz789, etc."
+    elsif PublicIdentifiable.models[components[:prefix]].nil?
+      @error = "Unknown prefix '#{components[:prefix]}'. This prefix does not match any known model."
+    else
+      @error = "Record not found. The #{PublicIdentifiable.models[components[:prefix]].name} with public ID '#{@public_id}' does not exist."
+    end
+  end
+
   private
 
   def stream_data(content_type, filename, data, download = true)

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -181,6 +181,12 @@ module Admin
             path: new_teenagers_leaderboard_admin_index_path,
             count: 0, # I think this would be expensive to calculate
             count_type: :records,
+          ),
+          make_item(
+            name: "Public ID Lookup",
+            path: public_id_lookup_admin_index_path,
+            count: 0,
+            count_type: :records,
           )
         ]
       )

--- a/app/models/concerns/public_identifiable.rb
+++ b/app/models/concerns/public_identifiable.rb
@@ -4,6 +4,42 @@
 module PublicIdentifiable
   extend ActiveSupport::Concern
 
+  # Central registry for public ID lookup
+  # Models still call set_public_id_prefix, this is just for admin lookup tool
+  # Lazy-loaded to avoid circular dependencies during Rails initialization
+  def self.models
+    @models ||= {
+      ach: AchTransfer,
+      act: PublicActivity::Activity,
+      apl: Event::Application,
+      bfe: BankFee,
+      cdg: CardGrant,
+      cdp: CheckDeposit,
+      chg: Api::Models::CardCharge,
+      chk: Check,
+      cmt: Comment,
+      crd: StripeCard,
+      don: Donation,
+      frv: FeeRevenue,
+      ick: IncreaseCheck,
+      inv: Invoice,
+      ivt: OrganizerPositionInvite,
+      org: Event,
+      rct: Receipt,
+      rep: Reimbursement::ExpensePayout,
+      rme: Reimbursement::Expense,
+      rmr: Reimbursement::Report,
+      rph: Reimbursement::PayoutHolding,
+      spr: Sponsor,
+      tag: Tag,
+      txn: HcbCode,
+      usr: User,
+      wir: Wire,
+      wse: WiseTransfer,
+      xfr: Disbursement
+    }.freeze
+  end
+
   included do
     include Hashid::Rails
     class_attribute :public_id_prefix
@@ -13,20 +49,45 @@ module PublicIdentifiable
     "#{self.public_id_prefix}_#{hashid}"
   end
 
+  # Extract prefix from public ID (e.g., "usr_abc123" => :usr)
+  def self.parse_components(public_id)
+    return unless public_id.is_a?(String)
+
+    components = public_id.split("_", 2)
+    return unless components.size == 2
+    return if components.first.blank? || components.last.blank?
+
+    {
+      prefix: components.first.to_s.downcase.to_sym,
+      hashid: components.last
+    }
+  end
+
+  # Module-level lookup - single interface for admin tools
+  def self.find_by_public_id(public_id)
+    return unless (components = parse_components(public_id))
+
+    prefix = components[:prefix]
+    model_class = models[prefix]
+    return nil unless model_class
+
+    model_class.find_by_public_id(public_id)
+  end
+
   module ClassMethods
     def set_public_id_prefix(prefix)
       self.public_id_prefix = prefix.to_s.downcase
     end
 
-    def find_by_public_id(id)
-      return nil unless id.is_a? String
+    def find_by_public_id(public_id)
+      # Return unless we were able to extract the components
+      return unless (components = PublicIdentifiable.parse_components(public_id))
 
-      prefix = id.split("_").first.to_s.downcase
-      hash = id.split("_").last
-      return nil unless prefix == self.get_public_id_prefix
+      # Prefix must match this model's prefix to prevent cross-model lookup (e.g., "usr_abc123" should not be found by Event)
+      return unless components[:prefix].to_s == self.get_public_id_prefix
 
       # ex. 'org_h1izp'
-      find_by_hashid(hash)
+      find_by_hashid(components[:hashid])
     end
 
     def find_by_public_id!(id)
@@ -39,7 +100,7 @@ module PublicIdentifiable
     def get_public_id_prefix
       return self.public_id_prefix.to_s.downcase if self.public_id_prefix.present?
 
-      raise NotImplementedError, "The #{self.class.name} model includes PublicIdentifiable module, but set_public_id_prefix hasn't been called."
+      raise NotImplementedError, "The #{self.class.name} model includes PublicIdentifiable module, but has not configure it's prefix in `PublicIdentifiable.models`."
     end
   end
 end

--- a/app/models/concerns/public_identifiable.rb
+++ b/app/models/concerns/public_identifiable.rb
@@ -78,11 +78,11 @@ module PublicIdentifiable
     def find_by_public_id(public_id)
       components = PublicIdentifiable.parse_components(public_id)
       return unless components
-    
+
       prefix = components[:prefix].to_s
       # Prefix must match this model's prefix
       return unless prefix == get_public_id_prefix
-    
+
       find_by_hashid(components[:hashid])
     end
 
@@ -96,6 +96,7 @@ module PublicIdentifiable
     def get_public_id_prefix
       return self.public_id_prefix.to_s.downcase if self.public_id_prefix.present?
 
-      raise NotImplementedError, "The #{self.class.name} model includes PublicIdentifiable module, but set_public_id_prefix hasn't been called."    end
+      raise NotImplementedError, "The #{self.class.name} model includes PublicIdentifiable module, but set_public_id_prefix hasn't been called."
+    end
   end
 end

--- a/app/views/admin/public_id_lookup.html.erb
+++ b/app/views/admin/public_id_lookup.html.erb
@@ -1,0 +1,61 @@
+<% title "Public ID Lookup" %>
+
+<h1>Public ID Lookup</h1>
+
+<p class="muted">
+  Look up any object by its public ID. Public IDs have a format like
+  <code>org_abc123</code>, <code>usr_xyz789</code>, etc.
+</p>
+
+<%= form_with(local: true, url: public_id_lookup_admin_index_path, method: :get) do |form| %>
+  <div class="flex items-center gap-2">
+    <%= form.text_field :public_id, value: @public_id, placeholder: "org_abc123", required: true, autofocus: true, class: "flex-1" %>
+    <%= form.submit "Look up", class: "btn" %>
+  </div>
+<% end %>
+
+<% if @public_id.present? %>
+  <hr style="margin: 2rem 0;">
+
+  <% if @error %>
+    <div class="card bg-error text-white mb-4">
+      <strong>Error:</strong> <%= @error %>
+    </div>
+  <% elsif @record %>
+    <table class="mt-3">
+      <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Value</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td><strong>Public ID</strong></td>
+        <td><code><%= @record.public_id %></code></td>
+      </tr>
+      <tr>
+        <td><strong>Model Name</strong></td>
+        <td><code><%= @record.class.name %></code></td>
+      </tr>
+
+      <%# Using raw values from database to prevent leaking encrypted values %>
+      <% attribute_values = @record.attributes_before_type_cast.slice(*@record.class.columns.map(&:name)) %>
+      <% attribute_values.each do |attr, value| %>
+        <tr>
+          <td><strong><%= attr %></strong></td>
+          <td>
+            <% if attr.ends_with?("ciphertext") %>
+              <i class="muted">Encrypted</i>
+            <% elsif value.nil? %>
+              <i class="muted">nil</i>
+            <% else %>
+              <%= value %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% end %>
+<% end %>

--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -88,6 +88,7 @@
       <ul class="grid text-left w-100 mt0" id="other-grid">
         <%= render partial: "static_pages/card", locals: { task_path: common_documents_path, human_name: "Common docs" } %>
         <%= render partial: "static_pages/card", locals: { task_path: flipper_path, human_name: "Flipper" } %>
+        <%= card_to "Public ID lookup", public_id_lookup_path %>
         <%= card_to "Pending ledger", pending_ledger_admin_index_path, badge: CanonicalPendingTransaction.unsettled.count %>
         <%= card_to "Account numbers", account_numbers_admin_index_path, badge: Column::AccountNumber.count, subtle_badge: true %>
         <%= card_to "Recurring donations", recurring_donations_admin_index_path, badge: RecurringDonation.active.count %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,6 +264,7 @@ Rails.application.routes.draw do
       post "request_balance_export", to: "admin#request_balance_export"
       get "active_teenagers_leaderboard", to: "admin#active_teenagers_leaderboard"
       get "new_teenagers_leaderboard", to: "admin#new_teenagers_leaderboard"
+      get "public_id_lookup", to: "admin#public_id_lookup"
     end
 
     member do

--- a/spec/models/concerns/public_identifiable_spec.rb
+++ b/spec/models/concerns/public_identifiable_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe PublicIdentifiable do
     end
 
     it "has keys that match model prefixes" do
-      # Verify that each model's prefix matches its key in the registry
       described_class.models.each do |prefix, model_class|
         expect(model_class.get_public_id_prefix).to eq(prefix.to_s),
                                                     "#{model_class.name} has prefix '#{model_class.get_public_id_prefix}' but is registered under '#{prefix}'"
@@ -140,7 +139,6 @@ RSpec.describe PublicIdentifiable do
 
   describe "auto-configuration" do
     it "sets prefix from MODELS registry when model is loaded" do
-      # Verify that models have their prefix set automatically
       described_class.models.each do |prefix, model_class|
         expect(model_class.public_id_prefix).to eq(prefix.to_s),
                                                 "#{model_class.name} should have prefix '#{prefix}' auto-configured"
@@ -159,7 +157,6 @@ RSpec.describe PublicIdentifiable do
       end
 
       it "returns nil when prefix doesn't match model" do
-        # Try to find a user with an org prefix
         result = User.find_by_public_id("org_abc123")
 
         expect(result).to be_nil

--- a/spec/models/concerns/public_identifiable_spec.rb
+++ b/spec/models/concerns/public_identifiable_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe PublicIdentifiable do
       # Exclude STI children that share the same prefix as their parent
       # Use ActiveRecord::Base.descendants to include gem models like PublicActivity::Activity
       all_models_with_public_id = ActiveRecord::Base.descendants
-        .select { |model| model.respond_to?(:get_public_id_prefix) }
-        .reject do |model|
-          model.superclass.respond_to?(:get_public_id_prefix) &&
-            model.get_public_id_prefix == model.superclass.get_public_id_prefix
-        end
+                                                    .select { |model| model.respond_to?(:get_public_id_prefix) }
+                                                    .reject do |model|
+        model.superclass.respond_to?(:get_public_id_prefix) &&
+          model.get_public_id_prefix == model.superclass.get_public_id_prefix
+      end
 
       registered_models = described_class.models.values.to_set
       actual_models = all_models_with_public_id.to_set
@@ -25,31 +25,31 @@ RSpec.describe PublicIdentifiable do
       extra_models = registered_models - actual_models
 
       expect(missing_models.map(&:name)).to be_empty,
-        "MODELS registry is missing: #{missing_models.map { |m| "#{m.name} (prefix: #{m.get_public_id_prefix})" }.join(", ")}"
+                                            "MODELS registry is missing: #{missing_models.map { |m| "#{m.name} (prefix: #{m.get_public_id_prefix})" }.join(", ")}"
 
       expect(extra_models.map(&:name)).to be_empty,
-        "MODELS registry has extra models that don't have PublicIdentifiable: #{extra_models.map(&:name).join(", ")}"
+                                          "MODELS registry has extra models that don't have PublicIdentifiable: #{extra_models.map(&:name).join(", ")}"
     end
 
     it "has keys that match model prefixes" do
       # Verify that each model's prefix matches its key in the registry
       described_class.models.each do |prefix, model_class|
         expect(model_class.get_public_id_prefix).to eq(prefix.to_s),
-          "#{model_class.name} has prefix '#{model_class.get_public_id_prefix}' but is registered under '#{prefix}'"
+                                                    "#{model_class.name} has prefix '#{model_class.get_public_id_prefix}' but is registered under '#{prefix}'"
       end
     end
 
     it "enforces prefix format (lowercase a-z only)" do
       described_class.models.each_key do |prefix|
         expect(prefix.to_s).to match(/\A[a-z]+\z/),
-          "Prefix '#{prefix}' must be lowercase and only contain letters a-z"
+                               "Prefix '#{prefix}' must be lowercase and only contain letters a-z"
       end
     end
 
     it "enforces prefix length (exactly 3 characters)" do
       described_class.models.each_key do |prefix|
         expect(prefix.to_s.length).to eq(3),
-          "Prefix '#{prefix}' must be exactly 3 characters long (current length: #{prefix.to_s.length})"
+                                      "Prefix '#{prefix}' must be exactly 3 characters long (current length: #{prefix.to_s.length})"
       end
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe PublicIdentifiable do
       # Verify that models have their prefix set automatically
       described_class.models.each do |prefix, model_class|
         expect(model_class.public_id_prefix).to eq(prefix.to_s),
-          "#{model_class.name} should have prefix '#{prefix}' auto-configured"
+                                                "#{model_class.name} should have prefix '#{prefix}' auto-configured"
       end
     end
   end

--- a/spec/models/concerns/public_identifiable_spec.rb
+++ b/spec/models/concerns/public_identifiable_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PublicIdentifiable do
+  describe "MODELS registry" do
+    it "includes all models with PublicIdentifiable" do
+      # Eager load all models to ensure we catch everything
+      Rails.application.eager_load!
+
+      # Find all models that include PublicIdentifiable
+      # Exclude STI children that share the same prefix as their parent
+      # Use ActiveRecord::Base.descendants to include gem models like PublicActivity::Activity
+      all_models_with_public_id = ActiveRecord::Base.descendants
+        .select { |model| model.respond_to?(:get_public_id_prefix) }
+        .reject do |model|
+          model.superclass.respond_to?(:get_public_id_prefix) &&
+            model.get_public_id_prefix == model.superclass.get_public_id_prefix
+        end
+
+      registered_models = described_class.models.values.to_set
+      actual_models = all_models_with_public_id.to_set
+
+      missing_models = actual_models - registered_models
+      extra_models = registered_models - actual_models
+
+      expect(missing_models.map(&:name)).to be_empty,
+        "MODELS registry is missing: #{missing_models.map { |m| "#{m.name} (prefix: #{m.get_public_id_prefix})" }.join(", ")}"
+
+      expect(extra_models.map(&:name)).to be_empty,
+        "MODELS registry has extra models that don't have PublicIdentifiable: #{extra_models.map(&:name).join(", ")}"
+    end
+
+    it "has keys that match model prefixes" do
+      # Verify that each model's prefix matches its key in the registry
+      described_class.models.each do |prefix, model_class|
+        expect(model_class.get_public_id_prefix).to eq(prefix.to_s),
+          "#{model_class.name} has prefix '#{model_class.get_public_id_prefix}' but is registered under '#{prefix}'"
+      end
+    end
+
+    it "enforces prefix format (lowercase a-z only)" do
+      described_class.models.each_key do |prefix|
+        expect(prefix.to_s).to match(/\A[a-z]+\z/),
+          "Prefix '#{prefix}' must be lowercase and only contain letters a-z"
+      end
+    end
+
+    it "enforces prefix length (exactly 3 characters)" do
+      described_class.models.each_key do |prefix|
+        expect(prefix.to_s.length).to eq(3),
+          "Prefix '#{prefix}' must be exactly 3 characters long (current length: #{prefix.to_s.length})"
+      end
+    end
+  end
+
+  describe ".parse_components" do
+    it "parses valid public ID format" do
+      result = described_class.parse_components("usr_abc123")
+
+      expect(result).to eq({ prefix: :usr, hashid: "abc123" })
+    end
+
+    it "handles multiple underscores by treating everything after first underscore as hashid" do
+      result = described_class.parse_components("usr_abc_123_xyz")
+
+      expect(result).to eq({ prefix: :usr, hashid: "abc_123_xyz" })
+    end
+
+    it "downcases prefix" do
+      result = described_class.parse_components("USR_abc123")
+
+      expect(result).to eq({ prefix: :usr, hashid: "abc123" })
+    end
+
+    it "returns nil for string without underscore" do
+      result = described_class.parse_components("usrabc123")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil for empty string" do
+      result = described_class.parse_components("")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil for non-string input" do
+      expect(described_class.parse_components(nil)).to be_nil
+      expect(described_class.parse_components(123)).to be_nil
+      expect(described_class.parse_components([])).to be_nil
+    end
+
+    it "returns nil for string with only underscore" do
+      result = described_class.parse_components("_")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil for string ending with underscore (no hashid)" do
+      result = described_class.parse_components("usr_")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil for string starting with underscore (no prefix)" do
+      result = described_class.parse_components("_abc123")
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe ".find_by_public_id" do
+    let(:user) { create(:user) }
+
+    it "returns record with valid public ID" do
+      result = described_class.find_by_public_id(user.public_id)
+
+      expect(result).to eq(user)
+    end
+
+    it "returns nil with invalid format" do
+      result = described_class.find_by_public_id("invalid")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil with unknown prefix" do
+      result = described_class.find_by_public_id("xyz_abc123")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil with non-existent record" do
+      result = described_class.find_by_public_id("usr_nonexistent999")
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe "auto-configuration" do
+    it "sets prefix from MODELS registry when model is loaded" do
+      # Verify that models have their prefix set automatically
+      described_class.models.each do |prefix, model_class|
+        expect(model_class.public_id_prefix).to eq(prefix.to_s),
+          "#{model_class.name} should have prefix '#{prefix}' auto-configured"
+      end
+    end
+  end
+
+  describe "ClassMethods" do
+    let(:user) { create(:user) }
+
+    describe ".find_by_public_id" do
+      it "finds record by its own public ID" do
+        result = User.find_by_public_id(user.public_id)
+
+        expect(result).to eq(user)
+      end
+
+      it "returns nil when prefix doesn't match model" do
+        # Try to find a user with an org prefix
+        result = User.find_by_public_id("org_abc123")
+
+        expect(result).to be_nil
+      end
+
+      it "returns nil for invalid format" do
+        result = User.find_by_public_id("invalid")
+
+        expect(result).to be_nil
+      end
+    end
+
+    describe ".find_by_public_id!" do
+      it "finds record by its public ID" do
+        result = User.find_by_public_id!(user.public_id)
+
+        expect(result).to eq(user)
+      end
+
+      it "raises ActiveRecord::RecordNotFound when record not found" do
+        expect {
+          User.find_by_public_id!("usr_nonexistent999")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises ActiveRecord::RecordNotFound for invalid format" do
+        expect {
+          User.find_by_public_id!("invalid")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe ".get_public_id_prefix" do
+      it "returns the configured prefix" do
+        expect(User.get_public_id_prefix).to eq("usr")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

As we use Public IDs more and more, including in Intercom, it will become more common for Ops to need to look up these user ids. It's also useful for engineers, too, so we don't need to open the Rails console if we want to convert a public ID to a numeric ID, such as for use in a blazer query

## Describe your changes

Add a Public ID look-up page. Adds better tests for PublicIdentifiable