### PR TITLE
[File uploads] Fix attachments clearing on file picker cancel

### DIFF
--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -29,7 +29,16 @@ export default class extends Controller {
     const input = this.inputTarget
     const fileName = input.files.length > 0 ? input.files[0].name : ''
 
-    if (!fileName) return
+    if (!fileName) {
+      if (this._savedFile) {
+        const dt = new DataTransfer()
+        dt.items.add(this._savedFile)
+        input.files = dt.files
+      }
+      return
+    }
+
+    this._savedFile = input.files[0]
     this.previewTarget.setAttribute('aria-label', fileName)
     this.previewTarget.innerHTML = `<img class="-ml-0.5 mr-2 w-4" src="https://cdn.jsdelivr.net/npm/file-icon-vectors@1.0.0/dist/icons/classic/${fileName.split('.').pop()}.svg" /> ${this.truncateMiddle(fileName)}`
     this.clearTarget.style.display = 'flex'
@@ -37,6 +46,7 @@ export default class extends Controller {
     this.clearTarget.innerHTML = this.constructor.xIcon
     this.clearTarget.type = 'button'
     this.clearTarget.addEventListener('click', () => {
+      this._savedFile = null
       input.value = ''
       this.clearTarget.innerHTML = ''
       this.clearTarget.style.display = 'none'


### PR DESCRIPTION
When a receipt was already attached and the user opened the file picker to replace it but then canceled, the existing attachment was being removed instead of preserved.

The issue was that the attachment state was being reset when the file picker opened rather than when a new file was actually selected. Canceling out of the dialog triggered the clear with no new file to replace it, leaving the field empty.

Now the existing attachment is only replaced if the user actually picks a new file. Canceling the dialog leaves whatever was already there untouched.