### PR TITLE
`User::PayoutMethod::Wire` Add `recipient_name` field

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -470,6 +470,7 @@ class UsersController < ApplicationController
             :address_state,
             :address_postal_code,
             :recipient_country,
+            :recipient_name,
             :bic_code,
             :account_number
           ] + Wire.recipient_information_accessors

--- a/app/models/user/payout_method/wire.rb
+++ b/app/models/user/payout_method/wire.rb
@@ -16,6 +16,7 @@
 #  bic_code_ciphertext       :string           not null
 #  recipient_country         :integer
 #  recipient_information     :jsonb
+#  recipient_name            :string
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #

--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -23,7 +23,7 @@ module Reimbursement
                   address_postal_code: payout_holding.report.user.payout_method.address_postal_code,
                   recipient_country: payout_holding.report.user.payout_method.recipient_country,
                   recipient_email: payout_holding.report.user.email,
-                  recipient_name: payout_holding.report.user.full_name,
+                  recipient_name: payout_holding.report.user.payout_method.recipient_name.presence || payout_holding.report.user.full_name,
                   account_number: payout_holding.report.user.payout_method.account_number,
                   bic_code: payout_holding.report.user.payout_method.bic_code,
                   recipient_information: payout_holding.report.user.payout_method.recipient_information.merge({

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -93,6 +93,14 @@
 
       <%= render partial: "wires/recipient_details", locals: { form:, disabled: false, required: false } %>
 
+      <div class="field">
+        <%= form.label :recipient_name, "Name on account" %>
+        <%= form.text_field :recipient_name,
+            required: false,
+            placeholder: user.full_name %>
+        <span class="muted">If the name on the bank account differs from your legal name on HCB.</span>
+      </div>
+
       <%= render partial: "wires/account_details", locals: { form:, disabled: false, required: false, account_number_field_name: :account_number } %>
 
       <%= render partial: "wires/country_specific_details", locals: { form:, disabled: false, required: false, excluded_fields: ["remittance_info", "purpose_code"] } %>

--- a/db/migrate/20260209232615_add_recipient_name_to_user_payout_method_wires.rb
+++ b/db/migrate/20260209232615_add_recipient_name_to_user_payout_method_wires.rb
@@ -1,0 +1,5 @@
+class AddRecipientNameToUserPayoutMethodWires < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_payout_method_wires, :recipient_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_04_200446) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_09_232615) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2536,6 +2536,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_04_200446) do
     t.datetime "created_at", null: false
     t.integer "recipient_country"
     t.jsonb "recipient_information"
+    t.string "recipient_name"
     t.datetime "updated_at", null: false
   end
 


### PR DESCRIPTION
## Summary of the problem

Sometimes, people request a reimbursement, but want to send it to a bank account that's not in their name. For example, it may be under a parent's name.

At the moment, we always use the User's `full_name` for these reimbursement wire which can cause issues.

## Describe your changes

Add a `recipient_name` field