### PR TITLE
Restore adding a default salt to hash IDs for new models

### DIFF
--- a/app/api/api/models/card_charge.rb
+++ b/app/api/api/models/card_charge.rb
@@ -26,7 +26,7 @@ module Api
 
       # Give Hashid a new pepper so that the public IDs look different than
       # the ones for transactions (HcbCodes).
-      hashid_config pepper: "api_card_charge"
+      hashid_config pepper: "api_card_charge", salt: ""
 
       # Set the default scope to HCB-600-* hcb codes (card charges).
       default_scope { where("hcb_code LIKE 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::STRIPE_CARD_CODE}-%'") }

--- a/app/models/ach_transfer.rb
+++ b/app/models/ach_transfer.rb
@@ -59,6 +59,9 @@ class AchTransfer < ApplicationRecord
   blind_index :routing_number
   monetize :amount, as: "amount_money"
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :ach
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -28,6 +28,8 @@
 #
 class Announcement < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
+
   include AASM
 
   ALLOWED_URL_SCHEMES = ["http", "https", "mailto", "tel"].freeze

--- a/app/models/bank_fee.rb
+++ b/app/models/bank_fee.rb
@@ -28,6 +28,9 @@ class BankFee < ApplicationRecord
   include AASM
   include HasBookTransfer
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :bfe
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -47,6 +47,8 @@
 #
 class CardGrant < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
+
   has_paper_trail
 
   include PublicIdentifiable

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -46,6 +46,9 @@ class Check < ApplicationRecord
   has_paper_trail skip: [:description] # ciphertext columns will still be tracked
   has_encrypted :description
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :chk
 

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -31,6 +31,9 @@ class CheckDeposit < ApplicationRecord
   include Freezable
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :cdp
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,6 +24,8 @@
 #
 class Comment < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
 
   set_public_id_prefix :cmt

--- a/app/models/concerns/public_identifiable.rb
+++ b/app/models/concerns/public_identifiable.rb
@@ -5,7 +5,6 @@ module PublicIdentifiable
   extend ActiveSupport::Concern
 
   included do
-    include Hashid::Rails
     class_attribute :public_id_prefix
   end
 

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -33,7 +33,15 @@
 #
 class Contract < ApplicationRecord
   include AASM
+
   include Hashid::Rails
+  hashid_config salt: ""
+  def self.inherited(subclass)
+    # Force STI subclasses to use the same hashid configuration to ensure no
+    # salt is used.
+    super
+    subclass.instance_variable_set(:@hashid_configuration, hashid_configuration)
+  end
 
   acts_as_paranoid
   has_paper_trail

--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -25,7 +25,6 @@ class Contract
   class Party < ApplicationRecord
     include AASM
     include Hashid::Rails
-    hashid_config salt: Credentials.fetch(:HASHID_SALT)
 
     acts_as_paranoid
     has_paper_trail

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -62,6 +62,9 @@ class Disbursement < ApplicationRecord
 
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :xfr # Transfer
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -59,6 +59,9 @@
 class Donation < ApplicationRecord
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :don
 

--- a/app/models/donation/tier.rb
+++ b/app/models/donation/tier.rb
@@ -26,6 +26,7 @@
 class Donation
   class Tier < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     belongs_to :event
 

--- a/app/models/emburse_card.rb
+++ b/app/models/emburse_card.rb
@@ -34,6 +34,8 @@
 #
 class EmburseCard < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
+
   extend FriendlyId
 
   scope :deactivated, -> { where.not(emburse_state: "active") }

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -24,7 +24,9 @@
 #
 class Employee < ApplicationRecord
   include AASM
+
   include Hashid::Rails
+  hashid_config salt: ""
 
   has_paper_trail
   acts_as_paranoid

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -62,6 +62,8 @@ class Event < ApplicationRecord
   MIN_WAITING_TIME_BETWEEN_FEES = 5.days
 
   include Hashid::Rails
+  hashid_config salt: ""
+
   extend FriendlyId
 
   include PublicIdentifiable

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -19,6 +19,7 @@
 class Event
   class Affiliation < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     include ActionView::Helpers::TextHelper
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -64,9 +64,10 @@ class Event
     include AASM
     include Contractable
 
+    include Hashid::Rails
+
     include PublicIdentifiable
     set_public_id_prefix :apl
-    hashid_config salt: Credentials.fetch(:HASHID_SALT)
 
     belongs_to :user
     belongs_to :event, optional: true

--- a/app/models/event/follow.rb
+++ b/app/models/event/follow.rb
@@ -23,6 +23,7 @@
 class Event
   class Follow < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     belongs_to :user
     belongs_to :event

--- a/app/models/fee_revenue.rb
+++ b/app/models/fee_revenue.rb
@@ -16,6 +16,9 @@ class FeeRevenue < ApplicationRecord
   include AASM
   include HasBookTransfer
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :frv
 

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -26,10 +26,11 @@
 class HcbCode < ApplicationRecord
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :txn
-
-  include Hashid::Rails
 
   include Commentable
   include Receiptable

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -63,6 +63,9 @@ class IncreaseCheck < ApplicationRecord
   include PublicActivity::Model
   tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :ick
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -100,6 +100,9 @@ class Invoice < ApplicationRecord
   has_paper_trail skip: [:payment_method_ach_credit_transfer_account_number] # ciphertext columns will still be tracked
   has_encrypted :payment_method_ach_credit_transfer_account_number
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :inv
 

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -28,7 +28,6 @@ class Ledger < ApplicationRecord
   self.table_name = "ledgers"
 
   include Hashid::Rails
-  hashid_config salt: Credentials.fetch(:HASHID_SALT)
   has_paper_trail
 
   # Possible owners for a primary ledger

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -24,7 +24,6 @@ class Ledger
     self.table_name = "ledger_items"
 
     include Hashid::Rails
