### PR TITLE
[Invoices] Replace sponsor select with custom dropdown with delete support

### DIFF
--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -51,8 +51,14 @@ class SponsorsController < ApplicationController
     authorize @sponsor
 
     @sponsor.destroy
-    flash[:success] = "Sponsor was successfully destroyed."
-    redirect_to sponsors_url
+
+    respond_to do |format|
+      format.html do
+        flash[:success] = "Sponsor was successfully destroyed."
+        redirect_to sponsors_url
+      end
+      format.json { head :no_content }
+    end
   end
 
   private

--- a/app/javascript/controllers/invoice_form_controller.js
+++ b/app/javascript/controllers/invoice_form_controller.js
@@ -1,8 +1,13 @@
 import { Controller } from '@hotwired/stimulus'
+import csrf from '../common/csrf'
 
 export default class extends Controller {
   static targets = [
-    'selectSponsor',
+    'sponsorDropdownContainer',
+    'sponsorDropdownTrigger',
+    'sponsorDropdownMenu',
+    'sponsorDropdownLabel',
+    'sponsorOptionRow',
     'sponsorCollapsible',
     'sponsorForm',
     'sponsorPreview',
@@ -24,8 +29,13 @@ export default class extends Controller {
     'id',
   ]
 
+  dropdownOpen = false
+  _selectedSponsorJson = null
+
   connect() {
-    if (this.selectSponsorTarget.disabled) {
+    const hasSponsors = this.hasSponsorDropdownContainerTarget
+
+    if (!hasSponsors) {
       this.continueButtonTarget.disabled = false
       this.showNewSponsorCard()
     }
@@ -35,7 +45,39 @@ export default class extends Controller {
       this.validateForm.bind(this)
     )
 
+    this._boundHandleDocumentClick = this.handleDocumentClick.bind(this)
+    document.addEventListener('click', this._boundHandleDocumentClick)
+
     this.validateForm()
+  }
+
+  disconnect() {
+    document.removeEventListener('click', this._boundHandleDocumentClick)
+  }
+
+  handleDocumentClick(event) {
+    if (
+      this.hasSponsorDropdownContainerTarget &&
+      !this.sponsorDropdownContainerTarget.contains(event.target) &&
+      this.dropdownOpen
+    ) {
+      this.closeSponsorDropdown()
+    }
+  }
+
+  toggleSponsorDropdown(event) {
+    event.stopPropagation()
+    this.dropdownOpen ? this.closeSponsorDropdown() : this.openSponsorDropdown()
+  }
+
+  openSponsorDropdown() {
+    this.dropdownOpen = true
+    this.sponsorDropdownMenuTarget.classList.remove('hidden')
+  }
+
+  closeSponsorDropdown() {
+    this.dropdownOpen = false
+    this.sponsorDropdownMenuTarget.classList.add('hidden')
   }
 
   validateForm() {
@@ -56,21 +98,82 @@ export default class extends Controller {
     }
   }
 
-  selectSponsor() {
+  chooseSponsorOption(event) {
+    const button = event.currentTarget
+    const value = button.dataset.value
+    const name = button.dataset.name
+
+    this.sponsorDropdownLabelTarget.innerHTML = name
+
     this.continueButtonTarget.disabled = false
     this.secondTabTarget.disabled = false
 
-    const { value } = this.selectSponsorTarget
-    if (parseInt(value)) this.showSponsorCard()
-    else this.showNewSponsorCard()
+    if (value) {
+      this._selectedSponsorJson = JSON.parse(button.dataset.json)
+      this.showSponsorCard()
+    } else {
+      this._selectedSponsorJson = null
+      this.showNewSponsorCard()
+    }
+
+    this.closeSponsorDropdown()
     this.validateForm()
   }
 
+  async deleteSponsor(event) {
+    event.stopPropagation()
+
+    const button = event.currentTarget
+    const sponsorId = button.dataset.sponsorId
+    const sponsorName = button.dataset.sponsorName
+    const sponsorPath = button.dataset.sponsorPath
+
+    if (
+      !confirm(
+        `Delete ${sponsorName}? This will also delete all of their invoices.`
+      )
+    )
+      return
+
+    try {
+      const response = await fetch(sponsorPath, {
+        method: 'DELETE',
+        headers: {
+          'X-CSRF-Token': csrf(),
+          Accept: 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        alert('Failed to delete sponsor.')
+        return
+      }
+
+      const row = document.getElementById(`sponsor-option-${sponsorId}`)
+      if (row) row.remove()
+
+      if (this._selectedSponsorJson?.id == sponsorId) {
+        this._selectedSponsorJson = null
+        this.sponsorDropdownLabelTarget.textContent = 'Select…'
+        this.showNewSponsorCard()
+      }
+
+      if (this.sponsorOptionRowTargets.length === 0) {
+        const divider = this.sponsorDropdownMenuTarget.querySelector('hr')
+        if (divider) divider.remove()
+        this.closeSponsorDropdown()
+        this.showNewSponsorCard()
+        this.sponsorDropdownContainerTarget.classList.add('hidden')
+      }
+    } catch (e) {
+      console.error('Failed to delete sponsor', e)
+      alert('Failed to delete sponsor.')
+    }
+  }
+
   setValues() {
-    let sponsor =
-      this.selectSponsorTarget.options[this.selectSponsorTarget.selectedIndex]
-        .dataset.json
-    sponsor = JSON.parse(sponsor)
+    const sponsor = this._selectedSponsorJson
+    if (!sponsor) return
 
     this.sponsorPreviewNameTarget.innerText = sponsor.name || ''
     this.sponsorPreviewEmailTarget.innerText = sponsor.contact_email || ''
@@ -97,6 +200,8 @@ export default class extends Controller {
     this.sponsorCollapsibleTarget.setAttribute('class', '')
     this.sponsorPreviewTarget.classList.add('!hidden')
     this.sponsorFormTarget.setAttribute('class', '')
+    const warning = document.getElementById('sponsor-warning')
+    if (warning) warning.hidden = true
     if (clear) this.clearValues()
   }
 
@@ -108,6 +213,8 @@ export default class extends Controller {
     )
     this.sponsorPreviewTarget.classList.remove('!hidden')
     this.sponsorFormTarget.setAttribute('class', 'px-7 p-4 pt-0')
+    const warning = document.getElementById('sponsor-warning')
+    if (warning) warning.hidden = false
     this.setValues()
   }
 }

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -30,21 +30,59 @@
       <%= form_errors invoice %>
       <%= form_errors sponsor %>
       <div data-tabs-target="tab" id="sponsor">
-        <div class="field">
-          <select
-            data-invoice-form-target="selectSponsor"
-            data-action="change->invoice-form#selectSponsor"
-            name="invoice[sponsor_id]"
-            id="invoice_sponsor_id"
-            class="max-w-full"
-            <%= "disabled hidden" if @event.sponsors.empty? %>>
-            <option value="default" selected disabled>Select…</option>
-            <option value="">+⠀New sponsor…</option>
-            <% @event.sponsors.select(:id, :name, :contact_email, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country).each do |sponsor| %>
-              <option value="<%= sponsor.id %>" data-json="<%= sponsor.to_json %>"><%= sponsor.name %></option>
-            <% end %>
-          </select>
-        </div>
+        <% unless @event.sponsors.empty? %>
+          <div class="field relative" data-invoice-form-target="sponsorDropdownContainer">
+            <button
+              type="button"
+              data-invoice-form-target="sponsorDropdownTrigger"
+              data-action="click->invoice-form#toggleSponsorDropdown"
+              class="input max-w-full w-full text-left flex items-center justify-between gap-2">
+              <span data-invoice-form-target="sponsorDropdownLabel">Select…</span>
+              <%= inline_icon "view-more", size: 16, class: "flex-shrink-0 opacity-50" %>
+            </button>
+            <div
+              data-invoice-form-target="sponsorDropdownMenu"
+              class="hidden absolute z-50 w-full bg-white dark:bg-darker border border-gray-200 dark:border-neutral-700 rounded-lg shadow-lg mt-1 overflow-hidden">
+              <button
+                type="button"
+                class="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-neutral-800 transition-colors text-sm"
+                data-action="click->invoice-form#chooseSponsorOption"
+                data-value=""
+                data-name="+&nbsp;&nbsp;New sponsor…">
+                +&nbsp;&nbsp;New sponsor…
+              </button>
+              <hr class="border-gray-200 dark:border-neutral-700 my-0" />
+              <% @event.sponsors.select(:id, :name, :contact_email, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country).each do |sponsor| %>
+                <div
+                  id="sponsor-option-<%= sponsor.id %>"
+                  class="flex items-center group hover:bg-gray-100 dark:hover:bg-neutral-800 transition-colors"
+                  data-invoice-form-target="sponsorOptionRow">
+                  <button
+                    type="button"
+                    class="flex-1 text-left px-4 py-2 text-sm truncate"
+                    data-action="click->invoice-form#chooseSponsorOption"
+                    data-value="<%= sponsor.id %>"
+                    data-json="<%= sponsor.to_json %>"
+                    data-name="<%= sponsor.name %>">
+                    <%= sponsor.name %>
+                  </button>
+                  <% if policy(sponsor).destroy? %>
+                    <button
+                      type="button"
+                      title="Delete <%= sponsor.name %>"
+                      class="px-3 py-2 text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                      data-action="click->invoice-form#deleteSponsor"
+                      data-sponsor-id="<%= sponsor.id %>"
+                      data-sponsor-name="<%= sponsor.name %>"
+                      data-sponsor-path="<%= sponsor_path(sponsor) %>">
+                      <%= inline_icon "view-close", size: 14 %>
+                    </button>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
         <details
           id="sponsor-collapsible"
           data-invoice-form-target="sponsorCollapsible">


### PR DESCRIPTION
## Summary

- Replaces the native `<select>` in the invoice form's sponsor step with a custom dropdown
- Each sponsor row shows a delete button (×) on hover — only visible to users with destroy permission
- Deleting a sponsor sends a `DELETE` request via `fetch`, removes the row from the dropdown without a page reload, and resets the selection if that sponsor was active
- If all sponsors are deleted, the dropdown hides and the new sponsor form appears automatically
- The "updating a previous sponsor" warning now correctly shows/hides based on whether an existing sponsor is selected