### PR TITLE
[Column] Handle webhook events for canceled ACH Transfers

### DIFF
--- a/app/controllers/column/webhooks_controller.rb
+++ b/app/controllers/column/webhooks_controller.rb
@@ -19,6 +19,8 @@ module Column
         handle_as_raw_pending_column_transaction("swift.incoming_transfer.completed")
       elsif type == "ach.outgoing_transfer.returned"
         handle_ach_outgoing_transfer_returned
+      elsif type == "ach.outgoing_transfer.canceled"
+        handle_ach_outgoing_transfer_canceled
       elsif type == "check.outgoing_debit.settled"
         handle_check_deposit_settled
       elsif type == "check.outgoing_debit.returned"
@@ -27,6 +29,8 @@ module Column
         handle_swift_outgoing_transfer_returned
       elsif type.start_with?("check.incoming_debit")
         handle_outgoing_check_update
+      else
+        Rails.error.unexpected("Unhandled Column webhook type: #{type}")
       end
     rescue => e
       Rails.error.report(e)
@@ -73,6 +77,10 @@ module Column
 
     def handle_ach_outgoing_transfer_returned
       AchTransfer.find_by(column_id: @object[:id])&.mark_failed!(reason: @object[:return_details].pick(:description)&.gsub(/\(trace #: \d+\)\Z/, "")&.strip)
+    end
+
+    def handle_ach_outgoing_transfer_canceled
+      AchTransfer.find_by(column_id: @object[:id])&.mark_failed!(reason: "Transfer canceled by sender")
     end
 
     def handle_swift_outgoing_transfer_returned


### PR DESCRIPTION
## Summary of the problem

We were not transitioning state for these on HCB when we cancel the transfer on column

## Describe your changes

Process these webhook events