### PR TITLE
Applications bug fixes and description word count for adults

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -233,7 +233,7 @@ class Event
     end
 
     def application_params
-      params.require(:event_application).permit(:name, :description, :political_description, :website_url, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country, :referrer, :referral_code, :accessibility_notes, :cosigner_email, :teen_led, :annual_budget, :committed_amount, :planning_duration, :team_size, :funding_source)
+      params.require(:event_application).permit(:name, :description, :political_description, :website_url, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country, :referrer, :referral_code, :accessibility_notes, :cosigner_email, :teen_led, :annual_budget, :committed_amount, :planning_duration, :team_size, :funding_source, :previously_applied)
     end
 
     def user_params

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -48,12 +48,14 @@ import Alpine from 'alpinejs'
 import ach_form from './datas/ach_form'
 import wire_form from './datas/wire_form'
 import check_form from './datas/check_form'
+import application_project_info_form from './datas/application_project_info_form'
 
 window.Alpine = Alpine
 Alpine.plugin(persist)
 Alpine.data('ach', ach_form)
 Alpine.data('wire', wire_form)
 Alpine.data('check', check_form)
+Alpine.data('application_project_info', application_project_info_form)
 
 Alpine.start()
 

--- a/app/javascript/datas/application_project_info_form.js
+++ b/app/javascript/datas/application_project_info_form.js
@@ -1,0 +1,37 @@
+export default ({
+  has_website,
+  has_political,
+  teenager,
+  committed,
+  description,
+}) => ({
+  has_website,
+  has_political,
+  teenager,
+  committed,
+  description,
+  description_word_count: 0,
+  init() {
+    this.$watch('description', this.setDescriptionWordCount)
+    this.$watch('description_word_count', this.setDescriptionValidity)
+
+    this.setDescriptionWordCount(description)
+    this.setDescriptionValidity(this.description_word_count)
+  },
+  setDescriptionWordCount(desc) {
+    this.description_word_count = desc.match(/\S+/g)?.length || 0
+  },
+  setDescriptionValidity(count) {
+    if (this.teenager === 'false') {
+      const descriptionElement = document.getElementById(
+        'event_application_description'
+      )
+
+      if (count < 50) {
+        descriptionElement.setCustomValidity('Please enter at least 50 words')
+      } else {
+        descriptionElement.setCustomValidity('')
+      }
+    }
+  },
+})

