### PR TITLE
[Accounting] Auto-categorize card grant disbursements

### DIFF
--- a/app/jobs/one_time_jobs/backfill_category_on_card_grant_disbursements.rb
+++ b/app/jobs/one_time_jobs/backfill_category_on_card_grant_disbursements.rb
@@ -7,7 +7,8 @@ module OneTimeJobs
       slug = "grants-stipends"
       category = TransactionCategory.find_or_create_by!(slug:)
 
-      disbursements.update(source_transaction_category: category, destination_transaction_category: category)
+      disbursements.where(source_transaction_category: nil).update(source_transaction_category: category)
+      disbursements.where(destination_transaction_category: nil).update(destination_transaction_category: category)
 
       hcb_codes = []
       disbursements.find_each(batch_size: 100) do |disbursement|
@@ -16,6 +17,8 @@ module OneTimeJobs
       end
 
       CanonicalTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |ct|
+        next unless ct.category.nil?
+
         TransactionCategoryService
           .new(model: ct)
           .set!(
@@ -25,6 +28,8 @@ module OneTimeJobs
       end
 
       CanonicalPendingTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |cpt|
+        next unless cpt.category.nil?
+
         TransactionCategoryService
           .new(model: cpt)
           .set!(

--- a/app/jobs/one_time_jobs/backfill_category_on_card_grant_disbursements.rb
+++ b/app/jobs/one_time_jobs/backfill_category_on_card_grant_disbursements.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillCategoryOnCardGrantDisbursements < ApplicationJob
+    def perform
+      disbursements = Disbursement.where.not(source_subledger_id: nil, destination_subledger_id: nil)
+      slug = "grants-stipends"
+      category = TransactionCategory.find_or_create_by!(slug:)
+
+      disbursements.update(source_transaction_category: category, destination_transaction_category: category)
+
+      hcb_codes = []
+      disbursements.find_each(batch_size: 100) do |disbursement|
+        hcb_codes << disbursement.incoming_hcb_code
+        hcb_codes << disbursement.outgoing_hcb_code
+      end
+
+      CanonicalTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |ct|
+        TransactionCategoryService
+          .new(model: ct)
+          .set!(
+            slug:,
+            assignment_strategy: "automatic"
+          )
+      end
+
+      CanonicalPendingTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |cpt|
+        TransactionCategoryService
+          .new(model: cpt)
+          .set!(
+            slug:,
+            assignment_strategy: "automatic"
+          )
+      end
+    end
+
+  end
+
+end

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -180,6 +180,7 @@ class CardGrant < ApplicationRecord
         requested_by_id: topped_up_by.id,
         source_transaction_category_slug: "grants-stipends",
         destination_transaction_category_slug: "grants-stipends",
+        category_assignment_strategy: "automatic"
       ).run
 
       disbursement.local_hcb_code.update_custom_memo!(custom_memo)
@@ -203,6 +204,7 @@ class CardGrant < ApplicationRecord
         requested_by_id: withdrawn_by.id,
         source_transaction_category_slug: "grants-stipends",
         destination_transaction_category_slug: "grants-stipends",
+        category_assignment_strategy: "automatic"
       ).run
 
       disbursement.local_hcb_code.update_custom_memo!(custom_memo)
@@ -241,6 +243,7 @@ class CardGrant < ApplicationRecord
       requested_by_id: requested_by.id,
       source_transaction_category_slug: "grants-stipends",
       destination_transaction_category_slug: "grants-stipends",
+      category_assignment_strategy: "automatic"
     ).run
     disbursement.local_hcb_code.update_custom_memo!(custom_memo)
   end
@@ -353,6 +356,7 @@ class CardGrant < ApplicationRecord
       destination_subledger_id: subledger_id,
       source_transaction_category_slug: "grants-stipends",
       destination_transaction_category_slug: "grants-stipends",
+      category_assignment_strategy: "automatic"
     ).run
     save!
   end

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -178,6 +178,8 @@ class CardGrant < ApplicationRecord
         amount: amount_cents / 100.0,
         destination_subledger_id: subledger_id,
         requested_by_id: topped_up_by.id,
+        source_transaction_category_slug: "grants-stipends",
+        destination_transaction_category_slug: "grants-stipends",
       ).run
 
       disbursement.local_hcb_code.update_custom_memo!(custom_memo)
@@ -199,6 +201,8 @@ class CardGrant < ApplicationRecord
         amount: amount_cents / 100.0,
         source_subledger_id: subledger_id,
         requested_by_id: withdrawn_by.id,
+        source_transaction_category_slug: "grants-stipends",
+        destination_transaction_category_slug: "grants-stipends",
       ).run
 
       disbursement.local_hcb_code.update_custom_memo!(custom_memo)
@@ -235,6 +239,8 @@ class CardGrant < ApplicationRecord
       amount: balance.amount,
       source_subledger_id: subledger_id,
       requested_by_id: requested_by.id,
+      source_transaction_category_slug: "grants-stipends",
+      destination_transaction_category_slug: "grants-stipends",
     ).run
     disbursement.local_hcb_code.update_custom_memo!(custom_memo)
   end
@@ -345,6 +351,8 @@ class CardGrant < ApplicationRecord
       amount: amount.amount,
       requested_by_id: sent_by_id,
       destination_subledger_id: subledger_id,
