### PR TITLE
Add option to freeze cards when locking users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -290,7 +290,8 @@ class UsersController < ApplicationController
           flash[:error] = "To lock this user, demote them to a regular admin first."
           return redirect_to admin_user_path(@user)
         elsif locked
-          @user.lock!
+          freeze_cards = params[:user][:freeze_cards] == "1"
+          @user.lock!(freeze_cards: freeze_cards)
         else
           @user.unlock!
         end

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -56,6 +56,7 @@ module StripeAuthorizationService
 
       def approve?
         return decline_with_reason!("event_frozen") if event.financially_frozen?
+        return decline_with_reason!("user_locked") if card.user&.locked?
 
         if forbidden_merchant_category? && !card.user&.admin?
           AdminMailer

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -18,7 +18,8 @@
             <%= {
                   merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
                   cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
-                  user_cards_locked: "by HCB because you have too many missing receipts"
+                  user_cards_locked: "by HCB because you have too many missing receipts",
+                  user_locked: "by HCB because your account has been locked"
                 }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
         <% else %>
             <span>
@@ -42,6 +43,7 @@
                   merchant_not_allowed: "Merchant not allowed",
                   cash_withdrawals_not_allowed: "Cash withdrawals disabled",
                   user_cards_locked: "Card locked due to missing receipts",
+                  user_locked: "Account locked",
                 }[hcb_decline_reason] || "Insufficient funds" %>
         <% else %>
             <%= {
@@ -77,6 +79,8 @@
             Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.
         <% elsif hcb_decline_reason == :user_cards_locked %>
             You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>. If you have 10 or more missing receipts, your cards will be locked until you submit them.
+        <% elsif hcb_decline_reason == :user_locked %>
+            Your account has been locked by an administrator. Please contact HCB support at <%= mail_to "hcb@hackclub.com" %>.
         <% elsif stripe_decline_reason == :authorization_controls %>
             This transaction exceeded daily limits set by our card issuer. Please try again later, or use a different card for this transaction.
         <% elsif stripe_decline_reason == :webhook_timeout %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -39,7 +39,7 @@
             <%= form.check_box :locked, checked: @user.locked?, disabled: !admin_signed_in?, id: "user_locked" %>
           </div>
 
-          <div class="field field--checkbox" id="freeze-cards-field" style="<%= 'display:none;' if @user.locked? %>">
+          <div class="field field--checkbox" id="freeze-cards-field" style="<%= "display:none;" if @user.locked? %>">
             <%= form.label :freeze_cards, "Also freeze all of this user's active cards" %>
             <%= form.check_box :freeze_cards, checked: true %>
             <% active_card_count = @user.stripe_cards.active.count %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -36,8 +36,31 @@
 
           <div class="field field--checkbox">
             <%= form.label :locked, "Lock user from signing into HCB" %>
-            <%= form.check_box :locked, checked: @user.locked?, disabled: !admin_signed_in? %>
+            <%= form.check_box :locked, checked: @user.locked?, disabled: !admin_signed_in?, id: "user_locked" %>
           </div>
+
+          <div class="field field--checkbox" id="freeze-cards-field" style="<%= 'display:none;' if @user.locked? %>">
+            <%= form.label :freeze_cards, "Also freeze all of this user's active cards" %>
+            <%= form.check_box :freeze_cards, checked: true %>
+            <% active_card_count = @user.stripe_cards.active.count %>
+            <% if active_card_count > 0 %>
+              <small class="muted"><%= active_card_count %> active card(s) will be frozen</small>
+            <% else %>
+              <small class="muted">This user has no active cards</small>
+            <% end %>
+          </div>
+
+          <script>
+            document.addEventListener("DOMContentLoaded", function() {
+              var lockCheckbox = document.getElementById("user_locked");
+              var freezeField = document.getElementById("freeze-cards-field");
+              if (lockCheckbox && freezeField) {
+                lockCheckbox.addEventListener("change", function() {
+                  freezeField.style.display = this.checked ? "" : "none";
+                });
+              }
+            });
+          </script>
 
           <div class="field field--checkbox">
             <%= form.label :running_balance_enabled, "Show running balance?" %>

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -195,16 +195,6 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
     end
   end
 
-  context "locked user" do
-    it "declines with user_locked reason" do
-      create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
-      stripe_card.user.update!(locked_at: Time.now)
-
-      expect(service.run).to be(false)
-      expect(service.declined_reason).to eq("user_locked")
-    end
-  end
-
   context "withdrawals" do
     let(:stripe_authorization) do
       build(

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -195,6 +195,16 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
     end
   end
 
+  context "locked user" do
+    it "declines with user_locked reason" do
+      create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+      stripe_card.user.update!(locked_at: Time.now)
+
+      expect(service.run).to be(false)
+      expect(service.declined_reason).to eq("user_locked")
+    end
+  end
+
   context "withdrawals" do
     let(:stripe_authorization) do
       build(


### PR DESCRIPTION
This PR introduces a new feature that allows admins to optionally freeze all of a user's active Stripe cards when locking their account. It also ensures that transactions are declined if the user is locked, and updates the UI and user-facing messages to reflect the new "user locked" state. 

Closes #12880 