### PR TITLE
[Applications] Fix checking if videos were watched

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -176,7 +176,7 @@ class Event
 
     def mark_videos_watched
       authorize @application
-      
+
       @application.update!(videos_watched: true)
 
       redirect_to agreement_application_path(@application)

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -174,6 +174,14 @@ class Event
       @party = @contract.party :signee
     end
 
+    def mark_videos_watched
+      authorize @application
+      
+      @application.update!(videos_watched: true)
+
+      redirect_to agreement_application_path(@application)
+    end
+
     def review
       authorize @application
     end
@@ -260,7 +268,7 @@ class Event
     end
 
     def application_params
-      params.require(:event_application).permit(:name, :description, :political_description, :website_url, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country, :referrer, :referral_code, :accessibility_notes, :cosigner_email, :teen_led, :annual_budget, :committed_amount, :planning_duration, :team_size, :funding_source, :previously_applied, :videos_watched)
+      params.require(:event_application).permit(:name, :description, :political_description, :website_url, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country, :referrer, :referral_code, :accessibility_notes, :cosigner_email, :teen_led, :annual_budget, :committed_amount, :planning_duration, :team_size, :funding_source, :previously_applied)
     end
 
     def user_params

--- a/app/policies/event/application_policy.rb
+++ b/app/policies/event/application_policy.rb
@@ -52,6 +52,7 @@ class Event
     alias_method :personal_info?, :show?
     alias_method :project_info?, :show?
     alias_method :videos?, :show?
+    alias_method :mark_videos_watched?, :show?
     alias_method :agreement?, :show?
     alias_method :review?, :show?
 

--- a/app/policies/event/application_policy.rb
+++ b/app/policies/event/application_policy.rb
@@ -52,9 +52,12 @@ class Event
     alias_method :personal_info?, :show?
     alias_method :project_info?, :show?
     alias_method :videos?, :show?
-    alias_method :mark_videos_watched?, :show?
     alias_method :agreement?, :show?
     alias_method :review?, :show?
+    
+    def mark_videos_watched?
+      user.admin? || record.user == user
+    end
 
     def submission?
       (record.user == user && !record.draft?) || user.auditor?

--- a/app/policies/event/application_policy.rb
+++ b/app/policies/event/application_policy.rb
@@ -54,7 +54,7 @@ class Event
     alias_method :videos?, :show?
     alias_method :agreement?, :show?
     alias_method :review?, :show?
-    
+
     def mark_videos_watched?
       user.admin? || record.user == user
     end

--- a/app/views/event/applications/agreement.html.erb
+++ b/app/views/event/applications/agreement.html.erb
@@ -21,5 +21,5 @@
 </div>
 
 <% content_for :footer do %>
-  <a class="btn bg-muted" href="<%= agreement_application_path(@application) %>">← Back</a>
+  <a class="btn bg-muted" href="<%= videos_application_path(@application) %>">← Back</a>
 <% end %>

--- a/app/views/event/applications/videos.html.erb
+++ b/app/views/event/applications/videos.html.erb
@@ -45,5 +45,5 @@
 
 <% content_for :footer do %>
   <a class="btn bg-muted" href="<%= application_path(@application) %>">← Back</a>
-  <%= button_to "Continue →", application_path(@application, return_to: agreement_application_path(@application)), class: "btn bg-blue", method: :patch, params: { event_application: { videos_watched: true } }, id: :continue_button, disabled: true %>
+  <%= button_to "Continue →", mark_videos_watched_application_path(@application), class: "btn bg-blue", method: :post, params: { event_application: { videos_watched: true } }, id: :continue_button, disabled: !@application.videos_watched %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -874,6 +874,7 @@ Rails.application.routes.draw do
         post "admin_reject"
         post "admin_activate"
         post "resend_to_cosigner"
+        post "mark_videos_watched"
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13337 added a `videos_watched` column to check if the onboarding videos were watched before someone goes to sign the agreement. However, this used the normal application update path, which is disabled for normal users after they submit their application, causing it to just show "You are not authorized to perform this action" when they try to continue.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Create a new `mark_videos_watched` route that allows users to set the column and move on to signing the contract. Also fixes the back button on the agreement page to point back to videos.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

