### PR TITLE
Show comment counts for admin transaction process pages

### DIFF
--- a/app/views/admin/ach_start_approval.html.erb
+++ b/app/views/admin/ach_start_approval.html.erb
@@ -6,7 +6,7 @@
 
   <%= link_to hcb_code_path(@ach_transfer.hcb_code), class: "btn btn-small bg-muted flex-shrink-0", target: "_blank" do %>
     <%= inline_icon "payment-transfer" %>
-    View transaction
+    View transaction (<%= pluralize(@ach_transfer.local_hcb_code.comments.count, "comment") %>)
   <% end %>
 
   <div class="flex-grow"></div>

--- a/app/views/admin/increase_check_process.html.erb
+++ b/app/views/admin/increase_check_process.html.erb
@@ -6,7 +6,7 @@
 
   <%= link_to hcb_code_path(@check.hcb_code), class: "btn btn-small bg-muted flex-shrink-0", target: "_blank" do %>
     <%= inline_icon "payment-transfer" %>
-    View transaction
+    View transaction (<%= pluralize(@check.local_hcb_code.comments.count, "comment") %>)
   <% end %>
 </div>
 

--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -6,7 +6,7 @@
 
   <%= link_to hcb_code_path(@wire.hcb_code), class: "btn btn-small bg-muted flex-shrink-0", target: "_blank" do %>
     <%= inline_icon "payment-transfer" %>
-    View transaction
+    View transaction (<%= pluralize(@wire.local_hcb_code.comments.count, "comment") %>)
   <% end %>
 
   <div class="flex-grow"></div>

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -6,7 +6,7 @@
 
   <%= link_to hcb_code_path(@wise_transfer.hcb_code), class: "btn btn-small bg-muted flex-shrink-0", target: "_blank" do %>
     <%= inline_icon "payment-transfer" %>
-    View transaction
+    View transaction (<%= pluralize(@wise_transfer.local_hcb_code.comments.count, "comment") %>)
   <% end %>
 
   <div class="flex-grow"></div>


### PR DESCRIPTION
## Summary of the problem

Currently, operations needs to start every transaction approval by going to the HCB code page to check for comments. We can simplify their workflow and provide peace of mind by showing the number of comments directly on the process page.


## Describe your changes

Show the comment count on the "View transaction" button