### PR TITLE
Add fading to overflowing callouts to indicate scrolling

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -859,3 +859,20 @@ if (navigator.setAppBadge) {
     }
   })
 }
+
+function updateScrollFadeClasses(el) {
+  const isScrolledToBottom =
+    el.scrollHeight < el.clientHeight + el.scrollTop + 1
+  const isScrolledToTop = isScrolledToBottom ? false : el.scrollTop === 0
+  el.classList.toggle('is-bottom-overflowing', !isScrolledToBottom)
+  el.classList.toggle('is-top-overflowing', !isScrolledToTop)
+}
+
+document.querySelectorAll('.scroll-fade').forEach(scrollable => {
+  scrollable.addEventListener('scroll', e => {
+    const el = e.currentTarget
+    updateScrollFadeClasses(el)
+  })
+
+  updateScrollFadeClasses(scrollable)
+})

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -687,3 +687,23 @@ html[data-ai-loading='true'] > .turbo-progress-bar {
     @apply bg-primary text-white;
   }
 }
+
+.scroll-fade {
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    black var(--top-mask-size, 0),
+    black calc(100% - var(--bottom-mask-size, 0)),
+    transparent 100%
+  );
+  --top-mask-size: 0px;
+  --bottom-mask-size: 0px;
+}
+
+.scroll-fade.is-top-overflowing {
+  --top-mask-size: 48px !important;
+}
+
+.scroll-fade.is-bottom-overflowing {
+  --bottom-mask-size: 48px !important;
+}

--- a/app/views/application/_callout.html.erb
+++ b/app/views/application/_callout.html.erb
@@ -1,8 +1,8 @@
 <% icon ||= type == "error" ? "important" : (type == "success" ? "emoji" : "info") %> <%# (success | info | warning | error) %>
 <% color ||= type == "error" ? "primary" : type %>
 
-<div class="<%= "card border b--#{color} #{"pb0" if local_assigns[:footer].present? } mt3 mb3 #{local_assigns[:class]}" %>">
-  <div class="<%= "flex items-center #{color}" %>">
+<div class="<%= "flex flex-col card border b--#{color} p-0 mt3 mb3 #{local_assigns[:class]}" %>">
+  <div class="<%= "flex items-center #{color}" %> p-4 pb-0">
     <%= inline_icon icon, size: 32, class: "mr1" %>
     <p class="bold mt0 mb0">
       <%= local_assigns[:title] %>
@@ -11,19 +11,21 @@
   </div>
 
   <% unless (block = yield).empty? %>
-    <div class="m0 mt1">
+    <div class="m0 mt1 flex-grow overflow-y-scroll scroll-fade p-4 pt-0 <%= "pb-0" if local_assigns[:footer].present? %>">
       <%= block %>
     </div>
   <% end %>
 
   <% if local_assigns[:footer].present? %>
-    <div class="border-top card__banner card__darker secondary mt2">
-      <% if local_assigns[:footer] == :questions %>
-        <strong>Questions?</strong>
-        <%= help_message %>
-      <% else %>
-        <%= local_assigns[:footer] %>
-      <% end %>
+    <div class="border-top card__banner card__darker secondary">
+      <p class="px-4 my-0">
+        <% if local_assigns[:footer] == :questions %>
+          <strong>Questions?</strong>
+          <%= help_message %>
+        <% else %>
+          <%= local_assigns[:footer] %>
+        <% end %>
+      </p>
     </div>
   <% end %>
 </div>

--- a/app/views/contract/parties/_contract_faq.html.erb
+++ b/app/views/contract/parties/_contract_faq.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (no_questions: false) %>
 
-<%= render "application/callout", title: "Questions about the HCB agreement?", type: "info", class: "mt-0 max-h-full overflow-y-scroll", footer: no_questions ? nil : :questions do %>
+<%= render "application/callout", title: "Questions about the HCB agreement?", type: "info", class: "mt-0 max-h-full", footer: no_questions ? nil : :questions do %>
   <p>
     <span class="font-bold">Why do I need to sign this agreement?</span><br>
     This Fiscal Sponsorship Agreement sets the terms and conditions of your usage of HCB. It allows your project to use HCB's 501(c)(3) nonprofit status and defines a restricted fund for your project.


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, we use an overflowing callout on the contract FAQ since there's a lot of items. However, if the browser automatically hides the scroll bar, it can be unclear that it is a scrollable container.

Closes #13240

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds fading (credit to stackoverflow) to overflowing callouts to indicate scrolling.

https://github.com/user-attachments/assets/8cfe1e52-a8a0-4ac3-b042-10fe911d5447