### PR TITLE
[Policy] Use `OrganizerPosition#role_at_least?` universally

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -193,7 +193,7 @@ class Invoice < ApplicationRecord
   before_create :set_defaults
 
   after_create_commit -> {
-    unless OrganizerPosition.find_by(user: creator, event: event)&.manager?
+    unless OrganizerPosition.role_at_least?(creator, event, :manager)
       InvoiceMailer.with(invoice: self).notify_organizers_sent.deliver_later
     end
   }

--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -53,7 +53,7 @@ class AchTransferPolicy < ApplicationPolicy
   end
 
   def admin_or_user?
-    user&.admin? || record.event.users.include?(user)
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def admin_or_manager?

--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -57,7 +57,7 @@ class AchTransferPolicy < ApplicationPolicy
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def is_public?

--- a/app/policies/announcement/block_policy.rb
+++ b/app/policies/announcement/block_policy.rb
@@ -33,7 +33,7 @@ class Announcement
     end
 
     def manager?
-      OrganizerPosition.find_by(user:, event: record.event)&.manager?
+      OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
   end

--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -42,7 +42,7 @@ class AnnouncementPolicy < ApplicationPolicy
   end
 
   def manager?
-    OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def reader?

--- a/app/policies/api/event_policy.rb
+++ b/app/policies/api/event_policy.rb
@@ -71,7 +71,7 @@ module Api
     end
 
     def user?
-      record.users.include?(user)
+      OrganizerPosition.role_at_least?(user, record, :reader)
     end
 
     def is_not_demo_mode?

--- a/app/policies/card_grant/pre_authorization_policy.rb
+++ b/app/policies/card_grant/pre_authorization_policy.rb
@@ -25,7 +25,7 @@ class CardGrant
     private
 
     def user_in_event?
-      record.event.users.include?(user)
+      OrganizerPosition.role_at_least?(user, record.event, :reader)
     end
 
     def manager_in_event?

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -46,7 +46,7 @@ class CheckDepositPolicy < ApplicationPolicy
   end
 
   def auditor_or_manager?
-    auditor? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def user_who_can_transfer?

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -34,7 +34,7 @@ class CheckDepositPolicy < ApplicationPolicy
   end
 
   def user?
-    record.event.users.include?(user)
+    OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def check_deposits_enabled?

--- a/app/policies/column/account_number_policy.rb
+++ b/app/policies/column/account_number_policy.rb
@@ -13,7 +13,7 @@ module Column
     private
 
     def admin_or_manager?
-      user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+      user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
   end

--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -65,7 +65,7 @@ class DisbursementPolicy < ApplicationPolicy
   private
 
   def auditor_or_user?
-    user&.auditor? || record.event.users.include?(user)
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -39,11 +39,11 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   def fiscal_sponsorship_letter?
-    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (record.users.include?(user) || user.auditor?)
+    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || user.auditor?)
   end
 
   def verification_letter?
-    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (record.users.include?(user) || user.auditor?) && record.account_number.present?
+    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || user.auditor?) && record.account_number.present?
   end
 
   def toggle_archive?

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -35,7 +35,7 @@ class DocumentPolicy < ApplicationPolicy
   end
 
   def download?
-    user.auditor? || record.event.nil? || record.event.users.include?(user)
+    user.auditor? || record.event.nil? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def fiscal_sponsorship_letter?

--- a/app/policies/donation_policy.rb
+++ b/app/policies/donation_policy.rb
@@ -2,11 +2,11 @@
 
 class DonationPolicy < ApplicationPolicy
   def show?
-    record.event.users.include?(user) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
   end
 
   def create?
-    record.event.users.include?(user) || user&.admin?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.admin?
   end
 
   def start_donation?
@@ -22,11 +22,11 @@ class DonationPolicy < ApplicationPolicy
   end
 
   def export?
-    record.event.users.include?(user) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
   end
 
   def export_donors?
-    record.event.users.include?(user) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
   end
 
   def update?

--- a/app/policies/donation_policy.rb
+++ b/app/policies/donation_policy.rb
@@ -30,7 +30,7 @@ class DonationPolicy < ApplicationPolicy
   end
 
   def update?
-    OrganizerPosition.find_by(user:, event: record.event)&.manager? || user&.admin?
+    OrganizerPosition.role_at_least?(user, record.event, :manager) || user&.admin?
   end
 
   def refund?

--- a/app/policies/emburse_card_policy.rb
+++ b/app/policies/emburse_card_policy.rb
@@ -6,7 +6,7 @@ class EmburseCardPolicy < ApplicationPolicy
   end
 
   def show?
-    record.event.users.include?(user) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
   end
 
 end

--- a/app/policies/emburse_transaction_policy.rb
+++ b/app/policies/emburse_transaction_policy.rb
@@ -6,7 +6,7 @@ class EmburseTransactionPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || record.event.users.include?(user)
+    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def edit?

