### PR TITLE
Fix popover loading spinner icon

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -40,7 +40,7 @@ const populateSharedPopover = trigger => {
     body.innerHTML = ''
     if (src && frameId) {
       const frame = document.createElement('turbo-frame')
-      frame.innerHTML = `<div class="flex items-center justify-center" style="height:calc(100vh - 150px)"><img src="/assets/loading.svg" class="dark:invert" /></div>`
+      frame.innerHTML = `<div class="flex items-center justify-center" style="height:calc(100vh - 150px)"><img src="/icons/loading.svg" class="dark:invert" /></div>`
       frame.id = frameId
       frame.src = src
       frame.setAttribute('target', '_top')


### PR DESCRIPTION
This PR removes the `/assets/` which causes the icon to 404
It will now load https://hcb.hackclub.com/icons/loading.svg which is correct