### PR TITLE
Wait until transaction commit before scheduling mail jobs

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -83,7 +83,7 @@ class Contract < ApplicationRecord
 
     event :mark_sent do
       transitions from: :pending, to: :sent
-      after do |reissue_signee_message = nil, reissue_cosigner_message = nil|
+      after_commit do |reissue_signee_message = nil, reissue_cosigner_message = nil|
         if reissue_signee_message.present? || reissue_cosigner_message.present?
           party(:signee).notify_reissued(message: reissue_signee_message)
           party(:cosigner).notify_reissued(message: reissue_cosigner_message) if party(:cosigner).present?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -466,7 +466,7 @@ class Event < ApplicationRecord
 
   after_update :generate_stripe_card_designs, if: -> { attachment_changes["stripe_card_logo"].present? && stripe_card_logo.attached? && !Rails.env.test? }
 
-  after_update if: :is_public_previously_changed? do
+  after_update_commit if: :is_public_previously_changed? do
     version = self.versions.where_object_changes(is_public:).last
     whodunnit = version&.whodunnit.present? ? User.find(version.whodunnit) : User.system_user
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/dashboard?overlay=search&q=ActiveJob%3A%3ADeserializationError - a common bug is when we schedule mail jobs before a record is created in the database, causing the job server to try to find a record that doesn't exist yet. While not major (the job gets retried shortly after), these are still bugs that should be fixed.

Note that Rails 8.2 (not released yet) adds a [configuration value](https://codewithrails.com/blog/rails-enqueue-after-transaction-commit/) that will prevent these errors globally, by delaying enqueuing jobs in a transaction until after that transaction commits.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Update the callbacks that send contract party notifications and organization settings notifications to run after commit.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

