### PR TITLE
[GSuite] Add `max_account` limit

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1073,14 +1073,19 @@ class AdminController < Admin::BaseController
   def google_workspace_update
     @g_suite = GSuite.find(params[:id])
 
-    @g_suite = GSuiteService::Update.new(
-      g_suite_id: @g_suite.id,
-      domain: @g_suite.domain,
-      verification_key: params[:verification_key],
-      dkim_key: params[:dkim_key]
-    ).run
+    begin
+      @g_suite = GSuiteService::Update.new(
+        g_suite_id: @g_suite.id,
+        domain: @g_suite.domain,
+        verification_key: params[:verification_key],
+        dkim_key: params[:dkim_key],
+        max_account: params[:max_account]
+      ).run
 
-    redirect_to google_workspace_process_admin_path(@g_suite), flash: { success: "Success" }
+      redirect_to google_workspace_process_admin_path(@g_suite), flash: { success: "Success" }
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to google_workspace_process_admin_path(@g_suite), flash: { error: e.record.errors.full_messages.to_sentence }
+    end
   end
 
   def google_workspace_toggle_revocation_immunity

--- a/app/models/g_suite.rb
+++ b/app/models/g_suite.rb
@@ -10,6 +10,7 @@
 #  dkim_key             :text
 #  domain               :citext
 #  immune_to_revocation :boolean          default(FALSE), not null
+#  max_accounts         :integer          default(75), not null
 #  remote_org_unit_path :text
 #  verification_key     :text
 #  created_at           :datetime         not null
@@ -90,6 +91,7 @@ class GSuite < ApplicationRecord
   scope :needs_ops_review, -> { where(aasm_state: ["creating", "verifying"]) }
 
   validates :domain, presence: true, format: { with: VALID_DOMAIN }
+  validates :max_accounts, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates_uniqueness_of_without_deleted :domain
 
   before_validation :clean_up_verification_key

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -47,6 +47,7 @@ class GSuiteAccount < ApplicationRecord
   validates :backup_email, nondisposable: true, on: :create
 
   validate :status_accepted_or_rejected
+  validate :within_quota, on: :create
   validates :address, uniqueness: { scope: :g_suite }
 
   before_update :sync_update_to_gsuite
@@ -165,6 +166,12 @@ class GSuiteAccount < ApplicationRecord
         notify_user_of_password_change
       end
     end
+  end
+
+  def within_quota
+    return if g_suite.accounts.count < g_suite.max_accounts
+
+    errors.add(:base, "You've reached your quota of #{g_suite.max_accounts} accounts and won't be able to create more accounts until you delete existing ones.")
   end
 
 end

--- a/app/services/g_suite_service/update.rb
+++ b/app/services/g_suite_service/update.rb
@@ -2,12 +2,13 @@
 
 module GSuiteService
   class Update
-    def initialize(g_suite_id:, domain:, verification_key:, dkim_key: nil)
+    def initialize(g_suite_id:, domain:, verification_key:, dkim_key: nil, max_accounts: nil)
       @g_suite_id = g_suite_id
 
       @domain = domain
       @verification_key = verification_key.nil? ? g_suite.verification_key : verification_key
       @dkim_key = dkim_key.nil? ? g_suite.dkim_key : dkim_key
+      @max_accounts = max_accounts.nil? ? g_suite.max_accounts : max_accounts
     end
 
     def run
@@ -18,6 +19,7 @@ module GSuiteService
         g_suite.domain = @domain
         g_suite.verification_key = smart_verification_key
         g_suite.dkim_key = @dkim_key
+        g_suite.max_accounts = @max_accounts
         g_suite.save!
 
         if domain_changing?

--- a/app/views/admin/google_workspace_process.html.erb
+++ b/app/views/admin/google_workspace_process.html.erb
@@ -46,6 +46,10 @@
       <td style="width: 90%"><%= @g_suite.dkim_key %></td>
     </tr>
     <tr>
