### PR TITLE
[Contracts] Check for party signed within database lock

### DIFF
--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -12,8 +12,11 @@ class DocusealController < ActionController::Base
 
       if params[:event_type] == "form.completed"
         party = contract.parties.detect { |party| party.docuseal_role == params[:data][:role] }
+        
         if party.present?
-          party.mark_signed! unless party.signed?
+          party.with_lock do
+            party.mark_signed! unless party.signed?
+          end
         else
           Rails.error.unexpected("Unexpected docuseal party #{params[:data][:role]}")
         end

--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -12,7 +12,7 @@ class DocusealController < ActionController::Base
 
       if params[:event_type] == "form.completed"
         party = contract.parties.detect { |party| party.docuseal_role == params[:data][:role] }
-        
+
         if party.present?
           party.with_lock do
             party.mark_signed! unless party.signed?

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -104,8 +104,10 @@ class Contract
     # We may miss a webhook or load a page before we've received the webhook,
     # so we can manually sync the party with this method!
     def sync_with_docuseal
-      if pending? && docuseal_submission&.[]("status") == "completed"
-        mark_signed!
+      self.with_lock do
+        if pending? && docuseal_submission&.[]("status") == "completed"
+          mark_signed!
+        end
       end
     end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
I believe this is the race condition that caused ERR-3D6180B4. `requires_lock: true` on `Contract` makes sure we can't run callbacks of `Contract` twice, but it does not prevent any errors when we try to mark it as signed twice.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check for party signed within database lock. This should prevent us from marking a party as signed twice, and since contracts are only marked as signed within a calllback when a party is signed, this race condition should no longer be possible with this PR.

https://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html#method-i-with_lock - the object being locked is reloaded before yielding, so we should have up to date data here

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

