### PR TITLE
[BREAKING CHANGE][V4] Ignore Event#demo_mode_request_meeting_at before removing

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -59,7 +59,7 @@
 #
 class Event < ApplicationRecord
   self.ignored_columns += ["demo_mode_request_meeting_at"]
-  
+
   MIN_WAITING_TIME_BETWEEN_FEES = 5.days
 
   include Hashid::Rails

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,6 @@
 #  country                                      :integer
 #  deleted_at                                   :datetime
 #  demo_mode                                    :boolean          default(FALSE), not null
-#  demo_mode_request_meeting_at                 :datetime
 #  description                                  :text
 #  donation_page_enabled                        :boolean          default(TRUE)
 #  donation_page_message                        :text
@@ -59,6 +58,8 @@
 #  fk_rails_...  (point_of_contact_id => users.id)
 #
 class Event < ApplicationRecord
+  self.ignored_columns += ["demo_mode_request_meeting_at"]
+  
   MIN_WAITING_TIME_BETWEEN_FEES = 5.days
 
   include Hashid::Rails

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -10,6 +10,7 @@ json.financially_frozen event.financially_frozen?
 json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
 json.donation_page_available event.donation_page_available?
 json.playground_mode event.demo_mode?
+json.playground_mode_meeting_requested nil # This field is deprecated and will be removed
 json.transparent event.is_public?
 json.fee_percentage event.revenue_fee.to_f
 json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -10,7 +10,6 @@ json.financially_frozen event.financially_frozen?
 json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
 json.donation_page_available event.donation_page_available?
 json.playground_mode event.demo_mode?
-json.playground_mode_meeting_requested event.demo_mode_request_meeting_at.present?
 json.transparent event.is_public?
 json.fee_percentage event.revenue_fee.to_f
 json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Api::V4::CardGrantsController do
         "icon"                              => nil,
         "donation_page_available"           => true,
         "playground_mode"                   => false,
-        "playground_mode_meeting_requested" => false,
         "transparent"                       => true
       }
 

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -41,19 +41,19 @@ RSpec.describe Api::V4::CardGrantsController do
       recipient = card_grant.user
 
       serialized_event = {
-        "id"                                => event.public_id,
-        "parent_id"                         => nil,
-        "name"                              => "Test Event",
-        "slug"                              => "test-event",
-        "background_image"                  => nil,
-        "country"                           => nil,
-        "created_at"                        => event.created_at.iso8601(3),
-        "fee_percentage"                    => 0.0,
-        "financially_frozen"                => false,
-        "icon"                              => nil,
-        "donation_page_available"           => true,
-        "playground_mode"                   => false,
-        "transparent"                       => true
+        "id"                      => event.public_id,
+        "parent_id"               => nil,
+        "name"                    => "Test Event",
+        "slug"                    => "test-event",
+        "background_image"        => nil,
+        "country"                 => nil,
+        "created_at"              => event.created_at.iso8601(3),
+        "fee_percentage"          => 0.0,
+        "financially_frozen"      => false,
+        "icon"                    => nil,
+        "donation_page_available" => true,
+        "playground_mode"         => false,
+        "transparent"             => true
       }
 
       expect(response.parsed_body).to eq(

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -41,19 +41,20 @@ RSpec.describe Api::V4::CardGrantsController do
       recipient = card_grant.user
 
       serialized_event = {
-        "id"                      => event.public_id,
-        "parent_id"               => nil,
-        "name"                    => "Test Event",
-        "slug"                    => "test-event",
-        "background_image"        => nil,
-        "country"                 => nil,
-        "created_at"              => event.created_at.iso8601(3),
-        "fee_percentage"          => 0.0,
-        "financially_frozen"      => false,
-        "icon"                    => nil,
-        "donation_page_available" => true,
-        "playground_mode"         => false,
-        "transparent"             => true
+        "id"                                => event.public_id,
+        "parent_id"                         => nil,
+        "name"                              => "Test Event",
+        "slug"                              => "test-event",
+        "background_image"                  => nil,
+        "country"                           => nil,
+        "created_at"                        => event.created_at.iso8601(3),
+        "fee_percentage"                    => 0.0,
+        "financially_frozen"                => false,
+        "icon"                              => nil,
+        "donation_page_available"           => true,
+        "playground_mode"                   => false,
+        "playground_mode_meeting_requested" => nil,
+        "transparent"                       => true
       }
 
       expect(response.parsed_body).to eq(


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
See https://github.com/hackclub/hcb/pull/13447#discussion_r3061503131 for context. This column is no longer being used and isn't needed in the database anymore.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Ignores the column and removes it from the v4 API event partial.

⚠️ **This is a v4 API breaking change, since this column's presence is currently included in the event partial.** Not sure what our current process is for this - @Mohamad-Mortada?

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

