### PR TITLE
Add shared comments for disbursements

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,7 +17,9 @@ class CommentsController < ApplicationController
 
     if @comment.save
       flash[:success] = "Comment created."
-      redirect_to @commentable.is_a?(Event) ? edit_event_path(@commentable, tab: :admin) : @commentable
+      # Use return_to param if provided, otherwise fall back to the commentable
+      # url_from validates the URL is internal to prevent open redirect vulnerabilities
+      redirect_back_or_to url_from(params[:comment][:return_to]) || @commentable
     else
       render :new, status: :unprocessable_entity
     end
@@ -73,7 +75,7 @@ class CommentsController < ApplicationController
     params.require(:comment).permit(:content, :file, :admin_only)
   end
 
-  COMMENTABLE_TYPE_MAP = [AchTransfer, EmburseCardRequest, EmburseTransaction,
+  COMMENTABLE_TYPE_MAP = [AchTransfer, Disbursement, EmburseCardRequest, EmburseTransaction,
                           EmburseTransfer, Event, GSuite, HcbCode, Api::Models::CardCharge,
                           OrganizerPositionDeletionRequest, User, Reimbursement::Report, CardGrant,
                           Ledger::Item].index_by(&:to_s).freeze

--- a/app/javascript/controllers/commentable_controller.js
+++ b/app/javascript/controllers/commentable_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['commentableType', 'commentableId']
+  static values = {
+    sharedType: String,
+    sharedId: String,
+  }
+
+  connect() {
+    // save initial commentable as the private comment association
+    // we need to set it back to this if a user toggles back and forth
+    this.privateType = this.commentableTypeTarget.value
+    this.privateId = this.commentableIdTarget.value
+
+    // listen for radio buttons
+    this.element.addEventListener('change', this.handleChange.bind(this))
+  }
+
+  handleChange(event) {
+    if (event.target.type !== 'radio') return
+
+    const value = event.target.value
+    this.updateHiddenFields(value)
+  }
+
+  updateHiddenFields(targetType) {
+    if (targetType === 'shared') {
+      this.commentableTypeTarget.value = this.sharedTypeValue
+      this.commentableIdTarget.value = this.sharedIdValue
+    } else {
+      this.commentableTypeTarget.value = this.privateType
+      this.commentableIdTarget.value = this.privateId
+    }
+  }
+}

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -96,6 +96,11 @@ class Comment < ApplicationRecord
     return "commented"
   end
 
