### PR TITLE
Fix error in subject of HCB's contract party notify email

### DIFF
--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -85,7 +85,7 @@ class Contract
 
     def notify_email_subject
       if hcb?
-        "Sign the #{contract.event_name}'s agreement as HCB Operations"
+        "Sign #{contract.event_name}'s agreement as HCB Operations"
       elsif cosigner?
         "#{contract.party(:signee).user.name} invited you to sign a fiscal sponsorship agreement for #{contract.event_name} on HCB 📝"
       else


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
I don't know how I missed this... "Sign the Expensicon's agreement" definitely doesn't sound right

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
remove "the"

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

