### PR TITLE
[Donation Receipt] Use "payment" when non-tax deductible

### DIFF
--- a/app/views/donation_mailer/donor_receipt.html.erb
+++ b/app/views/donation_mailer/donor_receipt.html.erb
@@ -1,4 +1,5 @@
 <% payment_term = @donation.tax_deductible ? "donation" : "payment" %>
+<% secondary_payment_term = @donation.tax_deductible ? "gift" : "payment" %>
 
 <p>Hi <%= @donation.name(show_anonymous: true) %>,</p>
 
@@ -9,7 +10,7 @@
     to <%= @donation.event.name %>
     has <%= @initial_recurring_donation ? "been started" : "renewed" %> and your
     card has been charged <%= render_money @donation.amount %>. Please consider
-    this email a receipt for your gift for the month of
+    this email a receipt for your <%= secondary_payment_term %> for the month of
     <strong><%= @donation.created_at.strftime("%B %Y") %></strong>.
   </p>
 <% else %>
@@ -18,7 +19,7 @@
     generous <%= "anonymous " if @donation.anonymous? %> <%= payment_term %>
     of <%= render_money @donation.amount %> to <%= @donation.event.name %>.
     Please
-    consider this email a receipt for your gift.
+    consider this email a receipt for your <%= secondary_payment_term %>.
   </p>
 <% end %>
 

--- a/app/views/donation_mailer/donor_receipt.html.erb
+++ b/app/views/donation_mailer/donor_receipt.html.erb
@@ -3,39 +3,53 @@
 <p>Hi <%= @donation.name(show_anonymous: true) %>,</p>
 
 <% if @donation.recurring? %>
-<p>
-  Your <%= "anonymous" if @donation.anonymous? %> <%= payment_term %> of <%= render_money @donation.recurring_donation.amount %> per month to <%= @donation.event.name %> has <%= @initial_recurring_donation ? "been started" : "renewed" %> and your card has been charged <%= render_money @donation.amount %>. Please consider this email a receipt for your gift for the month of <strong><%= @donation.created_at.strftime("%B %Y") %></strong>.
-</p>
+  <p>
+    Your <%= "anonymous" if @donation.anonymous? %> <%= payment_term %>
+    of <%= render_money @donation.recurring_donation.amount %> per month
+    to <%= @donation.event.name %>
+    has <%= @initial_recurring_donation ? "been started" : "renewed" %> and your
+    card has been charged <%= render_money @donation.amount %>. Please consider
+    this email a receipt for your gift for the month of
+    <strong><%= @donation.created_at.strftime("%B %Y") %></strong>.
+  </p>
 <% else %>
-<p>
-  Thank you for your generous <%= "anonymous " if @donation.anonymous? %> <%= payment_term %> of <%= render_money @donation.amount %> to <%= @donation.event.name %>. Please consider this email a receipt for your gift.
-</p>
+  <p>
+    Thank you for your
+    generous <%= "anonymous " if @donation.anonymous? %> <%= payment_term %>
+    of <%= render_money @donation.amount %> to <%= @donation.event.name %>.
+    Please
+    consider this email a receipt for your gift.
+  </p>
 <% end %>
 
 <% if @donation.event.donation_thank_you_message.present? %>
   <p>
     Here's a message from the <%= @donation.event.name %> team:
-    <blockquote>
-      <%= MarkdownService.instance.render @donation.event.donation_thank_you_message %>
-    </blockquote>
+  <blockquote>
+    <%= MarkdownService.instance.render @donation.event.donation_thank_you_message %>
+  </blockquote>
   </p>
 <% end %>
 
 <p>
-  <%= @donation.event.name %> is fiscally sponsored by Hack Club, a 501(c)(3) nonprofit. Our EIN is 81-2908499.
+  <%= @donation.event.name %> is fiscally sponsored by Hack Club, a 501(c)(3)
+  nonprofit. Our EIN is 81-2908499.
   <% if @donation.tax_deductible %>
-    Per IRS guidelines, you agree that no goods or services will be provided in return for this gift.
+    Per IRS guidelines, you agree that no goods or services will be provided in
+    return for this gift.
   <% end %>
 </p>
 
 <% if @donation.recurring? %>
   <p>
     To cancel your <%= payment_term %> or update your payment details, click
-    <%= link_to "this link", recurring_donation_url(@donation.recurring_donation.url_hash) %>.
+    <%= link_to "this link", recurring_donation_url(@donation.recurring_donation.url_hash) %>
+    .
   </p>
 <% end %>
 
-<p>If you have any questions or concerns, please reply directly to this email and our financial operations team will assist.</p>
+<p>If you have any questions or concerns, please reply directly to this email
+  and our financial operations team will assist.</p>
 
 <p>
   Best regards,<br>


### PR DESCRIPTION
## Summary of the problem

We already subbed out the word "donation" for "payment" when it's non-tax-deductible. But we're still saying "gift".

## Describe your changes

I'm subbing out the word "gift" for "payment". cc @MelSmith104 

Mel suggested "purchase". I chose "payment" since it feels more flexible than "purchase", but can make it "purchase" if we want.

PR also includes formatting for the file. Review each individual commit for an easier diff