### PR TITLE
Don't update event airtable status when sending contract for an invite

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -221,8 +221,6 @@ class OrganizerPositionInvite < ApplicationRecord
 
       update!(is_signee: true)
       organizer_position&.update(is_signee: true)
-
-      event.set_airtable_status("Documents sent")
     end
 
     fs_contract.send!(reissue_signee_message:, reissue_cosigner_message:)

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe OrganizerPositionInvitesController do
         receive(:all)
           .with(filter: include(event.id.to_s))
           .and_return([])
-          .twice
       )
       create_docuseal_request =
         stub_request(:post, "https://api.docuseal.co/submissions")

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe OrganizerPositionInvitesController do
         receive(:all)
           .with(filter: include(event.id.to_s))
           .and_return([])
+          .once
       )
       create_docuseal_request =
         stub_request(:post, "https://api.docuseal.co/submissions")


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
With the new applications flow, we shouldn't automatically update event's airtable record status when a contract is sent for an invite, as this is only used for adding additional contract signers.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove line updating event airtable status

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

