### PR TITLE
[CheckDeposit] Fix state color and admin show error

### DIFF
--- a/app/controllers/admin/check_deposits_controller.rb
+++ b/app/controllers/admin/check_deposits_controller.rb
@@ -17,7 +17,7 @@ module Admin
       @check_deposit = CheckDeposit.find(params[:id])
 
       unless @check_deposit.manual_submission_required?
-        redirect_to @check_deposit.local_hcb_code.url
+        redirect_to hcb_code_url(@check_deposit.local_hcb_code)
       end
     end
 

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -121,8 +121,8 @@ class CheckDeposit < ApplicationRecord
   has_hcb_code TransactionGroupingEngine::Calculate::HcbCode::CHECK_DEPOSIT_CODE
 
   def state
-    return :muted if column_id.nil? && increase_id.nil?
     return :error if rejected? || returned?
+    return :muted if column_id.nil? && increase_id.nil?
     return :success if local_hcb_code.ct.present?
 
     if pending? || manual_submission_required?

--- a/app/views/admin/check_deposits/show.html.erb
+++ b/app/views/admin/check_deposits/show.html.erb
@@ -1,6 +1,6 @@
 <%= link_to admin_check_deposits_path, class: "btn btn-small bg-muted" do %>
-    <%= inline_icon "view-back" %>
-    Back to check deposits
+  <%= inline_icon "view-back" %>
+  Back to check deposits
 <% end %>
 
 <h1>Process Check Deposit #<%= @check_deposit.id %></h1>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Admins could only view checks requiring manual submission.
The state returned muted too early bypassing the possible error state.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

