### PR TITLE
[v4] Move Active Record Error to be last resort instead of first

### DIFF
--- a/app/controllers/concerns/api/v4/error_handling.rb
+++ b/app/controllers/concerns/api/v4/error_handling.rb
@@ -6,6 +6,11 @@ module Api
       extend ActiveSupport::Concern
 
       included do
+        # Rails searches rescue_from handlers in reverse definition order
+        rescue_from ActiveRecord::ActiveRecordError do
+          render json: { error: "internal_error", messages: ["Internal database error"] }, status: :internal_server_error
+        end
+
         rescue_from Pundit::NotAuthorizedError do
           render json: { error: "not_authorized" }, status: :forbidden
         end
@@ -37,10 +42,6 @@ module Api
 
         rescue_from ActiveRecord::ConnectionNotEstablished, ActiveRecord::DatabaseConnectionError do
           render json: { error: "service_unavailable", messages: ["Database unavailable"] }, status: :service_unavailable
-        end
-
-        rescue_from ActiveRecord::ActiveRecordError do
-          render json: { error: "internal_error", messages: ["Internal database error"] }, status: :internal_server_error
         end
       end
     end


### PR DESCRIPTION
## Summary of the problem
I didn't know that rails searches rescue_from handlers in reverse definition order so this causes any Active Record Error to be called as internal server error which is bad as there is no context.


## Describe your changes
Moved definition to be first line (thus being last checked) 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

