### PR TITLE
Add rubocop extension to devcontainer as default formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,8 @@
         "Shopify.ruby-lsp",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "misogi.ruby-rubocop"
       ]
     }
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,8 @@
   "files.associations": {
     "apple-app-site-association": "json"
   },
-  "css.validate": false
+  "css.validate": false,
+  "[ruby]": {
+    "editor.defaultFormatter": "misogi.ruby-rubocop"
+  }
 }


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It's no fun pushing commits just for the Rubocop check to fail when you create a PR! Thankfully, there's a rubocop extension that's super helpful for catching these before you commit.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add rubocop extension to the devcontainer config and configure it as the default formatter for Ruby in VSCode.

_side note: [herb formatter](https://herb-tools.dev/projects/formatter) is in preview, and would be great to use for ERB files once it's ready!_

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

