### PR TITLE
[Contracts] Reload contract after syncing party with docuseal

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -325,6 +325,7 @@ class Event
 
     def activate_event!(risk_level:, tags: [])
       contract.party(:hcb).sync_with_docuseal
+      contract.reload
       raise "Contract must be signed before activation" unless contract.signed?
 
       self.with_lock do


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2726 - while `sync_with_docuseal` ensures that the party is synced, the specific contract object that `Event::Application` has is not updated by the callbacks on `Contract::Party`, and so it may be outdated when we check its status.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Reload the contract after syncing with docuseal to ensure up to date data before checking its status.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

