### PR TITLE
Fix callout styling

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -868,11 +868,17 @@ function updateScrollFadeClasses(el) {
   el.classList.toggle('is-top-overflowing', !isScrolledToTop)
 }
 
-document.querySelectorAll('.scroll-fade').forEach(scrollable => {
-  scrollable.addEventListener('scroll', e => {
-    const el = e.currentTarget
-    updateScrollFadeClasses(el)
-  })
+function attachScrollFadeListeners() {
+  document.querySelectorAll('.scroll-fade').forEach(scrollable => {
+    scrollable.addEventListener('scroll', e => {
+      const el = e.currentTarget
+      updateScrollFadeClasses(el)
+    })
 
-  updateScrollFadeClasses(scrollable)
-})
+    updateScrollFadeClasses(scrollable)
+  })
+}
+
+$(document).on('turbo:load', attachScrollFadeListeners)
+$(document).on('turbo:frame-load', attachScrollFadeListeners)
+$(document).on('turbo:after-stream-render', attachScrollFadeListeners)

--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -861,11 +861,13 @@ if (navigator.setAppBadge) {
 }
 
 function updateScrollFadeClasses(el) {
-  const isScrolledToBottom =
-    el.scrollHeight < el.clientHeight + el.scrollTop + 1
-  const isScrolledToTop = isScrolledToBottom ? false : el.scrollTop === 0
-  el.classList.toggle('is-bottom-overflowing', !isScrolledToBottom)
-  el.classList.toggle('is-top-overflowing', !isScrolledToTop)
+  if (el.scrollHeight > el.clientHeight) {
+    const isScrolledToBottom =
+      el.scrollHeight < el.clientHeight + el.scrollTop + 1
+    const isScrolledToTop = isScrolledToBottom ? false : el.scrollTop === 0
+    el.classList.toggle('is-bottom-overflowing', !isScrolledToBottom)
+    el.classList.toggle('is-top-overflowing', !isScrolledToTop)
+  }
 }
 
 function attachScrollFadeListeners() {

--- a/app/views/application/_callout.html.erb
+++ b/app/views/application/_callout.html.erb
@@ -11,8 +11,11 @@
   </div>
 
   <% unless (block = yield).empty? %>
-    <div class="m0 mt1 flex-grow overflow-y-scroll scroll-fade p-4 pt-0 <%= "pb-0" if local_assigns[:footer].present? %>">
+    <div class="m0 mt1 flex-grow overflow-y-auto scroll-fade p-4 pt-0 <%= "pb-0" if local_assigns[:footer].present? %>">
       <%= block %>
+      <% if local_assigns[:footer].present? %>
+        <div class="h-4 w-full"></div>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13334 added fading	to overflowing contracts to indicate scrolling. However, it didn't attach event listeners on Turbo load, applied fading when it shouldn't have, and removed padding on non-overflowing callouts.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Attach listeners on turbo load, add check for if an element scrolls, and fixes the padding.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

