### PR TITLE
[Applications] Clarify agreement signing for teen-led applications

### DIFF
--- a/app/views/event/applications/agreement.html.erb
+++ b/app/views/event/applications/agreement.html.erb
@@ -8,7 +8,9 @@
       Sign the HCB agreement
     </h2>
 
-    <p class="mt-0 text-lg muted">This agreement formalizes the relationship between your project and HCB</p>
+    <p class="mt-0 text-lg muted">
+      This agreement formalizes the relationship between your project and HCB<% if @application.teen_led? %>, but it is not finalized until we review and approve your application<% end %>
+    </p>
 
     <div class="h-[40vh]">
       <%= render partial: "contract/parties/contract_faq", locals: { no_questions: true } %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We want to make it clear to teenagers that even though they're signing the agreement before we review it, it isn't finalized until we approve it.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add copy to agreement page for teen-led applications

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

