### PR TITLE
Refactor balance_by_date endpoint to return sorted array format

### DIFF
--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -59,24 +59,14 @@ module Api
       def balance_by_date
         authorize @event, :show_in_v4?
 
-        @balance_by_date = Rails.cache.fetch("balance_by_date_#{@event.id}", expires_in: 5.minutes) do
+        balance_by_date = Rails.cache.fetch("balance_by_date_#{@event.id}", expires_in: 5.minutes) do
           ::TransactionGroupingEngine::Transaction::All.new(event_id: @event.id).running_balance_by_date
         end
 
-        @balance_by_date = @balance_by_date.dup
-        @balance_by_date[0.days.ago.to_date] = @event.balance_v2_cents
+        balance_by_date = balance_by_date.dup
+        balance_by_date[Date.today] = @event.balance_v2_cents
 
-        max = [365, (Date.today - @event.created_at.to_date).to_i + 5].min
-
-        begin
-          if (@balance_by_date[max.days.ago.to_date] || @balance_by_date[@balance_by_date.keys.first]) > @balance_by_date[0.days.ago.to_date]
-            @balance_trend = "down"
-          else
-            @balance_trend = "up"
-          end
-        rescue
-          @balance_trend = "up"
-        end
+        @balance_series = balance_by_date.sort.map { |date, amount| { date: date.to_s, amount: } }
       end
 
       require_oauth2_scope "organizations:read", :balance_by_date

--- a/app/views/api/v4/events/balance_by_date.json.jbuilder
+++ b/app/views/api/v4/events/balance_by_date.json.jbuilder
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-json.balance_by_date @balance_by_date.transform_keys(&:to_s)
-json.balance_trend @balance_trend
+json.array! @balance_series do |point|
+  json.date point[:date]
+  json.amount point[:amount]
+end


### PR DESCRIPTION
## Summary of the problem
The current `balance_by_date` endpoint returns a hash with trend analysis, but the response format and trend calculation logic can be simplified. The trend calculation is fragile (uses bare rescue) and the hash format is less ideal for API consumers who need chronological data.

## Describe your changes
- Changed the response format from a hash to a sorted array of date/amount objects for better chronological ordering and consistency
- Removed the complex and error-prone `balance_trend` calculation logic that relied on comparing balances across arbitrary date ranges
- Simplified the controller logic by:
  - Using local variable instead of instance variable for intermediate calculations
  - Replacing `0.days.ago.to_date` with clearer `Date.today`
  - Removing the max date calculation and trend comparison logic
  - Transforming the final data into a sorted array format with explicit date strings
- Updated the JSON view to render the new array format instead of the previous hash with trend

The new response is an array of objects with `date` (ISO string) and `amount` (in cents) fields, sorted chronologically.

https://claude.ai/code/session_01313DXVBrDTxydr7kMZqwwA