### PR TITLE
[Reimbursements] Fix permissions bugs for sub-organizations

### DIFF
--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -3,7 +3,7 @@
 module Reimbursement
   class ReportPolicy < ApplicationPolicy
     def new?
-      admin || team_member
+      admin || reader
     end
 
     def create?
@@ -11,7 +11,7 @@ module Reimbursement
     end
 
     def show?
-      admin || team_member || creator || auditor
+      admin || reader || creator || auditor
     end
 
     def wise_transfer_quote?
@@ -92,8 +92,8 @@ module Reimbursement
       record.event && OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
-    def team_member
-      record.event&.users&.include?(user)
+    def reader
+      record.event && OrganizerPosition.role_at_least?(user, record.event, :reader)
     end
 
     def creator


### PR DESCRIPTION
## Summary of the problem

We're not looking up to parent organizations for reimbursement report permissions checks


## Describe your changes

Use `OrganizerPosition.role_at_least?`