### PR TITLE
[Admin] Show ledger ID on event admin page

### DIFF
--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -45,6 +45,10 @@
                   class: "btn bg-success mb2",
                   disabled: disabled if event.persisted? %>
 
+      <div>
+        <p class="mt-0">Ledger: <%= link_to event.ledger.id, ledger_path(event.ledger) %></p>
+      </div>
+
       <div class="field" id="admin_settings">
         <%= form.label :name %>
         <%= form.text_field :name, disabled: %>


### PR DESCRIPTION
## Summary of the problem

Right now, accessing a `Ledger` for an event requires console access.

## Describe your changes

This PR makes the ledger available to admins from the event admin page.