### PR TITLE
[Contracts] Return created contract from OPI send_contract

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -226,6 +226,8 @@ class OrganizerPositionInvite < ApplicationRecord
     end
 
     fs_contract.send!(reissue_signee_message:, reissue_cosigner_message:)
+
+    fs_contract
   end
 
   def on_contract_signed(contract)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2771 - `OrganizerPositionInvite#send_contract` was returning `true` instead of the created contract.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Return the created contract

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

