### PR TITLE
[v4] Limit Event Balance graph data to one year

### DIFF
--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -66,7 +66,8 @@ module Api
         balance_by_date = balance_by_date.dup
         balance_by_date[Date.today] = @event.balance_v2_cents
 
-        @balance_series = balance_by_date.sort.map { |date, amount| { date: date.to_s, amount: } }
+        start_date = [@event.created_at.to_date, 1.year.ago.to_date].max
+        @balance_series = balance_by_date.sort.filter_map { |date, amount| { date: date.to_s, amount: } if date >= start_date }
       end
 
       require_oauth2_scope "organizations:read", :balance_by_date


### PR DESCRIPTION
We want to mimic the organization homepage but currently it will show all data from when the org was created which is inefficient if we only want one year