### PR TITLE
Disallow disposable email addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem "wicked_pdf" # HTML to PDF conversion
 gem "write_xlsx" # Export Excel files
 gem "rubyzip", "< 3.0", ">= 2.3.0" # Force `write_xlsx` to use an older version of `rubyzip`. See https://github.com/cxn03651/write_xlsx/issues/127
 
+gem "nondisposable" # disallow temporary/disposable email addresses
 gem "rack-cors" # manage CORS
 gem "rack-attack" # rate limiting
 gem "browser", "~> 6.2" # browser detection

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,6 +562,8 @@ GEM
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nondisposable (0.2.1)
+      rails (>= 7.0.0)
     observer (0.1.2)
     open4 (1.3.4)
     openssl (3.3.2)
@@ -1000,6 +1002,7 @@ DEPENDENCIES
   monetize
   money-rails
   namae
+  nondisposable
   paper_trail (~> 16.0.0)
   pg (>= 0.18, < 2.0)
   pg_query (>= 2)

--- a/app/jobs/disposable_email_domain_list_update_job.rb
+++ b/app/jobs/disposable_email_domain_list_update_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DisposableEmailDomainListUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Nondisposable::DomainListUpdater.update
+  end
+
+end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -48,6 +48,7 @@ class Contract < ApplicationRecord
 
   validates_email_format_of :cosigner_email, allow_nil: true, allow_blank: true
   normalizes :cosigner_email, with: ->(cosigner_email) { cosigner_email.strip.downcase }
+  validates :cosigner_email, nondisposable: true, on: :create
 
   # Always create HCB's party on all contracts
   # Contracts for subevents can be issued by non-admins, so fallback to system user in those cases

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -90,6 +90,7 @@ class Donation < ApplicationRecord
 
   validates :name, :email, presence: true, unless: -> { recurring? || in_person? } # recurring donations have a name/email in their `RecurringDonation` object
   validates :email, on: :create, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, unless: -> { recurring? || in_person? } # recurring donations have an email in their `RecurringDonation` object
+  validates :email, nondisposable: true, on: :create
   validates_presence_of :amount
   validates :amount, numericality: { greater_than_or_equal_to: 100, less_than_or_equal_to: 999_999_99 }
 

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -44,6 +44,7 @@ class GSuiteAccount < ApplicationRecord
 
   validates_presence_of :address, :backup_email, :first_name, :last_name
   normalizes :backup_email, with: ->(backup_email) { backup_email.strip.downcase }
+  validates :backup_email, nondisposable: true, on: :create
 
   validate :status_accepted_or_rejected
   validates :address, uniqueness: { scope: :g_suite }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,6 @@
 #  index_users_on_slug        (slug) UNIQUE
 #
 class User < ApplicationRecord
-  BLACKLISTED_DOMAINS = ["aboodbab.com"].freeze
-
   has_paper_trail skip: [:birthday] # ciphertext columns will still be tracked
 
   include PublicIdentifiable
@@ -191,7 +189,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates_email_format_of :email
   normalizes :email, with: ->(email) { email.strip.downcase }
-  validate :email_not_in_blacklisted_domains, on: :create
+  validates :email, nondisposable: true, on: :create
 
   validates :phone_number, phone: { allow_blank: true }
 
@@ -683,13 +681,6 @@ class User < ApplicationRecord
 
   def send_onboarded_email
     UserMailer.onboarded(user: self).deliver_later
-  end
-
-  def email_not_in_blacklisted_domains
-    domain = email.split("@").last.downcase
-    if BLACKLISTED_DOMAINS.include?(domain)
-      errors.add(:email, "is invalid. Please use a different email address.")
-    end
   end
 
 end

--- a/app/models/user/email_update.rb
+++ b/app/models/user/email_update.rb
@@ -56,6 +56,8 @@ class User
     normalizes :original, with: ->(original) { original.strip.downcase }
     normalizes :replacement, with: ->(replacement) { replacement.strip.downcase }
 
+    validates :replacement, nondisposable: true, on: :create
+
     after_create_commit do
       user.email_updates.requested.excluding(self).each(&:mark_stale!)
       send_emails unless confirmed?

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Nondisposable.configure do |config|
+  # Customize the error message if needed
+  # config.error_message = "is not allowed. Please use a non-disposable email address."
+  #
+  # Add custom domains you want to be considered as disposable
+  # config.additional_domains = ['custom-disposable-domain.com']
+  #
+  # Exclude domains that are considered disposable but you want to allow anyways
+  # config.excluded_domains = ['false-positive-domain.com']
+end

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -2,11 +2,11 @@
 
 Nondisposable.configure do |config|
   # Customize the error message if needed
-  # config.error_message = "is not allowed. Please use a non-disposable email address."
-  #
+  config.error_message = "provider is unsupported. Please try with another email address."
+
   # Add custom domains you want to be considered as disposable
-  # config.additional_domains = ['custom-disposable-domain.com']
-  #
+  config.additional_domains = ["aboodbab.com"]
+
   # Exclude domains that are considered disposable but you want to allow anyways
-  # config.excluded_domains = ['false-positive-domain.com']
+  config.excluded_domains = ['false-positive-domain.com']
 end

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -8,5 +8,5 @@ Nondisposable.configure do |config|
   config.additional_domains = ["aboodbab.com"]
 
   # Exclude domains that are considered disposable but you want to allow anyways
-  config.excluded_domains = ['false-positive-domain.com']
+  # config.excluded_domains = ["false-positive-domain.com"]
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -192,7 +192,7 @@ stripe_service_fee_job:
 user_seen_at_history_snapshot_job:
   cron: "0,30 * * * *" # twice every hour
   class: "User::SeenAtHistory::SnapshotJob"
-  
+
 user_update_card_locking_recurring:
   cron: "*/5 * * * *" # Every 5 minutes
   class: "User::UpdateCardLocking::RecurringJob"
@@ -248,3 +248,7 @@ announcement_delete_unsaved_job:
 notify_events_with_negative_balance_job:
   cron: "0 13 * * 1" # run at 9am est on monday
   class: "NotifyEventsWithNegativeBalanceJob"
+
+refresh_disposable_domains:
+  cron: "0 11 * * *" # run at 6am est every day
+  class: "DisposableEmailDomainListUpdateJob"

--- a/db/migrate/20260226081252_create_nondisposable_disposable_domains.rb
+++ b/db/migrate/20260226081252_create_nondisposable_disposable_domains.rb
@@ -1,0 +1,21 @@
+class CreateNondisposableDisposableDomains < ActiveRecord::Migration[8.0]
+  def change
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :nondisposable_disposable_domains, id: primary_key_type do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_25_175618) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_26_081252) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1670,6 +1670,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_25_175618) do
     t.integer "year"
     t.index ["subject_type", "subject_id", "type", "year"], name: "index_metrics_on_subject_type_and_subject_id_and_type_and_year", unique: true
     t.index ["subject_type", "subject_id"], name: "index_metrics_on_subject"
+  end
+
+  create_table "nondisposable_disposable_domains", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_nondisposable_disposable_domains_on_name", unique: true
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|


### PR DESCRIPTION
## Summary of the problem

We dislike spam users :)

## Describe your changes

Disallow disposable email addresses for the following model fields:
- `User.email`
- `Donation.email`
- `Contract.cosigner_email`
- `GSuiteAccount.backup_email`
- `EmailUpdate.replacement`