### PR TITLE
Add maintenance_tasks gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -235,3 +235,5 @@ gem "pghero", "~> 3.7"
 gem "pg_query", ">= 2"
 
 gem "intercom-rails"
+
+gem "maintenance_tasks", "~> 2.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,6 +448,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
+    job-iteration (1.13.0)
+      activejob (>= 7.0)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -511,6 +513,14 @@ GEM
       net-imap
       net-pop
       net-smtp
+    maintenance_tasks (2.14.0)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      csv
+      job-iteration (>= 1.3.6)
+      railties (>= 7.1)
+      zeitwerk (>= 2.6.2)
     marcel (1.0.4)
     matrix (0.4.3)
     memo_wise (1.13.0)
@@ -997,6 +1007,7 @@ DEPENDENCIES
   lockbox
   lograge
   loofah
+  maintenance_tasks (~> 2.14)
   memo_wise
   mini_magick
   monetize

--- a/app/jobs/one_time_jobs/README.md
+++ b/app/jobs/one_time_jobs/README.md
@@ -1,0 +1,3 @@
+Don't use one time jobs anymore. Use Maintance Tasks. Refer
+to https://github.com/hackclub/hcb/pull/13459 for
+more info

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -103,6 +103,7 @@ FriendlyId.defaults do |config|
     mobile
     deprecated
     apply
+    maintenance_tasks
   ]
 
   # This adds an option to to treat reserved words as conflicts rather than exceptions.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   constraints AdminConstraint do
     mount Sidekiq::Web => "/sidekiq"
+    mount MaintenanceTasks::Engine, at: "/maintenance_tasks"
     mount Flipper::UI.app(Flipper), at: "flipper", as: "flipper"
     mount PgHero::Engine, at: "pghero"
   end

--- a/db/migrate/20260410205819_create_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260410205819_create_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20201211151756)
+class CreateMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:maintenance_tasks_runs, id: primary_key_type) do |t|
+      t.string(:task_name, null: false)
+      t.datetime(:started_at)
+      t.datetime(:ended_at)
+      t.float(:time_running, default: 0.0, null: false)
+      t.integer(:tick_count, default: 0, null: false)
+      t.integer(:tick_total)
+      t.string(:job_id)
+      t.bigint(:cursor)
+      t.string(:status, default: :enqueued, null: false)
+      t.string(:error_class)
+      t.string(:error_message)
+      t.text(:backtrace)
+      t.timestamps
+      t.index(:task_name)
+      t.index([:task_name, :created_at], order: { created_at: :desc })
+    end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    setting || :primary_key
+  end
+end

--- a/db/migrate/20260410205820_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20260410205820_change_cursor_to_string.maintenance_tasks.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210219212931)
+class ChangeCursorToString < ActiveRecord::Migration[7.0]
+  # This migration will clear all existing data in the cursor column with MySQL.
+  # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
+  # Running tasks are able to gracefully handle this change, even if interrupted.
+  def up
+    safety_assured do
+      change_table(:maintenance_tasks_runs) do |t|
+        t.change(:cursor, :string)
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      change_table(:maintenance_tasks_runs) do |t|
+        t.change(:cursor, :bigint)
+      end
+    end
+  end
+end

--- a/db/migrate/20260410205820_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20260410205820_change_cursor_to_string.maintenance_tasks.rb
@@ -14,10 +14,6 @@ class ChangeCursorToString < ActiveRecord::Migration[7.0]
   end
 
   def down
-    safety_assured do
-      change_table(:maintenance_tasks_runs) do |t|
-        t.change(:cursor, :bigint)
-      end
-    end
+    change_column :maintenance_tasks_runs, :cursor, :bigint, using: 'cursor::bigint'
   end
 end

--- a/db/migrate/20260410205821_remove_index_on_task_name.maintenance_tasks.rb
+++ b/db/migrate/20260410205821_remove_index_on_task_name.maintenance_tasks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210225152418)
+class RemoveIndexOnTaskName < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      change_table(:maintenance_tasks_runs) do |t|
+        t.remove_index(:task_name)
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      change_table(:maintenance_tasks_runs) do |t|
+        t.index(:task_name)
+      end
+    end
+  end
+end

--- a/db/migrate/20260410205822_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260410205822_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210517131953)
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :arguments, :text)
+  end
+end

--- a/db/migrate/20260410205823_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260410205823_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20211210152329)
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :maintenance_tasks_runs,
+      :lock_version,
+      :integer,
+      default: 0,
+      null: false,
+    )
+  end
+end

--- a/db/migrate/20260410205824_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
+++ b/db/migrate/20260410205824_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220706101937)
+class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      change_table(:maintenance_tasks_runs, bulk: true) do |t|
+        t.change(:tick_count, :bigint)
+        t.change(:tick_total, :bigint)
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      change_table(:maintenance_tasks_runs, bulk: true) do |t|
+        t.change(:tick_count, :integer)
+        t.change(:tick_total, :integer)
+      end
+    end
+  end
+end

--- a/db/migrate/20260410205825_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260410205825_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220713131925)
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index(
+      :maintenance_tasks_runs,
+      column: [:task_name, :created_at],
+      order: { created_at: :desc },
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
+    )
+
+    add_index(
+      :maintenance_tasks_runs,
+      [:task_name, :status, :created_at],
+      name: :index_maintenance_tasks_runs,
+      order: { created_at: :desc },
+      algorithm: :concurrently
+    )
+  end
+end

--- a/db/migrate/20260410205826_add_metadata_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260410205826_add_metadata_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20230622035229)
+class AddMetadataToRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :metadata, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_06_231006) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_10_205826) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1658,6 +1658,27 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_06_231006) do
     t.bigint "user_id", null: false
     t.index ["address"], name: "index_mailbox_addresses_on_address", unique: true
     t.index ["user_id"], name: "index_mailbox_addresses_on_user_id"
+  end
+
+  create_table "maintenance_tasks_runs", force: :cascade do |t|
+    t.text "arguments"
+    t.text "backtrace"
+    t.datetime "created_at", null: false
+    t.string "cursor"
+    t.datetime "ended_at"
+    t.string "error_class"
+    t.string "error_message"
+    t.string "job_id"
+    t.integer "lock_version", default: 0, null: false
+    t.text "metadata"
+    t.datetime "started_at"
+    t.string "status", default: "enqueued", null: false
+    t.string "task_name", null: false
+    t.bigint "tick_count", default: 0, null: false
+    t.bigint "tick_total"
+    t.float "time_running", default: 0.0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_name", "status", "created_at"], name: "index_maintenance_tasks_runs", order: { created_at: :desc }
   end
 
   create_table "metrics", force: :cascade do |t|


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, whenever we need to run a "maintenance task" (typically associated with a database migration), we create a one-time job, and run it manually in the production Rails console. This isn't great since you need console access, our one-time jobs get cluttered, and if the job is interrupted, the entire job needs to restart. As our database grows, many of our maintenance tasks are taking longer to complete, so this is important to fix.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Shopify has a great gem [maintenance_tasks](https://github.com/Shopify/maintenance_tasks) that addresses the problems listed above. This PR adds the gem and initializes it - the default configuration is reasonable, so I've left it the same. See the gem README for how the gem works and its features. Once this PR merges, the dashboard will be accessible to admins at [hcb.hackclub.com/maintenance_tasks](hcb.hackclub.com/maintenance_tasks).

Any future maintenance tasks should use this gem, and we'll see then how well it works for us and if we need to change any configuration!
