### PR TITLE
Move balance warning to actions section in reimbursement report

### DIFF
--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -351,6 +351,11 @@
       </div>
     </div>
   <% end %>
+  <% if report.exceeds_event_balance? && !report.closed? %>
+    <% button_hint = capture do %>
+      <span class="bold warning">Warning</span>: This reimbursement exceeds <%= report.event.name %>'s available balance. The <%= report.event.name %> team may need time to secure additional funds to process this reimbursement.
+    <% end %>
+  <% end %>
   <% if report.rejected? && !member_viewing %>
     <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted mt2", method: :post do %>
       <%= inline_icon "view-reload" %>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -127,14 +127,6 @@
   </article>
 <% end %>
 
-<% if @report.exceeds_event_balance? && !@report.closed? %>
-  <%= render "application/callout",
-      type: "warning",
-      icon: "info",
-      title: "Waiting on #{@report.event.name}" do %>
-    This reimbursement exceeds <%= @report.event.name %>'s available balance. The <%= @report.event.name %> team may need time to secure additional funds to process this reimbursement.
-  <% end %>
-<% end %>
 <% if @report.draft? %>
   <section class="hidden md:flex items-start justify-center mt2 mb2" style="gap: 16px; position: relative;">
     <article class="card w-100">


### PR DESCRIPTION
## Summary of the problem
The warning callout for reimbursements exceeding event balance was displayed in a fixed location on the report page. This change relocates the warning to be more contextually relevant within the actions section, improving the information architecture and user experience.

## Describe your changes
- Removed the balance warning callout from the main report view (`show.html.erb`)
- Added the balance warning as a button hint in the actions section (`_actions.html.erb`)
- The warning is still conditionally displayed only when the reimbursement exceeds the event balance and the report is not closed
- The warning message content remains the same, now formatted as a hint with a "Warning" label

This change keeps the warning visible and accessible while placing it closer to the action buttons where users are most likely to interact with the reimbursement report.

https://claude.ai/code/session_01WP8wDrTzhLT77CvTpo5igo