### PR TITLE
Fix showing invites without contract parties

### DIFF
--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -29,7 +29,7 @@
 
   <div class="flex justify-center items-center flex-wrap mt-3 gap-2">
     <%= link_to "Reject", organizer_position_invite_reject_path(@invite), method: :post, class: "btn bg-error" %>
-    <% if @invite.contract && !@invite.contract.party(:signee).signed? %>
+    <% if @invite.contract && !@invite.contract.party(:signee)&.signed? %>
       <% if @invite.contract.party(:signee).present? %>
         <%= link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent" %>
       <% else %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
I added this extra check, but forgot to put a safe navigation operator. This is necessary because while we backfilled most contract parties, there were some that we did not have information for, so they do not have an associated signee party.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add safe nav operator

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

