### PR TITLE
Fix applications admin nav item

### DIFF
--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -222,7 +222,7 @@ module Admin
         name: "Organizations",
         items: [
           make_item(
-            name: "Applications",
+            name: "Applications (HCB)",
             path: applications_admin_index_path,
             count: Event::Application.under_review.count
           ),


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The admin nav determines if an item is active by comparing the page title and the nav item title. For applications, this didn't match, so it wasn't showing the Organizations section as selected.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Update the applications admin nav item name to match the page title.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

