### PR TITLE
[Affiliations] Fix Hack Club message on form

### DIFF
--- a/app/views/events/settings/_affiliation_form.html.erb
+++ b/app/views/events/settings/_affiliation_form.html.erb
@@ -75,7 +75,12 @@
 </template>
 
 <template x-if="type == 'hack_club'">
-  <p class="p-0 text-sm">Select this only if you're a local Hack Club chapter. If you're running an official project for Hack Club HQ, don't use this application form.</p>
+  <p class="p-0 text-sm">
+    Select this only if you're a local Hack Club chapter.
+    <% if affiliation.affiliable.is_a?(Event::Application) %>
+      If you're running an official project for Hack Club HQ, don't use this application form.
+    <% end %>
+  </p>
 </template>
 <template x-if="type == 'hack_club'">
   <div class="field">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We added copy to the affiliation form to clarify what the Hack Club affiliation is for, but the second part of it doesn't make sense when looking at the form from event settings.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Hide the second part of the message when viewing the form from event settings

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

