### PR TITLE
[v4 API] Block locked users

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -38,6 +38,10 @@ module Api
         end
 
         @current_user = current_token&.user
+
+        if @current_user&.locked?
+          return render json: { error: "user_locked" }, status: :forbidden
+        end
       end
 
       def require_admin!


### PR DESCRIPTION
Right now, if you have an active API token and your account gets locked - #12908 blocks new authorizations, but still allows existing tokens to function (because tokens aren't tied to the sessions that get destroyed).
This fixes that by erroring if the user is locked when we authorize against the token.