### PR TITLE
[Applications] Clarify word count message for description

### DIFF
--- a/app/javascript/datas/application_project_info_form.js
+++ b/app/javascript/datas/application_project_info_form.js
@@ -11,6 +11,7 @@ export default ({
   committed,
   description,
   description_word_count: 0,
+  description_word_count_text: '',
   init() {
     this.$watch('description', this.setDescriptionWordCount.bind(this))
     this.$watch(
@@ -23,6 +24,13 @@ export default ({
   },
   setDescriptionWordCount(desc) {
     this.description_word_count = desc.match(/\S+/g)?.length || 0
+
+    if (this.description_word_count < 50) {
+      const remainingWords = 50 - this.description_word_count
+      this.description_word_count_text = `${remainingWords} more word${remainingWords > 1 ? 's' : ''} required`
+    } else {
+      this.description_word_count_text = ''
+    }
   },
   setDescriptionValidity(count) {
     if (this.teenager === 'false') {

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -42,7 +42,7 @@
       </p>
       <%= form.text_area :description, class: "w-full max-w-full", required: true, "x-bind:disabled": "teenager == null", "x-model": "description" %>
       <% unless @application.teen_led? %>
-        <p class="text-sm muted mt-1 mb-2"><span x-text="description_word_count">0</span>/50 words</p>
+        <p class="text-sm muted mt-1 mb-2" x-text="description_word_count_text"></p>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Adult applications have a minimum word count of 50 words, but the current message under the description text box shows it as "x/50 words". This implies there's a cap of 50 words, when it's just a minimum.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change the message to say "x more words required" when < 50 words are entered, and clear the message when the requirement has been satisfied.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

