### PR TITLE
Fix tour

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -56,6 +56,8 @@ class EventsController < ApplicationController
     rescue Pundit::NotAuthorizedError
       return redirect_to root_path, flash: { error: "We couldn’t find that organization!" }
     end
+
+    render_tour @organizer_position, :welcome
   end
 
   def transaction_heatmap
@@ -144,8 +146,6 @@ class EventsController < ApplicationController
   end
 
   def transactions
-    render_tour @organizer_position, :welcome
-
     maybe_pending_invite = OrganizerPositionInvite.pending.find_by(user: current_user, event: @event)
 
     if maybe_pending_invite.present?

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -24,7 +24,8 @@
             tooltip: item[:tooltip],
             icon: item[:icon],
             async_badge: item[:async_badge],
-            selected: item[:selected] %>
+            selected: item[:selected],
+            data: item[:data] %>
       <% end %>
     <% end %>
     <%= render partial: "events/settings_dropdown" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
UI3 seems to have broken the tour for a couple reasons
- The tour starts on the transactions page instead of the home page, which is now the default
- We weren't properly passing through the `data` hash to the dock items, which tell the tour where to anchor the steps.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Move the tour rendering to the event home page and properly pass through the data hash.

The tour is still a little broken on mobile, since the cards can't align to the tab bar items like before UI3, but it still renders in the top.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

