### PR TITLE
Use custom hashid configuration on relations

### DIFF
--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+ActiveSupport.on_load(:active_record) do
+  Hashid::Rails::ClassMethods.module_eval do
+    def hashid_configuration
+      if is_a?(ActiveRecord::Relation)
+        klass.hashid_configuration
+      else
+        @hashid_configuration || hashid_config
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
hashid-rails [already has code](https://github.com/jcypret/hashid-rails/blob/e0e2982583fc32a635d1fd5da937588fb04a8e03/lib/hashid/rails.rb#L59) to make sure that its methods are applied on `ActiveRecord::Relation`, which is created from database models when any query methods are used. However, since `hashid_config` only sets configuration on the model class, `ActiveRecord::Relation` objects always fallback to the global default.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a (jank) patch that overrides the `hashid_configuration` method to reference the model's hashid configuration when called on an `ActiveRecord::Relation`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

