### PR TITLE
Flag pending payout holdings as unprocessed Wise reimbursements

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -492,7 +492,7 @@ class AdminController < Admin::BaseController
     relation = relation.reimbursement_requested if @pending
 
     @unprocessed_wise_report_ids = Reimbursement::Report
-                                   .where(id: Reimbursement::PayoutHolding.settled.select(:reimbursement_reports_id))
+                                   .where(id: Reimbursement::PayoutHolding.settled.or(Reimbursement::PayoutHolding.pending).select(:reimbursement_reports_id))
                                    .where(user_id: User.where(payout_method_type: "User::PayoutMethod::WiseTransfer").select(:id))
                                    .select(:id)
                                    .pluck(:id)


### PR DESCRIPTION
## Summary of the problem

It's easy for operations to forget about unsent Wise transfers that have been approved.


## Describe your changes

This PR brings them to the top and highlights them blue.