### PR TITLE
Allow admins to set event tags and risk level when activating an application

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -74,8 +74,13 @@ textarea {
   }
 }
 
-[data-dark='true'] option {
+[data-dark='true'] select:not([multiple]) option {
   background-color: $darkless;
+}
+
+[data-dark='true'] select[multiple] option:checked,
+[data-dark='true'] select[multiple] option::selection {
+  background-color: map-get($palette, info);
 }
 
 select {

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -124,7 +124,7 @@ class Event
     def admin_activate
       authorize @application
 
-      @application.activate_event!
+      @application.activate_event!(tags: params[:tags])
 
       redirect_to event_path(@application.event), flash: { success: "Successfully activated #{@application.event.name}!" }
     end

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -124,7 +124,7 @@ class Event
     def admin_activate
       authorize @application
 
-      @application.activate_event!(tags: params[:tags])
+      @application.activate_event!(tags: params[:tags], risk_level: params[:risk_level])
 
       redirect_to event_path(@application.event), flash: { success: "Successfully activated #{@application.event.name}!" }
     end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -297,7 +297,7 @@ class Event
       update!(last_viewed_at: Time.current, last_page_viewed:)
     end
 
-    def activate_event!(tags: [])
+    def activate_event!(risk_level:, tags: [])
       raise "Contract must be signed before activation" unless contract.signed?
 
       poc = contract.party(:hcb).user
@@ -307,7 +307,8 @@ class Event
         country: address_country,
         point_of_contact_id: poc.id,
         application: self,
-        event_tags: tags.filter { |tag| EventTag::Tags::ALL.include?(tag) }.map { |tag| EventTag.find_or_create_by!(name: tag) }
+        event_tags: tags.filter { |tag| EventTag::Tags::ALL.include?(tag) }.map { |tag| EventTag.find_or_create_by!(name: tag) },
+        risk_level:
       )
 
       service = OrganizerPositionInviteService::Create.new(event:, sender: poc, user_email: user.email, is_signee: true, role: :manager, initial: true)

--- a/app/views/contract/parties/show.html.erb
+++ b/app/views/contract/parties/show.html.erb
@@ -2,24 +2,31 @@
 
 <script src="https://cdn.docuseal.com/js/form.js"></script>
 
-<h2>Sign your HCB agreement</h2>
-
-<% admin_tool do %>
-  <div class="flex flex-row gap-3 items-center justify-start">
-    <% if @contract.contractable.is_a?(Event::Application) %>
-      <%= link_to "Go to associated application (#{@contract.contractable.id})", application_path(@contract.contractable), class: "btn" %>
-    <% end %>
-  </div>
-<% end %>
+<h2><%= @party.hcb? ? "Sign #{@contract.event_name}'s agreement as HCB Operations" : "Sign your HCB agreement" %></h2>
 
 <div class="grid md:grid-cols-5 gap-5" data-controller="contract" data-contract-advance-path-value="<%= completed_contract_party_path(@party) unless @contract.contractable.is_a?(Event::Application) && @party.hcb? %>">
   <%= render partial: "contract/parties/docuseal_embed", locals: { party: @party, klass: "md:col-span-3" } %>
   <div class="md:col-span-2 max-h-[75vh]">
     <% if @contract.contractable.is_a?(Event::Application) && @party.hcb? %>
-      <p class="text-center">Sign the contract before activating the organization</p>
-      <%= button_to admin_activate_application_path(@contract.contractable), method: :post, class: "btn bg-success w-full", disabled: @party.pending?, data: { "contract-target": "button" } do %>
-        Activate
-      <% end %>
+      <div class="card">
+        <div class="flex flex-row gap-3 items-center justify-start mb-2">
+          <% if @contract.contractable.is_a?(Event::Application) %>
+            <%= link_to "Go to associated application (#{@contract.contractable.id})", application_path(@contract.contractable), class: "btn" %>
+          <% end %>
+        </div>
+        <%= form_with url: admin_activate_application_path(@contract.contractable), method: :post do |form| %>
+          <div class="field">
+            <%= form.label "Tags" %>
+            <%= form.select :tags, options_for_select(EventTag::Tags::ALL, selected: @contract.contractable.default_tags), multiple: true, size: EventTag::Tags::ALL.size %>
+          </div>
+
+          <% if @party.pending? %>
+            <p>Sign the contract before activating the organization</p>
+          <% end %>
+
+          <%= form.submit "Activate", class: "btn bg-success w-full", disabled: @party.pending?, data: { "contract-target": "button" } %>
+        <% end %>
+      </div>
     <% else %>
       <%= render partial: "contract_faq" %>
     <% end %>

--- a/app/views/contract/parties/show.html.erb
+++ b/app/views/contract/parties/show.html.erb
@@ -20,6 +20,11 @@
             <%= form.select :tags, options_for_select(EventTag::Tags::ALL, selected: @contract.contractable.default_tags), multiple: true, size: EventTag::Tags::ALL.size %>
           </div>
 
+          <div class="field">
+            <%= form.label :risk_level %>
+            <%= form.collection_select :risk_level, Event.risk_levels.map { |k, _v| [k.humanize.capitalize, k] }, :last, :first, { include_blank: "Select a risk level" }, { required: true } %>
+          </div>
+
           <% if @party.pending? %>
             <p>Sign the contract before activating the organization</p>
           <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Previously, when activating an application from Airtable, we automatically set the organized by teens and robotics team tags, but admins had to manually go set any others after activating. With the new applications flow, we are currently not setting any tags automatically.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a form to the HCB contract signing page for an application that has a multiple select menu to choose tags. Organized by teens is selected by default based on `teen_led`, and robotics team and hack club are selected by default based on affiliations.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="1058" height="928" alt="image" src="https://github.com/user-attachments/assets/ed5b38b7-93ae-4230-b05f-dab3945b0201" />
<img width="1058" height="928" alt="image" src="https://github.com/user-attachments/assets/f5770407-fd83-4a86-b605-da0255075832" />


