### PR TITLE
[Contracts] Don't send contract reminders if scheduled for an onboarding call

### DIFF
--- a/app/jobs/contract/party/reminder_job.rb
+++ b/app/jobs/contract/party/reminder_job.rb
@@ -8,6 +8,9 @@ class Contract
       def perform(party)
         return unless party.pending? && party.contract.sent?
 
+        # If they're scheduled for an onboarding call, we shouldn't remind them
+        return if party.contract.contractable.is_a?(Event::Application) && ["Interview Scheduled", "Invited to Interview"].include?(party.contract.contractable.airtable_record["Status"])
+
         Contract::PartyMailer.with(party:).reminder.deliver_later
       end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We shouldn't need to remind people to sign if they're already scheduled to call with ops, possibly to go over the contract.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Skip the contract reminder if the application's airtable status is invited to interview or interview scheduled.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

