### PR TITLE
Add soft delete to organizer position invites

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -55,6 +55,7 @@
 #     creation.
 #
 class OrganizerPositionInvite < ApplicationRecord
+  acts_as_paranoid
   has_paper_trail
 
   include PublicIdentifiable

--- a/db/migrate/20260325000000_add_deleted_at_to_organizer_position_invites.rb
+++ b/db/migrate/20260325000000_add_deleted_at_to_organizer_position_invites.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToOrganizerPositionInvites < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :organizer_position_invites, :deleted_at, :datetime
+    add_index :organizer_position_invites, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_25_000000) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1769,6 +1769,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
     t.datetime "accepted_at", precision: nil
     t.datetime "cancelled_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
+    t.datetime "deleted_at"
     t.bigint "event_id", null: false
     t.boolean "initial", default: false
     t.integer "initial_control_allowance_amount_cents"
@@ -1780,6 +1781,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
     t.string "slug"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id", null: false
+    t.index ["deleted_at"], name: "index_organizer_position_invites_on_deleted_at"
     t.index ["event_id"], name: "index_organizer_position_invites_on_event_id"
     t.index ["organizer_position_id"], name: "index_organizer_position_invites_on_organizer_position_id"
     t.index ["sender_id"], name: "index_organizer_position_invites_on_sender_id"


### PR DESCRIPTION
Add deleted_at column to organizer_position_invites and create a concurrent index (migration disables DDL transaction). Enable acts_as_paranoid in OrganizerPositionInvite model.

Closes #13160