### PR TITLE
Add user_id to AppSignal errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   before_action :attach_error_reference
+  before_action :attach_user_id
 
   # Ensure users are signed in. Create one-off exceptions to this on routes
   # that you want to be unauthenticated with skip_before_action.
@@ -141,6 +142,11 @@ class ApplicationController < ActionController::Base
   def attach_error_reference
     error_reference = ErrorReference.from_request_id(request.uuid)
     Appsignal.add_tags(error_reference:) if defined?(Appsignal) && Appsignal.active?
+  end
+
+  def attach_user_id
+    user_id = current_user&.id
+    Appsignal.add_tags(user_id:) if defined?(Appsignal) && Appsignal.active?
   end
 
 end


### PR DESCRIPTION
## Summary of the problem

We're being hit with some abuse, but this should make it easier to track down.


## Describe your changes

Start tracking error user ID in AppSignal