### PR TITLE
Link transaction memo to HcbCode in notify_settled mailer

### DIFF
--- a/app/views/canonical_pending_transaction_mailer/notify_settled.html.erb
+++ b/app/views/canonical_pending_transaction_mailer/notify_settled.html.erb
@@ -1,3 +1,3 @@
-<%= @cpt.memo %> has settled at <%= render_money @ct.amount_cents %>; this was a charge on your card ending in <%= @cpt.stripe_card.last4 %> that previously was <%= render_money @cpt.amount_cents %>.
+<%= link_to @cpt.memo, hcb_code_url(@cpt.local_hcb_code) %> has settled at <%= render_money @ct.amount_cents %>; this was a charge on your card ending in <%= @cpt.stripe_card.last4 %> that previously was <%= render_money @cpt.amount_cents %>.
 
 <%= render partial: "canonical_pending_transaction_mailer/attach_receipt", locals: { hcb_code: @cpt.local_hcb_code, upload_url: @upload_url } if @cpt.local_hcb_code.missing_receipt? %>


### PR DESCRIPTION
Closes #13260

Links the transaction memo in `CanonicalPendingTransactionMailer#notify_settled` to the HcbCode page, so users can click through to view the transaction.