### PR TITLE
Force utf8 comment encodings

### DIFF
--- a/app/mailboxes/comment_mailbox.rb
+++ b/app/mailboxes/comment_mailbox.rb
@@ -21,7 +21,7 @@ class CommentMailbox < ApplicationMailbox
     return bounce_missing_comment unless @comment && @commentable && ensure_permissions?
 
     comment = @commentable.comments.build({
-                                            content: EmailReplyParser.parse_reply(text || body),
+                                            content: EmailReplyParser.parse_reply(text || body).encode("utf-8", invalid: :replace, undef: :replace),
                                             file: @attachments&.first,
                                             admin_only: @comment.admin_only,
                                             user: @user


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C047Y01MHJQ/p1759419037175179 & https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/790/samples/timestamp/2026-04-06T19:18:30Z - somehow, we got an email with `ISO-8859-1` encoding! When decrypted though, Rails assumes that it's utf8 encoding, throwing an error.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
This seems to only be happening in CommentMailbox due to various encodings coming from emails and then us encrypting the content, so I added `encode` to ensure that we always get `utf8` before encrypting and saving to the DB. If it's already utf8 (majority of cases), this won't do anything. I've also already fixed the encoding on the comment causing this error.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

