### PR TITLE
[v3 API] show `financially_frozen` on organizations

### DIFF
--- a/app/api/api/entities/organization.rb
+++ b/app/api/api/entities/organization.rb
@@ -21,6 +21,7 @@ module Api
         end
         expose :is_public, as: :transparent, documentation: { type: "boolean" }
         expose :demo_mode, documentation: { type: "boolean" }
+        expose :financially_frozen, documentation: { type: "boolean" }
         expose :logo do |organization|
           url_for_attached organization.logo
         end


### PR DESCRIPTION
## Summary of the problem

This pull adds the `financially_frozen` value to the organization API, helping third party tools track organizations.

## Describe your changes

Added the `financially_frozen` attribute to the organization API response.