### PR TITLE
[Disbursements] Remove reliance on hash IDs for org dropdown

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -71,10 +71,10 @@ class DisbursementsController < ApplicationController
   def create
     if admin_signed_in?
       @source_event = Event.find(disbursement_params[:source_event_id])
-      @destination_event = params[:receiving_other] ? Event.friendly.find(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id]) : 
+      @destination_event = params[:receiving_other] == "on" ? Event.friendly.find(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id])
     else
       @source_event = Event.find_by_public_id(disbursement_params[:source_event_id])
-      @destination_event = params[:receiving_other] ? Event.find_by_public_id(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id]) : 
+      @destination_event = params[:receiving_other] == "on" ? Event.find_by_public_id(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id])
     end
 
     @disbursement = Disbursement.new(destination_event: @destination_event, source_event: @source_event)

--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -69,8 +69,14 @@ class DisbursementsController < ApplicationController
   end
 
   def create
-    @source_event = Event.find_by_public_id(disbursement_params[:source_event_id])
-    @destination_event = Event.find_by_public_id(disbursement_params[:event_id]) || Event.friendly.find(disbursement_params[:event_id])
+    if admin_signed_in?
+      @source_event = Event.find(disbursement_params[:source_event_id])
+      @destination_event = params[:receiving_other] ? Event.friendly.find(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id]) : 
+    else
+      @source_event = Event.find_by_public_id(disbursement_params[:source_event_id])
+      @destination_event = params[:receiving_other] ? Event.find_by_public_id(disbursement_params[:event_id]) : Event.find(disbursement_params[:event_id]) : 
+    end
+
     @disbursement = Disbursement.new(destination_event: @destination_event, source_event: @source_event)
 
     authorize @disbursement

