### PR TITLE
[Logins] Bug fix / symbolize login preference

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -58,7 +58,7 @@ class LoginsController < ApplicationController
 
   # post to set preference
   def set_login_preference
-    continue_login(preference: params[:login_preference])
+    continue_login(preference: params[:login_preference].to_sym)
   end
 
   # post to request email login code


### PR DESCRIPTION
## Summary of the problem

When we converted login preferences to symbols (from strings) we left in an instance of user input being a string.


## Describe your changes

This symbolizes that string for use with our existing logic.