### PR TITLE
[Contracts] Improve HCB party notify email

### DIFF
--- a/app/views/contract/party_mailer/notify_hcb.html.erb
+++ b/app/views/contract/party_mailer/notify_hcb.html.erb
@@ -1,7 +1,14 @@
 <p>Hi there! 👋</p>
 
+<% signee_user = @contract.party(:signee).user %>
+
 <p>
-  <%= @contract.party(:signee).email %> from <%= @contract.event_name %> is ready for you (HCB Operations) to sign the fiscal sponsorship agreement!
+  <%= link_to "#{signee_user.name} (#{signee_user.email})", admin_user_url(signee_user) %> is ready for you (HCB Operations) to sign the fiscal sponsorship agreement for
+  <% if @contract.contractable.is_a?(Event::Application) %>
+    <%= link_to "their application for #{@contract.event_name}", submission_application_url(@contract.contractable) %>!
+  <% else %>
+    <%= link_to "their invitation to #{@contract.event_name}", organizer_position_invite_url(@contract.contractable) %>!
+  <% end %>
 </p>
 
 <p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It was brought up that it's difficult for HCB ops to know whether they're signing a contract for an application or an invite when they get the email to sign. 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds more information in the HCB party notify email (user name and contractable)

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

