### PR TITLE
[Admin] Show when/who locked a user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -350,6 +350,10 @@ class User < ApplicationRecord
     locked_at.present?
   end
 
+  def locked_by
+    User.find_by(id: self.versions.where_object_changes_from(locked_at: nil).last.whodunnit)
+  end
+
   def lock!
     update!(locked_at: Time.now)
 

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -41,7 +41,10 @@
   <tbody>
     <% @users.each do |user| %>
       <tr style="<%= "background: #ff8c38;" if user.auditor? %>">
-        <td><%= user.id %></td>
+        <td>
+          <%= "🔒" if user.locked? %>
+          <%= user.id %>
+        </td>
         <td><%= user.created_at.strftime("%Y-%m-%d") %></td>
         <td>
           <%= link_to admin_user_path(user) do %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -7,7 +7,12 @@
   <% admin_tool "p-3" do %>
     <h3 class="mb2 mt1">User info</h3>
     <section>
-      Updating <%= user_mention @user %>'s profile that was created on <%= @user.created_at.strftime("%B %d, %Y at %I:%M %P") %>
+      <p>
+        <%= user_mention @user %>'s profile was created on <%= @user.created_at.strftime("%B %d, %Y at %I:%M %P") %>
+      </p>
+      <% if @user.locked? %>
+        <p>Locked by <%= user_mention @user.locked_by %> on <%= format_date @user.locked_at %></p>
+      <% end %>
       <p>
         <strong>User ID:</strong> <%= @user.id %> (<%= @user.public_id %>)
       </p>


### PR DESCRIPTION
## Summary of the problem

It's not possible for admins to see when/who locked a user

## Describe your changes

add it on the User admin edit page. And also show a 🔒 emoji next to the ID on the admin users index page.

<img width="552" height="235" alt="image" src="https://github.com/user-attachments/assets/40ef6fb4-9a29-4542-a8ce-190c97d86579" />


<img width="216" height="173" alt="image" src="https://github.com/user-attachments/assets/7a2f2eeb-a49d-4272-923a-ae14b578adb8" />
