### PR TITLE
[Inbound Webhooks] Tests to ensure signatures are validated

### DIFF
--- a/app/controllers/column/webhooks_controller.rb
+++ b/app/controllers/column/webhooks_controller.rb
@@ -114,6 +114,8 @@ module Column
     end
 
     def verify_signature
+      return head :bad_request if request.headers["Column-Signature"].blank?
+
       signature_valid = ActiveSupport::SecurityUtils.secure_compare(
         OpenSSL::HMAC.hexdigest(
           "SHA256",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
+# Set before Rails boots so the Rack::TwilioWebhookAuthentication middleware
+# (initialized in config/initializers/twilio.rb) uses a known auth token.
+ENV["TWILIO__AUTH_TOKEN"] ||= "test_twilio_auth_token"
 require File.expand_path("../config/environment", __dir__)
 # PaperTrail helper to make it easier to use PaperTrail in specs
 require "paper_trail/frameworks/rspec"

--- a/spec/requests/column_webhook_spec.rb
+++ b/spec/requests/column_webhook_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Column Webhook", type: :request do
 
   describe "POST /webhooks/column" do
     context "with a valid Column signature" do
-      it "does not return 400" do
+      it "returns 200" do
         post "/webhooks/column",
              params: payload,
              headers: { "Column-Signature" => column_signature(payload), "Content-Type" => "application/json" }

--- a/spec/requests/column_webhook_spec.rb
+++ b/spec/requests/column_webhook_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Column Webhook", type: :request do
+  let(:webhook_secret) { "test_column_webhook_secret" }
+  let(:payload) { { type: "ach.incoming_transfer.settled", data: { id: "acht_test", account_number_id: "acno_test", amount: 1000 } }.to_json }
+
+  around do |example|
+    original = ENV["COLUMN__SANDBOX__WEBHOOK_SECRET"]
+    ENV["COLUMN__SANDBOX__WEBHOOK_SECRET"] = webhook_secret
+    example.run
+  ensure
+    ENV["COLUMN__SANDBOX__WEBHOOK_SECRET"] = original
+  end
+
+  def column_signature(body)
+    OpenSSL::HMAC.hexdigest("SHA256", webhook_secret, body)
+  end
+
+  describe "POST /webhooks/column" do
+    context "with a valid Column signature" do
+      it "does not return 400" do
+        post "/webhooks/column",
+             params: payload,
+             headers: { "Column-Signature" => column_signature(payload), "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with an invalid Column signature" do
+      it "returns 400" do
+        post "/webhooks/column",
+             params: payload,
+             headers: { "Column-Signature" => "invalidsignature", "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "with no Column signature" do
+      it "returns 400" do
+        post "/webhooks/column",
+             params: payload,
+             headers: { "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/requests/column_webhook_spec.rb
+++ b/spec/requests/column_webhook_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe "Column Webhook", type: :request do
     end
 
     context "with an invalid Column signature" do
-      it "returns 400" do
+      it "returns 400 and does not process the webhook" do
+        expect(Column::WebhooksController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(Column::WebhooksController).not_to receive(:webhook)
+
         post "/webhooks/column",
              params: payload,
              headers: { "Column-Signature" => "invalidsignature", "Content-Type" => "application/json" }
@@ -40,7 +43,10 @@ RSpec.describe "Column Webhook", type: :request do
     end
 
     context "with no Column signature" do
-      it "returns 400" do
+      it "returns 400 and does not process the webhook" do
+        expect(Column::WebhooksController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(Column::WebhooksController).not_to receive(:webhook)
+
         post "/webhooks/column",
              params: payload,
              headers: { "Content-Type" => "application/json" }

--- a/spec/requests/discord_webhook_spec.rb
+++ b/spec/requests/discord_webhook_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Pre-generated Ed25519 keypair for testing.
+# Generated with: ruby -r ed25519 -e 'k = Ed25519::SigningKey.generate; puts k.seed.unpack1("H*"); puts k.verify_key.to_bytes.unpack1("H*")'
+DISCORD_TEST_SIGNING_KEY_SEED = "a689dcab6e98940e48e69ddac835ec9240ef5a93d0db32db56617b7992c717d6"
+DISCORD_TEST_PUBLIC_KEY = "b8e2071ed84201e2a2fe7e55a6d64f5ed6017706b3f2edde795789ff6ce7f9fb"
+
+RSpec.describe "Discord Webhook", type: :request do
+  let(:signing_key) { Ed25519::SigningKey.new([DISCORD_TEST_SIGNING_KEY_SEED].pack("H*")) }
+
+  around do |example|
+    original = ENV["DISCORD__PUBLIC_KEY"]
+    ENV["DISCORD__PUBLIC_KEY"] = DISCORD_TEST_PUBLIC_KEY
+    example.run
+  ensure
+    ENV["DISCORD__PUBLIC_KEY"] = original
+  end
+
+  def discord_signature(body, timestamp: Time.now.to_i.to_s)
+    signature = signing_key.sign(timestamp + body)
+    [timestamp, signature.unpack1("H*")]
+  end
+
+  describe "POST /discord/event_webhook" do
+    let(:payload) { { type: 0 }.to_json }
+
+    context "with a valid Discord signature" do
+      it "does not return 401" do
+        timestamp, signature = discord_signature(payload)
+
+        post "/discord/event_webhook",
+             params: payload,
+             headers: {
+               "X-Signature-Timestamp" => timestamp,
+               "X-Signature-Ed25519"   => signature,
+               "Content-Type"          => "application/json"
+             }
+
+        expect(response).not_to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with an invalid Discord signature" do
+      it "returns 401" do
+        post "/discord/event_webhook",
+             params: payload,
+             headers: {
+               "X-Signature-Timestamp" => Time.now.to_i.to_s,
+               "X-Signature-Ed25519"   => "a" * 128,
+               "Content-Type"          => "application/json"
+             }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with no Discord signature" do
+      it "returns 401" do
+        post "/discord/event_webhook",
+             params: payload,
+             headers: { "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST /discord/interaction_webhook" do
+    let(:payload) { { type: 1 }.to_json }
+
+    context "with a valid Discord signature" do
+      it "does not return 401" do
+        timestamp, signature = discord_signature(payload)
+
+        post "/discord/interaction_webhook",
+             params: payload,
+             headers: {
+               "X-Signature-Timestamp" => timestamp,
+               "X-Signature-Ed25519"   => signature,
+               "Content-Type"          => "application/json"
+             }
+
+        expect(response).not_to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with an invalid Discord signature" do
+      it "returns 401" do
+        post "/discord/interaction_webhook",
+             params: payload,
+             headers: {
+               "X-Signature-Timestamp" => Time.now.to_i.to_s,
+               "X-Signature-Ed25519"   => "a" * 128,
+               "Content-Type"          => "application/json"
+             }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with no Discord signature" do
+      it "returns 401" do
+        post "/discord/interaction_webhook",
+             params: payload,
+             headers: { "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/discord_webhook_spec.rb
+++ b/spec/requests/discord_webhook_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Discord Webhook", type: :request do
     let(:payload) { { type: 0 }.to_json }
 
     context "with a valid Discord signature" do
-      it "does not return 401" do
+      it "returns 204" do
         timestamp, signature = discord_signature(payload)
 
         post "/discord/event_webhook",
@@ -38,7 +38,7 @@ RSpec.describe "Discord Webhook", type: :request do
                "Content-Type"          => "application/json"
              }
 
-        expect(response).not_to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:no_content)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe "Discord Webhook", type: :request do
     let(:payload) { { type: 1 }.to_json }
 
     context "with a valid Discord signature" do
-      it "does not return 401" do
+      it "returns 200" do
         timestamp, signature = discord_signature(payload)
 
         post "/discord/interaction_webhook",
@@ -82,7 +82,7 @@ RSpec.describe "Discord Webhook", type: :request do
                "Content-Type"          => "application/json"
              }
 
-        expect(response).not_to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/requests/discord_webhook_spec.rb
+++ b/spec/requests/discord_webhook_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe "Discord Webhook", type: :request do
     end
 
     context "with an invalid Discord signature" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DiscordController.method_defined?(:event_webhook)).to be(true)
+        expect_any_instance_of(DiscordController).not_to receive(:event_webhook)
+
         post "/discord/event_webhook",
              params: payload,
              headers: {
@@ -57,7 +60,10 @@ RSpec.describe "Discord Webhook", type: :request do
     end
 
     context "with no Discord signature" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DiscordController.method_defined?(:event_webhook)).to be(true)
+        expect_any_instance_of(DiscordController).not_to receive(:event_webhook)
+
         post "/discord/event_webhook",
              params: payload,
              headers: { "Content-Type" => "application/json" }
@@ -71,7 +77,7 @@ RSpec.describe "Discord Webhook", type: :request do
     let(:payload) { { type: 1 }.to_json }
 
     context "with a valid Discord signature" do
-      it "returns 200" do
+      it "returns 200 with PONG" do
         timestamp, signature = discord_signature(payload)
 
         post "/discord/interaction_webhook",
@@ -83,11 +89,15 @@ RSpec.describe "Discord Webhook", type: :request do
              }
 
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["type"]).to eq(1)
       end
     end
 
     context "with an invalid Discord signature" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DiscordController.method_defined?(:interaction_webhook)).to be(true)
+        expect_any_instance_of(DiscordController).not_to receive(:interaction_webhook)
+
         post "/discord/interaction_webhook",
              params: payload,
              headers: {
@@ -101,7 +111,10 @@ RSpec.describe "Discord Webhook", type: :request do
     end
 
     context "with no Discord signature" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DiscordController.method_defined?(:interaction_webhook)).to be(true)
+        expect_any_instance_of(DiscordController).not_to receive(:interaction_webhook)
+
         post "/discord/interaction_webhook",
              params: payload,
              headers: { "Content-Type" => "application/json" }

--- a/spec/requests/docuseal_webhook_spec.rb
+++ b/spec/requests/docuseal_webhook_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Docuseal Webhook", type: :request do
+  let(:webhook_secret) { "test_docuseal_webhook_secret" }
+  let(:payload) do
+    {
+      event_type: "form.completed",
+      data: { submission_id: 1, role: "signer" }
+    }
+  end
+
+  around do |example|
+    original = ENV["DOCUSEAL__WEBHOOK_SECRET"]
+    ENV["DOCUSEAL__WEBHOOK_SECRET"] = webhook_secret
+    example.run
+  ensure
+    ENV["DOCUSEAL__WEBHOOK_SECRET"] = original
+  end
+
+  describe "POST /docuseal/webhook" do
+    context "with a valid Docuseal secret" do
+      it "returns 200 with success" do
+        post "/docuseal/webhook",
+             params: payload,
+             headers: { "X-Docuseal-Secret" => webhook_secret }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be true
+      end
+    end
+
+    context "with an invalid Docuseal secret" do
+      it "returns 200 with failure" do
+        post "/docuseal/webhook",
+             params: payload,
+             headers: { "X-Docuseal-Secret" => "wrong_secret" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be false
+      end
+    end
+
+    context "with no Docuseal secret" do
+      it "returns 200 with failure" do
+        post "/docuseal/webhook",
+             params: payload
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["success"]).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/stripe_webhook_spec.rb
+++ b/spec/requests/stripe_webhook_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe "Stripe Webhook", type: :request do
 
   describe "POST /stripe/webhook" do
     context "with a valid Stripe signature" do
-      it "does not return 400" do
+      it "returns 204" do
         post "/stripe/webhook",
              params: payload,
              headers: { "Stripe-Signature" => stripe_signature(payload), "Content-Type" => "application/json" }
 
-        expect(response).not_to have_http_status(:bad_request)
+        expect(response).to have_http_status(:no_content)
       end
     end
 

--- a/spec/requests/stripe_webhook_spec.rb
+++ b/spec/requests/stripe_webhook_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe "Stripe Webhook", type: :request do
     end
 
     context "with an invalid Stripe signature" do
-      it "returns 400" do
+      it "returns 400 and does not process the webhook" do
+        expect(StripeController.private_method_defined?(:handle_charge_updated)).to be(true)
+        expect_any_instance_of(StripeController).not_to receive(:handle_charge_updated)
+
         post "/stripe/webhook",
              params: payload,
              headers: { "Stripe-Signature" => "t=1234567890,v1=invalidsignature", "Content-Type" => "application/json" }
@@ -48,7 +51,10 @@ RSpec.describe "Stripe Webhook", type: :request do
     end
 
     context "with no Stripe signature" do
-      it "returns 400" do
+      it "returns 400 and does not process the webhook" do
+        expect(StripeController.private_method_defined?(:handle_charge_updated)).to be(true)
+        expect_any_instance_of(StripeController).not_to receive(:handle_charge_updated)
+
         post "/stripe/webhook",
              params: payload,
              headers: { "Content-Type" => "application/json" }

--- a/spec/requests/stripe_webhook_spec.rb
+++ b/spec/requests/stripe_webhook_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Stripe Webhook", type: :request do
+  let(:webhook_secret) { "whsec_test_stripe_webhook_secret" }
+  let(:payload) do
+    {
+      id: "evt_test",
+      object: "event",
+      type: "charge.updated",
+      data: { object: { id: "ch_test", metadata: {} } }
+    }.to_json
+  end
+
+  around do |example|
+    original = ENV["STRIPE__TEST__WEBHOOK_SIGNING_SECRETS__PRIMARY"]
+    ENV["STRIPE__TEST__WEBHOOK_SIGNING_SECRETS__PRIMARY"] = webhook_secret
+    example.run
+  ensure
+    ENV["STRIPE__TEST__WEBHOOK_SIGNING_SECRETS__PRIMARY"] = original
+  end
+
+  def stripe_signature(body, timestamp: Time.now)
+    signature = Stripe::Webhook::Signature.compute_signature(timestamp, body, webhook_secret)
+    Stripe::Webhook::Signature.generate_header(timestamp, signature)
+  end
+
+  describe "POST /stripe/webhook" do
+    context "with a valid Stripe signature" do
+      it "does not return 400" do
+        post "/stripe/webhook",
+             params: payload,
+             headers: { "Stripe-Signature" => stripe_signature(payload), "Content-Type" => "application/json" }
+
+        expect(response).not_to have_http_status(:bad_request)
+      end
+    end
+
+    context "with an invalid Stripe signature" do
+      it "returns 400" do
+        post "/stripe/webhook",
+             params: payload,
+             headers: { "Stripe-Signature" => "t=1234567890,v1=invalidsignature", "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "with no Stripe signature" do
+      it "returns 400" do
+        post "/stripe/webhook",
+             params: payload,
+             headers: { "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/requests/twilio_webhook_spec.rb
+++ b/spec/requests/twilio_webhook_spec.rb
@@ -33,24 +33,26 @@ RSpec.describe "Twilio Webhook", type: :request do
     end
 
     context "with an invalid Twilio signature" do
-      it "returns 403 and does not enqueue the processing job" do
-        expect {
-          post "/twilio/webhook",
-               params:,
-               headers: xml_headers.merge("X-Twilio-Signature" => "invalidsignature")
-        }.not_to have_enqueued_job(Twilio::ProcessWebhookJob)
+      it "returns 403 and does not process the webhook" do
+        expect(TwilioController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(TwilioController).not_to receive(:webhook)
+
+        post "/twilio/webhook",
+             params:,
+             headers: xml_headers.merge("X-Twilio-Signature" => "invalidsignature")
 
         expect(response).to have_http_status(:forbidden)
       end
     end
 
     context "with no Twilio signature" do
-      it "returns 403 and does not enqueue the processing job" do
-        expect {
-          post "/twilio/webhook",
-               params:,
-               headers: xml_headers
-        }.not_to have_enqueued_job(Twilio::ProcessWebhookJob)
+      it "returns 403 and does not process the webhook" do
+        expect(TwilioController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(TwilioController).not_to receive(:webhook)
+
+        post "/twilio/webhook",
+             params:,
+             headers: xml_headers
 
         expect(response).to have_http_status(:forbidden)
       end

--- a/spec/requests/twilio_webhook_spec.rb
+++ b/spec/requests/twilio_webhook_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Twilio Webhook", type: :request do
+  let(:auth_token) { ENV.fetch("TWILIO__AUTH_TOKEN") }
+  let(:validator) { Twilio::Security::RequestValidator.new(auth_token) }
+  let(:webhook_url) { "http://www.example.com/twilio/webhook" }
+  let(:params) do
+    {
+      "From"     => "+1234567890",
+      "To"       => "+0987654321",
+      "Body"     => "Hello",
+      "NumMedia" => "0"
+    }
+  end
+  let(:xml_headers) { { "Accept" => "application/xml" } }
+
+  describe "POST /twilio/webhook" do
+    context "with a valid Twilio signature" do
+      it "returns 200 and enqueues the processing job" do
+        signature = validator.build_signature_for(webhook_url, params)
+
+        expect {
+          post "/twilio/webhook",
+               params:,
+               headers: xml_headers.merge("X-Twilio-Signature" => signature)
+        }.to have_enqueued_job(Twilio::ProcessWebhookJob)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("<Response></Response>")
+      end
+    end
+
+    context "with an invalid Twilio signature" do
+      it "returns 403 and does not enqueue the processing job" do
+        expect {
+          post "/twilio/webhook",
+               params:,
+               headers: xml_headers.merge("X-Twilio-Signature" => "invalidsignature")
+        }.not_to have_enqueued_job(Twilio::ProcessWebhookJob)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with no Twilio signature" do
+      it "returns 403 and does not enqueue the processing job" do
+        expect {
+          post "/twilio/webhook",
+               params:,
+               headers: xml_headers
+        }.not_to have_enqueued_job(Twilio::ProcessWebhookJob)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

We were **_already validating_** signatures for all inbound webhooks. This PR just adds tests to prove that and ensure we continue to validate them.


## Describe your changes

Adds tests, and also makes the Column Webhook control return a 400 instead of 500 when a request is missing the `Column-Signature` header. Our previous code was secure, but technically should have returned a 400 instead of 500.