### PR TITLE
[Admin] Include `end_date` in Org Balances export filename

### DIFF
--- a/app/models/export/event/balances.rb
+++ b/app/models/export/event/balances.rb
@@ -32,7 +32,11 @@ class Export
       end
 
       def filename
-        "hcb_balances_#{Time.now.strftime("%Y%m%d%H%M")}.csv"
+        [
+          "hcb_balances",
+          end_date.present? ? "ending_#{end_date}" : nil,
+          "exported_#{Time.now.strftime("%Y-%m-%d_%H-%M")}.csv"
+        ].compact.join("_")
       end
 
       def mime_type


### PR DESCRIPTION
## Summary of the problem

Peter said he'll export multiple of these (with different end dates) at a time. It can get confusing since all the exports have similar filenames that don't include the end date.


## Describe your changes

Add the end date to the file name (if there is an end_date)