+  def shared?
+    # currently the only situation where we share comments at the moment. If we expand this, do something smarter
+    commentable_type == "Disbursement"
+  end
+
   # This regex was stolen from URI::MailTo::EMAIL_REGEXP
   USER_MENTION_REGEX = /@([a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)/
 

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -17,4 +17,21 @@ module Commentable
   def comment_mentionable(current_user: nil)
     []
   end
+
+  # Override in models that share comments with another commentable
+  def shared_commentable
+    nil
+  end
+
+  def shared_commentable?
+    shared_commentable.present?
+  end
+
+  def all_comments
+    if shared_commentable
+      Comment.where(commentable: self).or(Comment.where(commentable: shared_commentable))
+    else
+      comments
+    end
+  end
 end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -53,6 +53,7 @@ class Disbursement < ApplicationRecord
   include AASM
 
   include Freezable
+  include Commentable
 
   validate on: :create do
     if source_event.financially_frozen?
@@ -250,6 +251,11 @@ class Disbursement < ApplicationRecord
       HcbCode.find_or_create_by(hcb_code: incoming_hcb_code)
       HcbCode.find_or_create_by(hcb_code: outgoing_hcb_code)
     end
+  end
+
+  # Override Commentable#all_comments to include comments from both sides of the disbursement
+  def all_comments
+    Comment.where(commentable: [self, outgoing_disbursement.local_hcb_code, incoming_disbursement.local_hcb_code])
   end
 
   def canonical_transactions

--- a/app/models/disbursement/base.rb
+++ b/app/models/disbursement/base.rb
@@ -43,6 +43,23 @@ class Disbursement
     def local_hcb_code
       @local_hcb_code ||= HcbCode.find_or_create_by(hcb_code:)
     end
+
+    def self_label
+      format_party_label(subledger, event)
+    end
+
+    def counterparty_label
+      format_party_label(counterparty_subledger, counterparty_event)
+    end
+
+    private
+
+    # A card grant is a disbursement between the same event, so we want to use the grant recipient
+    # to differentiate transaction parties
+    def format_party_label(subledger, event)
+      card_grant = subledger&.card_grant
+      card_grant ? "Grant recipient #{card_grant.user.name}" : event.name
+    end
   end
 
 end

--- a/app/models/disbursement/incoming.rb
+++ b/app/models/disbursement/incoming.rb
@@ -4,6 +4,8 @@ class Disbursement
   class Incoming
     include Base
 
+    delegate :amount, to: :disbursement
+
     def hcb_code
       disbursement.incoming_hcb_code
     end
@@ -12,10 +14,20 @@ class Disbursement
       disbursement.destination_event
     end
 
-    delegate :amount, to: :disbursement
+    def counterparty_event
+      disbursement.source_event
+    end
 
     def subledger
       disbursement.destination_subledger
+    end
+
+    def counterparty_subledger
+      disbursement.source_subledger
+    end
+
+    def counterparty
+      disbursement.outgoing_disbursement
     end
 
     def transaction_category

--- a/app/models/disbursement/outgoing.rb
+++ b/app/models/disbursement/outgoing.rb
@@ -4,6 +4,10 @@ class Disbursement
   class Outgoing
     include Base
 
+    def amount
+      -disbursement.amount
+    end
+
     def hcb_code
       disbursement.outgoing_hcb_code
     end
@@ -12,12 +16,20 @@ class Disbursement
       disbursement.source_event
     end
 
-    def amount
-      -disbursement.amount
+    def counterparty_event
+      disbursement.destination_event
     end
 
     def subledger
       disbursement.source_subledger
+    end
+
+    def counterparty_subledger
+      disbursement.destination_subledger
+    end
+
+    def counterparty
+      disbursement.incoming_disbursement
     end
 
     def transaction_category

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -372,7 +372,7 @@ class HcbCode < ApplicationRecord
   def disbursement?
     Rails.application.deprecators[:hcb].warn("HcbCode#disbursement? accessed")
 
-    return [::TransactionGroupingEngine::Calculate::HcbCode::OUTGOING_DISBURSEMENT_CODE, ::TransactionGroupingEngine::Calculate::HcbCode::INCOMING_DISBURSEMENT_CODE].include?(hcb_i1)
+    outgoing_disbursement? || incoming_disbursement?
   end
 
   def outgoing_disbursement?
@@ -467,6 +467,16 @@ class HcbCode < ApplicationRecord
     return @outgoing_disbursement if defined?(@outgoing_disbursement)
 
     @outgoing_disbursement = Disbursement.find_by(id: hcb_i2)&.outgoing_disbursement
+  end
+
+  # Overrides shared_commentable? in Commentable concern to avoid
+  # unnecessary database read
+  def shared_commentable?
+    outgoing_disbursement? || incoming_disbursement?
+  end
+
+  def shared_commentable
+    (outgoing_disbursement || incoming_disbursement)&.disbursement
   end
 
   def card_grant

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -56,6 +56,9 @@ class CommentPolicy < ApplicationPolicy
         user_list += record.commentable.event&.users || [] # event&.users can be nil (event-less reports)
         user_list += record.commentable.event&.ancestor_users || []
       end
+    elsif record.commentable.is_a?(Disbursement)
+      # TODO: possibly replace this by adding #events to Disbursement?
+      user_list = record.commentable.source_event.users + record.commentable.destination_event.users
     elsif record.commentable.is_a?(Event)
       user_list = []
     else

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -41,9 +41,6 @@
       </div>
     <% end %>
 
-    <%= form.hidden_field :commentable_type, value: commentable&.class %>
-    <%= form.hidden_field :commentable_id, value: commentable&.id %>
-
     <% admin_tool("inline-flex", "span") do %>
       <% if defined?(admin_only) %>
         <%= form.hidden_field :admin_only, value: true %>
@@ -58,7 +55,30 @@
 
   </div>
 
-  <%= form.submit "Add comment", disabled: !policy(commentable.comments.build).create? %>
+  <% if commentable.shared_commentable? && !@comment&.persisted? %>
+    <% disbursement = commentable.outgoing_disbursement || commentable.incoming_disbursement %>
+    <div data-controller="commentable"
+         data-commentable-shared-type-value="<%= commentable.shared_commentable.class.to_s %>"
+         data-commentable-shared-id-value="<%= commentable.shared_commentable.id %>">
+      <%= form.hidden_field :commentable_type, value: commentable.class.to_s, data: { "commentable-target": "commentableType" } %>
+      <%= form.hidden_field :commentable_id, value: commentable.id, data: { "commentable-target": "commentableId" } %>
+      <%= form.hidden_field :return_to, value: url_for(only_path: false) %>
+      <%= dropdown_button form:,
+                          options: [
+                            ["Add comment", "private", "Only visible to #{commentable.event&.name || 'this organization'}"],
+                            ["Share with #{disbursement.counterparty_label}", "shared", "Visible to both organizations"]
+                          ],
+                          button_class: "bg-info",
+                          button_icon: "send",
+                          name: "comment_target",
+                          template: ->(value) { value == "shared" ? "Share with #{disbursement.counterparty_label}" : "Add comment" },
+                          button_options: { disabled: !policy(commentable.comments.build).create? } %>
+    </div>
+  <% else %>
+    <%= form.hidden_field :commentable_type, value: commentable&.class %>
+    <%= form.hidden_field :commentable_id, value: commentable&.id %>
+    <%= form.submit local_assigns[:submit_text] || "Add comment", disabled: !policy(commentable.comments.build).create? %>
+  <% end %>
 <% end %>
 
 <% unless @popover %>

--- a/app/views/comments/_item.html.erb
+++ b/app/views/comments/_item.html.erb
@@ -23,6 +23,18 @@
             <%= inline_icon "edit", size: 24, 'aria-label': "Edit" %>
           <% end %>
         <% end %>
+        <% viewing_commentable = local_assigns[:viewing_commentable] %>
+        <% if viewing_commentable.is_a?(HcbCode) && comment.shared? %>
+          <% viewing_disbursement = viewing_commentable.outgoing_disbursement || viewing_commentable.incoming_disbursement %>
+          <span class="muted right">shared with <%= viewing_disbursement.counterparty_label %></span>
+        <% elsif viewing_commentable.is_a?(Disbursement) %>
+          <% if comment.shared? %>
+            <span class="muted right">visible to both organizations</span>
+          <% else %>
+            <% comment_disbursement = comment.commentable.outgoing_disbursement || comment.commentable.incoming_disbursement %>
+            <span class="muted right">only visible to <%= comment_disbursement.self_label %></span>
+          <% end %>
+        <% end %>
       </div>
       <div class="card__banner card__darker comment--container">
         <% if comment.content.blank? %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -2,6 +2,6 @@
   <% if policy_scope(comments).empty? && defined?(show_blankslate) %>
     <%= blankslate "No comments yet." %>
   <% else %>
-    <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file.order(created_at: :asc), as: :comment %>
+    <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file.order(created_at: :asc), as: :comment, locals: { viewing_commentable: local_assigns[:viewing_commentable] } %>
   <% end %>
 </section>

--- a/app/views/disbursements/show.html.erb
+++ b/app/views/disbursements/show.html.erb
@@ -136,6 +136,6 @@
       } %>
 
   <h2>Comments</h2>
