### PR TITLE
Void contract on application rejection

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -146,6 +146,8 @@ class Event
       event :mark_rejected do
         transitions from: [:submitted, :under_review], to: :rejected
         after do |rejection_message|
+          contract.mark_voided! if contract.present?
+
           if rejection_message.present?
             Event::ApplicationMailer.with(application: self, rejection_message: rejection_message).rejected.deliver_later
           end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Contracts would be left as sent when we reject - let's keep the data tidy

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Void the contract (if present, which would only be for teen-led applications) when we reject an application.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

