### PR TITLE
Add link to associated event on application submission page

### DIFF
--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -8,7 +8,7 @@
       </span>
 
       <h2 class="text-4xl mt-2">
-        <%= current_user == @application.user ? "Your" : "#{@application.user.name}'s" %> application for <%= @application.name %>
+        <%= current_user == @application.user ? "Your" : "#{@application.user.name}'s" %> application for <%= @application.event.present? ? link_to(@application.name, @application.event) : @application.name %>
       </h2>
 
       <p class="m-0 text-lg muted">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The admin applications page links you to the application submission. From this page though, it's not clear how to get to the associated event.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a link on the application name in the heading to the associated event, if it exists.

<img width="823" height="171" alt="image" src="https://github.com/user-attachments/assets/79d342db-669f-4e9e-b277-9b950d058b2d" />
<img width="823" height="171" alt="image" src="https://github.com/user-attachments/assets/6a15130a-38dd-45e0-b263-87824789fb65" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

