### PR TITLE
Separate admin activity streams from regular user streams

### DIFF
--- a/app/views/my/_activities.html.erb
+++ b/app/views/my/_activities.html.erb
@@ -1,5 +1,6 @@
 <ul class="list-reset comments w-100 my-0 p-3 activity overflow-y-visible overflow-x-hidden">
   <%= turbo_stream_from current_user, "activities" %>
+  <%= turbo_stream_from current_user, "admin_activities" if auditor_signed_in? && cookies[:admin_activities] == "everyone" %>
   <turbo-frame id="activities-<%= @activities.current_page %>" target="_top">
     <%= render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
     <% if @activities.next_page %>

--- a/app/views/my/_activities.html.erb
+++ b/app/views/my/_activities.html.erb
@@ -1,6 +1,9 @@
 <ul class="list-reset comments w-100 my-0 p-3 activity overflow-y-visible overflow-x-hidden">
-  <%= turbo_stream_from current_user, "activities" %>
-  <%= turbo_stream_from current_user, "admin_activities" if auditor_signed_in? && cookies[:admin_activities] == "everyone" %>
+  <% if auditor_signed_in? && cookies[:admin_activities] == "everyone" %>
+    <%= turbo_stream_from current_user, "admin_activities" %>
+  <% else %>
+    <%= turbo_stream_from current_user, "activities" %>
+  <% end %>
   <turbo-frame id="activities-<%= @activities.current_page %>" target="_top">
     <%= render_activities(@activities.reject { |activity| activity.trackable.nil? && !activity.trackable_is_deletable? }) %>
     <% if @activities.next_page %>

--- a/config/initializers/public_activity.rb
+++ b/config/initializers/public_activity.rb
@@ -60,7 +60,7 @@ class PublicActivity::Activity
       end
 
       User.admin.each do |user|
-        streams << [user, "activities"]
+        streams << [user, "admin_activities"]
       end
 
       streams.uniq.each do |stream|


### PR DESCRIPTION
## Summary of the problem
Admin users were receiving activity updates through the same stream as regular users. This change separates admin activity streams to allow for independent filtering and management of admin-specific activities.

## Describe your changes
closes #13408
- Modified the activities view to conditionally subscribe to different Turbo streams based on user role and admin preferences
- When an auditor is signed in and has enabled the "everyone" admin activities filter via cookie, they subscribe to the `admin_activities` stream instead of the regular `activities` stream
- Updated the public activity initializer to broadcast admin activities to a dedicated `admin_activities` stream rather than the shared `activities` stream
- This allows admins to selectively view all activities without affecting the regular activity feed for other users

The changes enable a cleaner separation of concerns where admin activity monitoring can be toggled independently without polluting the standard activity stream.

https://claude.ai/code/session_01R5J8wkuGRoJUg4VVnkcd2h