### PR TITLE
[v4] Improve transaction pagination performance

### DIFF
--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -94,7 +94,7 @@ module Api
                         cursor_hcb_code = HcbCode.find_by_public_id(params[:after])&.hcb_code
                         index = transactions.index { |tx| tx.hcb_code == cursor_hcb_code }
                         return render json: { error: "Invalid cursor" }, status: :bad_request unless index
-      
+
                         index + 1
                       else
                         0

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -91,7 +91,11 @@ module Api
       def paginate_transactions(transactions)
         limit = params[:limit]&.to_i || 25
         start_index = if params[:after]
-                        transactions.index { |tx| tx.local_hcb_code.public_id == params[:after] } + 1
+                        cursor_hcb_code = HcbCode.find_by_public_id(params[:after])&.hcb_code
+                        index = transactions.index { |tx| tx.hcb_code == cursor_hcb_code }
+                        return render json: { error: "Invalid cursor" }, status: :bad_request unless index
+      
+                        index + 1
                       else
                         0
                       end

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -93,7 +93,7 @@ module Api
         start_index = if params[:after]
                         cursor_hcb_code = HcbCode.find_by_public_id(params[:after])&.hcb_code
                         index = transactions.index { |tx| tx.hcb_code == cursor_hcb_code }
-                        return render json: { error: "Invalid cursor" }, status: :bad_request unless index
+                        return render json: { error: "bad_request", messages: ["invalid cursor"] }, status: :bad_request unless index
 
                         index + 1
                       else

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -92,6 +92,8 @@ module Api
         limit = params[:limit]&.to_i || 25
         start_index = if params[:after]
                         cursor_hcb_code = HcbCode.find_by_public_id(params[:after])&.hcb_code
+                        return render json: { error: "bad_request", messages: ["invalid cursor"] }, status: :bad_request unless cursor_hcb_code
+
                         index = transactions.index { |tx| tx.hcb_code == cursor_hcb_code }
                         return render json: { error: "bad_request", messages: ["invalid cursor"] }, status: :bad_request unless index
 


### PR DESCRIPTION
## Summary of the problem
Poor performance ❌  Better performance 👍 

We shouldn't be finding the `public_id` of the list of transactions as that loads HCB Code object which is poor performance as we do this multiple times. 


## Describe your changes
We should just find the hcb code of the param then compare. So becomes 1 DB request instead of however many transactions it takes to find the param one. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

