### PR TITLE
Add `verified` to `User`

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -155,6 +155,8 @@ class LoginsController < ApplicationController
     end
 
     if @login.complete? && @login.user_session.present?
+      @login.user.update(verified: true) if @login.user.unverified?
+
       if @referral_link.present?
         redirect_to referral_link_path(@referral_link)
       elsif (@user.full_name.blank? || @user.phone_number.blank?) && !@login.for_application?

--- a/app/jobs/one_time_jobs/backfill_verified_on_user.rb
+++ b/app/jobs/one_time_jobs/backfill_verified_on_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module OneTimeJobs
+  class BackfillVerifiedOnUser < ApplicationJob
+    def perform
+      User.update(verified: true)
+    end
+
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@
 #  teenager                      :boolean
 #  use_sms_auth                  :boolean          default(FALSE)
 #  use_two_factor_authentication :boolean          default(FALSE)
+#  verified                      :boolean          default(FALSE), not null
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
 #  discord_id                    :string
@@ -615,6 +616,10 @@ class User < ApplicationRecord
 
   def reimbursement_event_options
     events.not_demo_mode.or(Event.where(id: reimbursement_events.where(public_reimbursement_page_enabled: true).select(:id))).uniq.pluck(:name, :id)
+  end
+
+  def unverified?
+    !verified?
   end
 
   private

--- a/db/migrate/20260411143808_add_verified_to_user.rb
+++ b/db/migrate/20260411143808_add_verified_to_user.rb
@@ -1,0 +1,5 @@
+class AddVerifiedToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :verified, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_08_015031) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_11_143808) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2653,6 +2653,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_08_015031) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "use_sms_auth", default: false
     t.boolean "use_two_factor_authentication", default: false
+    t.boolean "verified", default: false, null: false
     t.string "webauthn_id"
     t.index ["discord_id"], name: "index_users_on_discord_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ email = Rails.env.staging? ? "staging@bank.engineering" : "admin@bank.engineerin
 
 if user.nil?
   puts "Woah there, there aren't any users! Creating an user (#{email})."
-  user = User.create!(email:, full_name: "Stagey McStageface", phone_number: "+19064225632")
+  user = User.create!(email:, full_name: "Stagey McStageface", phone_number: "+19064225632", verified: true)
 end
 
 puts "Continuing with #{user.email}..."
@@ -15,7 +15,7 @@ user.make_admin! unless user.admin?
 
 Governance::Admin::Transfer::Limit.create(user_id: user.id, amount_cents: 1000000000)
 
-system_user = User.create_with(email: User::SYSTEM_USER_EMAIL).create_or_find_by!(id: User::SYSTEM_USER_ID)
+system_user = User.create_with(email: User::SYSTEM_USER_EMAIL, verified: true).create_or_find_by!(id: User::SYSTEM_USER_ID)
 system_user.make_admin! unless system_user.admin?
 
 # DEMO


### PR DESCRIPTION
## Summary of the problem

We're looking to allow users to create new accounts and set certain attributes on `User` prior to verifying their email address. As a result, we want to store in the DB whether or not a user is verified.

## Describe your changes

Before we can build out protections against unverified users, we want to make sure that all existing users are backfilled as verified and that new users signing in get marked as verified.
