### PR TITLE
[Code Quality] Use `Rails.logger` instead of `puts`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -282,9 +282,11 @@ module ApplicationHelper
     stripe_obj = begin
       record.stripe_obj
     rescue Stripe::InvalidRequestError
-      puts "Can't access stripe object, skipping"
+      Rails.logger.warn "Can't access stripe object, skipping"
+      nil
     rescue NoMethodError
-      puts "Not a stripe object, skipping"
+      Rails.logger.warn "Not a stripe object, skipping"
+      nil
     end
 
     if stripe_obj.nil?

--- a/app/jobs/topup_stripe_job.rb
+++ b/app/jobs/topup_stripe_job.rb
@@ -78,7 +78,7 @@ class TopupStripeJob < ApplicationJob
     StatsD.gauge("stripe_issuing_available_issuing_balance", available, sample_rate: 1.0)
     StatsD.gauge("stripe_issuing_pending_issuing_balance", pending, sample_rate: 1.0)
 
-    puts "topup amount == #{topup_amount}"
+    Rails.logger.info "topup amount == #{topup_amount}"
     return unless topup_amount >= 5_000 * 100
 
     # The maximum amount for a single top-up is $300k
@@ -92,7 +92,7 @@ class TopupStripeJob < ApplicationJob
       statement_descriptor: "Stripe Top-up"
     )
 
-    puts "Just created a topup for #{limited_topup_amount}"
+    Rails.logger.info "Just created a topup for #{limited_topup_amount}"
 
     StatsD.increment("stripe_issuing_topup", limited_topup_amount)
   end

--- a/app/services/transaction_engine/nightly.rb
+++ b/app/services/transaction_engine/nightly.rb
@@ -35,7 +35,7 @@ module TransactionEngine
     def import_raw_plaid_transactions!
       BankAccount.syncing_v2.pluck(:id).each do |bank_account_id|
         Rails.error.handle do
-          puts "raw_plaid_transactions: #{bank_account_id}"
+          Rails.logger.info "raw_plaid_transactions: #{bank_account_id}"
 
           ::TransactionEngine::RawPlaidTransactionService::Plaid::Import.new(bank_account_id:, start_date: @start_date).run
         end


### PR DESCRIPTION
Improve code quality by using rails logger instead of puts in jobs and helpers