### PR TITLE
Add airtable_synced_at to applications

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -47,7 +47,7 @@ class Event
 
       airrecord.save
 
-      # update_columns bypasses callbacks, preventing schedule_airtable_sync from re-enqueuing and infinite looping.
+      # Updating airtable_synced_at prevents infinite looping this job
       @application.update!(airtable_record_id: airrecord.id, airtable_status: airrecord["Status"], airtable_synced_at: DateTime.now)
     end
 

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -48,7 +48,7 @@ class Event
       airrecord.save
 
       # update_columns bypasses callbacks, preventing schedule_airtable_sync from re-enqueuing and infinite looping.
-      @application.update_columns(airtable_record_id: airrecord.id, airtable_status: airrecord["Status"])
+      @application.update!(airtable_record_id: airrecord.id, airtable_status: airrecord["Status"], airtable_synced_at: DateTime.now)
     end
 
   end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -14,6 +14,7 @@
 #  address_postal_code          :string
 #  address_state                :string
 #  airtable_status              :string
+#  airtable_synced_at           :datetime
 #  annual_budget_cents          :integer
 #  approved_at                  :datetime
 #  archived_at                  :datetime
@@ -77,7 +78,7 @@ class Event
     validate :cosigner_cannot_change_after_sign
 
     after_save :check_cosigner_update
-    after_commit :schedule_airtable_sync
+    after_commit :schedule_airtable_sync, unless: :saved_change_to_airtable_synced_at?
 
     monetize :annual_budget_cents, allow_nil: true
     monetize :committed_amount_cents, allow_nil: true

--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -35,6 +35,10 @@
             <strong>Airtable status</strong>
             <span class="badge w-max m-0 bg-muted"><%= @application.airtable_status %></span>
           </p>
+          <p>
+            <strong>Airtable last synced at</strong>
+            <span><%= @application.airtable_synced_at.present? ? format_datetime(@application.airtable_synced_at) : "Not synced" %></span>
+          </p>
         </section>
       </div>
     <% end %>

--- a/db/migrate/20260223152545_add_airtable_synced_at_to_event_application.rb
+++ b/db/migrate/20260223152545_add_airtable_synced_at_to_event_application.rb
@@ -1,5 +1,13 @@
 class AddAirtableSyncedAtToEventApplication < ActiveRecord::Migration[8.0]
   def change
     add_column :event_applications, :airtable_synced_at, :datetime
+
+    reversible do |direction|
+      direction.up do
+        Event::Application.find_each do |application|
+          application.update!(airtable_synced_at: application.updated_at) if application.airtable_record_id.present?
+        end
+      end
+    end
   end
 end

--- a/db/migrate/20260223152545_add_airtable_synced_at_to_event_application.rb
+++ b/db/migrate/20260223152545_add_airtable_synced_at_to_event_application.rb
@@ -1,0 +1,5 @@
+class AddAirtableSyncedAtToEventApplication < ActiveRecord::Migration[8.0]
+  def change
+    add_column :event_applications, :airtable_synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_09_232615) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_23_152545) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -986,6 +986,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_09_232615) do
     t.string "address_state"
     t.string "airtable_record_id"
     t.string "airtable_status"
+    t.datetime "airtable_synced_at"
     t.integer "annual_budget_cents"
     t.datetime "approved_at"
     t.datetime "archived_at"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The application sync to airtable job is currently using `update_columns`, which prevents infinite looping the job but also prevents other callbacks from running, such as PaperTrail. It'd also be useful to have this data to debug any Airtable syncing issues.

Closes #13029

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds an `airtable_synced_at` column to applications, and updates the job to use it to prevent re-enqueing instead of `update_columns`. Also displays this to admins on the application submission page.

Backfills `airtable_synced_at` based on `updated_at` if the application has an airtable ID.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