--- a/app/javascript/datas/application_project_info_form.js
+++ b/app/javascript/datas/application_project_info_form.js
@@ -12,8 +12,11 @@ export default ({
   description,
   description_word_count: 0,
   init() {
-    this.$watch('description', this.setDescriptionWordCount)
-    this.$watch('description_word_count', this.setDescriptionValidity)
+    this.$watch('description', this.setDescriptionWordCount.bind(this))
+    this.$watch(
+      'description_word_count',
+      this.setDescriptionValidity.bind(this)
+    )
 
     this.setDescriptionWordCount(description)
     this.setDescriptionValidity(this.description_word_count)

--- a/app/views/event/applications/personal_info.html.erb
+++ b/app/views/event/applications/personal_info.html.erb
@@ -15,7 +15,7 @@
 
 <%= form_with model: @application, url: application_path(@application), method: :patch, id: "edit_application_#{@application.id}", class: "mt-7", data: { action: "input->application-autosave#save", "application-autosave-target": "form" } do |form| %>
   <div class="card mb-6" x-data="{ minor: <%= @application.user.age&.<(18) || false %> }">
-    <div class="md:flex gap-2">
+    <div class="md:flex items-end gap-2">
       <div class="field flex-1">
         <%= form.label :full_name do %>
           Full name <span class="text-primary">*</span>
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="md:flex items-center gap-2">
+    <div class="md:flex items-end gap-2">
       <div class="field flex-1">
         <%= form.label :phone_number do %>
           Mobile phone number <span class="text-primary">*</span>

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -43,7 +43,7 @@
       </p>
       <%= form.text_area :description, class: "w-full max-w-full", required: true, "x-bind:disabled": "teenager == null", "x-model": "description" %>
       <% unless @application.teen_led? %>
-        <p class="text-sm muted mt-1 mb-2"><span x-text="description.match(/\S+/g)?.length || 0">0</span>/50 words</p>
+        <p class="text-sm muted mt-1 mb-2"><span x-text="description_word_count">0</span>/50 words</p>
       <% end %>
     </div>
 

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -16,8 +16,7 @@
 <%= form_with model: @application, url: application_path(@application), method: :patch, id: "edit_application_#{@application.id}", class: "mt-7", data: { action: "input->application-autosave#save", "application-autosave-target": "form" } do |form| %>
   <div
     class="card card--outline mb-6"
-    x-data="application_project_info({ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', teenager: '<%= @application.teen_led? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>', description: '<%= @application.description %>' })"
-  >
+    x-data="application_project_info({ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', teenager: '<%= @application.teen_led? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>', description: '<%= @application.description %>' })">
     <div class="field">
       <%= form.label :name do %>
         Project name <span class="text-primary">*</span>

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -32,7 +32,13 @@
         <% end %>
         <span class="text-primary">*</span>
       <% end %>
-      <p class="text-sm muted mt-1 mb-2">Are you running a hackathon, leading a robotics team, organizing a nonprofit, building a project, or something else? We want to know!</p>
+      <p class="text-sm muted mt-1 mb-2">
+        <% if @application.teen_led? %>
+          Are you running a hackathon, leading a robotics team, organizing a nonprofit, building a project, or something else? We want to know!
+        <% else %>
+          Please share some additional details about your project’s charitable mission, operations and reason for seeking fiscal sponsorship.
+        <% end %>
+      </p>
       <%= form.text_area :description, class: "w-full max-w-full", required: true, "x-bind:disabled": "teenager == null" %>
     </div>
 

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -14,8 +14,10 @@
 
 <div class=" mb-6">
 <%= form_with model: @application, url: application_path(@application), method: :patch, id: "edit_application_#{@application.id}", class: "mt-7", data: { action: "input->application-autosave#save", "application-autosave-target": "form" } do |form| %>
-  <div class="card card--outline mb-6" x-data="{ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', teenager: '<%= @application.teen_led? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>' }">
-
+  <div
+    class="card card--outline mb-6"
+    x-data="application_project_info({ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', teenager: '<%= @application.teen_led? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>', description: '<%= @application.description %>' })"
+  >
     <div class="field">
       <%= form.label :name do %>
         Project name <span class="text-primary">*</span>
@@ -36,10 +38,13 @@
         <% if @application.teen_led? %>
           Are you running a hackathon, leading a robotics team, organizing a nonprofit, building a project, or something else? We want to know!
         <% else %>
-          Please share some additional details about your project’s charitable mission, operations and reason for seeking fiscal sponsorship.
+          Please share some additional details about your project’s charitable mission, operations and reason for seeking fiscal sponsorship. (minimum 50 words)
         <% end %>
       </p>
-      <%= form.text_area :description, class: "w-full max-w-full", required: true, "x-bind:disabled": "teenager == null" %>
+      <%= form.text_area :description, class: "w-full max-w-full", required: true, "x-bind:disabled": "teenager == null", "x-model": "description" %>
+      <% unless @application.teen_led? %>
+        <p class="text-sm muted mt-1 mb-2"><span x-text="description.match(/\S+/g)?.length || 0">0</span>/50 words</p>
+      <% end %>
     </div>
 
     <div class="field">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Couple bugs:
- Alignment of half-width fields in personal info was off on small screen sizes
- `previously_applied` was not being saved as it was not in `application_params`

Also, adult applications need a word count on the project description

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Fix the small bugs and use a new Alpine data to implement a word count on the project description for adults.

<img width="637" height="273" alt="image" src="https://github.com/user-attachments/assets/a4266ce6-2016-42a2-82fd-0b152d074586" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

