### PR TITLE
[Reimbursement] Show "Name on Account" for all payout types

### DIFF
--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -19,6 +19,10 @@
         <td><%= user.name %></td>
       </tr>
       <tr>
+        <td>Name on account:</td>
+        <td><%= payout_method.try(:account_holder).presence || user.full_name %></td>
+      </tr>
+      <tr>
         <td>Email:</td>
         <td><%= user.email %></td>
       </tr>
@@ -114,12 +118,6 @@
           <td>Currency:</td>
           <td><%= payout_method.currency %></td>
         </tr>
-        <% if payout_method.recipient_information["account_holder"].present? %>
-          <tr>
-            <td>Name on account:</td>
-            <td><%= payout_method.recipient_information["account_holder"] %></td>
-          </tr>
-        <% end %>
         <% if payout_method.bank_name.present? %>
           <tr>
             <td>Bank name:</td>


### PR DESCRIPTION
Updated payout information display to show account holder name from payout method or user full name