### PR TITLE
Fix ApplicationHelper rescue return value bug and remove FeeRevenue d…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -283,8 +283,10 @@ module ApplicationHelper
       record.stripe_obj
     rescue Stripe::InvalidRequestError
       Rails.logger.warn "Can't access stripe object, skipping"
+      nil
     rescue NoMethodError
       Rails.logger.warn "Not a stripe object, skipping"
+      nil
     end
 
     if stripe_obj.nil?

--- a/app/models/fee_revenue.rb
+++ b/app/models/fee_revenue.rb
@@ -38,14 +38,6 @@ class FeeRevenue < ApplicationRecord
     end
   end
 
-  def hcb_code
-    "HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::FEE_REVENUE_CODE}-#{id}"
-  end
-
-  def local_hcb_code
-    @local_hcb_code ||= HcbCode.find_or_create_by(hcb_code:)
-  end
-
   def canonical_transaction
     @canonical_transaction ||= CanonicalTransaction.find_by(hcb_code:)
   end


### PR DESCRIPTION
…uplicate methods

Rails.logger.warn returns true (not nil like puts), which broke the stripe_obj.nil? conditional in admin_inspectable_attributes. Added explicit nil returns in rescue blocks to preserve original behavior.

Also removed duplicate hcb_code/local_hcb_code methods from FeeRevenue that were left behind when the HasHcbCode concern was added.

https://claude.ai/code/session_01Rv5ip1L63WT7oKyBu47ycL

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