+      source_transaction_category_slug: "grants-stipends",
+      destination_transaction_category_slug: "grants-stipends",
     ).run
     save!
   end

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -23,7 +23,8 @@ module DisbursementService
       skip_auto_approve: false,
       fronted: false,
       source_transaction_category_slug: nil,
-      destination_transaction_category_slug: nil
+      destination_transaction_category_slug: nil,
+      category_assignment_strategy: nil
     )
       @source_event_id = source_event_id
       @source_event = Event.find(@source_event_id)
@@ -41,6 +42,7 @@ module DisbursementService
       @fronted = fronted
       @source_transaction_category_slug = source_transaction_category_slug
       @destination_transaction_category_slug = destination_transaction_category_slug
+      @category_assignment_strategy = category_assignment_strategy
     end
 
     def run
@@ -60,7 +62,7 @@ module DisbursementService
           # 1. Create the raw pending transactions
           rpodt = ::PendingTransactionEngine::RawPendingOutgoingDisbursementTransactionService::Disbursement::ImportSingle.new(disbursement:).run
           # 2. Canonize the newly added raw pending transactions
-          o_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::OutgoingDisbursement.new(raw_pending_outgoing_disbursement_transaction: rpodt).run
+          o_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::OutgoingDisbursement.new(raw_pending_outgoing_disbursement_transaction: rpodt, category_assignment_strategy: @category_assignment_strategy).run
           # 3. Map to event
           ::PendingEventMappingEngine::Map::Single::OutgoingDisbursement.new(canonical_pending_transaction: o_cpt).run
           # 4. Front if required
@@ -72,7 +74,7 @@ module DisbursementService
             # 1. Create the raw pending transactions
             rpidt = ::PendingTransactionEngine::RawPendingIncomingDisbursementTransactionService::Disbursement::ImportSingle.new(disbursement:).run
             # 2. Canonize the newly added raw pending transactions
-            i_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::IncomingDisbursement.new(raw_pending_incoming_disbursement_transaction: rpidt).run
+            i_cpt = ::PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::IncomingDisbursement.new(raw_pending_incoming_disbursement_transaction: rpidt, category_assignment_strategy: @category_assignment_strategy).run
             # 3. Map to event
             ::PendingEventMappingEngine::Map::Single::IncomingDisbursement.new(canonical_pending_transaction: i_cpt).run
             # 4. Front if required

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -24,7 +24,7 @@ module DisbursementService
       fronted: false,
       source_transaction_category_slug: nil,
       destination_transaction_category_slug: nil,
-      category_assignment_strategy: nil
+      category_assignment_strategy: "manual"
     )
       @source_event_id = source_event_id
       @source_event = Event.find(@source_event_id)

--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/incoming_disbursement.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/incoming_disbursement.rb
@@ -4,8 +4,9 @@ module PendingTransactionEngine
   module CanonicalPendingTransactionService
     module ImportSingle
       class IncomingDisbursement
-        def initialize(raw_pending_incoming_disbursement_transaction:)
+        def initialize(raw_pending_incoming_disbursement_transaction:, category_assignment_strategy: "manual")
           @rpidt = raw_pending_incoming_disbursement_transaction
+          @category_assignment_strategy = category_assignment_strategy
         end
 
         def run
@@ -23,7 +24,7 @@ module PendingTransactionEngine
                 .new(model: cpt)
                 .set!(
                   slug: @rpidt.disbursement.destination_transaction_category.slug,
-                  assignment_strategy: "manual"
+                  assignment_strategy: @category_assignment_strategy
                 )
             end
 

--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement.rb
@@ -4,8 +4,9 @@ module PendingTransactionEngine
   module CanonicalPendingTransactionService
     module ImportSingle
       class OutgoingDisbursement
-        def initialize(raw_pending_outgoing_disbursement_transaction:)
+        def initialize(raw_pending_outgoing_disbursement_transaction:, category_assignment_strategy: "manual")
           @rpodt = raw_pending_outgoing_disbursement_transaction
+          @category_assignment_strategy = @category_assignment_strategy
         end
 
         def run
@@ -23,7 +24,7 @@ module PendingTransactionEngine
                 .new(model: cpt)
                 .set!(
                   slug: @rpodt.disbursement.source_transaction_category.slug,
-                  assignment_strategy: "manual"
+                  assignment_strategy: @category_assignment_strategy
                 )
             end
 

--- a/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement.rb
+++ b/app/services/pending_transaction_engine/canonical_pending_transaction_service/import_single/outgoing_disbursement.rb
@@ -6,7 +6,7 @@ module PendingTransactionEngine
       class OutgoingDisbursement
         def initialize(raw_pending_outgoing_disbursement_transaction:, category_assignment_strategy: "manual")
           @rpodt = raw_pending_outgoing_disbursement_transaction
-          @category_assignment_strategy = @category_assignment_strategy
+          @category_assignment_strategy = category_assignment_strategy
         end
 
         def run


### PR DESCRIPTION
## Summary of the problem

Disbursements that are automatically generated from card grants are currently uncategorized. However, we know that they fall under the "Grants / stipends" category, so we can assign it automatically.


## Describe your changes

This PR automatically categorizes card grant disbursements as "Grants / stipends".