### PR TITLE
[Applications] Add affiliations to admin edit page

### DIFF
--- a/app/views/event/applications/edit.html.erb
+++ b/app/views/event/applications/edit.html.erb
@@ -4,10 +4,10 @@
   <div class="md:max-w-[600px] w-full my-3 space-y-8 pb-5">
     <%= form_with model: @application, url: application_path(@application, return_to: submission_application_path(@application), confirm: true), method: :patch, id: "edit_application_#{@application.id}", class: "space-y-8" do |form| %>
 
-      <div class="card card--outline">
+      <div class="card card--outline" x-data="{ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>', teenager: '<%= @application.teen_led? ? "true" : "false" %>' }">
         <h3 class="text-2xl my-0 mb-6">Project Information</h3>
 
-        <div class="field" x-data="{ has_website: '<%= @application.website_url.present? ? "true" : "false" %>', has_political: '<%= @application.political_description.present? ? "true" : "false" %>', committed: '<%= @application.committed_amount %>' }">
+        <div class="field">
           <%= form.label :name do %>
             Project name <span class="text-primary">*</span>
           <% end %>

--- a/app/views/event/applications/edit.html.erb
+++ b/app/views/event/applications/edit.html.erb
@@ -238,6 +238,19 @@
       </div>
 
     <% end %>
+
+    <%= turbo_frame_tag :affiliations_settings do %>
+      <h3 class="mb2">Affiliations</h3>
+
+      <div class="card mb3">
+        <% affiliation = Event::Affiliation.new(affiliable: @application) %>
+        <%= form_with(url: affiliations_path(affiliable_type: @application.class.name, affiliable_id: @application.id), local: true, html: { "x-data": "{ type: '', disabled: #{!policy(affiliation).update?} }" }) do |form| %>
+          <%= render "events/settings/affiliation_form", affiliation:, form: %>
+        <% end %>
+      </div>
+
+      <%= render partial: "events/settings/affiliation", collection: @application.affiliations.nonempty %>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, admins can't edit affiliations on submitted applications - they would have to activate it and then edit it on the event affiliation page. Also, Alpine wasn't set up properly on this page, causing not applicable fields to show.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Fix Alpine and add affiliations to the admin edit page (at the bottom since we can't have a nested form).

<img width="1918" height="1002" alt="image" src="https://github.com/user-attachments/assets/6a8c8a8b-56a1-4e18-91cd-8629975e02f4" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

