### PR TITLE
Fix padding on title-only callouts

### DIFF
--- a/app/views/application/_callout.html.erb
+++ b/app/views/application/_callout.html.erb
@@ -17,6 +17,8 @@
         <div class="h-4 w-full"></div>
       <% end %>
     </div>
+  <% else %>
+    <div class="h-4 w-full"></div>
   <% end %>
 
   <% if local_assigns[:footer].present? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13334 adding scroll fading to callouts that overflow, and changed the padding on the callout elements. This left title-only callouts (such as on the branding page) without any bottom padding.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a div for bottom padding on title-only callouts.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

