### PR TITLE
Use ActiveSupport deprecators for HCB deprecations

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -370,7 +370,7 @@ class HcbCode < ApplicationRecord
   end
 
   def disbursement?
-    Rails.error.unexpected "HcbCode#disbursement? accessed"
+    Rails.application.deprecators[:hcb].warn("HcbCode#disbursement? accessed")
 
     return [::TransactionGroupingEngine::Calculate::HcbCode::OUTGOING_DISBURSEMENT_CODE, ::TransactionGroupingEngine::Calculate::HcbCode::INCOMING_DISBURSEMENT_CODE].include?(hcb_i1)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -123,5 +123,6 @@ module Bank
     config.active_storage.previewers << ActiveStorage::Previewer::DocumentPreviewer
 
     config.active_support.deprecation = :notify
+
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -122,5 +122,6 @@ module Bank
     # CSV previews
     config.active_storage.previewers << ActiveStorage::Previewer::DocumentPreviewer
 
+    config.active_support.deprecation = :notify
   end
 end

--- a/config/initializers/deprecation_warnings.rb
+++ b/config/initializers/deprecation_warnings.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-ActiveSupport::Notifications.subscribe("deprecation.rails") do |_name, _start, _finish, _id, payload|
+HcbDeprecator = ActiveSupport::Deprecation.new("1.0", "HCB")
+Rails.application.deprecators[:hcb] = HcbDeprecator
+
+def handle_deprecation(_name, _start, _finish, _id, payload)
   message = payload[:message]
   callstack = payload[:callstack]
   deprecation_horizon = payload[:deprecation_horizon]
@@ -13,7 +16,7 @@ ActiveSupport::Notifications.subscribe("deprecation.rails") do |_name, _start, _
   end
 
   Appsignal.report_error(ActiveSupport::DeprecationException.new(message)) do
-    Appsignal.set_namespace("deprecation.rails")
+    Appsignal.set_namespace("deprecation")
     Appsignal.set_action(appsignal_action)
     Appsignal.add_tags(
       deprecation: true,
@@ -26,3 +29,6 @@ ActiveSupport::Notifications.subscribe("deprecation.rails") do |_name, _start, _
     )
   end
 end
+
+ActiveSupport::Notifications.subscribe("deprecation.rails", &method(:handle_deprecation))
+ActiveSupport::Notifications.subscribe("deprecation.hcb", &method(:handle_deprecation))


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We're currently using `Rails.error.unexpected` to see where we're calling `HcbCode#disbursement?`. However, this is noisy and influencing our error statistics, as it's being treated as any other error.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Create a new deprecator for HCB and use it for reporting the `HcbCode#disbursement?` deprecation. Also sets the default deprecation behavior to `notify`, which is what we listen on - we may have been missing Rails deprecations in Appsignal since this defaults to `stderr`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

