### PR TITLE
Remove duplicate CSS rule

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -165,15 +165,6 @@ input[type='submit'],
     }
   }
 
-  &.bg-warning {
-    background-color: map-get($palette, warning);
-    color: darken(map-get($palette, warning), 33.3%) !important;
-
-    html[data-dark='true'] & {
-      color: darken(map-get($palette, warning), 33.3%) !important;
-    }
-  }
-
   &.bg-light-warning {
     background-color: map-get($palette, white) !important;
     color: darken(map-get($palette, warning), 33.3%) !important;


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We accidentally duplicated this `bg-warning` rule in UI3!

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove the duplicate rule.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