--- a/app/javascript/controllers/organization_select_controller.js
+++ b/app/javascript/controllers/organization_select_controller.js
@@ -4,6 +4,7 @@ import fuzzysort from 'fuzzysort'
 export default class extends Controller {
   static targets = [
     'dropdown',
+    'otherCheckbox',
     'menu',
     'search',
     'organization',
@@ -40,7 +41,7 @@ export default class extends Controller {
         keys: ['name', 'id', 'slug'],
         all: false,
         threshold: -500000,
-        limit: 50,
+        limit: 25,
       })
 
       const visible =
@@ -50,8 +51,7 @@ export default class extends Controller {
             ? []
             : orgValues
                 .sort((a, b) => a.index - b.index)
-
-                .slice(0, 50)
+                .slice(0, 25)
 
       firstOrganization = visible[0]
 
@@ -123,6 +123,7 @@ export default class extends Controller {
         fieldValue.innerText = button.children[0].innerText
 
         const newValue = id == 'other' ? this.searchTarget.value : id
+        this.otherCheckbox.value = id == 'other'
         fieldValue.value = newValue
         fieldValue.dataset.fee = fee
         this.dropdownTarget.value = newValue

--- a/app/javascript/controllers/organization_select_controller.js
+++ b/app/javascript/controllers/organization_select_controller.js
@@ -121,7 +121,8 @@ export default class extends Controller {
         fieldValue.innerText = button.children[0].innerText
 
         const newValue = id == 'other' ? this.searchTarget.value : id
-        if (this.hasOtherCheckboxTarget) this.otherCheckboxTarget.checked = id == 'other'
+        if (this.hasOtherCheckboxTarget)
+          this.otherCheckboxTarget.checked = id == 'other'
         fieldValue.value = newValue
         fieldValue.dataset.fee = fee
         this.dropdownTarget.value = newValue

--- a/app/javascript/controllers/organization_select_controller.js
+++ b/app/javascript/controllers/organization_select_controller.js
@@ -49,9 +49,7 @@ export default class extends Controller {
           ? result.map(r => r.obj)
           : this.searchTarget.value.length > 0
             ? []
-            : orgValues
-                .sort((a, b) => a.index - b.index)
-                .slice(0, 25)
+            : orgValues.sort((a, b) => a.index - b.index).slice(0, 25)
 
       firstOrganization = visible[0]
 
@@ -123,7 +121,7 @@ export default class extends Controller {
         fieldValue.innerText = button.children[0].innerText
 
         const newValue = id == 'other' ? this.searchTarget.value : id
-        this.otherCheckbox.value = id == 'other'
+        if (this.hasOtherCheckboxTarget) this.otherCheckboxTarget.checked = id == 'other'
         fieldValue.value = newValue
         fieldValue.dataset.fee = fee
         this.dropdownTarget.value = newValue

--- a/app/views/admin/ledger_audits/tasks/show.html.erb
+++ b/app/views/admin/ledger_audits/tasks/show.html.erb
@@ -57,7 +57,7 @@
         <div class="h4 leading-[1.125] mb2 flex justify-between item-center">
           <span style="white-space: nowrap; gap: 4px;" class="flex items-center">
             <%= inline_icon "payment", size: 16, class: "muted align-middle", 'aria-label': "Dollar sign", style: "transform: scale(2)" %>
-            <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
+            <%= turbo_frame_tag "event_balance_#{event.slug}", src: event_async_balance_path(event), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
               <strong>-</strong>
             <% end %>
           </span>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -4,7 +4,7 @@
   <%= form.label field_name, sending ? "From" : "To" %>
   <select name="disbursement[<%= field_name %>]" id="disbursement_<%= field_name %>" <%= "disabled" if disabled %> class="bg-[transparent] dark:bg-darkless input input--select flex items-center select-none cursor-pointer disabled:cursor-default" data-organization-select-target="dropdown">
     <option value>Select one...</option>
-    <option <%= "default" if default_event.present? %> value="<%= default_event.public_id if default_event.present? %>"><%= default_event.name if default_event.present? %></option>
+    <option <%= "default" if default_event.present? %> value="<%= (admin_signed_in? ? default_event.id : default_event.public_id) if default_event.present? %>"><%= default_event.name if default_event.present? %></option>
   </select>
 
   <div data-organization-select-target="wrapper" style="max-width: 384px;">
@@ -17,12 +17,12 @@
             <% disabled_message = nil %>
             <% disabled_message = "Insufficient balance" if sending && !admin_signed_in? && event.balance_available <= 0 %>
             <% disabled_message = "HCB transfers disabled" if sending && !policy(event).create_transfer? %>
-            <div data-id="<%= event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
+            <div data-id="<%= admin_signed_in? ? event.id : event.public_id %>" data-slug="<%= event.slug %>" data-name="<%= event.name %>" data-organization-select-target="organization" style="<%= i > 50 ? "display: none" : "" %>" data-index="<%= i %>">
               <button <%= "disabled" if disabled_message %> aria-label="<%= disabled_message %>" class="<%= "tooltipped tooltipped--i" if disabled_message %> text-[length:inherit] border-none bg-[transparent] w-full flex justify-between p-2 cursor-pointer disabled:cursor-default hover:bg-smoke hover:dark:bg-darkless transition-colors duration-150" type="button">
                 <div class="text-left <%= "tooltipped tooltipped--e" if admin_signed_in? %>" aria-label="<%= "ID: #{event.id}" if admin_signed_in? %>"><%= event.name %></div>
 
                 <div class="text-muted pl-2">
-                  <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
+                  <%= turbo_frame_tag "event_balance_#{event.slug}", src: event_async_balance_path(event, symbol: true), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
                     <strong>-</strong>
                   <% end %>
                 </div>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -7,6 +7,10 @@
     <option <%= "default" if default_event.present? %> value="<%= (admin_signed_in? ? default_event.id : default_event.public_id) if default_event.present? %>"><%= default_event.name if default_event.present? %></option>
   </select>
 
+  <% if receiving %>
+    <input type="checkbox" name="receiving_other" data-organization-select-target="otherCheckbox" class="hidden">
+  <% end %>
+
   <div data-organization-select-target="wrapper" style="max-width: 384px;">
     <input data-organization-select-target="search" style="display: none; border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;" type="text" placeholder="Search">
 

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -8,7 +8,7 @@
   </select>
 
   <% if receiving %>
-    <input type="checkbox" name="receiving_other" data-organization-select-target="otherCheckbox" class="hidden">
+    <input type="checkbox" id="receiving_other" name="receiving_other" data-organization-select-target="otherCheckbox" class="hidden">
   <% end %>
 
   <div data-organization-select-target="wrapper" style="max-width: 384px;">

--- a/app/views/events/_event_card.html.erb
+++ b/app/views/events/_event_card.html.erb
@@ -86,7 +86,7 @@
     <div class="h4 leading-[1.125] mb2 mt-1 flex justify-between item-center">
       <span class="flex items-center gap-1 whitespace-nowrap tabular-nums">
         <%= inline_icon "payment", size: 16, class: "muted align-middle", 'aria-label': "Dollar sign", style: "transform: scale(2)" %>
-        <%= turbo_frame_tag "event_balance_#{event.public_id}", src: event_async_balance_path(event), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
+        <%= turbo_frame_tag "event_balance_#{event.slug}", src: event_async_balance_path(event), data: { turbo_permanent: true, controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" }, loading: :lazy do %>
           —
         <% end %>
       </span>

--- a/app/views/events/async_balance.html.erb
+++ b/app/views/events/async_balance.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "event_balance_#{@event.public_id}" do %>
+<%= turbo_frame_tag "event_balance_#{@event.slug}" do %>
   <% if params[:symbol] == "true" %>
     <%= render_money(@event.balance_available_v2_cents) %>
   <% else %>


### PR DESCRIPTION
## Summary of the problem

This page is very slow! ([Flamegraph](https://hackclub.enterprise.slack.com/files/U022XFD2TML/F0ALL6H1P9Q/frame_1_-_2026-03-13t231946.241.png)) Hash IDs take about 3 seconds per page load for admins. Numeric IDs don't have this problem, but we don't want to expose numeric IDs to non-admin users. 


## Describe your changes

* Remove reliance on public IDs for admins loading the page by using numeric ID instead.
* Use friendly ID instead of public ID as the identifier for Turbo