### PR TITLE
[Applications] Prevent approving teen applications that are not yet signed

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -137,7 +137,7 @@ class Event
       end
 
       event :mark_approved do
-        transitions from: [:submitted, :under_review], to: :approved
+        transitions from: [:submitted, :under_review], to: :approved, if: :ready_to_approve?
         after do
           unless teen_led?
             send_contract unless contract.present?
@@ -375,6 +375,10 @@ class Event
     end
 
     private
+
+    def ready_to_approve?
+      (!teen_led && submitted?) || (teen_led && under_review?) 
+    end
 
     def schedule_airtable_sync
       Event::ApplicationSyncToAirtableJob.perform_later(self)

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -377,7 +377,7 @@ class Event
     private
 
     def ready_to_approve?
-      (!teen_led && submitted?) || (teen_led && under_review?) 
+      (!teen_led && submitted?) || (teen_led && under_review?)
     end
 
     def schedule_airtable_sync

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -137,7 +137,7 @@ class Event
       end
 
       event :mark_approved do
-        transitions from: [:submitted, :under_review], to: :approved, if: :ready_to_approve?
+        transitions from: :under_review, to: :approved
         after do
           unless teen_led?
             send_contract unless contract.present?
@@ -375,10 +375,6 @@ class Event
     end
 
     private
-
-    def ready_to_approve?
-      (!teen_led && submitted?) || (teen_led && under_review?)
-    end
 
     def schedule_airtable_sync
       Event::ApplicationSyncToAirtableJob.perform_later(self)

--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -68,17 +68,22 @@
     <% admin_tool do %>
       <%= link_to "View in Airtable", airtable_application_path(@application), class: "btn bg-blue", target: "_blank" %>
     <% end %>
+
+    <% pending_parties = @application.contract&.parties&.not_hcb&.select(&:pending?)&.map(&:role) %>
     <% if @application.may_mark_approved? %>
       <% admin_tool do %>
-        <%= button_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}" %>
+        <% disabled = @application.teen_led? && pending_parties.any? %>
+        <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>">
+          <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: %>
+        </p>
       <% end %>
     <% elsif @application.approved? && (party = @application.contract&.party(:hcb))&.pending? %>
       <% admin_tool do %>
-        <% pending_parties = @application.contract&.parties&.not_hcb&.select(&:pending?)&.map(&:role) %>
         <% disabled = pending_parties.any? %>
         <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>"><%= link_to "Sign contract", contract_party_path(party), class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
       <% end %>
     <% end %>
+
     <% if @application.may_mark_rejected? %>
       <% admin_tool do %>
         <button type="button" class="btn bg-primary tooltipped tooltipped--w" data-behavior="modal_trigger" data-modal="reject_application" aria-label="Reject this application and send a rejection email">

--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -69,7 +69,7 @@
       <%= link_to "View in Airtable", airtable_application_path(@application), class: "btn bg-blue", target: "_blank" %>
     <% end %>
 
-    <% pending_parties = @application.contract&.parties&.not_hcb&.select(&:pending?)&.map(&:role) %>
+    <% pending_parties = @application.contract&.parties&.not_hcb&.select(&:pending?)&.map(&:role) || [] %>
     <% if @application.may_mark_approved? %>
       <% admin_tool do %>
         <% disabled = @application.teen_led? && pending_parties.any? %>
@@ -77,7 +77,7 @@
           <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: %>
         </p>
       <% end %>
-    <% elsif @application.approved? && @application.event.nil? %>
+    <% elsif @application.approved? && @application.event.nil? && @application.contract.present? %>
       <% admin_tool do %>
         <% disabled = pending_parties.any? %>
         <% party = @application.contract.party(:hcb) %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Approving a teen-led application brings you to the sign for HCB operations page, but HCB should not be signing until the signee (and cosigner if present) have both signed.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Disable approving a teen led organization that is not ready for HCB to sign, with a frontend disable/tooltip and AASM guard. 

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

