### PR TITLE
[Google Workspace Account] Allow manager to delete accounts

### DIFF
--- a/app/policies/g_suite_account_policy.rb
+++ b/app/policies/g_suite_account_policy.rb
@@ -26,7 +26,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.admin?
+    admin_or_manager?
   end
 
   def reject?

--- a/app/views/g_suite_accounts/_panel.html.erb
+++ b/app/views/g_suite_accounts/_panel.html.erb
@@ -49,8 +49,7 @@
                 <%= link_to "Delete",
                   account,
                   method: :delete,
-                  'data-confirm': "Deleting #{account.address} is *permanent, irreversible, and does not back up any data*. Think carefully before you click ok.",
-                  class: "admin-tools" if admin_signed_in? %>
+                  'data-confirm': "Deleting #{account.address} is *permanent, irreversible, and does not back up any data*. Are you sure you want to continue?" if policy(account).destroy? %>
               </div>
             </action>
           </div>


### PR DESCRIPTION
## Summary of the problem

We had previously decided to disallow HCB users from deleting Google Workspace accounts — they could only suspend. Now we're running into the Google Workspace user limit.


## Describe your changes

Allow managers to delete them. Previously admin-only.