### PR TITLE
[v4] check deposit show doesn't need set_api_event

### DIFF
--- a/app/controllers/api/v4/check_deposits_controller.rb
+++ b/app/controllers/api/v4/check_deposits_controller.rb
@@ -5,7 +5,7 @@ module Api
     class CheckDepositsController < ApplicationController
       include SetEvent
 
-      before_action :set_api_event
+      before_action :set_api_event, only: [:index, :create]
 
       def index
         authorize @event, :index_in_v4?

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CheckDepositPolicy < ApplicationPolicy
-  
   def show?
     auditor_or_user?
   end

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class CheckDepositPolicy < ApplicationPolicy
+  
+  def show?
+    auditor_or_user?
+  end
+
   def index?
     auditor_or_user? && check_deposits_enabled?
   end


### PR DESCRIPTION
## Summary of the problem
When I do something like GET `https://hcb.hackclub.com/api/v4/check_deposits/cdp_62ACea` I shouldn't need to provide event ID


## Describe your changes
remove set_api_event for show


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

