### PR TITLE
Add missing annotations for deleted_at on OPI

### DIFF
--- a/app/models/organizer_position_invite.rb
+++ b/app/models/organizer_position_invite.rb
@@ -7,6 +7,7 @@
 #  id                                     :bigint           not null, primary key
 #  accepted_at                            :datetime
 #  cancelled_at                           :datetime
+#  deleted_at                             :datetime
 #  initial                                :boolean          default(FALSE)
 #  initial_control_allowance_amount_cents :integer
 #  is_signee                              :boolean          default(FALSE)
@@ -22,6 +23,7 @@
 #
 # Indexes
 #
+#  index_organizer_position_invites_on_deleted_at             (deleted_at)
 #  index_organizer_position_invites_on_event_id               (event_id)
 #  index_organizer_position_invites_on_organizer_position_id  (organizer_position_id)
 #  index_organizer_position_invites_on_sender_id              (sender_id)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13274 added soft deletion to organizer position invites, but left out the annotations in the model file.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add annotations

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