--- a/app/policies/employee/payment_policy.rb
+++ b/app/policies/employee/payment_policy.rb
@@ -29,7 +29,7 @@ class Employee
     end
 
     def manager
-      OrganizerPosition.find_by(user:, event: record.employee.event)&.manager?
+      OrganizerPosition.role_at_least?(user, record.employee.event, :manager)
     end
 
     def employee

--- a/app/policies/employee_policy.rb
+++ b/app/policies/employee_policy.rb
@@ -36,7 +36,7 @@ class EmployeePolicy < ApplicationPolicy
   end
 
   def manager
-    OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def team_member

--- a/app/policies/employee_policy.rb
+++ b/app/policies/employee_policy.rb
@@ -40,7 +40,7 @@ class EmployeePolicy < ApplicationPolicy
   end
 
   def team_member
-    record.event.users.include?(user)
+    OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def employee

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -220,7 +220,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def receive_grant?
-    record.users.include?(user)
+    OrganizerPosition.role_at_least?(user, record, :reader)
   end
 
   def audit_log?

--- a/app/policies/g_suite_account_policy.rb
+++ b/app/policies/g_suite_account_policy.rb
@@ -10,7 +10,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
   end
 
   def show?
-    user.auditor? || (record.event.users.include?(user) && !record.g_suite.revocation.present?)
+    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.g_suite.revocation.present?)
   end
 
   def reset_password?

--- a/app/policies/g_suite_account_policy.rb
+++ b/app/policies/g_suite_account_policy.rb
@@ -43,7 +43,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
     return true if user&.admin?
 
     revocation = record.is_a?(GSuite) ? record.revocation : record&.g_suite&.revocation
-    OrganizerPosition.find_by(user:, event: record.event)&.manager? && !revocation&.revoked?
+    OrganizerPosition.role_at_least?(user, record.event, :manager) && !revocation&.revoked?
   end
 
 end

--- a/app/policies/g_suite_alias_policy.rb
+++ b/app/policies/g_suite_alias_policy.rb
@@ -12,7 +12,7 @@ class GSuiteAliasPolicy < ApplicationPolicy
   private
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record.g_suite.event)&.manager?
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.g_suite.event, :manager)
   end
 
 end

--- a/app/policies/g_suite_policy.rb
+++ b/app/policies/g_suite_policy.rb
@@ -10,7 +10,7 @@ class GSuitePolicy < ApplicationPolicy
   end
 
   def show?
-    user.auditor? || (record.event.users.include?(user) && !record.revocation.present?)
+    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
   end
 
   def edit?
@@ -26,7 +26,7 @@ class GSuitePolicy < ApplicationPolicy
   end
 
   def status?
-    user.auditor? || (record.event.users.include?(user) && !record.revocation.present?)
+    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
   end
 
 end

--- a/app/policies/increase_check_policy.rb
+++ b/app/policies/increase_check_policy.rb
@@ -20,7 +20,7 @@ class IncreaseCheckPolicy < ApplicationPolicy
   private
 
   def admin_or_user?
-    user&.admin? || record.event.users.include?(user)
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def user_who_can_transfer?

--- a/app/policies/organizer_position/spending/control/allowance_policy.rb
+++ b/app/policies/organizer_position/spending/control/allowance_policy.rb
@@ -10,7 +10,7 @@ class OrganizerPosition
 
         def create?
           user.admin? ||
-            OrganizerPosition.find_by(user:, event: record.event)&.manager?
+            OrganizerPosition.role_at_least?(user, record.event, :manager)
         end
 
       end

--- a/app/policies/organizer_position/spending/control_policy.rb
+++ b/app/policies/organizer_position/spending/control_policy.rb
@@ -26,7 +26,7 @@ class OrganizerPosition
       private
 
       def current_user_manager?
-        OrganizerPosition.find_by(user:, event: record.organizer_position.event)&.manager?
+        OrganizerPosition.role_at_least?(user, record.organizer_position.event, :manager)
       end
 
       def own_control?

--- a/app/policies/organizer_position_deletion_request_policy.rb
+++ b/app/policies/organizer_position_deletion_request_policy.rb
@@ -37,7 +37,7 @@ class OrganizerPositionDeletionRequestPolicy < ApplicationPolicy
   end
 
   def current_user_is_manager?
-    OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def current_user_is_the_user?

--- a/app/policies/organizer_position_deletion_request_policy.rb
+++ b/app/policies/organizer_position_deletion_request_policy.rb
@@ -33,7 +33,7 @@ class OrganizerPositionDeletionRequestPolicy < ApplicationPolicy
   private
 
   def user_in_event?
-    record.event.users.include? user
+    OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def current_user_is_manager?

