### PR TITLE
[Reimbursements] Show currency on index page when necessary

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -692,6 +692,8 @@ class EventsController < ApplicationController
     @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)
     @pending = @total - @reimbursed
 
+    @format_reports_with_currency = @event.reimbursement_reports.where.not(currency: "USD").exists?
+
     @reports = @event.reimbursement_reports.visible
     @reports = @reports.draft if params[:status] == "draft"
     @reports = @reports.submitted if params[:status] == "review_required"

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -75,7 +75,7 @@
                 <%= user_mention report.user %>
               </td>
               <td class="text-right">
-                <%= report.amount.format %>
+                <%= report.amount.format(with_currency: @format_reports_with_currency) %>
               </td>
               <td class="text-right">
                 <%= format_date report.created_at %>


### PR DESCRIPTION
## Summary of the problem

When you have USD and CAD reports, for example, it can be difficult to differentiate which dollar is which.


## Describe your changes

When an organization has any reimbursement reports in a non-USD currency, we'll always show the currency symbol.