### PR TITLE
[Admin] Add View transaction button to wire page

### DIFF
--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -8,7 +8,6 @@
   View transaction
 <% end %>
 
-
 <h1>Process Wire #<%= @wire.id %></h1>
 <p><small>Current Status: <%= @wire.aasm_state %></small></p>
 

--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -3,6 +3,12 @@
     Back to wires
 <% end %>
 
+<%= link_to hcb_code_path(@wire.hcb_code), class: "btn btn-small bg-muted flex-shrink-0", target: "_blank" do %>
+  <%= inline_icon "payment-transfer" %>
+  View transaction
+<% end %>
+
+
 <h1>Process Wire #<%= @wire.id %></h1>
 <p><small>Current Status: <%= @wire.aasm_state %></small></p>
 


### PR DESCRIPTION
## Summary of the problem

It can be difficult for admins to navigate between the wire admin process page and the Wire HCB code page.


## Describe your changes

Adds a button on the Wire admin process page to take you to the wire HCB code page