### PR TITLE
[Applications] Improve assignment of points of contact

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -111,6 +111,7 @@ class Event
 
       if @application.teen_led?
         party = @application.contract.party :hcb
+        party.update!(user: current_user)
         redirect_to contract_party_path(party)
       else
         redirect_to submission_application_path(@application)
@@ -129,7 +130,7 @@ class Event
     def admin_activate
       authorize @application
 
-      @application.activate_event!(tags: params[:tags], risk_level: params[:risk_level])
+      @application.activate_event!(tags: params[:tags], risk_level: params[:risk_level], point_of_contact: current_user)
 
       redirect_to event_path(@application.event), flash: { success: "Successfully activated #{@application.event.name}!" }
     end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -331,17 +331,18 @@ class Event
       self.with_lock do
         raise ArgumentError.new("Event was already created") if event.present?
 
+        poc_user = point_of_contact.present? ? point_of_contact : contract.party(:hcb).user
         Event.create!(
           name:,
           country: address_country,
-          point_of_contact_id: point_of_contact.present? ? point_of_contact.id : contract.party(:hcb).user.id,
+          point_of_contact_id: poc_user.id,
           application: self,
           event_tags: tags.filter { |tag| EventTag::Tags::ALL.include?(tag) }.map { |tag| EventTag.find_or_create_by!(name: tag) },
           risk_level:
         )
         contract.create_document!
 
-        service = OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: user.email, is_signee: true, role: :manager, initial: true)
+        service = OrganizerPositionInviteService::Create.new(event:, sender: poc_user, user_email: user.email, is_signee: true, role: :manager, initial: true)
         invite = service.model
         service.run!
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -323,7 +323,7 @@ class Event
       update!(last_viewed_at: Time.current, last_page_viewed:)
     end
 
-    def activate_event!(risk_level:, tags: [])
+    def activate_event!(risk_level:, tags: [], point_of_contact: nil)
       contract.party(:hcb).sync_with_docuseal
       contract.reload
       raise "Contract must be signed before activation" unless contract.signed?
@@ -331,18 +331,17 @@ class Event
       self.with_lock do
         raise ArgumentError.new("Event was already created") if event.present?
 
-        poc = contract.party(:hcb).user
         Event.create!(
           name:,
           country: address_country,
-          point_of_contact_id: poc.id,
+          point_of_contact_id: point_of_contact.present? ? point_of_contact.id : contract.party(:hcb).user.id,
           application: self,
           event_tags: tags.filter { |tag| EventTag::Tags::ALL.include?(tag) }.map { |tag| EventTag.find_or_create_by!(name: tag) },
           risk_level:
         )
         contract.create_document!
 
-        service = OrganizerPositionInviteService::Create.new(event:, sender: poc, user_email: user.email, is_signee: true, role: :manager, initial: true)
+        service = OrganizerPositionInviteService::Create.new(event:, sender: point_of_contact, user_email: user.email, is_signee: true, role: :manager, initial: true)
         invite = service.model
         service.run!
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -331,7 +331,7 @@ class Event
       self.with_lock do
         raise ArgumentError.new("Event was already created") if event.present?
 
-        poc_user = point_of_contact.present? ? point_of_contact : contract.party(:hcb).user
+        poc_user = point_of_contact.presence || contract.party(:hcb).user
         Event.create!(
           name:,
           country: address_country,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We currently infer event point of contacts from the user associated to HCB's signing party on the application contract, and send reminder emails to this user. However, for teen-led applications, this user is set by default to the system user (hcb@hackclub.com).

This means reminder emails for teen-led applications are sent to everyone, and when activated, these events don't have a real point of contact.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Updates HCB's signing party on the application contract to match the user who approved an application, and explicitly pass `Event::Application#activate_event!` a point of contact to use.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

