### PR TITLE
Fix reimbursement report page performance (flickering, listener leaks, redundant queries)

### DIFF
--- a/app/controllers/reimbursement/expenses_controller.rb
+++ b/app/controllers/reimbursement/expenses_controller.rb
@@ -120,6 +120,7 @@ module Reimbursement
     end
 
     def actions_turbo_stream
+      @expense.report.expenses.reload
       turbo_stream.replace("action-wrapper", partial: "reimbursement/reports/actions", locals: { report: @expense.report, user: @expense.report.user })
     end
 

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -430,7 +430,7 @@ module Reimbursement
     private
 
     def set_report_user_and_event
-      @report = Reimbursement::Report.find(params[:report_id] || params[:id])
+      @report = Reimbursement::Report.includes(expenses: [:approved_by, :receipts]).find(params[:report_id] || params[:id])
       @event = @report.event
       @user = @report.user
     rescue ActiveRecord::RecordNotFound

--- a/app/javascript/controllers/expense_form_controller.js
+++ b/app/javascript/controllers/expense_form_controller.js
@@ -18,6 +18,19 @@ export default class extends Controller {
   }
 
   connect() {
+    this._handleKeydown = (e) => {
+      if (e.key === 'Escape' && this.enabledValue) {
+        this.formTarget.reset()
+        this.close()
+      }
+    }
+    document.addEventListener('keydown', this._handleKeydown)
+
+    this._handleLightboxClick = (e) => {
+      e.preventDefault()
+      this.formTarget.requestSubmit()
+    }
+
     for (const field of this.fieldTargets) {
       if (field.nodeName == 'SELECT') {
         field.disabled = !this.enabledValue
@@ -26,13 +39,6 @@ export default class extends Controller {
         field.addEventListener('dblclick', () => this.edit())
         this.#addTooltip(field, 'Double-click to edit...')
       }
-
-      document.addEventListener('keydown', e => {
-        if (e.key === 'Escape' && this.enabledValue) {
-          this.formTarget.reset()
-          this.close()
-        }
-      })
     }
 
     // we don't render the button if the report is reimbursed
@@ -54,6 +60,11 @@ export default class extends Controller {
     this.#card()
     this.#move()
     this.#lightbox()
+  }
+
+  disconnect() {
+    document.removeEventListener('keydown', this._handleKeydown)
+    this.lightboxTarget.removeEventListener('click', this._handleLightboxClick)
   }
 
   close(e) {
@@ -166,19 +177,19 @@ export default class extends Controller {
   #addTooltip(field, label) {
     if (!label || this.lockedValue || this.enabledValue) return
 
-    const fieldWrapper = document.createElement('div')
-    field.parentNode.insertBefore(fieldWrapper, field)
-    fieldWrapper.appendChild(field)
-    fieldWrapper.classList.add('tooltipped', 'tooltipped--n')
-    fieldWrapper.setAttribute('aria-label', label)
+    const wrapper = field.closest('[data-tooltip-wrapper]')
+    if (!wrapper) return
 
-    window.attachTooltipListener()
+    wrapper.classList.add('tooltipped', 'tooltipped--n')
+    wrapper.setAttribute('aria-label', label)
   }
 
   #removeTooltip(field) {
-    const fieldWrapper = field.parentNode
-    fieldWrapper.parentNode.insertBefore(field, fieldWrapper)
-    fieldWrapper.remove()
+    const wrapper = field.closest('[data-tooltip-wrapper]')
+    if (!wrapper) return
+
+    wrapper.classList.remove('tooltipped', 'tooltipped--n')
+    wrapper.removeAttribute('aria-label')
   }
 
   #lightbox() {
@@ -186,14 +197,12 @@ export default class extends Controller {
       this.lightboxTarget.style.display = 'block'
       this.cardTarget.style.position = 'relative'
       this.cardTarget.style.zIndex = '11'
-      this.lightboxTarget.addEventListener('click', e => {
-        e.preventDefault()
-        this.formTarget.requestSubmit()
-      })
+      this.lightboxTarget.addEventListener('click', this._handleLightboxClick)
     } else {
       this.lightboxTarget.style.display = 'none'
       this.cardTarget.style.position = 'relative'
       this.cardTarget.style.zIndex = 'auto'
+      this.lightboxTarget.removeEventListener('click', this._handleLightboxClick)
     }
   }
 }

