### PR TITLE
[Contracts] Void contracts before contractable is destroyed

### DIFF
--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -6,6 +6,7 @@ module Contractable
   included do
     has_many :contracts, as: :contractable, dependent: :destroy
 
+    # We need to void associated contracts before contractable is deleted so that callbacks and validations can run
     before_destroy do
       contracts.where(aasm_state: [:pending, :sent]).find_each(&:mark_voided!)
     end

--- a/app/models/concerns/contractable.rb
+++ b/app/models/concerns/contractable.rb
@@ -6,6 +6,10 @@ module Contractable
   included do
     has_many :contracts, as: :contractable, dependent: :destroy
 
+    before_destroy do
+      contracts.where(aasm_state: [:pending, :sent]).find_each(&:mark_voided!)
+    end
+
     def send_contract(cosigner_email: nil, include_videos: false, reissue_signee_message: nil, reissue_cosigner_message: nil)
       # This method should be overwritten in specific classes
       raise NotImplementedError, "The #{self.class.name} model includes Contractable, but hasn't implemented it's own version of send_contract."


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Voiding contracts triggers validations and callbacks that assume that contractable exists. When we delete contractables, voiding needs to happen before they get deleted and the contractable no longer exists.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add back the callback to contractable

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