-  <%= render "comments/list", comments: @hcb_code.comments %>
-  <%= render "comments/form", commentable: @hcb_code %>
+  <%= render "comments/list", comments: @disbursement.all_comments, viewing_commentable: @disbursement %>
+  <%= render "comments/form", commentable: @disbursement, submit_text: "Add comment (visible to both organizations)" %>
 <% end %>

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -48,7 +48,18 @@
 
   <%= turbo_frame_tag :subscriptions, src: subscriptions_transactions_hcb_code_path(@hcb_code) if @hcb_code.stripe_card? %>
 
-  <%= render "comments/list", comments: @hcb_code.comments %>
+  <%= render "comments/list", comments: @hcb_code.all_comments, viewing_commentable: @hcb_code %>
+  <% if @hcb_code.shared_commentable? %>
+    <% viewing_disbursement = @hcb_code.outgoing_disbursement || @hcb_code.incoming_disbursement %>
+    <% counterparty_hcb_code = viewing_disbursement.counterparty.local_hcb_code %>
+    <% if policy(counterparty_hcb_code).show? && counterparty_hcb_code.comments.count > 0 %>
+      <p class="muted">
+        <%= link_to counterparty_hcb_code do %>
+          View <%= pluralize(counterparty_hcb_code.comments.count, "other comment") %> from <%= viewing_disbursement.counterparty_label %>
+        <% end %>
+      </p>
+    <% end %>
+  <% end %>
   <%= render "comments/form", commentable: @hcb_code %>
 
   <% admin_tool("mt2 p-3") do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -494,7 +494,7 @@ Rails.application.routes.draw do
     get "confirmation", to: "ach_transfers#transfer_confirmation_letter"
   end
 
