### PR TITLE
[AASM] Make `checks` table's `aasm_state` column not null

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -5,7 +5,7 @@
 # Table name: checks
 #
 #  id                     :bigint           not null, primary key
-#  aasm_state             :string
+#  aasm_state             :string           not null
 #  amount                 :integer
 #  approved_at            :datetime
 #  check_number           :integer

--- a/db/migrate/20260326031913_add_check_aasm_state_not_null_check_constraint.rb
+++ b/db/migrate/20260326031913_add_check_aasm_state_not_null_check_constraint.rb
@@ -1,0 +1,5 @@
+class AddCheckAasmStateNotNullCheckConstraint < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :checks, "aasm_state IS NOT NULL", name: "checks_aasm_state_null", validate: false
+  end
+end

--- a/db/migrate/20260326031931_validate_check_aasm_state_not_null_check_constraint.rb
+++ b/db/migrate/20260326031931_validate_check_aasm_state_not_null_check_constraint.rb
@@ -1,0 +1,12 @@
+class ValidateCheckAasmStateNotNullCheckConstraint < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :checks, name: "checks_aasm_state_null"
+    change_column_null :checks, :aasm_state, false
+    remove_check_constraint :checks, name: "checks_aasm_state_null"
+  end
+
+  def down
+    add_check_constraint :checks, "aasm_state IS NOT NULL", name: "checks_aasm_state_null", validate: false
+    change_column_null :checks, :aasm_state, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_26_031931) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -526,7 +526,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_12_205901) do
   end
 
   create_table "checks", force: :cascade do |t|
-    t.string "aasm_state"
+    t.string "aasm_state", null: false
     t.integer "amount"
     t.datetime "approved_at", precision: nil
     t.integer "check_number"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

previously, was nullable

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

now, not nullable. Confirmed via Blazer on 3/25 that there are no null entries in this column on prod

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

