### PR TITLE
[v3 API] expose transaction users in lists

### DIFF
--- a/app/api/api/entities/transaction.rb
+++ b/app/api/api/entities/transaction.rb
@@ -87,6 +87,10 @@ module Api
         hcb_code.event
       end
 
+      expose_associated User do |hcb_code, options|
+        hcb_code.author
+      end
+
       expose_associated Tag, documentation: { type: Tag, is_array: true }, as: :tags do |hcb_code, options|
         hcb_code.tags
       end


### PR DESCRIPTION
## Summary of the problem

The v3 API's transaction list endpoint (`/api/v3/organizations/:id/transactions` ([example](https://hcb.hackclub.com/api/v3/organizations/org_a29uVj/transactions?per_page=25))) doesn't include any user information. There's no way to tell who initiated a transaction (e.g., who used their card, sent the ACH, etc.). User data is only available when fetching individual linked objects, such as card charges, but not at the list level, and I would prefer to not hammer HCB with more requests than needed.

## Describe your changes

Added `expose_associated User` to the `Transaction` entity, using the existing `HcbCode#author` method, which already shows the correct user across all transaction types (card charges, ACH transfers, checks, disbursements, etc.). Returns `null` for transaction types without an associated user (in this case we can assume its not done by a real human)