### PR TITLE
[DocuSeal] Return 401 instead of 200 with `success: false`

### DIFF
--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -4,11 +4,11 @@ class DocusealController < ActionController::Base
   protect_from_forgery except: :webhook
 
   def webhook
-    ActiveRecord::Base.transaction do
-      return render json: { success: false } unless request.headers["X-Docuseal-Secret"] == Credentials.fetch(:DOCUSEAL, :WEBHOOK_SECRET)
+    return head :unauthorized unless request.headers["X-Docuseal-Secret"] == Credentials.fetch(:DOCUSEAL, :WEBHOOK_SECRET)
 
+    ActiveRecord::Base.transaction do
       contract = Contract.find_by(external_id: params[:data][:submission_id])
-      return render json: { success: true } if contract.nil? || contract.signed? # sometimes contracts are sent using Docuseal that aren't in HCB
+      return head :ok if contract.nil? || contract.signed? # sometimes contracts are sent using Docuseal that aren't in HCB
 
       if params[:event_type] == "form.completed"
         party = contract.parties.detect { |party| party.docuseal_role == params[:data][:role] }
@@ -25,10 +25,10 @@ class DocusealController < ActionController::Base
       end
     end
 
-    return render json: { success: true }
+    head :ok
   rescue => e
     Rails.error.report(e)
-    return render json: { success: false }
+    head :internal_server_error
   end
 
 end

--- a/app/controllers/docuseal_controller.rb
+++ b/app/controllers/docuseal_controller.rb
@@ -3,9 +3,9 @@
 class DocusealController < ActionController::Base
   protect_from_forgery except: :webhook
 
-  def webhook
-    return head :unauthorized unless request.headers["X-Docuseal-Secret"] == Credentials.fetch(:DOCUSEAL, :WEBHOOK_SECRET)
+  before_action :verify_signature
 
+  def webhook
     ActiveRecord::Base.transaction do
       contract = Contract.find_by(external_id: params[:data][:submission_id])
       return head :ok if contract.nil? || contract.signed? # sometimes contracts are sent using Docuseal that aren't in HCB
@@ -29,6 +29,17 @@ class DocusealController < ActionController::Base
   rescue => e
     Rails.error.report(e)
     head :internal_server_error
+  end
+
+  private
+
+  def verify_signature
+    unless ActiveSupport::SecurityUtils.secure_compare(
+      request.headers["X-Docuseal-Secret"].to_s,
+      Credentials.fetch(:DOCUSEAL, :WEBHOOK_SECRET)
+    )
+      head :unauthorized # calling head/render in a before_action stops the request from reaching the controller action
+    end
   end
 
 end

--- a/spec/requests/docuseal_webhook_spec.rb
+++ b/spec/requests/docuseal_webhook_spec.rb
@@ -21,34 +21,31 @@ RSpec.describe "Docuseal Webhook", type: :request do
 
   describe "POST /docuseal/webhook" do
     context "with a valid Docuseal secret" do
-      it "returns 200 with success" do
+      it "returns 200" do
         post "/docuseal/webhook",
              params: payload,
              headers: { "X-Docuseal-Secret" => webhook_secret }
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["success"]).to be true
       end
     end
 
     context "with an invalid Docuseal secret" do
-      it "returns 200 with failure" do
+      it "returns 401" do
         post "/docuseal/webhook",
              params: payload,
              headers: { "X-Docuseal-Secret" => "wrong_secret" }
 
-        expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["success"]).to be false
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "with no Docuseal secret" do
-      it "returns 200 with failure" do
+      it "returns 401" do
         post "/docuseal/webhook",
              params: payload
 
-        expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["success"]).to be false
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/docuseal_webhook_spec.rb
+++ b/spec/requests/docuseal_webhook_spec.rb
@@ -31,7 +31,10 @@ RSpec.describe "Docuseal Webhook", type: :request do
     end
 
     context "with an invalid Docuseal secret" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DocusealController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(DocusealController).not_to receive(:webhook)
+
         post "/docuseal/webhook",
              params: payload,
              headers: { "X-Docuseal-Secret" => "wrong_secret" }
@@ -41,7 +44,10 @@ RSpec.describe "Docuseal Webhook", type: :request do
     end
 
     context "with no Docuseal secret" do
-      it "returns 401" do
+      it "returns 401 and does not process the webhook" do
+        expect(DocusealController.method_defined?(:webhook)).to be(true)
+        expect_any_instance_of(DocusealController).not_to receive(:webhook)
+
         post "/docuseal/webhook",
              params: payload
 


### PR DESCRIPTION
## Summary of the problem

At the moment, when the webhook is unauthorized, we return a 200 with `success: false`. However, I can't find anywhere in the DocuSeal docs where it asks for this.

## Describe your changes

It's a lot more standard to return a 4XX when unauthorized. So I'm doing that here — returning a 401 when unauthorized.

Either way, HCB has been and continues to be secure from forged webhooks here.