### PR TITLE
Revert "Use `minify_html` instead of `htmlcompressor`"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -235,7 +235,3 @@ gem "pghero", "~> 3.7"
 gem "pg_query", ">= 2"
 
 gem "intercom-rails"
-
-group :production do
-  gem "minify_html"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,8 +523,6 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minify_html (0.18.1)
-      fiddle (~> 1.0)
     minitest (6.0.1)
       prism (~> 1.5)
     monetize (1.13.0)
@@ -1001,7 +999,6 @@ DEPENDENCIES
   loofah
   memo_wise
   mini_magick
-  minify_html
   monetize
   money-rails
   namae

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,17 +16,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery
 
-  MINIFY_HTML_OPTS = {
-    keep_spaces_between_attributes: true,
-    keep_html_and_head_opening_tags: true,
-    keep_input_type_text_attr: true,
-    minify_css: true,
-    minify_js: true,
-    keep_comments: false
-  }.freeze
-
-  after_action :minify_html_response if Rails.env.production?
-
   before_action :attach_error_reference
   before_action :attach_user_id
 
@@ -154,12 +143,6 @@ class ApplicationController < ActionController::Base
   def attach_user_id
     user_id = current_user&.id
     Appsignal.add_tags(user_id:) if defined?(Appsignal) && Appsignal.active?
-  end
-
-  def minify_html_response
-    return unless response.content_type&.include?("text/html")
-
-    response.body = minify_html(response.body, MINIFY_HTML_OPTS)
   end
 
 end

--- a/config/initializers/html_minify.rb
+++ b/config/initializers/html_minify.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-return unless Rails.env.production?
-
-require "minify_html"


### PR DESCRIPTION
Reverts hackclub/hcb#13127

This is causing Organization home page graphs to not load