-    hashid_config salt: Credentials.fetch(:HASHID_SALT)
     has_paper_trail
 
     include Commentable

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -23,7 +23,9 @@
 #
 class Login < ApplicationRecord
   include AASM
+
   include Hashid::Rails
+  hashid_config salt: ""
 
   belongs_to :user
   belongs_to :user_session, class_name: "User::Session", optional: true

--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -57,6 +57,9 @@
 class OrganizerPositionInvite < ApplicationRecord
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :ivt
 

--- a/app/models/organizer_position_invite/link.rb
+++ b/app/models/organizer_position_invite/link.rb
@@ -28,6 +28,7 @@
 class OrganizerPositionInvite
   class Link < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     DEFAULT_EXPIRATION = 30.days
 

--- a/app/models/organizer_position_invite/request.rb
+++ b/app/models/organizer_position_invite/request.rb
@@ -27,6 +27,8 @@
 class OrganizerPositionInvite
   class Request < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
+
     include AASM
 
     belongs_to :organizer_position_invite, optional: true

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -45,6 +45,9 @@ class Receipt < ApplicationRecord
 
   include StripeAuthorizationsHelper
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :rct
 

--- a/app/models/recurring_donation.rb
+++ b/app/models/recurring_donation.rb
@@ -38,6 +38,7 @@
 #
 class RecurringDonation < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
 
   include HasStripeDashboardUrl
   has_stripe_dashboard_url "subscriptions", :stripe_subscription_id

--- a/app/models/referral/link.rb
+++ b/app/models/referral/link.rb
@@ -26,6 +26,7 @@
 module Referral
   class Link < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     after_create_commit :set_default_slug!
     validates :slug, uniqueness: true

--- a/app/models/referral/program.rb
+++ b/app/models/referral/program.rb
@@ -26,6 +26,7 @@
 module Referral
   class Program < ApplicationRecord
     include Hashid::Rails
+    hashid_config salt: ""
 
     validates :name, presence: true
     validates :redirect_to, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), if: -> { redirect_to.present? }

--- a/app/models/reimbursement/expense.rb
+++ b/app/models/reimbursement/expense.rb
@@ -43,7 +43,16 @@ module Reimbursement
     belongs_to :approved_by, class_name: "User", optional: true
     include AASM
     include Receiptable
+
     include Hashid::Rails
+    hashid_config salt: ""
+    def self.inherited(subclass)
+      # Force STI subclasses to use the same hashid configuration to ensure no
+      # salt is used.
+      super
+      subclass.instance_variable_set(:@hashid_configuration, hashid_configuration)
+    end
+
     has_paper_trail
     acts_as_paranoid
 

--- a/app/models/reimbursement/expense_payout.rb
+++ b/app/models/reimbursement/expense_payout.rb
@@ -31,6 +31,9 @@ module Reimbursement
     include AASM
     include HasBookTransfer
 
+    include Hashid::Rails
+    hashid_config salt: ""
+
     include PublicIdentifiable
     set_public_id_prefix :rep
 

--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -31,6 +31,9 @@ module Reimbursement
     include AASM
     include HasBookTransfer
 
+    include Hashid::Rails
+    hashid_config salt: ""
+
     include PublicIdentifiable
     set_public_id_prefix :rph
 

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -44,6 +44,9 @@ module Reimbursement
   class Report < ApplicationRecord
     include ::Shared::AmpleBalance
 
+    include Hashid::Rails
+    hashid_config salt: ""
+
     include PublicIdentifiable
     set_public_id_prefix :rmr
 
@@ -84,7 +87,6 @@ module Reimbursement
 
     include AASM
     include Commentable
-    include Hashid::Rails
 
     include PublicActivity::Model
     tracked owner: proc{ |controller, record| controller&.current_user }, recipient: proc { |controller, record| record.user }, event_id: proc { |controller, record| record.event&.id }, only: [:create]

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -31,6 +31,9 @@
 class Sponsor < ApplicationRecord
   has_paper_trail
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :spr
 

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -54,6 +54,8 @@
 #
 class StripeCard < ApplicationRecord
   include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   include Freezable
   set_public_id_prefix :crd

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,6 +19,9 @@
 class Tag < ApplicationRecord
   include ActionView::Helpers::TextHelper # for `pluralize`
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :tag
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,9 @@
 class User < ApplicationRecord
   has_paper_trail skip: [:birthday] # ciphertext columns will still be tracked
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :usr
 

--- a/app/models/wire.rb
+++ b/app/models/wire.rb
@@ -62,6 +62,9 @@ class Wire < ApplicationRecord
   include Freezable
   include Payment
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :wir
 

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -53,6 +53,9 @@ class WiseTransfer < ApplicationRecord
 
   include HasWiseRecipient
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :wse
 

--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -11,3 +11,7 @@ ActiveSupport.on_load(:active_record) do
     end
   end
 end
+
+Hashid::Rails.configure do |config|
+  config.salt = Credentials.fetch(:HASHID_SALT)
+end

--- a/config/initializers/public_activity.rb
+++ b/config/initializers/public_activity.rb
@@ -20,6 +20,9 @@ class PublicActivity::Activity
 
   include Turbo::Broadcastable
 
+  include Hashid::Rails
+  hashid_config salt: ""
+
   include PublicIdentifiable
   set_public_id_prefix :act
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This was originally merged in #12958, but was later reverted after we discovered a bug in Hashid that caused model-specific salts to not take effect on relations. This bug was patched in HCB in #13164 and #13231.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Reverts the commit that reverted the merge of #12958 and add empty salt override to `Donation::Tier`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

