### PR TITLE
Rename Interac to Interac e-Transfer

### DIFF
--- a/app/models/concerns/has_wise_recipient.rb
+++ b/app/models/concerns/has_wise_recipient.rb
@@ -55,7 +55,7 @@ module HasWiseRecipient
         fields << ACCOUNT_NUMBER_FIELD
         fields << { type: :select, key: "account_type", label: "Account type", options: { "Checking": "checking", "Savings": "savings" } }
       elsif currency == "CAD"
-        fields << { type: :select, key: "account_type", label: "Account type", options: { "Bank Account": "bank_account", "Interac": "interac" } }
+        fields << { type: :select, key: "account_type", label: "Account type", options: { "Bank Account": "bank_account", "Interac e-Transfer": "interac" } }
         fields << { type: :text_field, key: "institution_number", placeholder: "123", label: "Institution number", conditional: "account_type != 'interac'" }
         fields << { type: :text_field, key: "branch_number", placeholder: "45678", label: "Branch number", conditional: "account_type != 'interac'" }
         fields << { type: :text_field, key: "account_number", placeholder: "123456789", label: "Account number", conditional: "account_type != 'interac'" }


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Most canadians call an Interac transfer an "e-Transfer". Interac refers to the overall payment network (they also handle debit cards), while e-Transfer is the particular service used for sending money.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Renamed "Interac" to "Interac e-Transfer"


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

