### PR TITLE
[Ledger::Item] Wrap create in a `safely` block

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -162,7 +162,9 @@ class CanonicalPendingTransaction < ApplicationRecord
   belongs_to :ledger_item, optional: true, class_name: "Ledger::Item"
 
   after_create_commit unless: -> { ledger_item.present? } do
-    update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+    safely do
+      update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+    end
   end
 
   after_commit if: -> { ledger_item.present? } do

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -136,7 +136,9 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   after_create_commit unless: -> { ledger_item.present? } do
-    update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+    safely do
+      update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+    end
   end
 
   after_commit if: -> { ledger_item.present? } do


### PR DESCRIPTION
## Summary of the problem

We likely need to change these to a find or create since we're getting unique errors on `short_code`.


## Describe your changes

wrap creation in a `safely` block.