### PR TITLE
[Reimbursement] Fix soft deletion of associated Expenses

### DIFF
--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -74,7 +74,7 @@ module Reimbursement
     monetize :amount_to_reimburse_cents, allow_nil: true, with_model_currency: :currency
     monetize :amount_cents, as: "amount", allow_nil: true, with_model_currency: :currency
     validates :maximum_amount_cents, numericality: { greater_than: 0 }, allow_nil: true
-    has_many :expenses, foreign_key: "reimbursement_report_id", inverse_of: :report, dependent: :delete_all
+    has_many :expenses, foreign_key: "reimbursement_report_id", inverse_of: :report, dependent: :destroy
     has_one :payout_holding, inverse_of: :report
     alias_attribute :report_name, :name
     attribute :name, :string, default: -> { "Expenses from #{Time.now.strftime("%B %e, %Y")}" }


### PR DESCRIPTION
## Summary of the problem

When we delete a report, we actually were not cascading soft-deletion correctly because we had

```
has_many :expenses, dependent: :delete_all
```

`delete_all` directly issues a SQL DELETE without running it through ActiveRecord, which means that soft-deletion is skipped and it is actually deleted.


## Describe your changes

Use `dependent: destroy` instead.