### PR TITLE
[Applications] Add link to activate an application with a fully signed contract

### DIFF
--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -72,11 +72,12 @@
       <% admin_tool do %>
         <%= button_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}" %>
       <% end %>
-    <% elsif @application.approved? && (party = @application.contract&.party(:hcb))&.pending? %>
+    <% elsif @application.approved? %>
       <% admin_tool do %>
-        <% pending_parties = @application.contract&.parties&.not_hcb&.select(&:pending?)&.map(&:role) %>
+        <% pending_parties = @application.contract.parties.not_hcb.select(&:pending?)&.map(&:role) %>
         <% disabled = pending_parties.any? %>
-        <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>"><%= link_to "Sign contract", contract_party_path(party), class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
+        <% party = @application.contract.party(:hcb) %>
+        <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>"><%= link_to(party.pending? ? "Sign contract" : "Activate", contract_party_path(party), class: "btn bg-success #{"pointer-events-none" if disabled}", disabled:) %></p>
       <% end %>
     <% end %>
     <% if @application.may_mark_rejected? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We have a couple applications that errored during activation, but since the contract has been fully signed, there's no link for admins to activate the organization.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add an "Activate" link when the contract has been signed by HCB. In the future, there will be a separate activation page that we can link to. For now, this will unblock ops.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

