### PR TITLE
[Applications] Fix typo causing an error & access URL helpers properly

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -63,7 +63,7 @@ class Event
 
       if @application.event.present?
         airrecord["HCB ID"] = @application.event.id
-        airrecord["HCB account URL"] = Rails.application.helpers.url_helpers.event_url(@application.event)
+        airrecord["HCB account URL"] = Rails.application.routes.url_helpers.event_url(@application.event)
       end
 
       airrecord.save


### PR DESCRIPTION
## Summary of the problem

```
undefined method 'url_helpers' for module #<Module:0x0000000000000000> (NoMethodError)
```


## Describe your changes

<img width="905" height="268" alt="image" src="https://github.com/user-attachments/assets/10cc2e51-cf9c-47fd-a624-42bd0214b21d" />
