### PR TITLE
Sync HCB's signing status before application activation

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -299,6 +299,7 @@ class Event
     end
 
     def activate_event!
+      contract.party(:hcb).sync_with_docuseal
       raise "Contract must be signed before activation" unless contract.signed?
 
       poc = contract.party(:hcb).user


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Sometimes, DocuSeal might be a little slow when sending webhooks, and ops might try to activate before DocuSeal tells us the contract is signed. This throws an error when they try to activate.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Sync HCB's signing status before checking if it's signed

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

