### PR TITLE
Fix contract association to organizer position

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -41,7 +41,7 @@ class Contract < ApplicationRecord
   belongs_to :document, optional: true
   belongs_to :contractable, polymorphic: true
 
-  has_one :organizer_position, required: false
+  has_one :organizer_position, required: false, foreign_key: :fiscal_sponsorship_contract_id, inverse_of: :fiscal_sponsorship_contract
   has_many :parties
 
   validate :one_non_void_contract


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Rails was trying to find a foreign key of `organizer_position_id`, but we named it `fiscal_sponsorship_contract_id` on `OrganizerPosition`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Set the correct foreign key and inverse relationship

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

