### PR TITLE
Prevent users from accessing application form after submitting

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -3,6 +3,7 @@
 class Event
   class ApplicationsController < ApplicationController
     before_action :set_application, except: [:apply, :new, :create, :index]
+    before_action :prevent_access_after_submission, only: [:project_info, :personal_info, :review]
     after_action :record_pageview
     skip_before_action :signed_in_user, only: [:new, :apply, :create]
     skip_after_action :verify_authorized, only: :create
@@ -243,6 +244,13 @@ class Event
     def record_pageview
       if Event::Application.last_page_vieweds.keys.include?(action_name.to_s) && @application.user == current_user
         @application&.record_pageview(action_name.to_s)
+      end
+    end
+
+    def prevent_access_after_submission
+      unless @application.draft? || current_user.auditor?
+        redirect_to application_path(@application)
+        return
       end
     end
 

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -250,7 +250,6 @@ class Event
     def prevent_access_after_submission
       unless @application.draft? || current_user.auditor?
         redirect_to application_path(@application)
-        return
       end
     end
 

--- a/app/views/event/applications/review.html.erb
+++ b/app/views/event/applications/review.html.erb
@@ -21,12 +21,10 @@
   <div class="flex flex-row gap-6 items-start justify-center">
     <%= link_to "← Back", personal_info_application_path(@application), class: "btn bg-muted" %>
   </div>
-
-  <% if @application.draft? %>
-    <%= button_to submit_application_path(@application), method: :post, class: "btn bg-blue #{"tooltipped !pointer-events-auto" unless @application.ready_to_submit?}", disabled: !@application.ready_to_submit?, "aria-label": "This application is not ready to submit" do %>
-      Submit application
-    <% end %>
-  <% else %>
-    <%= link_to "Submit application", application_path(@application), class: "btn bg-blue" %>
+  <%= form_with model: @application, url: application_path(@application), method: :patch, id: "edit_application_#{@application.id}" do |form| %>
+    <%= form.hidden_field :return_to, value: review_application_path(@application) %>
+  <% end %>
+  <%= button_to submit_application_path(@application), method: :post, class: "btn bg-blue #{"tooltipped !pointer-events-auto" unless @application.ready_to_submit?}", disabled: !@application.ready_to_submit?, "aria-label": "This application is not ready to submit" do %>
+    Submit application
   <% end %>
 <% end %>

--- a/app/views/event/applications/review.html.erb
+++ b/app/views/event/applications/review.html.erb
@@ -21,10 +21,12 @@
   <div class="flex flex-row gap-6 items-start justify-center">
     <%= link_to "← Back", personal_info_application_path(@application), class: "btn bg-muted" %>
   </div>
-  <%= form_with model: @application, url: application_path(@application), method: :patch, id: "edit_application_#{@application.id}" do |form| %>
-    <%= form.hidden_field :return_to, value: review_application_path(@application) %>
-  <% end %>
-  <%= button_to submit_application_path(@application), method: :post, class: "btn bg-blue #{"tooltipped !pointer-events-auto" unless @application.ready_to_submit?}", disabled: !@application.ready_to_submit?, "aria-label": "This application is not ready to submit" do %>
-    Submit application
+
+  <% if @application.draft? %>
+    <%= button_to submit_application_path(@application), method: :post, class: "btn bg-blue #{"tooltipped !pointer-events-auto" unless @application.ready_to_submit?}", disabled: !@application.ready_to_submit?, "aria-label": "This application is not ready to submit" do %>
+      Submit application
+    <% end %>
+  <% else %>
+    <%= link_to "Submit application", application_path(@application), class: "btn bg-blue" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2738/samples/timestamp/2026-02-20T23:16:31Z - this was likely caused by a user submitting the form, but going back to the review page and clicking the submit button again. After submitting, we should make sure users can't go back to any of the form pages.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Prevents users (allows auditors/admins) from accessing the form pages after submitting.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

