### PR TITLE
[User] Allow more users to verify phone number

### DIFF
--- a/app/services/user_service/enroll_sms_auth.rb
+++ b/app/services/user_service/enroll_sms_auth.rb
@@ -15,11 +15,10 @@ module UserService
       # doing this here to be safe.
       raise ArgumentError.new("phone number for user: #{@user.id} not in E.164 format") unless @user.phone_number =~ /\A\+[1-9]\d{1,14}\z/
 
-      unless has_verified_phone_number_before?
+      unless has_meaningful_activity? || has_verified_phone_number_before? || not_fresh_user?
         raise SMSEnrollmentError, "SMS authentication currently unavailable for your account, please try again later."
       end
 
-      disallow_fresh_users
       disallow_excessive_sms_verifications
 
       TwilioVerificationService.new.send_verification_request(@user.phone_number)
@@ -58,12 +57,6 @@ module UserService
 
     private
 
-    def disallow_fresh_users
-      return if @user.created_at < 1.day.ago
-
-      raise SMSEnrollmentError, "Please wait at least 24 hours after creating your account before enrolling in SMS authentication."
-    end
-
     def disallow_excessive_sms_verifications
       cache_key = "sms_verify_count:#{@user.id}:#{Date.current}"
       count = Rails.cache.increment(cache_key, 1, expires_in: 25.hours).to_i
@@ -76,6 +69,14 @@ module UserService
 
     def has_verified_phone_number_before?
       @user.versions.where_object_changes_to(phone_number_verified: true).any?
+    end
+
+    def has_meaningful_activity?
+      @user.organizer_position_invites.any? || @user.card_grants.any? || @user.organizer_positions.any? || @user.reimbursement_reports.any? || @user.applications.any?
+    end
+
+    def not_fresh_user?
+      @user.created_at >= 1.day.ago
     end
 
   end


### PR DESCRIPTION
## Summary of the problem

The wave of SMS pumping attacks has passed. We can now relax some of the restrictions around who can use SMS.


## Describe your changes

We allow users to verify their phone number if they meet at least one of the following requirements:
- `has_meaningful_activity?`: They've got an OPI, org, card grant, reimbursement report, or application, etc.
- `has_verified_phone_number_before?`: With the SMS pumping attack we saw, they never actually successfully verified (they're just trying to trigger more messages to be sent). So users who have previously verified their phone number are fairly safe.
- `not_fresh_user?`: If you've created your account more than 24hr ago.