### PR TITLE
[Contracts] Fix signee_docuseal_url

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -190,7 +190,7 @@ class Contract < ApplicationRecord
 
   # Adding this back temporarily while we work on fixing missing parties
   def signee_docuseal_url
-    "https://docuseal.co/s/#{contract.docuseal_document["submitters"].select { |s| s["role"] == "Contract Signee" }[0]["slug"]}"
+    "https://docuseal.co/s/#{docuseal_document["submitters"].select { |s| s["role"] == "Contract Signee" }[0]["slug"]}"
   end
 
   def create_document!


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2286
`signee_docuseal_url` was added back to `Contract`, but had an error.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove `contract.` as `docuseal_document` is defined on the same model.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

