### PR TITLE
Skip description prefill on Argosy contract

### DIFF
--- a/app/models/event/plan/argosy_2025.rb
+++ b/app/models/event/plan/argosy_2025.rb
@@ -39,6 +39,12 @@ class Event
         { is_public: true }
       end
 
+      def contract_skip_prefills
+        {
+          "Contract Signee" => ["The Project"]
+        }
+      end
+
     end
 
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2739/samples
We're assuming that the "The Project" field is on the signee party, but it needs to be kept for the HCB party for the Argosy contract.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Since this contract is only being used for subevents which don't have a value to prefill this field anyways, we can skip the prefill.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

