### PR TITLE
Fix user empty string name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -304,7 +304,7 @@ class User < ApplicationRecord
   end
 
   def name
-    preferred_name.presence || full_name || email_handle
+    preferred_name.presence || full_name.presence || email_handle
   end
 
   def possessive_name


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/580 / https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/701

We were missing a `.presence` when determining which name to use for a user, which resulted in us having "" as a user's name instead of their email handle.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add `.presence` in `User#name`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

