### PR TITLE
Disable HCB's contract email for teen-led applications

### DIFF
--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -30,5 +30,10 @@ module Contractable
       # This method can be overwritten in specific classes to set the path that contract-related routes should redirect to
       "/"
     end
+
+    def contract_notify_hcb?
+      # This method can be overwritten in specific classes to disable sending HCB's notification when all other parties have signed
+      true
+    end
   end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -150,7 +150,7 @@ class Contract < ApplicationRecord
   def on_party_signed(party)
     if parties.all?(&:signed?)
       mark_signed!
-    elsif parties.not_hcb.all?(&:signed?)
+    elsif parties.not_hcb.all?(&:signed?) && contractable.contract_notify_hcb?
       party(:hcb).notify
     end
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -226,7 +226,7 @@ class Event
     end
 
     def contract_notify_hcb?
-      false
+      !teen_led?
     end
 
     def create_contract

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -225,6 +225,10 @@ class Event
       Rails.application.routes.url_helpers.application_path(self)
     end
 
+    def contract_notify_hcb?
+      false
+    end
+
     def create_contract
       if name.nil? || description.nil?
         raise StandardError.new("Cannot create a contract for application #{hashid}: missing name and/or description")


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
HCB's currently getting spammed with contract notification emails, since teens/cosigners sign the contract when they submit their application. For teen-led applications, HCB doesn't need these emails since they'll go through the normal application review flow and sign the contract then. However, this email is still needed for adult applications, since they'll sign after HCB approves them.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a `contract_notify_hcb?` method used by `Contract` to `Contractable` that defaults to true and is set to `false` when implemented by a teen-led application.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

