### PR TITLE
[Admin] Add USD cap to modal for wise reimbursements

### DIFF
--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -3,8 +3,17 @@
 <table class="w-full table-fixed my-6">
   <tbody>
     <tr>
-      <td>Amount (<%= report.currency %>):</td>
-      <td><%= Money.from_cents(report.amount_to_reimburse_cents, report.currency).format %></td>
+      <td>
+        <strong>Amount (<%= report.currency %>):</strong>
+      </td>
+      <td>
+        <strong><%= Money.from_cents(report.amount_to_reimburse_cents, report.currency).format %></strong>
+        <% if report.maximum_amount_cents.present? %>
+          (<%= report.maximum_amount.format %> USD cap)
+        <% else %>
+          (No cap)
+        <% end %>
+      </td>
     </tr>
     <% if report.payout_holding %>
       <tr>


### PR DESCRIPTION
## Summary of the problem

The reimbursement report cap is visible, but it's in a different location from where admins go to process Wise reimbursement reports.


## Describe your changes

This PR moves the USD reimbursement cap right next to the local currency amount.