### PR TITLE
[Reimbursements] Fix sub-organization peer-review bug

### DIFF
--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -314,7 +314,7 @@ module Reimbursement
     end
 
     def team_review_required?
-      !event.users.include?(user) || !OrganizerPosition.role_at_least?(user, event, :manager) || (event.reimbursements_require_organizer_peer_review && event.users.size > 1)
+      !OrganizerPosition.role_at_least?(user, event, :manager) || (event.reimbursements_require_organizer_peer_review && event.users.size > 1)
     end
 
     def reimbursement_confirmation_message


### PR DESCRIPTION
## Summary of the problem

Managers of parent organizations that aren't managers on child organizations should still have manager permissions, even if they're not directly on the organization.


## Describe your changes

Remove redundant line of code that causes a permissions bug.