### PR TITLE
[Applications] Fix syncing of currency fields and remove adult field prefix

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -43,8 +43,8 @@ class Event
       airrecord["Planning Duration"] = @application.planning_duration
       airrecord["Currently fiscally sponsored?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
       airrecord["Previously applied?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
-      airrecord["Committed Amount"] = @application.committed_amount_cents / 100
-      airrecord["(Adults) Annual Budget"] = @application.annual_budget_cents / 100
+      airrecord["Committed Amount"] = @application.committed_amount_cents / 100.0 if @application.committed_amount_cents.present?
+      airrecord["(Adults) Annual Budget"] = @application.annual_budget_cents / 100.0 if @application.annual_budget_cents.present?
       airrecord["Funding Source"] = @application.funding_source
       airrecord["How did you hear about HCB?"] = @application.referrer
       airrecord["Accommodations"] = @application.accessibility_notes

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -43,8 +43,8 @@ class Event
       airrecord["Planning Duration"] = @application.planning_duration
       airrecord["Currently fiscally sponsored?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
       airrecord["Previously applied?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
-      airrecord["Committed Amount"] = @application.committed_amount_cents / 100.0 if @application.committed_amount_cents.present?
-      airrecord["(Adults) Annual Budget"] = @application.annual_budget_cents / 100.0 if @application.annual_budget_cents.present?
+      airrecord["Committed Amount"] = @application.committed_amount.to_f if @application.committed_amount.present?
+      airrecord["(Adults) Annual Budget"] = @application.annual_budget.to_f if @application.annual_budget.present?
       airrecord["Funding Source"] = @application.funding_source
       airrecord["How did you hear about HCB?"] = @application.referrer
       airrecord["Accommodations"] = @application.accessibility_notes

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -43,8 +43,8 @@ class Event
       airrecord["Planning Duration"] = @application.planning_duration
       airrecord["Currently fiscally sponsored?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
       airrecord["Previously applied?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
-      airrecord["Committed Amount"] = @application.committed_amount
-      airrecord["(Adults) Annual Budget"] = @application.annual_budget
+      airrecord["Committed Amount"] = @application.committed_amount_cents / 100
+      airrecord["(Adults) Annual Budget"] = @application.annual_budget_cents / 100
       airrecord["Funding Source"] = @application.funding_source
       airrecord["How did you hear about HCB?"] = @application.referrer
       airrecord["Accommodations"] = @application.accessibility_notes

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -44,11 +44,11 @@ class Event
       airrecord["Currently fiscally sponsored?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
       airrecord["Previously applied?"] = @application.currently_fiscally_sponsored? ? "Yes" : "No"
       airrecord["Committed Amount"] = @application.committed_amount.to_f if @application.committed_amount.present?
-      airrecord["(Adults) Annual Budget"] = @application.annual_budget.to_f if @application.annual_budget.present?
+      airrecord["Annual Budget"] = @application.annual_budget.to_f if @application.annual_budget.present?
       airrecord["Funding Source"] = @application.funding_source
       airrecord["How did you hear about HCB?"] = @application.referrer
       airrecord["Accommodations"] = @application.accessibility_notes
-      airrecord["(Adults) Political Activity"] = @application.political_description
+      airrecord["Political Activity"] = @application.political_description
       airrecord["Referral Code"] = @application.referral_code
       airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
       airrecord["Synced from HCB at"] = Time.current


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Airtable was returning errors because we were passing serialized objects from `Monetize` instead of a plain number.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Sync using a number and remove the adult field prefixes

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

