### PR TITLE
[Applications] Sync HCB ID and account URL fields to Airtable

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -44,7 +44,11 @@ class Event
       airrecord["Referral Code"] = @application.referral_code
       airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
       airrecord["Synced from HCB at"] = Time.current
-      airrecord["HCB ID"] = @application.event&.id
+
+      if @application.event.present?
+        airrecord["HCB ID"] = @application.event.id 
+        airrecord["HCB account URL"] = Rails.application.helpers.url_helpers.event_url(@application.event)
+      end
 
       airrecord.save
 

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -45,7 +45,6 @@ class Event
       airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
       airrecord["Synced from HCB at"] = Time.current
       airrecord["HCB ID"] = @application.event&.id
-      airrecord["HCB Slug"] = @application.event&.slug
 
       airrecord.save
 

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -46,7 +46,7 @@ class Event
       airrecord["Synced from HCB at"] = Time.current
 
       if @application.event.present?
-        airrecord["HCB ID"] = @application.event.id 
+        airrecord["HCB ID"] = @application.event.id
         airrecord["HCB account URL"] = Rails.application.helpers.url_helpers.event_url(@application.event)
       end
 

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -44,6 +44,8 @@ class Event
       airrecord["Referral Code"] = @application.referral_code
       airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
       airrecord["Synced from HCB at"] = Time.current
+      airrecord["HCB ID"] = @application.event&.id
+      airrecord["HCB Slug"] = @application.event&.slug
 
       airrecord.save
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -325,6 +325,8 @@ class Event
         affiliation_copy.save!
       end
 
+      schedule_airtable_sync
+
       Event::ApplicationMailer.with(application: self).activated.deliver_later
 
       self


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We're not currently syncing the HCB ID and account URL fields, which is important to have! (HCB Slug is calculated from account URL)

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Sync those fields if the event is present, and make sure to schedule a sync after activation.

We should go into console and manually schedule syncs for applications with an event after this is deployed.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

