### PR TITLE
[Contracts] Fix completed redirect

### DIFF
--- a/app/controllers/contract/parties_controller.rb
+++ b/app/controllers/contract/parties_controller.rb
@@ -44,7 +44,12 @@ class Contract
       authorize @party
 
       if @party.signee? && @contract.signed?
-        redirect_to @contract.contractable
+        if @contract.contractable.is_a?(Event::Application)
+          redirect_to application_path(@contract.contractable)
+        elsif @contract.contractable.is_a?(OrganizerPositionInvite)
+          redirect_to organizer_position_invite_path(@contract.contractable)
+        end
+
         return
       end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Redirecting to `@contract.contractable` doesn't work here since Rails infers `event_application_path`, which doesn't exist since we use `application_path` instead.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Explicitly match the contractable type to use the correct redirect path instead of letting Rails infer.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

