### PR TITLE
Add spacing below transactions table in account number view

### DIFF
--- a/app/views/events/account_number.html.erb
+++ b/app/views/events/account_number.html.erb
@@ -128,6 +128,7 @@
             </tbody>
           </table>
           <%= paginate @transactions %>
+          <div class="mb-4"></div>
         </div>
       <% end %>
     <% else %>


### PR DESCRIPTION
fixes this ugly bug

<img width="1289" height="175" alt="image" src="https://github.com/user-attachments/assets/7127de37-fed4-4a9a-932f-da34d06fe168" />