-  resources :disbursements, only: [:new, :create, :show, :edit, :update] do
+  resources :disbursements, only: [:new, :create, :show, :edit, :update], concerns: :commentable do
     post "mark_fulfilled"
     post "reject"
     post "cancel"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -21,6 +21,28 @@ RSpec.describe Comment, type: :model, versioning: true do
     expect(comment.versions.size).to eq(2)
   end
 
+  describe "#shared?" do
+    it "returns true when commentable is a Disbursement" do
+      disbursement = create(:disbursement)
+      comment = create(:comment, commentable: disbursement)
+
+      expect(comment.shared?).to be true
+    end
+
+    it "returns false when commentable is an HcbCode" do
+      hcb_code = create(:hcb_code)
+      comment = create(:comment, commentable: hcb_code)
+
+      expect(comment.shared?).to be false
+    end
+
+    it "returns false when commentable is an Event" do
+      comment = create(:comment, commentable: event)
+
+      expect(comment.shared?).to be false
+    end
+  end
+
   context "when missing content" do
     before do
       comment.content = ""

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Disbursement, type: :model do
+  def add_balance_to_event(event)
+    ct = create(:canonical_transaction, amount_cents: 100_000, memo: "Test balance")
+    create(:canonical_event_mapping, canonical_transaction: ct, event: event)
+  end
+
   let(:disbursement) { create(:disbursement) }
 
   it "is valid" do
@@ -291,6 +296,98 @@ RSpec.describe Disbursement, type: :model do
     end
   end
 
+  describe "Disbursement::Incoming" do
+    let(:incoming) { disbursement.incoming_disbursement }
+
+    describe "#counterparty_label" do
+      it "returns the source event name" do
+        expect(incoming.counterparty_label).to eq(disbursement.source_event.name)
+      end
+
+      context "with a card grant subledger" do
+        let(:card_grant) do
+          add_balance_to_event(disbursement.source_event)
+          create(:card_grant, event: disbursement.source_event)
+        end
+
+        before do
+          disbursement.update!(source_subledger: card_grant.subledger)
+        end
+
+        it "returns the grant recipient name" do
+          expect(incoming.counterparty_label).to eq("Grant recipient #{card_grant.user.name}")
+        end
+      end
+    end
+
+    describe "#self_label" do
+      it "returns the destination event name" do
+        expect(incoming.self_label).to eq(disbursement.destination_event.name)
+      end
+
+      context "with a card grant subledger" do
+        let(:card_grant) do
+          add_balance_to_event(disbursement.destination_event)
+          create(:card_grant, event: disbursement.destination_event)
+        end
+
+        before do
+          disbursement.update!(destination_subledger: card_grant.subledger)
+        end
+
+        it "returns the grant recipient name" do
+          expect(incoming.self_label).to eq("Grant recipient #{card_grant.user.name}")
+        end
+      end
+    end
+  end
+
+  describe "Disbursement::Outgoing" do
+    let(:outgoing) { disbursement.outgoing_disbursement }
+
+    describe "#counterparty_label" do
+      it "returns the destination event name" do
+        expect(outgoing.counterparty_label).to eq(disbursement.destination_event.name)
+      end
+
+      context "with a card grant subledger" do
+        let(:card_grant) do
+          add_balance_to_event(disbursement.destination_event)
+          create(:card_grant, event: disbursement.destination_event)
+        end
+
+        before do
+          disbursement.update!(destination_subledger: card_grant.subledger)
+        end
+
+        it "returns the grant recipient name" do
+          expect(outgoing.counterparty_label).to eq("Grant recipient #{card_grant.user.name}")
+        end
+      end
+    end
+
+    describe "#self_label" do
+      it "returns the source event name" do
+        expect(outgoing.self_label).to eq(disbursement.source_event.name)
+      end
+
+      context "with a card grant subledger" do
+        let(:card_grant) do
+          add_balance_to_event(disbursement.source_event)
+          create(:card_grant, event: disbursement.source_event)
+        end
+
+        before do
+          disbursement.update!(source_subledger: card_grant.subledger)
+        end
+
+        it "returns the grant recipient name" do
+          expect(outgoing.self_label).to eq("Grant recipient #{card_grant.user.name}")
+        end
+      end
+    end
+  end
+
   describe "helper methods" do
 
     describe "#outgoing_hcb_code" do
@@ -302,6 +399,21 @@ RSpec.describe Disbursement, type: :model do
     describe "#incoming_hcb_code" do
       it "returns the correct HCB code format" do
         expect(disbursement.incoming_hcb_code).to eq("HCB-550-#{disbursement.id}")
