### PR TITLE
Add turbo frame data attribute to personal transaction link in invoice

### DIFF
--- a/app/views/hcb_codes/_invoice.html.erb
+++ b/app/views/hcb_codes/_invoice.html.erb
@@ -95,7 +95,7 @@
     <% if @invoice.personal_transaction.present? %>
       <p>
         <strong>Repayment for</strong>
-        <%= link_to @invoice.personal_transaction.hcb_code.memo, @invoice.personal_transaction.hcb_code %>
+        <%= link_to @invoice.personal_transaction.hcb_code.memo, @invoice.personal_transaction.hcb_code, data: { turbo_frame: "_top" } %>
       </p>
     <% end %>
     <p>


### PR DESCRIPTION
Fixes this bug when you click on the transaction for repayment in an invoice

<img width="854" height="668" alt="image" src="https://github.com/user-attachments/assets/2b6f85f0-0b95-47f9-813b-a539252fe8ad" />
