### PR TITLE
[Affiliations] Hide bad data and add metadata validation

### DIFF
--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -27,6 +27,7 @@ class Event
     store_accessor :metadata, :league, :team_number, :size, :venue_name
 
     scope :robotics, -> { where(name: %w[first vex]) }
+    scope :nonempty, -> { where.not(metadata: {}) }
 
     def display_name
       case name

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -75,7 +75,7 @@ class Event
                         else
                           return errors.add(:name, "is not a valid affiliation")
                         end
-      
+
       missing_fields = required_fields.select { |field| metadata[field].nil? }
       if missing_fields.any?
         errors.add(:metadata, "is missing fields: #{missing_fields.to_sentence}")

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -29,6 +29,8 @@ class Event
     scope :robotics, -> { where(name: %w[first vex]) }
     scope :nonempty, -> { where.not(metadata: {}) }
 
+    validate :metadata_contains_required_fields
+
     def display_name
       case name
       when "first"
@@ -58,6 +60,26 @@ class Event
 
     def to_s
       [display_name, league&.upcase, team_number, size&.positive? ? pluralize(size, "people") : nil].compact.join(" – ")
+    end
+
+    private
+
+    def metadata_contains_required_fields
+      required_fields = case name
+                        when "first"
+                          ["league", "team_number", "size"]
+                        when "vex"
+                          ["league", "team_number", "size"]
+                        when "hack_club"
+                          ["venue_name", "size"]
+                        else
+                          errors.add(:name, "is not a valid affiliation name")
+                        end
+      
+      missing_fields = required_fields.select { |field| metadata[field].nil? }
+      if missing_fields.any?
+        errors.add(:metadata, "is missing fields: #{missing_fields.to_sentence}")
+      end
     end
 
   end

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -73,7 +73,7 @@ class Event
                         when "hack_club"
                           ["venue_name", "size"]
                         else
-                          errors.add(:name, "is not a valid affiliation name")
+                          return errors.add(:name, "is not a valid affiliation")
                         end
       
       missing_fields = required_fields.select { |field| metadata[field].nil? }

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -143,7 +143,7 @@
     <% end %>
   </div>
 
-  <%= render partial: "events/settings/affiliation", collection: @application.affiliations %>
+  <%= render partial: "events/settings/affiliation", collection: @application.affiliations.nonempty %>
 <% end %>
 </div>
 

--- a/app/views/events/settings/_affiliations.html.erb
+++ b/app/views/events/settings/_affiliations.html.erb
@@ -12,5 +12,5 @@
   <% unless event.affiliations.none? %>
     <h3 class="mb2"><%= possessive(event.name) %> affiliations</h3>
   <% end %>
-  <%= render partial: "events/settings/affiliation", collection: event.affiliations %>
+  <%= render partial: "events/settings/affiliation", collection: event.affiliations.nonempty %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2761
Our frontend validations seem to have been bypassed, and affiliations with metadata `{}` were created.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
- Adds a `nonempty` scope to `Event::Affiliation` to hide any existing affiliations with empty metadata
- Adds a `metadata_contains_required_fields` validation to ensure that all affiliation types have backend validations that match their frontend validations

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