+      end
+    end
+
+    describe "#all_comments" do
+      let(:user) { create(:user) }
+
+      it "includes comments from the disbursement and both sides" do
+        outgoing_hcb_code = disbursement.outgoing_disbursement.local_hcb_code
+        incoming_hcb_code = disbursement.incoming_disbursement.local_hcb_code
+
+        disbursement_comment = create(:comment, commentable: disbursement, user:)
+        outgoing_comment = create(:comment, commentable: outgoing_hcb_code, user:)
+        incoming_comment = create(:comment, commentable: incoming_hcb_code, user:)
+
+        expect(disbursement.all_comments).to contain_exactly(disbursement_comment, outgoing_comment, incoming_comment)
       end
     end
 

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -222,6 +222,78 @@ RSpec.describe HcbCode, type: :model do
       end
     end
 
+    describe "#shared_commentable?" do
+      let(:disbursement) { create(:disbursement) }
+
+      it "returns true for outgoing disbursement codes" do
+        outgoing = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+
+        expect(outgoing.shared_commentable?).to be true
+      end
+
+      it "returns true for incoming disbursement codes" do
+        incoming = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+
+        expect(incoming.shared_commentable?).to be true
+      end
+
+      it "returns false for non-disbursement codes" do
+        hcb_code = create(:hcb_code)
+
+        expect(hcb_code.shared_commentable?).to be false
+      end
+    end
+
+    describe "#shared_commentable" do
+      let(:disbursement) { create(:disbursement) }
+
+      it "returns the Disbursement for outgoing disbursement codes" do
+        outgoing = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+
+        expect(outgoing.shared_commentable).to eq(disbursement)
+      end
+
+      it "returns the Disbursement for incoming disbursement codes" do
+        incoming = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+
+        expect(incoming.shared_commentable).to eq(disbursement)
+      end
+
+      it "returns nil for non-disbursement codes" do
+        hcb_code = create(:hcb_code)
+
+        expect(hcb_code.shared_commentable).to be_nil
+      end
+    end
+
+    describe "#all_comments" do
+      let(:disbursement) { create(:disbursement) }
+      let(:user) { create(:user) }
+
+      it "includes comments on both the HcbCode and the Disbursement" do
+        outgoing = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+        hcb_code_comment = create(:comment, commentable: outgoing, user:)
+        disbursement_comment = create(:comment, commentable: disbursement, user:)
+
+        expect(outgoing.all_comments).to include(hcb_code_comment, disbursement_comment)
+      end
+
+      it "does not include comments from the paired HcbCode" do
+        outgoing = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+        incoming = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+        incoming_comment = create(:comment, commentable: incoming, user:)
+
+        expect(outgoing.all_comments).not_to include(incoming_comment)
+      end
+
+      it "returns regular comments for non-disbursement codes" do
+        hcb_code = create(:hcb_code)
+        comment = create(:comment, commentable: hcb_code, user:)
+
+        expect(hcb_code.all_comments).to include(comment)
+      end
+    end
+
     describe "#humanized_type" do
       it "returns 'Transfer' for disbursements" do
         disbursement = create(:disbursement)


### PR DESCRIPTION
## Summary of the problem

https://hackclub.slack.com/archives/C026RKHLPNJ/p1773163261567279

Previously, since we had a single HcbCode for disbursements, comments were always shared. Now they can be on either side of the disbursement, but we still want the ability to share comments selectively.

## Describe your changes

Since both sides of a disbursement still have a connection to the Disbursement, we are adding Commentable to that model.

It was unavoidable to add shared comment specific methods to HcbCode but we tried to delegate them to models that make more sense as much as possible (e.g. `shared_comment_recipient_label` lives on ingoing/outgoing disbursements)


- Switch from hardcoded redirect to `redirect_back_or_to` since it is exactly for the case we want to handle. Redirect to the original commentable as a fallback because we don't want to redirect to a Disbursement on a shared comment vs the HcbCode that the comment is originating from.
- Add `all_comments` to Commentable that aggregates comments from both the primary commentable and its shared_commentable. Currently it doesn't own ordering because that's already handled in the view, but we should probably push that to the model
- UI shows all comments on your side and shared comments, interleaved by created_at (post time). For the checkbox we show the name of the other. Added some styling to shared comments similar to admin comments. side, but for created comments we can't since they are only stored on the shared Disbursement model and it's possible the author has access to both sides of the disbursement.
- Minor refactor of `HcbCode#disbursement?` to use existing predicate methods