### PR TITLE
[Contracts] Properly handle contract deletion

### DIFF
--- a/app/jobs/contract/party/reminder_job.rb
+++ b/app/jobs/contract/party/reminder_job.rb
@@ -4,6 +4,7 @@ class Contract
   class Party
     class ReminderJob < ApplicationJob
       queue_as :low
+      discard_on ActiveJob::DeserializationError
 
       def perform(party)
         return unless party.pending? && party.contract.sent?

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -4,7 +4,11 @@ module Contractable
   extend ActiveSupport::Concern
 
   included do
-    has_many :contracts, as: :contractable, dependent: :destroy
+    has_many :contracts, as: :contractable
+
+    after_destroy_commit do
+      contracts.where(aasm_state: [:pending, :sent]).each(&:mark_voided!)
+    end
 
     def send_contract(cosigner_email: nil, include_videos: false, reissue_signee_message: nil, reissue_cosigner_message: nil)
       # This method should be overwritten in specific classes

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -7,7 +7,7 @@ module Contractable
     has_many :contracts, as: :contractable, dependent: :destroy
 
     before_destroy do
-      contracts.where(aasm_state: [:pending, :sent]).each(&:mark_voided!)
+      contracts.where(aasm_state: [:pending, :sent]).find_each(&:mark_voided!)
     end
 
     def send_contract(cosigner_email: nil, include_videos: false, reissue_signee_message: nil, reissue_cosigner_message: nil)

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -6,10 +6,6 @@ module Contractable
   included do
     has_many :contracts, as: :contractable, dependent: :destroy
 
-    before_destroy do
-      contracts.where(aasm_state: [:pending, :sent]).find_each(&:mark_voided!)
-    end
-
     def send_contract(cosigner_email: nil, include_videos: false, reissue_signee_message: nil, reissue_cosigner_message: nil)
       # This method should be overwritten in specific classes
       raise NotImplementedError, "The #{self.class.name} model includes Contractable, but hasn't implemented it's own version of send_contract."

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -6,7 +6,7 @@ module Contractable
   included do
     has_many :contracts, as: :contractable
 
-    after_destroy_commit do
+    before_destroy do
       contracts.where(aasm_state: [:pending, :sent]).each(&:mark_voided!)
     end
 

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -4,7 +4,7 @@ module Contractable
   extend ActiveSupport::Concern
 
   included do
-    has_many :contracts, as: :contractable
+    has_many :contracts, as: :contractable, dependent: :destroy
 
     before_destroy do
       contracts.where(aasm_state: [:pending, :sent]).each(&:mark_voided!)

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -42,7 +42,7 @@ class Contract < ApplicationRecord
   belongs_to :contractable, polymorphic: true
 
   has_one :organizer_position, required: false, foreign_key: :fiscal_sponsorship_contract_id, inverse_of: :fiscal_sponsorship_contract
-  has_many :parties
+  has_many :parties, dependent: :destroy
 
   validate :one_non_void_contract
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -63,6 +63,10 @@ class Contract < ApplicationRecord
     parties.create!(user:, role: :hcb)
   end
 
+  before_destroy do
+    mark_voided! if may_mark_voided?
+  end
+
   aasm timestamps: true, requires_lock: true do
     state :pending, initial: true
     state :sent


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We've been getting some errors such as https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2769 and https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2586 due to contracts getting deleted.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The only case in which contracts should be (soft) deleted is if the associated contractable is deleted. This PR adds cascade (soft) deletion to contract parties and handles a deleted party in the reminder job.

I think we should go ahead and delete existing contracts that link to a nonexistent OPI (https://hcb.hackclub.com/blazer/queries/1129-contracts-with-deleted-opis) - we make the assumption in code that all contracts have a contractable and should avoid related errors by deleting these contracts.

