### PR TITLE
[Code Quality] Introduce `PubliclyTrackable` concern

### DIFF
--- a/app/models/ach_transfer.rb
+++ b/app/models/ach_transfer.rb
@@ -75,8 +75,7 @@ class AchTransfer < ApplicationRecord
   include PgSearch::Model
   pg_search_scope :search_recipient, against: [:recipient_name], using: { tsearch: { prefix: true, dictionary: "english" } }, ranked_by: "ach_transfers.created_at"
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   belongs_to :creator, class_name: "User", optional: true
   belongs_to :processor, class_name: "User", optional: true

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -105,8 +105,7 @@ class CheckDeposit < ApplicationRecord
     unknown: "unknown"
   }, prefix: :rejection_reason
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   def submit!
     ProcessColumnCheckDepositJob.perform_later(check_deposit: self)

--- a/app/models/concerns/publicly_trackable.rb
+++ b/app/models/concerns/publicly_trackable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Shared concern for models that use the standard PublicActivity tracking
+# configuration: owner = current_user, event_id = record.event.id, only create.
+#
+# Models with non-standard configurations (comment, disbursement, donation,
+# event, organizer_position_invite, raw_pending_stripe_transaction, user,
+# webauthn_credential) continue to call `tracked` directly.
+module PubliclyTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    include PublicActivity::Model
+    tracked owner: proc { |controller, record| controller&.current_user },
+            event_id: proc { |controller, record| record.event.id },
+            only: [:create]
+  end
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -29,8 +29,7 @@ class Employee < ApplicationRecord
   has_paper_trail
   acts_as_paranoid
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   validates_presence_of :gusto_id, if: -> { onboarded? }
 

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -60,8 +60,7 @@ class IncreaseCheck < ApplicationRecord
   include PgSearch::Model
   pg_search_scope :search_recipient, against: [:recipient_name, :memo], using: { tsearch: { prefix: true, dictionary: "english" } }, ranked_by: "increase_checks.created_at"
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   include PublicIdentifiable
   set_public_id_prefix :ick

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -111,8 +111,7 @@ class Invoice < ApplicationRecord
 
   include Freezable
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   include PgSearch::Model
   pg_search_scope :search_description, associated_against: { sponsor: :name }, against: [:item_description, :item_amount], using: { tsearch: { prefix: true, dictionary: "english" } }, ranked_by: "invoices.created_at"

--- a/app/models/paypal_transfer.rb
+++ b/app/models/paypal_transfer.rb
@@ -45,8 +45,7 @@ class PaypalTransfer < ApplicationRecord
 
   monetize :amount_cents, as: "amount"
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   validate on: :create do
     errors.add(:base, "Due to integration issues, transfers via PayPal are currently unavailable.")

--- a/app/models/wire.rb
+++ b/app/models/wire.rb
@@ -78,8 +78,7 @@ class Wire < ApplicationRecord
   monetize :amount_cents, as: "amount", with_model_currency: :currency
 
 
-  include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   after_create do
     create_canonical_pending_transaction!(

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -71,8 +71,7 @@ class WiseTransfer < ApplicationRecord
   validates :usd_amount_cents, numericality: { greater_than_or_equal_to: 0, message: "must be positive" }, allow_nil: true
   validates :quoted_usd_amount_cents, numericality: { greater_than_or_equal_to: 0, message: "must be positive" }, allow_nil: true
 
-  include PublicActivity::Model
-  tracked owner: proc { |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  include PubliclyTrackable
 
   WISE_ID_FORMAT = /\A\d+\z/
   before_validation(:normalize_wise_id)


### PR DESCRIPTION
Introduces a standard PublicActivity tracking configuration:
   - Improves AchTransfer, CheckDeposit, Employee, IncreaseCheck, Invoice, PaypalTransfer, Wire, WiseTransfer
   - Replaces boilerplate `include PublicActivity::Model` + `tracked` declarations with a single include
