### PR TITLE
Fix Hashid model-specific configuration patch

### DIFF
--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -3,7 +3,7 @@
 ActiveSupport.on_load(:active_record) do
   Hashid::Rails::ClassMethods.module_eval do
     def hashid_configuration
-      if is_a?(ActiveRecord::Relation)
+      if is_a?(ActiveRecord::Relation) && klass.respond_to?(:hashid_configuration)
         klass.hashid_configuration
       else
         @hashid_configuration || hashid_config


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2777/samples/timestamp/2026-03-17T12:50:54Z - since User includes Hashid, the relation created from it does as well, even though it's no longer a relation for User.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Checks if the relation klass responds to hashid_configuration (which it will if it includes hashid) before calling it. If it doesn't respond to hashid_configuration, then the klass does not include hashid and cannot have a model-specific config.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