--- a/app/models/reimbursement/expense.rb
+++ b/app/models/reimbursement/expense.rb
@@ -86,10 +86,6 @@ module Reimbursement
       end
     end
 
-    include TouchHistory
-
-    broadcasts_refreshes_to ->(expense) { expense.was_touched? ? :_noop : expense.report }
-
     scope :complete, -> { where.not(memo: nil, amount_cents: 0).merge(self.with_receipt) }
 
     aasm do

--- a/app/views/reimbursement/expenses/_expense.html.erb
+++ b/app/views/reimbursement/expenses/_expense.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (expense:, new: false) -%>
+<%# locals: (expense:, new: false, move_report_options: nil, move_event_options: nil) -%>
 <% read_only = !OrganizerPosition.role_at_least?(current_user, expense.report.event, :manager) && current_user != expense.report.user && !admin_signed_in? %>
 <%= turbo_frame_tag expense do %>
   <div
@@ -103,12 +103,15 @@
   <%= form_with(model: expense.becomes(Reimbursement::Expense), class: "mb3 mt1", style: "max-width: 600px;", html: { "x-data" => "{reportId: null, eventId: null}" }, local: true, data: { turbo: false }) do |form| %>
     <div class="field event-select-target">
       <%= form.label :reimbursement_report_id, "Move to a pre-existing report", class: "mt2 bold" %>
