### PR TITLE
Add sortable table headers to invoices index

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -447,3 +447,48 @@ form .flex-auto + input[type='submit'] {
     color: map-get($palette, success) !important;
   }
 }
+
+.sort-button {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: start;
+  width: 100%;
+  font-weight: 600;
+  transition: color 0.125s ease-in-out;
+  gap: 0.5rem;
+  color: inherit;
+
+  [data-dark='true'] & {
+    color: map-get($palette, muted);
+  }
+
+  &.sort-button--right {
+    justify-content: end;
+    flex-direction: row-reverse;
+  }
+
+  &:hover,
+  &:focus {
+    color: map-get($palette, info);
+  }
+
+  & svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+    opacity: 0;
+    transition:
+      opacity 0.125s ease-in-out,
+      transform 0.125s ease-in-out;
+  }
+
+  &:hover svg,
+  &:focus svg {
+    opacity: 1;
+  }
+
+  &.sort-button--active svg {
+    opacity: 1;
+  }
+}

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -55,7 +55,12 @@ class InvoicesController < ApplicationController
 
     relation = relation.search_description(params[:q]) if params[:q].present?
 
-    @invoices = relation.order(created_at: :desc).includes(:sponsor).page(params[:page]).per(25)
+    @invoices = helpers.sorted_relation(
+      relation,
+      INVOICE_COLUMNS,
+      sort: [params[:sort], params[:direction]],
+      default: [:created_at, :desc]
+    ).includes(:sponsor).page(params[:page]).per(25)
 
     @sponsor = Sponsor.new(event: @event)
     @invoice = Invoice.new(sponsor: @sponsor, event: @event)
@@ -63,6 +68,8 @@ class InvoicesController < ApplicationController
     @filter_options = filter_options
     helpers.validate_filter_options(@filter_options, params)
     @has_filter = helpers.check_filters?(@filter_options, params)
+
+    @table_columns = INVOICE_COLUMNS
   end
 
   def new
@@ -212,6 +219,14 @@ class InvoicesController < ApplicationController
   end
 
   private
+
+  INVOICE_COLUMNS = [
+    { key: "status" },
+    { key: "created_at", default: true, display: "Date" },
+    { key: "sponsor_name", display: "To", column: "sponsors.name", join: :sponsor },
+    { key: "amount_due", right: true, display: "Amount" },
+  ].freeze
+  private_constant :INVOICE_COLUMNS
 
   def filtered_params
     params.require(:invoice).permit(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,19 @@ module ApplicationHelper
     params.merge(new_params)
   end
 
+  def sorted_relation(relation, columns, sort:, default:)
+    sort_key, sort_direction = organizer_signed_in? ? sort : default
+    default_key, default_direction = default
+
+    sort_direction = sort_direction.to_s.in?(%w[asc desc]) ? sort_direction : default_direction.to_s
+    column_def = columns.find { |c| c[:key] == sort_key.to_s } ||
+                 columns.find { |c| c[:key] == default_key.to_s } ||
+                 columns.first
+    relation = relation.left_joins(column_def[:join]) if column_def[:join]
+    relation.order(column_def.fetch(:column, column_def[:key]) => sort_direction)
+  end
+
+
   def render_money(amount, opts = {})
     amount = amount.cents if amount.is_a?(Money)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,6 @@ module ApplicationHelper
     relation.order(column_def.fetch(:column, column_def[:key]) => sort_direction)
   end
 
-
   def render_money(amount, opts = {})
     amount = amount.cents if amount.is_a?(Money)
 

--- a/app/views/events/_sort_table_header.html.erb
+++ b/app/views/events/_sort_table_header.html.erb
@@ -1,0 +1,12 @@
+<% if organizer_signed_in? %>
+  <% is_active = params[:sort] == sort || (params[:sort].nil? && local_assigns[:default]) %>
+  <% current_direction = params[:direction].presence || "desc" %>
+  <% direction = is_active ? (current_direction == "asc" ? "desc" : "asc") : "desc" %>
+  <%= link_to upsert_query_params(sort: sort, direction: direction),
+    class: ["sort-button", ("sort-button--active" if is_active), ("sort-button--right" if local_assigns[:right])].compact.join(" ") do %>
+    <%= display || sort.humanize %>
+    <%= inline_icon(current_direction == "desc" ? "down-caret" : "up-caret", size: 16) %>
+  <% end %>
+<% else %>
+  <%= display || sort.humanize %>
+<% end %>

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -53,10 +53,11 @@
     <table>
       <thead>
         <tr>
-          <th>Status</th>
-          <th>Date</th>
-          <th>To</th>
-          <th class="text-right">Amount</th>
+          <% @table_columns.each do |column| %>
+            <th class="<%= 'text-right' if column[:right] %>">
+              <%= render "events/sort_table_header", sort: column[:key], display: column[:display], right: column[:right], default: column[:default] %>
+            </th>
+          <% end %>
         </tr>
       </thead>
 


### PR DESCRIPTION
## Summary of the problem
The invoices index table has static headers with no sorting capability. Users cannot sort invoices by different columns, making it harder to find and organize invoices by status, date, sponsor, or amount.

## Describe your changes
This PR adds dynamic, sortable table headers to the invoices index view:

1. **New `sort-button` styles** (`_buttons.scss`): Added styling for sortable column headers with hover effects and animated sort direction indicators (up/down carets).

2. **Sortable table header component** (`_sort_table_header.html.erb`): Created a reusable partial that renders either a clickable sort link (for organizers) or plain text (for non-organizers). The component:
   - Toggles sort direction when clicking an active column
   - Displays visual indicators for active sort columns
   - Supports right-aligned columns (e.g., Amount)

3. **Invoice sorting logic** (`application_helper.rb`): Added `sorted_relation` helper that:
   - Validates sort parameters against allowed columns
   - Handles database joins for related columns (e.g., sponsor name)
   - Falls back to default sort if invalid parameters provided
   - Respects organizer authentication status

4. **Invoices controller updates** (`invoices_controller.rb`):
   - Defined `INVOICE_COLUMNS` constant with sortable columns (status, created_at, sponsor_name, amount_due)
   - Replaced hardcoded `.order(created_at: :desc)` with dynamic sorting via `sorted_relation` helper
   - Passed column definitions to view for rendering headers

5. **Updated invoices index view** (`invoices/index.html.erb`): Replaced static table headers with dynamic headers using the new sort component.

The implementation maintains backward compatibility—the default sort remains by created date descending, and non-organizers see static headers.

https://claude.ai/code/session_01HB1UL8kpQu1LwKmuTK2s8G