### PR TITLE
Require database lock when updating contract AASM state

### DIFF
--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -12,8 +12,8 @@ class DocusealController < ActionController::Base
 
       if params[:event_type] == "form.completed"
         party = contract.parties.detect { |party| party.docuseal_role == params[:data][:role] }
-        if party.present? && !party.signed?
-          party.mark_signed!
+        if party.present?
+          party.mark_signed! unless party.signed?
         else
           Rails.error.unexpected("Unexpected docuseal party #{params[:data][:role]}")
         end

--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -12,7 +12,7 @@ class DocusealController < ActionController::Base
 
       if params[:event_type] == "form.completed"
         party = contract.parties.detect { |party| party.docuseal_role == params[:data][:role] }
-        if party.present?
+        if party.present? && !party.signed?
           party.mark_signed!
         else
           Rails.error.unexpected("Unexpected docuseal party #{params[:data][:role]}")

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -62,7 +62,7 @@ class Contract < ApplicationRecord
     parties.create!(user:, role: :hcb)
   end
 
-  aasm timestamps: true do
+  aasm timestamps: true, requires_lock: true do
     state :pending, initial: true
     state :sent
     state :signed


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
There's a small risk of a race condition where we end up running AASM callbacks for the contract being signed twice - once with `Contract::Party#sync_with_docuseal`, and another via the DocuSeal webhook.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Require locking when updating AASM state for contracts (https://github.com/aasm/aasm#pessimistic-locking)


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

