### PR TITLE
Fix application contracts uploaded as common docs

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -69,6 +69,7 @@ class Event
 
     belongs_to :user
     belongs_to :event, optional: true
+    belongs_to :contract_event, foreign_key: :event_id, class_name: "Event", inverse_of: :application, optional: true
 
     has_many :affiliations, as: :affiliable
     has_one :contract, ->{ where.not(aasm_state: :voided) }, inverse_of: :contractable, as: :contractable
@@ -308,6 +309,7 @@ class Event
         point_of_contact_id: poc.id,
         application: self
       )
+      contract.create_document!
 
       service = OrganizerPositionInviteService::Create.new(event:, sender: poc, user_email: user.email, is_signee: true, role: :manager, initial: true)
       invite = service.model


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Since an application contract does not have an associated event at the time it's signed, the callback was creating documents with a `nil` event, a.k.a. common docs visible to everybody.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Move uploading documents to the application activation method for application contracts.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

