### PR TITLE
[Disbursements] Reduce SQL queries on organization selector

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -48,20 +48,19 @@ class DisbursementsController < ApplicationController
     )
 
     user_event_ids = current_user.organizer_positions.reorder(sort_index: :asc).pluck(:event_id)
-    user_accesible_events = Event.where(id: current_user.events.pluck(:id) + current_user.events.collect(&:descendant_ids).flatten)
 
     @allowed_source_events = if admin_signed_in?
                                Event.select(:name, :id, :demo_mode, :slug).all.reorder(Event::CUSTOM_SORT).includes(:plan)
                              else
-                               user_accesible_events.not_hidden.filter_demo_mode(false)
+                               current_user.manageable_events.not_hidden.filter_demo_mode(false)
                              end.to_enum.with_index.sort_by { |e, i| [user_event_ids.index(e.id) || Float::INFINITY, i] }.map(&:first)
     @allowed_destination_events = if admin_signed_in?
                                     Event.select(:name, :id, :demo_mode, :can_front_balance, :slug).all.reorder(Event::CUSTOM_SORT).includes(:plan)
                                   elsif @source_event&.plan&.unrestricted_disbursements_enabled?
-                                    allowed_destination_event_ids = user_accesible_events.not_hidden.filter_demo_mode(false).select(:id) + Event.indexable.select(:id)
+                                    allowed_destination_event_ids = current_user.manageable_events.not_hidden.filter_demo_mode(false).select(:id) + Event.indexable.select(:id)
                                     Event.where(id: allowed_destination_event_ids).select(:name, :id, :demo_mode, :can_front_balance, :slug).includes(:plan)
                                   else
-                                    user_accesible_events.not_hidden.filter_demo_mode(false)
+                                    current_user.manageable_events.not_hidden.filter_demo_mode(false)
                                   end.to_enum.with_index.sort_by { |e, i| [user_event_ids.index(e.id) || Float::INFINITY, i] }.map(&:first)
 
     authorize @disbursement

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -593,7 +593,25 @@ class User < ApplicationRecord
     versions.where(created_at: since..).where("object_changes ? 'phone_number'").count
   end
 
+  def readable_events
+    @readable_events ||= accessible_events(roles: OrganizerPosition.roles.keys)
+  end
+
+  def manageable_events
+    @manageable_events ||= accessible_events(roles: ["manager"])
+  end
+
   private
+
+  def accessible_events(roles:)
+    flatten = lambda do |nodes|
+      nodes.flat_map do |node|
+        [(node.event if node.role.in?(roles))].compact + flatten.call(node.child_nodes)
+      end
+    end
+
+    flatten.call User::PermissionsOverview.new(user: self).event_graph
+  end
 
   def update_stripe_cardholder
     stripe_cardholder&.update!(stripe_email: email, stripe_phone_number: phone_number)


### PR DESCRIPTION

## Summary of the problem

Right now, sub-organizations are incredibly inefficient on the organization selector for the disbursement form. We run an extra SQL query for each event to fetch their child IDs.

## Describe your changes

Re-use David's code for a user's permissions graph to get a list of a user's accessible organizations all at once rather than making multiple DB round-trips.