### PR TITLE
[Event] Disallow users to comment

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -57,7 +57,7 @@ class CommentPolicy < ApplicationPolicy
         user_list += record.commentable.event&.ancestor_users || []
       end
     elsif record.commentable.is_a?(Event)
-      user_list = record.commentable.users
+      user_list = []
     else
       user_list = record.commentable.event.users
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This form is admin only so we should not be enabling it on the backend for the event's users.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

