### PR TITLE
[Suborg] Fix incorrect plan type label

### DIFF
--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -77,8 +77,11 @@
     </div>
   </div>
 
-  <small class="muted mt-0 mb-4">This project will be created on the
-    <strong><%= event.plan.label %></strong> plan</small>
+  <small class="muted mt-0 mb-4">
+    This project will be created on the
+    <strong><%= event.config.subevent_plan.constantize.new.label %></strong>
+    plan.
+  </small>
 
   <div class="inline-block">
     <%= form.submit "Create sub-organization", class: "mt1", disabled: event&.demo_mode? %>


### PR DESCRIPTION
## Summary of the problem

On the form, we claim that the subevent will be created with the _**same plan as the parent**_. That is incorrect since we actually have an entire setting for it.

<img width="450" height="135" alt="image" src="https://github.com/user-attachments/assets/06f9b6f2-0f43-440e-8ed4-b6fc900382c3" />


## Describe your changes

Refer to the subevent plan setting