### PR TITLE
[Event::Application] Lock during creation of new Airtable record

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -5,38 +5,50 @@ class Event
     queue_as :low
 
     def perform(application)
-      return if application.draft?
+      @application = application
+      return if @application.draft?
 
-      app = ApplicationsTable.all(filter: "{recordID} = \"#{application.airtable_record_id}\"").first if application.airtable_record_id.present?
-      app ||= ApplicationsTable.all(filter: "{HCB Application ID} = \"#{application.hashid}\"").first
-      app ||= ApplicationsTable.new("HCB Application ID" => application.hashid)
+      # If Airtable record already exists, update it and move on! (no concerns for race conditions)
+      airrecord = @application.airtable_record
+      return update_airtable(airrecord) if airrecord.present?
 
-      app["First Name"] = application.user.first_name
-      app["Last Name"] = application.user.last_name
-      app["Email Address"] = application.user.email
-      app["Phone Number"] = application.user.phone_number
-      app["Date of Birth"] = application.user.birthday
-      app["Event Name"] = application.name
-      app["Event Website"] = application.website_url
-      app["Zip Code"] = application.address_postal_code
-      app["Tell us about your event"] = application.description
-      app["Have you used HCB for any previous events?"] = application.user.events.any? ? "Yes, I have used HCB before" : "No, first time!"
-      app["Teenager Led?"] = application.user.teenager?
-      app["Address Line 1"] = application.address_line1
-      app["City"] = application.address_city
-      app["State"] = application.address_state
-      app["Address Country"] = application.address_country
-      app["Event Location"] = application.address_country
-      app["How did you hear about HCB?"] = application.referrer
-      app["Accommodations"] = application.accessibility_notes
-      app["(Adults) Political Activity"] = application.political_description
-      app["Referral Code"] = application.referral_code
-      app["HCB Status"] = application.aasm_state.humanize unless application.draft?
-      app["Synced from HCB at"] = Time.current
+      # Airtable record doesn't exist, let's create it! Lock Application to prevent duplicate new Airtable records
+      @application.with_lock do
+        airrecord = @application.airtable_record # Check again for Airtable record (inside lock)
+        airrecord ||= ApplicationsTable.new("HCB Application ID" => @application.hashid)
 
-      app.save
+        update_airtable(airrecord)
+      end
+    end
 
-      application.update_columns(airtable_record_id: app.id, airtable_status: app["Status"])
+    def update_airtable(airrecord)
+      airrecord["First Name"] = @application.user.first_name
+      airrecord["Last Name"] = @application.user.last_name
+      airrecord["Email Address"] = @application.user.email
+      airrecord["Phone Number"] = @application.user.phone_number
+      airrecord["Date of Birth"] = @application.user.birthday
+      airrecord["Event Name"] = @application.name
+      airrecord["Event Website"] = @application.website_url
+      airrecord["Zip Code"] = @application.address_postal_code
+      airrecord["Tell us about your event"] = @application.description
+      airrecord["Have you used HCB for any previous events?"] = @application.user.events.any? ? "Yes, I have used HCB before" : "No, first time!"
+      airrecord["Teenager Led?"] = @application.user.teenager?
+      airrecord["Address Line 1"] = @application.address_line1
+      airrecord["City"] = @application.address_city
+      airrecord["State"] = @application.address_state
+      airrecord["Address Country"] = @application.address_country
+      airrecord["Event Location"] = @application.address_country
+      airrecord["How did you hear about HCB?"] = @application.referrer
+      airrecord["Accommodations"] = @application.accessibility_notes
+      airrecord["(Adults) Political Activity"] = @application.political_description
+      airrecord["Referral Code"] = @application.referral_code
+      airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
+      airrecord["Synced from HCB at"] = Time.current
+
+      airrecord.save
+
+      # update_columns bypasses callbacks, preventing schedule_airtable_sync from re-enqueuing and infinite looping.
+      @application.update_columns(airtable_record_id: airrecord.id, airtable_status: airrecord["Status"])
     end
 
   end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -352,6 +352,11 @@ class Event
       tags
     end
 
+    def airtable_record
+      app = ApplicationsTable.all(filter: "{recordID} = \"#{airtable_record_id}\"").first if airtable_record_id.present?
+      app ||= ApplicationsTable.all(filter: "{HCB Application ID} = \"#{hashid}\"").first
+    end
+
     private
 
     def schedule_airtable_sync

--- a/spec/factories/event_application_factory.rb
+++ b/spec/factories/event_application_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :event_application, class: "Event::Application" do
+    association :user
+    name { Faker::Company.name }
+  end
+end

--- a/spec/models/event/application_spec.rb
+++ b/spec/models/event/application_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Event::Application, type: :model do
+  describe "#schedule_airtable_sync" do
+    let!(:application) { create(:event_application) }
+
+    it "enqueues a sync job on save" do
+      expect {
+        application.update!(name: "Updated Name")
+      }.to have_enqueued_job(Event::ApplicationSyncToAirtableJob).with(application)
+    end
+
+    context "when the job runs after a save" do
+      let!(:application) { create(:event_application, aasm_state: "submitted") }
+
+      before do
+        fake_record = double("airtable_record")
+        allow(fake_record).to receive(:[]=)
+        allow(fake_record).to receive(:[]).and_return(nil)
+        allow(fake_record).to receive(:save)
+        allow(fake_record).to receive(:id).and_return("recABC123")
+        allow(ApplicationsTable).to receive(:all).and_return([fake_record])
+      end
+
+      it "only runs the sync job once, preventing an infinite loop" do
+        perform_enqueued_jobs do
+          application.update!(name: "Changed")
+        end
+
+        syncs_performed = performed_jobs.count { |j| j[:job] == Event::ApplicationSyncToAirtableJob }
+        expect(syncs_performed).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

We've been seeing duplicate new airtable records due to race conditions

## Describe your changes

When creating a new record on Airtable, lock the `Event::Application` record so that we ensure only one new Airtable record is created. If we're just updating an existing airtable record, then no lock is necessary.

I also added some tests— primarily to make sure we don't end up with an infinite loop from the `schedule_airtable_sync` callback. I didn't change any of that code, but I have suggestions: https://github.com/hackclub/hcb/issues/13029