### PR TITLE
[Accounting] Add internal transfer category for disbursements

### DIFF
--- a/app/jobs/one_time_jobs/backfill_category_on_internal_disbursements.rb
+++ b/app/jobs/one_time_jobs/backfill_category_on_internal_disbursements.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillCategoryOnInternalDisbursements < ApplicationJob
+    def perform
+      disbursements = Disbursement.where(source_subledger_id: nil, destination_subledger_id: nil)
+      slug = "internal-transfer"
+      category = TransactionCategory.find_or_create_by!(slug:)
+
+      disbursements.where(source_transaction_category: nil).update(source_transaction_category: category)
+      disbursements.where(destination_transaction_category: nil).update(destination_transaction_category: category)
+
+      hcb_codes = []
+      disbursements.find_each(batch_size: 100) do |disbursement|
+        hcb_codes << disbursement.incoming_hcb_code
+        hcb_codes << disbursement.outgoing_hcb_code
+      end
+
+      CanonicalTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |ct|
+        next unless ct.category.nil?
+
+        TransactionCategoryService
+          .new(model: ct)
+          .set!(
+            slug:,
+            assignment_strategy: "automatic"
+          )
+      end
+
+      CanonicalPendingTransaction.where(hcb_code: hcb_codes).find_each(batch_size: 100) do |cpt|
+        next unless cpt.category.nil?
+
+        TransactionCategoryService
+          .new(model: cpt)
+          .set!(
+            slug:,
+            assignment_strategy: "automatic"
+          )
+      end
+    end
+
+  end
+
+end

--- a/app/views/disbursements/_form.html.erb
+++ b/app/views/disbursements/_form.html.erb
@@ -52,9 +52,10 @@
            form.select(
              field,
              options_for_select(
-               TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] }
+               TransactionCategory::Definition::ALL.map { |_, d| [d.label, d.slug] },
+               "internal-transfer"
              ),
-             include_blank: "None",
+             include_blank: "None"
            )
          } %>
 

--- a/db/data/transaction_categories.json
+++ b/db/data/transaction_categories.json
@@ -100,6 +100,9 @@
       "insurance_underwriting_premiums"
     ]
   },
+  "internal-transfer": {
+    "label": "Internal transfer"
+  },
   "internet-phone": {
     "label": "Internet / Phone",
     "stripe_merchant_categories": [


### PR DESCRIPTION
## Summary of the problem

Disbursements are currently uncategorized.


## Describe your changes

This PR creates the "Internal transfer" category and makes it the default for new disbursements. It also adds a one-time-job to backfill uncategorized disbursements as "Internal transfer".