### PR TITLE
[Applications] Hide activate button for already activated events

### DIFF
--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -72,7 +72,7 @@
       <% admin_tool do %>
         <%= button_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}" %>
       <% end %>
-    <% elsif @application.approved? %>
+    <% elsif @application.approved? && @application.event.nil? %>
       <% admin_tool do %>
         <% pending_parties = @application.contract.parties.not_hcb.select(&:pending?)&.map(&:role) %>
         <% disabled = pending_parties.any? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13090 added an activate button to provide a link for applications that had been approved but not yet activated, but it kept that button there even after it had been activated.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Hide the button once the application is activated.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