+      <td style="text-align: right;">Max Accounts:</td>
+      <td><%= @g_suite.max_accounts %></td>
+    </tr>
+    <tr>
       <td style="text-align: right;">DNS Check:</td>
       <td> <%= link_to @g_suite.domain, @g_suite.dns_check_url, target: :_blank %></td>
     </tr>
@@ -137,6 +141,12 @@
     <%= dkim_key_form.text_field :dkim_key, value: @g_suite.dkim_key %>
   <% end %>
   <%= dkim_key_form.submit "Update DKIM key" %>
+<% end %>
+<br>
+<%= form_with(model: false, local: true, url: google_workspace_update_admin_path(@g_suite), method: :post) do |max_accounts_form| %>
+  <%= max_accounts_form.label :max_accounts, "Max allowed accounts" %>
+  <%= max_accounts_form.number_field :max_accounts, value: @g_suite.max_accounts, min: 1, step: 1 %>
+  <%= max_accounts_form.submit "Update" %>
 <% end %>
 <hr>
 <h3>Google Workspace Revocation Immunity</h3>

--- a/db/migrate/20260312205901_add_max_accounts_to_g_suite.rb
+++ b/db/migrate/20260312205901_add_max_accounts_to_g_suite.rb
@@ -1,0 +1,5 @@
+class AddMaxAccountsToGSuite < ActiveRecord::Migration[8.0]
+  def change
+    add_column :g_suites, :max_accounts, :integer, default: 75, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_10_040000) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1277,6 +1277,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_10_040000) do
     t.citext "domain"
     t.bigint "event_id"
     t.boolean "immune_to_revocation", default: false, null: false
+    t.integer "max_accounts", default: 75, null: false
     t.text "remote_org_unit_id"
     t.text "remote_org_unit_path"
     t.datetime "updated_at", precision: nil, null: false

--- a/spec/services/g_suite_account_service/create_spec.rb
+++ b/spec/services/g_suite_account_service/create_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe GSuiteAccountService::Create, type: :model do
 
   context "when g suite account quota is reached" do
     before do
-      g_suite.update!(max_account: 1)
+      g_suite.update!(max_accounts: 1)
       GSuiteAccount.create!(
         g_suite:,
         creator: current_user,

--- a/spec/services/g_suite_account_service/create_spec.rb
+++ b/spec/services/g_suite_account_service/create_spec.rb
@@ -98,6 +98,33 @@ RSpec.describe GSuiteAccountService::Create, type: :model do
     end
   end
 
+  context "when g suite account quota is reached" do
+    before do
+      g_suite.update!(max_account: 1)
+      GSuiteAccount.create!(
+        g_suite:,
+        creator: current_user,
+        backup_email: "a@example.com",
+        address: "asl@event.example.com",
+        first_name: "Test",
+        last_name: "User",
+        accepted_at: DateTime.now
+      )
+    end
+
+    it "does not create an account" do
+      expect do
+        service.run rescue nil
+      end.not_to change(GSuiteAccount, :count)
+    end
+
+    it "raises an error" do
+      expect do
+        service.run
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
   describe "private" do
     describe "#full_email_address" do
       it "builds" do

--- a/spec/services/g_suite_service/update_spec.rb
+++ b/spec/services/g_suite_service/update_spec.rb
@@ -122,4 +122,27 @@ RSpec.describe GSuiteService::Update, type: :model do
       expect(g_suite_result.verification_key).to eql(nil)
     end
   end
+
+  context "when max account quota is changed" do
+    let(:service) {
+      GSuiteService::Update.new(
+        g_suite_id: g_suite.id,
+        domain: g_suite.domain,
+        verification_key: g_suite.verification_key,
+        max_accounts: 100
+      )
+    }
+
+    it "updates max account quota" do
+      expect do
+        service.run
+      end.to change { g_suite.reload.max_accounts }.to(100)
+    end
+
+    it "does not send a mailer" do
+      expect do
+        service.run
+      end.to_not change(ActionMailer::Base.deliveries, :count)
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

We didn't limit max accounts per g_suite before which caused certain organizations to have a lot more than others, denying other organizations fair usage of the perk

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

we now limit max accounts per g_suite to 75 by default and this is a quota that can be updated by admins.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

