### PR TITLE
Safe navigate email attachment content disposition

### DIFF
--- a/app/mailboxes/concerns/has_attachments.rb
+++ b/app/mailboxes/concerns/has_attachments.rb
@@ -7,7 +7,7 @@ module HasAttachments
     private
 
     def set_attachments(include_body: true, convert_emls: true)
-      files = mail.attachments.select { |a| valid_content_type(a.content_type) && a.content_disposition.starts_with?("attachment") }.map do |atta|
+      files = mail.attachments.select { |a| valid_content_type(a.content_type) && a.content_disposition&.starts_with?("attachment") }.map do |atta|
         {
           io: StringIO.new(atta.decoded),
           content_type: atta.content_type,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/539 - while I haven't verified this, this may just be caused by the `mail` gem, as it was upgraded to a new minor version a few weeks before this issue started. Either way, it seems to just be that `content_disposition` can now be `nil`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add safe navigation operator when accessing `content_disposition`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

