### PR TITLE
Don't show "view pending contract" on invite once signee has signed

### DIFF
--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -36,7 +36,7 @@
         <%= link_to "View pending contract", @invite.contract.signee_docuseal_url, class: "btn bg-accent" %>
       <% end %>
     <% else %>
-      <% disabled = !@invite.contract.signed? %>
+      <% disabled = !@invite.contract&.signed? %>
       <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
     <% end %>
   </div>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -29,14 +29,15 @@
 
   <div class="flex justify-center items-center flex-wrap mt-3 gap-2">
     <%= link_to "Reject", organizer_position_invite_reject_path(@invite), method: :post, class: "btn bg-error" %>
-    <% if @invite.contract && !@invite.contract.signed? %>
+    <% if @invite.contract && !@invite.contract.party(:signee).signed? %>
       <% if @invite.contract.party(:signee).present? %>
         <%= link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent" %>
       <% else %>
         <%= link_to "View pending contract", @invite.contract.signee_docuseal_url, class: "btn bg-accent" %>
       <% end %>
     <% else %>
-      <%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success" %>
+      <% disabled = !@invite.contract.signed? %>
+      <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
     <% end %>
   </div>
 </main>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -36,7 +36,7 @@
         <%= link_to "View pending contract", @invite.contract.signee_docuseal_url, class: "btn bg-accent" %>
       <% end %>
     <% else %>
-      <% disabled = !@invite.contract&.signed? %>
+      <% disabled = @invite.contract.present? && !@invite.contract.signed? %>
       <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
     <% end %>
   </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
People were confused when there was a "view pending contract" button that simply redirects to the thank you page if you click on it after signing.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Show a disabled accept button instead of the view pending contract button if the signee has signed but the contract is not, with a tooltip.

<img width="1026" height="562" alt="image" src="https://github.com/user-attachments/assets/0d42d6f7-65ac-4661-9859-4f480f7e1fdb" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

