### PR TITLE
[Applications] Pull referral code from query param

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -13,7 +13,9 @@ class Event
 
     def index
       skip_authorization
+
       @applications = current_user.applications.active
+      @referral_code = params[:ref]
     end
 
     def apply
@@ -22,14 +24,16 @@ class Event
       if signed_in? && current_user.applications.draft.one?
         redirect_to application_path(current_user.applications.draft.first)
       elsif signed_in? && current_user.applications.any?
-        redirect_to applications_path
+        redirect_to applications_path(ref: params[:ref])
       else
-        redirect_to new_application_path
+        redirect_to new_application_path(ref: params[:ref])
       end
     end
 
     def new
       skip_authorization
+
+      @referral_code = params[:ref]
     end
 
     def show
@@ -139,7 +143,7 @@ class Event
         redirect_to auth_users_path(return_to: start_applications_path(teen_led: params[:teen_led].presence), require_reload: true) and return
       end
 
-      authorize(@application = Event::Application.new(user: current_user, teen_led: params[:teen_led] == "true"))
+      authorize(@application = Event::Application.new(user: current_user, teen_led: params[:teen_led] == "true", referral_code: params[:referral_code]))
       @application.save!
 
       redirect_to project_info_application_path(@application)

--- a/app/views/event/applications/_begin.html.erb
+++ b/app/views/event/applications/_begin.html.erb
@@ -40,6 +40,8 @@
   <div class="flex flex-col items-center flex-grow">
     <div class="md:max-w-[600px] w-full">
       <%= form_with model: @application || false, url: "#", method: @application.present? ? :patch : :post, id: @application.present? ? "edit_application_#{@application.id}" : "create_application", class: "mt-7" do |form| %>
+        <%= form.hidden_field(:referral_code, value: @referral_code) if @referral_code.present? %>
+
         <div class="card card--outline mb-6" x-data="{ teenager: '<%= @application&.teen_led? ? "true" : @application&.teen_led? == false ? "false" : "" %>' }">
           <%= form.label :teen_led do %>
             Are you a teenager? <span class="text-primary">*</span>

--- a/app/views/event/applications/_summary.html.erb
+++ b/app/views/event/applications/_summary.html.erb
@@ -150,10 +150,12 @@
         <p class="text-sm muted mb-1">How did you hear about HCB?</p>
         <p class="mb-0"><%= application.referrer.present? ? application.referrer : blank %></p>
       </div>
-      <div>
-        <p class="text-sm muted mb-1">Referral code</p>
-        <p class="mb-0"><%= application.referral_code.present? ? application.referral_code : blank %></p>
-      </div>
+      <% admin_tool do %>
+        <div>
+          <p class="text-sm muted mb-1">Referral code</p>
+          <p class="mb-0"><%= application.referral_code.present? ? application.referral_code : blank %></p>
+        </div>
+      <% end %>
     </div>
 
     <% if application.accessibility_notes.present? %>

--- a/app/views/event/applications/index.html.erb
+++ b/app/views/event/applications/index.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "event/applications/application_card", locals: { application: } %>
   <% end %>
 
-  <%= link_to new_application_path do %>
+  <%= link_to new_application_path(ref: @referral_code) do %>
     <li class="card card--hover bold font-brand flex items-center justify-center align-center h-full" style="max-width: calc(100vw - 2rem)">
       <div class="center">
         <div class="pop success mx-auto flex mb-1">

--- a/app/views/event/applications/personal_info.html.erb
+++ b/app/views/event/applications/personal_info.html.erb
@@ -121,11 +121,6 @@
     </div>
 
     <div class="field">
-      <%= form.label :referral_code, "Referral code" %>
-      <%= form.text_field :referral_code, class: "w-full !max-w-full" %>
-    </div>
-
-    <div class="field">
       <%= form.label :accessibility_notes, "Accessibility needs" %>
       <%= form.text_area :accessibility_notes, class: "w-full max-w-full" %>
     </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some people are getting confused or putting in random data into the referral code field on the application form. This isn't really meant for users to fill in, and it's more useful to just pull from a query param so that we can link to something like https://hcb.hackclub.com/apply?ref=first, and see the data in [Blazer](https://hcb.hackclub.com/blazer/queries/1113-application-referral-codes).

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
- Remove the field for applicants to enter a referral code
- Pass the `ref` query param to application creation
- Show the referral code to admins in summary and edit
