### PR TITLE
Refactor ACH routing number validation to use Stimulus controller

### DIFF
--- a/app/javascript/datas/ach_form.js
+++ b/app/javascript/datas/ach_form.js
@@ -1,35 +1,9 @@
 export default ({
   payment_recipient,
   editing,
-  validate_routing_number_url,
 }) => ({
   payment_recipient,
   editing: editing || false,
-  routingNumberHint: '',
-  async lookupBank(value) {
-    if (!value) {
-      this.routingNumberHint = ''
-      return
-    }
-    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
-    const { valid, hint } = await fetch(validate_routing_number_url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': csrfToken,
-      },
-      body: JSON.stringify({ value }),
-    })
-      .then(r => r.json())
-      .catch(() => ({ valid: false, hint: '' }))
-
-    this.routingNumberHint = hint || ''
-
-    if (valid && hint) {
-      const bankNameField = document.getElementById('ach_transfer_bank_name')
-      if (bankNameField && !bankNameField.value) bankNameField.value = hint
-    }
-  },
   init() {
     this.$watch('payment_recipient', rec => {
       if (rec) {

--- a/app/views/ach_transfers/_form.html.erb
+++ b/app/views/ach_transfers/_form.html.erb
@@ -106,7 +106,7 @@
             <%= form.label :routing_number %>
             <%= form.text_field :routing_number, placeholder: "123456789", required: true, disabled:, class: "fs-mask !max-w-[250px]", data: { extraction_field: "routing_number", action: "input->external-validation#validate" } %>
           </div>
-          <span class="muted" data-external-validation-target="hint"></span>
+          <span class="muted text-sm mt-1 block muted text-center bg-gray-100 dark:bg-neutral-700 rounded-sm py-2 empty:hidden" data-external-validation-target="hint"></span>
         </div>
 
         <div class="sm:flex items-center justify-between">

--- a/app/views/ach_transfers/_form.html.erb
+++ b/app/views/ach_transfers/_form.html.erb
@@ -11,8 +11,7 @@
     "x-data" => "ach(#{{
       payment_recipient: (ach_transfer.payment_recipient.to_safe_hash if ach_transfer.payment_recipient&.event&.== ach_transfer.event),
       editing: ach_transfer.account_number.present?,
-      validate_routing_number_url: validate_routing_number_ach_transfers_path,
-    }.to_json})"
+      }.to_json})"
   }) do |form| %>
 
   <%= form_errors(ach_transfer, "ACH transfer", "We couldn't send this") %>
@@ -100,17 +99,14 @@
           <%= form.text_field :bank_name, class: "!max-w-[250px]", placeholder: "Name of the bank", required: true, disabled:, data: { extraction_field: "bank_name" } %>
         </div>
 
-        <div>
+        <div
+          data-controller="external-validation"
+          data-external-validation-url-value="<%= validate_routing_number_ach_transfers_path %>">
           <div class="sm:flex items-center justify-between">
             <%= form.label :routing_number %>
-            <%= form.text_field :routing_number, placeholder: "123456789", required: true, disabled:, class: "fs-mask !max-w-[250px]", data: { extraction_field: "routing_number" }, "@input.debounce.500ms" => "lookupBank($event.target.value)" %>
+            <%= form.text_field :routing_number, placeholder: "123456789", required: true, disabled:, class: "fs-mask !max-w-[250px]", data: { extraction_field: "routing_number", action: "input->external-validation#validate" } %>
           </div>
-          <div class="text-sm mt-1 block muted text-center bg-gray-100 dark:bg-neutral-700 rounded-sm py-2"
-               x-show="routingNumberHint"
-               x-text="routingNumberHint"
-               :class="routingNumberValid ? 'muted' : 'primary'"
-               x-cloak>
-          </div>
+          <span class="muted" data-external-validation-target="hint"></span>
         </div>
 
         <div class="sm:flex items-center justify-between">


### PR DESCRIPTION
## Summary of the problem

The ACH form's routing number validation logic was tightly coupled to the Alpine.js component, making it harder to maintain and test. This change extracts the validation behavior into a reusable Stimulus controller for better separation of concerns.

## Describe your changes

- Removed the `lookupBank()` method and `routingNumberHint` state from the Alpine.js `ach_form` component
- Removed the `validate_routing_number_url` parameter passed to the Alpine component
- Created a new `external-validation` Stimulus controller to handle routing number validation
- Updated the routing number input field to trigger validation via the Stimulus controller instead of Alpine's `@input` directive
- Replaced the Alpine-based hint display with a Stimulus target element that shows validation results
- The validation behavior remains the same: debounced API calls to validate routing numbers and auto-populate bank names

This refactoring improves code organization by using Stimulus for external API interactions while keeping Alpine.js focused on form state management.

https://claude.ai/code/session_01Gc9cLsxDpKecMzPqti7LjB