-      <%= form.select(:reimbursement_report_id,
+      <% report_options = move_report_options || (
             admin_signed_in? ?
-              (current_user.reimbursement_reports.excluding(expense.report) + Reimbursement::Report.all.pending.excluding(expense.report)).reject(&:locked?).map { |report| [report.name, report.id] } :
+              (current_user.reimbursement_reports.excluding(expense.report) + Reimbursement::Report.all.pending.excluding(expense.report)).reject(&:locked?).map { |r| [r.name, r.id] } :
             current_user == expense.report.user ?
-              current_user.reimbursement_reports.excluding(expense.report).reject(&:locked?).map { |report| [report.name, report.id] } :
-              expense.report.event.reimbursement_reports.excluding(expense.report).reject(&:locked?).map { |report| [report.name, report.id] },
+              current_user.reimbursement_reports.excluding(expense.report).reject(&:locked?).map { |r| [r.name, r.id] } :
+              expense.report.event.reimbursement_reports.excluding(expense.report).reject(&:locked?).map { |r| [r.name, r.id] }
+          ) %>
+      <%= form.select(:reimbursement_report_id,
+            report_options,
             { prompt: "Select a report…", required: false, include_blank: "Select a report..." }, "x-model": "reportId") %>
       <% unless admin_signed_in? %>
         <span class="muted mt1">You can transfer an expense to any report of yours.</span>
@@ -116,9 +119,10 @@
     </div>
     <div class="field event-select-target">
       <%= form.label :event_id, "Create a new report", class: "mt2 bold" %>
+      <% event_options = move_event_options || current_user.events.not_hidden.filter_demo_mode(false).map { |e| [e.name, e.id] } %>
       <%= form.select(
             :event_id,
-            current_user.events.not_hidden.filter_demo_mode(false).map { |event| [event.name, event.id] },
+            event_options,
             { prompt: "Select an event…", required: false }, "x-model": "eventId"
           ) %>
       <% unless admin_signed_in? %>

--- a/app/views/reimbursement/expenses/_form.html.erb
+++ b/app/views/reimbursement/expenses/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with(model: expense.becomes(Reimbursement::Expense), url: reimbursement_expense_path(expense), class: "h-100 flex flex-col mb-3", style: "max-width: 600px;", local: true, data: { "expense-form-target": "form", turbo: true }) do |form| %>
   <div class="flex flex-row items-center">
-    <div style="flex-grow: 1;">
+    <div style="flex-grow: 1;" data-tooltip-wrapper>
       <%= form.label :memo, "Memo", class: "bold" %>
       <%= form.text_field :memo, placeholder: "Lunch during layover at SFO", required: true, data: { "expense-form-target": "field memoField", "action": "dblclick->expense-form#edit", "behavior": "ctrl_enter_submit" }, id: "reimbursement_expense_memo_#{expense.id}" %>
     </div>
@@ -10,7 +10,7 @@
     <% if expense.is_standard? || expense.is_fee? %>
       <span class="bold muted flex self-end items-center justify-center ml1" style="width: 1rem; height: 48px;"><%= expense.amount.currency.symbol %></span>
     <% end %>
-    <div class="ml1">
+    <div class="ml1" data-tooltip-wrapper>
       <%= form.label :value, expense.value_label, class: "bold" %>
       <% if expense.rate == 100 %>
         <%= form.number_field :value, placeholder: "500.00", step: 0.01, min: 0.01, value: number_with_precision(expense.value, precision: 2), data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad", "expense-form-target": "field", "behavior": "ctrl_enter_submit select_if_empty" } %>
@@ -20,13 +20,13 @@
     </div>
   </div>
   <% if expense.report.event&.plan&.requires_reimbursement_expense_categorization? && !expense.is_fee? %>
-    <div class="field mt1 mb1 flex flex-col w-100">
+    <div class="field mt1 mb1 flex flex-col w-100" data-tooltip-wrapper>
       <%= form.label :category, "Category", class: "bold" %>
       <%= form.select :category, Reimbursement::Expense.categories.keys, { include_blank: "Uncategorized" }, { style: "max-width: 100vw;", data: { "expense-form-target": "field" } } %>
     </div>
   <% end %>
   <% unless expense.is_fee? %>
-    <div class="field mt1 flex flex-col flex-grow">
+    <div class="field mt1 flex flex-col flex-grow" data-tooltip-wrapper>
       <div class="flex flex-row items-center justify-between flex-wrap gap-x-3">
         <%= form.label :description, "Description", class: "bold" %>
         <span class="h5 muted mt0 mb0 flex items-center">

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -1,4 +1,8 @@
 <% member_viewing = !OrganizerPosition.role_at_least?(current_user, report.event, :manager) && current_user != report.user && !admin_signed_in? %>
+<% loaded_expenses = report.expenses.load %>
+<% expenses_to_sum = loaded_expenses.reject(&:is_fee?) %>
+<% approved_to_sum = expenses_to_sum.select(&:approved?) %>
+<% complete_to_sum = expenses_to_sum.select { |e| e.memo.present? && !e.amount_cents.zero? && e.receipts.any? } %>
 
 <div class="flex flex-col-reverse" id="action-wrapper">
   <%# Using a reverse column flex container, we can
@@ -37,7 +41,7 @@
         <% elsif current_user == report.user && !admin_signed_in? %>
           <div class="btn bg-success disabled" class="tooltipped tooltipped--n" aria-label="Expenses can't be added to locked reports">
             <%= inline_icon "plus" %>
-            Add <%= report.expenses.count > 0 ? "another" : "an" %> expense
+            Add <%= loaded_expenses.any? ? "another" : "an" %> expense
           </div>
         <% elsif !report.closed? %>
           <%= link_to reimbursement_report_reject_path(report_id: report.id), class: "btn bg-error", data: { turbo: true, turbo_method: :post } do %>
@@ -155,9 +159,9 @@
             <%= inline_icon "send" %>
             Submit & request review
             <% button_hint = capture do %>
-              <% if report.expenses.none? %>
+              <% if loaded_expenses.empty? %>
                 Get started by adding an expense to this report.
-              <% elsif report.missing_receipts? || report.expenses.any? { |e| e.amount.zero? } %>
+              <% elsif report.missing_receipts? || loaded_expenses.any? { |e| e.amount.zero? } %>
                 <span class="bold">Your next step:</span> make sure you have a receipt, memo, and amount for each expense to continue.
               <% elsif report.exceeds_maximum_amount? %>
                <span class="bold warning">Warning</span>: your report is above <%= report.event.name %>'s limit. To continue, lower the amount requested.
@@ -224,7 +228,7 @@
               Reimburse <%= report.amount_to_reimburse.format %>
             </div>
           </div>
-        <% elsif report.submitted? && policy(report).approve_all_expenses? && report.expenses.approved.none? %>
+        <% elsif report.submitted? && policy(report).approve_all_expenses? && loaded_expenses.none?(&:approved?) %>
           <%= link_to reimbursement_report_approve_all_expenses_path(report), class: "btn bg-success", method: :post do %>
             <%= inline_icon "thumbsup" %>
             Approve all expenses
@@ -365,7 +369,7 @@
       Re-open report for review
     <% end %>
   <% end %>
-  <% if report.expenses.any? %>
+  <% if loaded_expenses.any? %>
     <div class="card mt2 flex-1 <%= "closed" if report.closed? || member_viewing %>">
       <div id="summary">
         <div class="stat stat--small" style="flex-shrink: 0;">
@@ -375,7 +379,7 @@
         <% if report.locked? %>
           <div class="stat stat--small stat--plain" style="flex-shrink: 0;">
             <span class="stat__label">Expenses approved</span>
-            <span class="stat__value"><%= report.expenses.approved.to_sum.count %>/<%= report.expenses.to_sum.count %></span>
+            <span class="stat__value"><%= approved_to_sum.size %>/<%= expenses_to_sum.size %></span>
           </div>
           <div class="stat stat--small" style="flex-shrink: 0;">
             <span class="stat__label">Amount approved</span>
@@ -390,11 +394,11 @@
         <% else %>
           <div class="stat stat--small stat--plain" style="flex-shrink: 0;">
             <span class="stat__label">Total expenses</span>
-            <span class="stat__value"><%= report.expenses.to_sum.count %></span>
+            <span class="stat__value"><%= expenses_to_sum.size %></span>
           </div>
           <div class="stat stat--small stat--plain" style="flex-shrink: 0;">
             <span class="stat__label">Complete</span>
-            <span class="stat__value"><%= report.expenses.to_sum.complete.count %>/<%= report.expenses.to_sum.count %></span>
+            <span class="stat__value"><%= complete_to_sum.size %>/<%= expenses_to_sum.size %></span>
           </div>
         <% end %>
         <p class="mt-1 mb0" id="summary-hint">

--- a/app/views/reimbursement/reports/_expenses.html.erb
+++ b/app/views/reimbursement/reports/_expenses.html.erb
@@ -1,5 +1,14 @@
 <% if report.expenses.any? %>
+  <% move_report_options = if admin_signed_in?
+      (current_user.reimbursement_reports.excluding(report) + Reimbursement::Report.all.pending.excluding(report)).reject(&:locked?).map { |r| [r.name, r.id] }
+    elsif current_user == report.user
+      current_user.reimbursement_reports.excluding(report).reject(&:locked?).map { |r| [r.name, r.id] }
+    else
+      report.event.reimbursement_reports.excluding(report).reject(&:locked?).map { |r| [r.name, r.id] }
+    end
+  %>
+  <% move_event_options = current_user.events.not_hidden.filter_demo_mode(false).map { |event| [event.name, event.id] } %>
   <% report.expenses.order(created_at: :asc).includes(:approved_by, :event, :receipts).each do |expense| %>
-    <%= render "reimbursement/expenses/expense", expense:, new: @editing == expense.id %>
+    <%= render "reimbursement/expenses/expense", expense:, new: @editing == expense.id, move_report_options:, move_event_options: %>
   <% end %>
 <% end %>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -218,7 +218,7 @@
   <%= render partial: "reimbursement/reports/blankslate", locals: { report: @report } %>
 </div>
 
-<% if @report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
+<% if @report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name && @report.expenses.none?(&:is_fee?) %>
   <%= render "application/callout",
       type: "info",
       icon: "wise",


### PR DESCRIPTION
This pr was written 100% by claude code and is for the purposes of Ian's entertainment. Don't merge it!
                                                           
  ## Summary

  The reimbursement report show page (`app/views/reimbursement/reports/show.html.erb`) is laggy and glitchy when creating, editing, and deleting expenses. Users experience flickering, slow responses, and sluggish interactions.

  Root causes: (1) Turbo broadcast triggers a full-page morph on top of already-applied turbo_stream updates, (2) JavaScript event listener leaks and heavy DOM manipulation, (3) redundant SQL queries in the _actions partial re-rendered on
  every CRUD operation, (4) per-expense duplicate queries for move modals.

  ### Phase 1: Remove redundant Turbo broadcast from Expense model

  **`app/models/reimbursement/expense.rb`**

  Removed `broadcasts_refreshes_to` and its `include TouchHistory` guard. Every expense save was broadcasting a refresh to the report channel. The show page subscribes via `turbo_stream_from @report` + `turbo_refreshes_with method: :morph`,
  causing a full page re-fetch + morph AFTER the controller's targeted turbo_stream updates had already applied. This double-update reset Stimulus controller state (edit mode, tooltips, focus) and caused flickering.

  The controller already returns comprehensive turbo_stream responses for all CRUD ops. The Report model's own broadcast (guarded by `was_touched?`) still provides real-time updates for direct report changes.

  ### Phase 2: Fix JavaScript event listener leaks and DOM manipulation

  **`app/javascript/controllers/expense_form_controller.js`**

  - **2a: Fix duplicate keydown listeners.** Lines 30-35 registered `document.addEventListener('keydown', ...)` inside the `for (const field of this.fieldTargets)` loop. N fields = N duplicate global listeners, never removed. Fixed by moving
   to a single bound listener registered once in `connect()`, removed in `disconnect()`.

  - **2b: Fix lightbox click listener accumulation.** `#lightbox()` added a new click listener every time `edit()` was called. Fixed by creating the bound handler once in `connect()` and adding/removing it in `#lightbox()` based on state.

  - **2c: Replace DOM-restructuring tooltips with class toggling.** `#addTooltip()` wrapped fields in new DOM nodes via `insertBefore`/`appendChild`; `#removeTooltip()` unwrapped them. This restructured the DOM every toggle and called
  `window.attachTooltipListener()` globally. Fixed by toggling `tooltipped` and `tooltipped--n` classes + `aria-label` on existing parent `<div>`s marked with `data-tooltip-wrapper` in `_form.html.erb`.

  - **2d: Added `disconnect()` method** to clean up keydown and lightbox listeners.

  **`app/views/reimbursement/expenses/_form.html.erb`**

  Added `data-tooltip-wrapper` attributes to the memo, value, category, and description parent `<div>`s so the tooltip class toggling can find them.

  ### Phase 3: Reduce SQL queries in _actions.html.erb

  - **3a: Eager-load expenses in the controller.** `set_report_user_and_event` now uses `Reimbursement::Report.includes(expenses: [:approved_by, :receipts]).find(...)`.

  - **3b: Pre-compute collections at top of `_actions.html.erb`.** Added `loaded_expenses`, `expenses_to_sum`, `approved_to_sum`, `complete_to_sum` computed once from the loaded association. Replaced all scoped queries throughout the partial
   (`report.expenses.count > 0`, `report.expenses.none?`, `report.expenses.any?`, `report.expenses.approved.none?`, `report.expenses.approved.to_sum.count`, `report.expenses.to_sum.count`, `report.expenses.to_sum.complete.count`) with
  in-memory operations on these collections.

  - **3c: Reload association in `actions_turbo_stream`.** Added `@expense.report.expenses.reload` so the partial gets fresh data after create/update/delete.

  ### Phase 4: Deduplicate per-expense move modal queries

  **`app/views/reimbursement/reports/_expenses.html.erb`**

  Each expense rendered a move modal querying `current_user.reimbursement_reports` and `current_user.events` — identical queries running N times. Pre-computed `move_report_options` and `move_event_options` once before the loop and passed as
  locals.

  **`app/views/reimbursement/expenses/_expense.html.erb`**

  Added `move_report_options: nil, move_event_options: nil` to strict locals. When nil (turbo_stream rendering of a single expense), falls back to computing inline. When pre-computed values are passed from the loop, uses those directly.

  ### Phase 5: Fix inline expense query in show.html.erb

  **`app/views/reimbursement/reports/show.html.erb`**, line 221

  Replaced `@report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty?` with `@report.expenses.none?(&:is_fee?)`. The `is_fee?` method already exists on the Expense model, and with eager-loaded expenses from Phase 3a
  this operates in memory.
