### PR TITLE
Fix wrong email address in email update success message

### DIFF
--- a/app/controllers/users/email_updates_controller.rb
+++ b/app/controllers/users/email_updates_controller.rb
@@ -32,7 +32,7 @@ module Users
       if @request.confirmed?
         return redirect_to root_path, flash: { success: "We've updated your email address to #{@request.user.email}." }
       else
-        return redirect_to root_path, flash: { success: "Verified; please check your old email's inbox (#{@request.replacement}) to authorize this change." }
+        return redirect_to root_path, flash: { success: "Verified; please check your old email's inbox (#{@request.original}) to authorize this change." }
       end
     rescue ActiveRecord::RecordNotFound => e
       flash[:error] = "This authorization token has expired, please request another."


### PR DESCRIPTION
## Summary of the problem

When changing email addresses, the replacement email was shown as the "old email" instead of the original email in the success message. It used to say `please check your old email's inbox (#{@request.replacement}) to authorize this change` instead of `request.original`.

## Describe your changes

This issue only existed in one place in `email_updates_controller.rb`, and this PR fixes the message to display the correct original/old email.

This closes https://github.com/hackclub/hcb/issues/13471