### PR TITLE
Fix parent events retrieval to include all ancestors

### DIFF
--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -1,4 +1,4 @@
-<% parent_events ||= @event.ancestors[0...-1].reject { |e| e.id == @event.id } %>
+<% parent_events ||= @event.ancestors.reject { |e| e.id == @event.id } %>
 <% if parent_events.present? %>
   <div data-controller="menu" class="-mb-2">
     <button


### PR DESCRIPTION
Closes #13140

<img width="832" height="161" alt="image" src="https://github.com/user-attachments/assets/2c7319bb-93a1-47fb-91ac-8f2e39a4023a" />

the issue was that [0...-1] is unreliable because Event.where doesn't guarantee a specific order. however .reject makes sure that the current event is hidden (a previous bug with the subevent picker)