### PR TITLE
Don't guess invoice CT mappings while in transit

### DIFF
--- a/app/services/pending_event_mapping_engine/settle/invoice.rb
+++ b/app/services/pending_event_mapping_engine/settle/invoice.rb
@@ -36,7 +36,7 @@ module PendingEventMappingEngine
               canonical_transaction: ct,
               canonical_pending_transaction: cpt
             ).run!
-          else
+          elsif invoice.arriving_late?
             # invoice.manually_marked_as_paid? as true typically
             # special case for invoices that are marked paid but are missing a payout! these seem to be sent to bill.com
             # these typically can match based on amount cents and nearest date as a result

--- a/app/services/pending_event_mapping_engine/settle/invoice.rb
+++ b/app/services/pending_event_mapping_engine/settle/invoice.rb
@@ -36,7 +36,7 @@ module PendingEventMappingEngine
               canonical_transaction: ct,
               canonical_pending_transaction: cpt
             ).run!
-          elsif invoice.arriving_late?
+          elsif invoice.manually_marked_as_paid? || invoice.arriving_late?
             # invoice.manually_marked_as_paid? as true typically
             # special case for invoices that are marked paid but are missing a payout! these seem to be sent to bill.com
             # these typically can match based on amount cents and nearest date as a result


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2810. This notice is caused by an invoice that was paid but hasn't been deposited yet, that matches by amount and date to an unrelated check deposit. Thankfully, we removed the code that automatically matches this CPT and CT, but it's not great to have this notice be spammed to our alerts every half hour.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The `else` block in the logic seems to just be as a fallback in case we have a CPT for an invoice without a payout, which will happen for manually paid invoices and briefly for normal invoices since it takes time between when the invoice is paid to when the payout arrives in our bank account.

There's no reason to try to guess what CT belongs to an invoice CPT if we don't think the CT should even exist yet, so I added a condition to only fallback if the invoice is manually paid or arriving late, at which point we can assume that there may not have been a payout created and we can guess instead.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

