### PR TITLE
[Admin] Fix disbursements performance

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -855,13 +855,14 @@ class AdminController < Admin::BaseController
     @processing = params[:processing] == "1" ? true : nil
 
     @event_id = params[:event_id].presence
+    @events_for_select = Event.reorder(Event::CUSTOM_SORT).select(:id, :name, :demo_mode)
 
     if @event_id
       @event = Event.find(@event_id)
 
-      relation = @event.disbursements.includes(:event)
+      relation = @event.disbursements.includes(:event, :source_event)
     else
-      relation = Disbursement.includes(:event)
+      relation = Disbursement.includes(:event, :source_event)
     end
 
     if @q

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -205,7 +205,7 @@ class Disbursement < ApplicationRecord
   end
 
   def pending_expired?
-    local_hcb_code.has_pending_expired?
+    canonical_pending_transactions.pending_expired.any?
   end
 
   # Eagerly create HcbCode object

--- a/app/views/admin/disbursements.html.erb
+++ b/app/views/admin/disbursements.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, url: disbursements_admin_index_path, method: :get do |form| %>
   <%= form.text_field :q, value: params[:q], placeholder: "Search" %>
-  <%= form.collection_select(:event_id, Event.reorder(Event::CUSTOM_SORT), :id, :admin_dropdown_description, { include_blank: "Select An Event", selected: @event_id }, { width: 250, style: "max-width: 250px" }) %>
+ <%= form.collection_select(:event_id, @events_for_select, :id, :admin_dropdown_description, { include_blank: "Select An Event", selected: @event_id }, { width: 250, style: "max-width: 250px" }) %>
   <fieldset>
     <%= form.label :reviewing do %>
       <%= form.check_box :reviewing, checked: @reviewing %>


### PR DESCRIPTION
this PR improves the disbursements admin interface by moving event dropdown data into a preloaded `@events_for_select` variable in the controller

* it selects only necessary fields and applying a custom order — instead of querying the database directly from the view. 
* eagerly loads both the `event` and `source_event` associations on disbursement queries to eliminate N+1 issues
* tightens the `pending_expired?` model method to check for expired canonical pending transactions directly