### PR TITLE
Fix application relation to contract

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -71,7 +71,7 @@ class Event
     belongs_to :event, optional: true
 
     has_many :affiliations, as: :affiliable
-    has_one :contract, ->{ where.not(aasm_state: :voided) }, inverse_of: :contractable
+    has_one :contract, ->{ where.not(aasm_state: :voided) }, inverse_of: :contractable, as: :contractable
 
     validate :cosigner_cannot_change_after_sign
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We changed applications to use a `has_one` relation to the contract, but didn't add the `as` option, which is required for polymorphic associations! This is why we were getting https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2715 - Rails was linking a contract that belonged to an `OrganizerPositionInvite` to the application 😬

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add `as: :contractable` to the `has_one` relation

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

