### PR TITLE
Add Grants to command palette (fixes #12721)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -27,7 +27,7 @@ class EventsController < ApplicationController
           @current_user
           .events
           .with_attached_logo
-          .preload(:config)
+          .preload(:config, :plan)
           .reorder("organizer_positions.sort_index ASC", "events.id ASC")
           .strict_loading
           .map { |event| serialize_event(event, member: true) }
@@ -37,7 +37,7 @@ class EventsController < ApplicationController
             Event
               .excluding(@current_user.events)
               .with_attached_logo
-              .preload(:config)
+              .preload(:config, :plan)
               .strict_loading
               .map { |event| serialize_event(event, member: false) }
           )
@@ -1311,7 +1311,8 @@ class EventsController < ApplicationController
       demo_mode: event.demo_mode,
       member:,
       features: {
-        subevents: event.subevents_enabled?
+        subevents: event.subevents_enabled?,
+        card_grants: event.plan.card_grants_enabled?
       }
     }
   end

--- a/app/javascript/components/command_bar/actions.js
+++ b/app/javascript/components/command_bar/actions.js
@@ -9,7 +9,6 @@ import ReimbursementIcon from '../icons/reimbursement'
 const restrictedFilter = e => !e.demo_mode
 
 export const generateEventActions = data => {
-  console.log(data)
   return [
     ...data.map(event => ({
       id: event.slug,
@@ -117,6 +116,15 @@ export const generateEventActions = data => {
         name: 'Sub-organizations',
         perform: navigate(`/${event.slug}/sub_organizations`),
         icon: <Icon glyph="channels" size={16} />,
+        parent: event.slug,
+      })),
+    ...data
+      .filter(e => e.features.card_grants)
+      .map(event => ({
+        id: `${event.slug}-card-grants`,
+        name: 'Grants',
+        perform: navigate(`/${event.slug}/card_grants`),
+        icon: <Icon glyph="bag" size={16} />,
         parent: event.slug,
       })),
     ...data.filter(restrictedFilter).map(event => ({

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe EventsController do
             "logo"      => Rails.application.routes.url_helpers.url_for(event2.logo),
             "demo_mode" => true,
             "member"    => true,
-            "features"  => { "subevents" => true },
+            "features"  => { "card_grants" => false, "subevents" => true },
           },
           {
             "name"      => "Event 1",
@@ -44,7 +44,7 @@ RSpec.describe EventsController do
             "logo"      => "none",
             "demo_mode" => false,
             "member"    => true,
-            "features"  => { "subevents" => false },
+            "features"  => { "card_grants" => false, "subevents" => false },
           }
         ]
       )
@@ -74,7 +74,7 @@ RSpec.describe EventsController do
             "logo"      => "none",
             "demo_mode" => false,
             "member"    => true,
-            "features"  => { "subevents" => false },
+            "features"  => { "card_grants" => false, "subevents" => false },
           },
           {
             "name"      => "Event 2",
@@ -82,10 +82,25 @@ RSpec.describe EventsController do
             "logo"      => Rails.application.routes.url_helpers.url_for(event2.logo),
             "demo_mode" => true,
             "member"    => false,
-            "features"  => { "subevents" => true },
+            "features"  => { "card_grants" => false, "subevents" => true },
           },
         ]
       )
+    end
+
+    it "returns card_grants: true for events on a plan with card grants enabled" do
+      user = create(:user)
+
+      event = create(:event, name: "Card Grant Event", plan_type: Event::Plan::HackClubAffiliate)
+      create(:organizer_position, user:, event:, sort_index: 1)
+
+      sign_in(user)
+
+      get(:index, format: :json)
+
+      expect(response).to have_http_status(:ok)
+      card_grants_feature = response.parsed_body.find { |e| e["name"] == "Card Grant Event" }.dig("features", "card_grants")
+      expect(card_grants_feature).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Implements the command palette Grants entry originally proposed in #12721, with all review issues resolved before merge.

## Changes vs #12721

**`app/controllers/events_controller.rb`**
- Preload `:plan` on both event query branches (member + auditor) so it's available under `.strict_loading`
- Use `event.plan.card_grants_enabled?` directly instead of `policy(event).card_grant_overview?`
  - The policy calls `record.card_grants.any?` which is not preloaded → `ActiveRecord::StrictLoadingViolationError` in production when `plan.card_grants_enabled?` is false
  - `event.plan.card_grants_enabled?` follows the same pattern as `event.subevents_enabled?` and was the fix suggested by @garyhtou in the original review

**`app/javascript/components/command_bar/actions.js`**
- Removed pre-existing `console.log(data)` debug statement
- Moved Grants action block to alongside Sub-organizations (other feature-gated items), not between Cards and Transactions

**`spec/controllers/events_controller_spec.rb`**
- Updated existing expectations to include the new `card_grants` key
- Added a test covering `card_grants: true` using `Event::Plan::HackClubAffiliate` (which includes `card_grants` in its feature set), addressing the missing positive-case coverage flagged in review

Closes #12561