### PR TITLE
[User] Fix erroneous "Welcome to HCB" email sends

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -373,7 +373,7 @@ class User < ApplicationRecord
   end
 
   def was_onboarding?
-    full_name_before_last_save.blank?
+    full_name_before_last_save.blank? && full_name_previously_changed?
   end
 
   def active_mailbox_address
@@ -467,7 +467,7 @@ class User < ApplicationRecord
   end
 
   def queue_sync_with_loops_job
-    new_user = full_name_before_last_save.blank? && !onboarding?
+    new_user = was_onboarding? && !onboarding?
     User::SyncUserToLoopsJob.perform_later(user_id: id, new_user:)
   end
 


### PR DESCRIPTION
## Summary of the problem

Users are getting a "Welcome to HCB" email when updating their user (e.g. uploading a new profile picture).

Problem: `full_name_before_last_save` is `nil` if `full_name` wasn't changed

## Describe your changes

Check to see that full name was changed AND it was blank before save.

I haven't tested this—I would appreciate if someone tests it lol