### PR TITLE
[Code Quality] Fix custom memo update duplication

### DIFF
--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -66,8 +66,7 @@ module Api
         @hcb_code = authorize HcbCode.find_by_public_id(params[:id])
 
         if params.key? :memo
-          @hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: params[:memo]) }
-          @hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: params[:memo]) }
+          @hcb_code.update_custom_memo!(params[:memo])
         end
 
         render "show"

--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -130,8 +130,7 @@ class HcbCodesController < ApplicationController
     hcb_code_params = params.require(:hcb_code).permit(:memo, :prepended_to_memo, :location, :ledger_instance)
     hcb_code_params[:memo] = hcb_code_params[:memo].presence
 
-    @hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: hcb_code_params[:memo]) }
-    @hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: hcb_code_params[:memo]) }
+    @hcb_code.update_custom_memo!(hcb_code_params[:memo])
 
     if params[:hcb_code][:inline].present?
       return render partial: "hcb_codes/memo", locals: { hcb_code: @hcb_code, form: false, prepended_to_memo: params[:hcb_code][:prepended_to_memo], location: params[:hcb_code][:location], ledger_instance: params[:hcb_code][:ledger_instance], renamed: true }

--- a/app/controllers/suggested_pairings_controller.rb
+++ b/app/controllers/suggested_pairings_controller.rb
@@ -27,8 +27,7 @@ class SuggestedPairingsController < ApplicationController
 
     if params[:memo] == "true"
       custom_memo = @receipt.suggested_memo
-      @receiptable.canonical_transactions.each { |ct| ct.update!(custom_memo:) }
-      @receiptable.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo:) }
+      @receiptable.update_custom_memo!(custom_memo)
     end
 
     respond_to do |format|

--- a/app/mailboxes/hcb_code_mailbox.rb
+++ b/app/mailboxes/hcb_code_mailbox.rb
@@ -61,8 +61,7 @@ class HcbCodeMailbox < ApplicationMailbox
     when "@rename"
       return unless command["argument"]
 
-      @hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: command["argument"]) }
-      @hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: command["argument"]) }
+      @hcb_code.update_custom_memo!(command["argument"])
       @renamed_to = command["argument"]
     when "@tag"
       return unless command["argument"]

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -177,8 +177,7 @@ class CardGrant < ApplicationRecord
         requested_by_id: topped_up_by.id,
       ).run
 
-      disbursement.local_hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo:) }
-      disbursement.local_hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo:) }
+      disbursement.local_hcb_code.update_custom_memo!(custom_memo)
     end
   end
 
@@ -199,8 +198,7 @@ class CardGrant < ApplicationRecord
         requested_by_id: withdrawn_by.id,
       ).run
 
-      disbursement.local_hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo:) }
-      disbursement.local_hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo:) }
+      disbursement.local_hcb_code.update_custom_memo!(custom_memo)
     end
   end
 
@@ -235,8 +233,7 @@ class CardGrant < ApplicationRecord
       source_subledger_id: subledger_id,
       requested_by_id: requested_by.id,
     ).run
-    disbursement.local_hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo:) }
-    disbursement.local_hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo:) }
+    disbursement.local_hcb_code.update_custom_memo!(custom_memo)
   end
 
   def cancel!(canceled_by = User.system_user, expired: false)

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -717,4 +717,9 @@ class HcbCode < ApplicationRecord
     update(event_id: event&.id, subledger_id: subledger&.id)
   end
 
+  def update_custom_memo!(memo)
+    canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
+    canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
+  end
+
 end


### PR DESCRIPTION
### Problem 
```ruby
canonical_transactions.each { |ct| ct.update!(custom_memo:) } 
canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo:) }
```
This code was copy-pasted verbatim across card_grant.rb (3 times!), hcb_codes_controller.rb, suggested_pairings_controller.rb, api/v4/transactions_controller.rb, and hcb_code_mailbox.rb. 


### Solution
Extracted to a single method on HcbCode