--- a/app/policies/organizer_position_invite/link_policy.rb
+++ b/app/policies/organizer_position_invite/link_policy.rb
@@ -29,7 +29,7 @@ class OrganizerPositionInvite
     end
 
     def manager?
-      OrganizerPosition.find_by(user:, event: record.event)&.manager?
+      OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
     def admin_or_manager?

--- a/app/policies/organizer_position_invite/request_policy.rb
+++ b/app/policies/organizer_position_invite/request_policy.rb
@@ -21,7 +21,7 @@ class OrganizerPositionInvite
     end
 
     def manager?
-      OrganizerPosition.find_by(user:, event: record.link.event)&.manager?
+      OrganizerPosition.role_at_least?(user, record.link.event, :manager)
     end
 
     def admin_or_manager?

--- a/app/policies/organizer_position_invite_policy.rb
+++ b/app/policies/organizer_position_invite_policy.rb
@@ -48,7 +48,7 @@ class OrganizerPositionInvitePolicy < ApplicationPolicy
   private
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
 end

--- a/app/policies/organizer_position_policy.rb
+++ b/app/policies/organizer_position_policy.rb
@@ -33,7 +33,7 @@ class OrganizerPositionPolicy < ApplicationPolicy
 
   def admin_or_manager?
     user&.admin? ||
-      OrganizerPosition.find_by(user:, event: record.event)&.manager? # This is not just `record`!
+      OrganizerPosition.role_at_least?(user, record.event, :manager) # This is not just `record`!
   end
 
   def admin_or_contract_signee?

--- a/app/policies/reimbursement/expense_policy.rb
+++ b/app/policies/reimbursement/expense_policy.rb
@@ -39,7 +39,7 @@ module Reimbursement
     end
 
     def manager
-      record.event && OrganizerPosition.find_by(user:, event: record.event)&.manager?
+      record.event && OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
     def team_member

--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -89,7 +89,7 @@ module Reimbursement
     end
 
     def manager
-      record.event && OrganizerPosition.find_by(user:, event: record.event)&.manager?
+      record.event && OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
     def team_member

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -69,7 +69,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.manager?
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def grantee?

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -32,7 +32,7 @@ class WirePolicy < ApplicationPolicy
   private
 
   def admin_or_user?
-    user&.admin? || record.event.users.include?(user)
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def user_who_can_transfer?

--- a/app/policies/wise_transfer_policy.rb
+++ b/app/policies/wise_transfer_policy.rb
@@ -36,7 +36,7 @@ class WiseTransferPolicy < ApplicationPolicy
   private
 
   def admin_or_user?
-    user&.admin? || record.event.users.include?(user)
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def user_who_can_transfer?

--- a/app/views/public_activity/reimbursement_report/_review_requested.html.erb
+++ b/app/views/public_activity/reimbursement_report/_review_requested.html.erb
@@ -1,7 +1,7 @@
 <% current_user ||= local_assigns[:p][:current_user] %>
 
 <% if activity.trackable.present? %>
-  <% if activity.owner != current_user && OrganizerPosition.find_by(user: current_user, event: activity.trackable.event)&.manager? && (activity.trackable.reviewer.nil? || activity.trackable.reviewer == current_user) %>
+  <% if activity.owner != current_user && OrganizerPosition.role_at_least?(current_user, activity.trackable.event, :manager) && (activity.trackable.reviewer.nil? || activity.trackable.reviewer == current_user) %>
     <%= render layout: "/public_activity/common", locals: { activity:, current_user:, url: reimbursement_report_path(activity.trackable) } do %>
       requested your review on <i><%= link_to activity.trackable.name, activity.trackable %></i> on <%= link_to activity.trackable.event.name, activity.trackable.event %>
     <% end %>

--- a/app/views/reimbursement/expenses/_expense.html.erb
+++ b/app/views/reimbursement/expenses/_expense.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (expense:, new: false) -%>
-<% read_only = !OrganizerPosition.find_by(user: current_user, event: expense.report.event)&.manager? && current_user != expense.report.user && !admin_signed_in? %>
+<% read_only = !OrganizerPosition.role_at_least?(current_user, expense.report.event, :manager) && current_user != expense.report.user && !admin_signed_in? %>
 <%= turbo_frame_tag expense do %>
   <div
     data-controller="expense-form"

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -1,4 +1,4 @@
-<% member_viewing = !OrganizerPosition.find_by(user: current_user, event: report.event)&.manager? && current_user != report.user && !admin_signed_in? %>
+<% member_viewing = !OrganizerPosition.role_at_least?(current_user, report.event, :manager) && current_user != report.user && !admin_signed_in? %>
 
 <div class="flex flex-col-reverse" id="action-wrapper">
   <%# Using a reverse column flex container, we can


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
`OrganizerPosition#find_by` and `record.users.include?` do not account for sub-organizations properly.
closes #12933

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

