### PR TITLE
Add honeypot to login flow

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -7,6 +7,7 @@ class LoginsController < ApplicationController
   before_action :set_for_application
   before_action :set_user, except: [:new, :create, :reauthenticate]
   before_action :set_return_to
+  invisible_captcha only: [:create, :complete], honeypot: :remember_me
 
   layout ->{ @for_application ? "apply" : "login" }
 

--- a/app/views/logins/backup_code.html.erb
+++ b/app/views/logins/backup_code.html.erb
@@ -15,6 +15,7 @@
   </p>
   <%= form_tag complete_login_path(@login) do %>
     <%= text_field :backup_code, "", placeholder: "Enter your backup code", name: "backup_code", class: "!max-w-full w-max", required: true, autofocus: true %>
+    <%= invisible_captcha :remember_me %>
     <%= hidden_field_tag :method, :backup_code %>
     <%= hidden_field_tag :fingerprint %>
     <%= hidden_field_tag :device_info %>

--- a/app/views/logins/login_code.html.erb
+++ b/app/views/logins/login_code.html.erb
@@ -44,6 +44,7 @@
             inputmode: "numeric",
           ) %>
     <% end %>
+    <%= invisible_captcha :remember_me %>
 
     <%= hidden_field_tag :method, :login_code %>
     <%= hidden_field_tag :fingerprint %>

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -18,6 +18,7 @@
       <%= hidden_field_tag :return_to, @return_to if @return_to %>
       <%= hidden_field_tag :referral_link_id, @referral_link.slug if @referral_link %>
       <%= email_field_tag :email, @prefill_email, placeholder: "Enter your email...", autofocus: true, autocomplete: "username", class: "!max-w-full w-full", style: "padding: 12px 15px", required: true, "data-webauthn-auth-target" => "loginEmailInput" %>
+      <%= invisible_captcha :remember_me %>
       <div class="flex justify-between items-center gap-4">
         <% if @for_application %>
           <span></span>

--- a/app/views/logins/totp.html.erb
+++ b/app/views/logins/totp.html.erb
@@ -40,6 +40,7 @@
             autofocus: true
           ) %>
     <% end %>
+    <%= invisible_captcha :remember_me %>
 
     <%= hidden_field_tag :email, @email %>
     <%= hidden_field_tag :method, :totp %>


### PR DESCRIPTION
## Summary of the problem

We're getting bot spam

## Describe your changes

Add an invisible honeypot. I was going to name the field `password`, but the docs said not to give it a name that Chrome would easily autofill.