### PR TITLE
[Admin][Account Number] Fix template error when event's deleted

### DIFF
--- a/app/models/column/account_number.rb
+++ b/app/models/column/account_number.rb
@@ -26,7 +26,7 @@
 #
 module Column
   class AccountNumber < ApplicationRecord
-    belongs_to :event
+    belongs_to :event, with_deleted: true
 
     has_encrypted :account_number, :routing_number, :bic_code
 

--- a/app/models/column/account_number.rb
+++ b/app/models/column/account_number.rb
@@ -26,7 +26,7 @@
 #
 module Column
   class AccountNumber < ApplicationRecord
-    belongs_to :event, with_deleted: true
+    belongs_to :event
 
     has_encrypted :account_number, :routing_number, :bic_code
 

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -41,14 +41,12 @@
         <td><%= an.id %></td>
         <td>
           <% event = an.event || Event.with_deleted.find_by(id: an.event_id) %>
-          <% if event %>
-            <%= link_to event_path(event) do %>
-              <%= event.name.upcase %>
-            <% end %>
-            (#<%= event.id %>)
-            <% if event.deleted? %>
-              <em>(deleted)</em>
-            <% end %>
+          <%= link_to event_path(event) do %>
+            <%= event.name.upcase %>
+          <% end %>
+          (#<%= event.id %>)
+          <% if event.deleted? %>
+            <em>(deleted)</em>
           <% end %>
         </td>
         <td><%= an.account_number %></td>

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -40,13 +40,12 @@
       <tr>
         <td><%= an.id %></td>
         <td>
-          <% if an.event %>
-            <%= link_to event_path(an.event) do %>
-              <%= an.event.name.upcase %>
-            <% end %>
-            (#<%= an.event.id %>)
-          <% else %>
-            <em>No event</em>
+          <%= link_to event_path(an.event) do %>
+            <%= an.event.name.upcase %>
+          <% end %>
+          (#<%= an.event.id %>)
+          <% if an.event.deleted? %>
+            <em>(deleted)</em>
           <% end %>
         </td>
         <td><%= an.account_number %></td>

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -36,11 +36,12 @@
     </tr>
   </thead>
   <tbody>
+    <% events_by_id = Event.with_deleted.where(id: @account_numbers.map(&:event_id)).index_by(&:id) %>
     <% @account_numbers.each do |an| %>
       <tr>
         <td><%= an.id %></td>
         <td>
-          <% event = an.event || Event.with_deleted.find_by(id: an.event_id) %>
+          <% event = events_by_id[an.event_id] %>
           <%= link_to event_path(event) do %>
             <%= event.name.upcase %>
           <% end %>

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -40,12 +40,15 @@
       <tr>
         <td><%= an.id %></td>
         <td>
-          <%= link_to event_path(an.event) do %>
-            <%= an.event.name.upcase %>
-          <% end %>
-          (#<%= an.event.id %>)
-          <% if an.event.deleted? %>
-            <em>(deleted)</em>
+          <% event = an.event || Event.with_deleted.find_by(id: an.event_id) %>
+          <% if event %>
+            <%= link_to event_path(event) do %>
+              <%= event.name.upcase %>
+            <% end %>
+            (#<%= event.id %>)
+            <% if event.deleted? %>
+              <em>(deleted)</em>
+            <% end %>
           <% end %>
         </td>
         <td><%= an.account_number %></td>

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -40,10 +40,14 @@
       <tr>
         <td><%= an.id %></td>
         <td>
-          <%= link_to event_path(an.event) do %>
-            <%= an.event.name.upcase %>
+          <% if an.event %>
+            <%= link_to event_path(an.event) do %>
+              <%= an.event.name.upcase %>
+            <% end %>
+            (#<%= an.event.id %>)
+          <% else %>
+            <em>No event</em>
           <% end %>
-          (#<%= an.event.id %>)
         </td>
         <td><%= an.account_number %></td>
         <td><%= an.routing_number %></td>


### PR DESCRIPTION
## Summary
- Fixes `ActionView::Template::Error` in `AdminController#account_numbers` when an account number's associated event has been soft-deleted
- Batch-loads all events (including soft-deleted) in a single query using `Event.with_deleted.where(...).index_by(&:id)` before the loop
- Shows a `(deleted)` indicator next to soft-deleted events in the admin view

## Root cause
Events use `acts_as_paranoid` (soft delete). When an event is deleted, the `column_account_numbers` row remains but `an.event` returns `nil` because paranoid filters out deleted records. This caused `event_path(nil)` to raise a routing error.

## Test plan
- [ ] Visit `/admin/account_numbers`
- [ ] Verify account numbers with active events render correctly with links
- [ ] Verify account numbers with soft-deleted events show the event name with a `(deleted)` indicator

Closes #13284

https://claude.ai/code/session_014MohpvFunncybJbtMV58di