### PR TITLE
[Announcements] Clarify prompts for non-managers

### DIFF
--- a/app/views/event_mailer/donation_goal_reached.html.erb
+++ b/app/views/event_mailer/donation_goal_reached.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   Congrats! Your donation goal of <%= render_money @goal.amount_cents %> has been reached after <%= distance_of_time_in_words @goal.tracking_since, DateTime.now %>!
-  If you wish, <%= link_to "create an announcement", edit_announcement_url(@announcement) %> to celebrate having reached your goal.
+  If you're a manager, you can <%= link_to "create an announcement", edit_announcement_url(@announcement) %> to celebrate having reached your goal.
 </p>
 
 <p>Here are all the donations that helped to contribute to this goal:</p>

--- a/app/views/organizer_position_invites_mailer/accepted.html.erb
+++ b/app/views/organizer_position_invites_mailer/accepted.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 </p>
 
-If you wish, <%= link_to "create an announcement", edit_announcement_url(@announcement) %> to introduce your new team member!
+If you're a manager, you can <%= link_to "create an announcement", edit_announcement_url(@announcement) %> to introduce your new team member!
 
 <p>
   From,<br>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://hackclub.slack.com/archives/C068U0JMV19/p1775676352096819 - non-managers cannot create announcements, but we still link it to them in the donation goal reached and team member accepted emails. 

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
While the ideal solution here would be to not include this sentence for non-managers, this would require re-working these mailers to send individual emails to team members instead of one with many recipients. As we're working on a new notification system soon that should have the capability to do this, I think clarifying the copy here to avoid confusion will work for now.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

