### PR TITLE
[CI] Shard RSpec across 8 GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,16 @@ jobs:
       - name: Run Prettier
         run: yarn format:check
   rspec:
-    name: RSpec
+    name: RSpec (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel remaining shards when one fails — we want to see all
+      # failures in a single run rather than a slow loop of retries.
+      fail-fast: false
+      matrix:
+        # Bumping this number adds more parallel runners. Keep it in sync
+        # with SHARD_TOTAL below.
+        shard: [1, 2, 3, 4]
     services:
       postgres:
         image: postgres:15
@@ -159,11 +167,26 @@ jobs:
           REDIS_URL: redis://localhost:6379
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: '1' # Force SimpleCov to generate a JSON report
-        run: bundle exec rspec --tag ~skip
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_TOTAL: 4
+        # Deterministic round-robin split of spec files across shards. We
+        # sort the file list first so each runner computes the same ordering,
+        # then `awk` keeps only the files whose 1-based index mod SHARD_TOTAL
+        # maps to this shard. With 143 spec files over 4 shards, each shard
+        # runs ~35 files. This is simple and doesn't require extra gems;
+        # upgrade to a balancer (ci-queue, knapsack_pro) later if shards
+        # drift apart in wall time.
+        run: |
+          specs=$(find spec -name '*_spec.rb' | sort | awk -v i="$SHARD_INDEX" -v n="$SHARD_TOTAL" 'NR % n == (i - 1) % n { print }')
+          echo "Running $(echo "$specs" | wc -l) spec files on shard $SHARD_INDEX/$SHARD_TOTAL"
+          bundle exec rspec --tag ~skip $specs
       - name: Upload coverage report
         uses: actions/upload-artifact@v6
         with:
-          name: simplecov-report
+          # Each shard generates its own coverage file; name them uniquely
+          # so the upload action doesn't clash. Merging into a single report
+          # can be done in a downstream job if needed.
+          name: simplecov-report-shard-${{ matrix.shard }}
           path: coverage/coverage.json
   annotate:
     name: Annotate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       matrix:
         # Bumping this number adds more parallel runners. Keep it in sync
         # with SHARD_TOTAL below.
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     services:
       postgres:
         image: postgres:15
@@ -168,12 +168,12 @@ jobs:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: '1' # Force SimpleCov to generate a JSON report
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: 4
+          SHARD_TOTAL: 8
         # Deterministic round-robin split of spec files across shards. We
         # sort the file list first so each runner computes the same ordering,
         # then `awk` keeps only the files whose 1-based index mod SHARD_TOTAL
-        # maps to this shard. With 143 spec files over 4 shards, each shard
-        # runs ~35 files. This is simple and doesn't require extra gems;
+        # maps to this shard. With 143 spec files over 8 shards, each shard
+        # runs ~18 files. This is simple and doesn't require extra gems;
         # upgrade to a balancer (ci-queue, knapsack_pro) later if shards
         # drift apart in wall time.
         run: |


### PR DESCRIPTION
## Summary

Parallelizes the RSpec job into 8 matrix shards so CI wall time drops roughly in proportion to runner count, until per-shard setup overhead becomes the floor.

- Adds a `matrix.shard: [1..8]` with `fail-fast: false` so a failure in one shard doesn't cancel the others.
- Splits specs deterministically: `find spec -name '*_spec.rb' | sort | awk 'NR % SHARD_TOTAL == (SHARD_INDEX - 1) % SHARD_TOTAL'`. Round-robin by sorted filename — each runner computes the same file list independently, no coordinator needed.
- Uploads one coverage artifact per shard (`simplecov-report-shard-N`) to avoid upload-artifact name collisions. Merging into a single report can be added downstream if needed.

## Why 8 shards

Rough wall-time curve assuming ~4 min setup + ~20 min unsharded specs:

| Shards | Wall time |
|---|---|
| 4 | ~9 min |
| 6 | ~7.3 min |
| 8 | ~6.5 min |
| 12 | ~5.7 min |

8 captures nearly all the available savings before per-shard setup (apt-get poppler + libpq, bundle, yarn install, asset build, db:schema:load) becomes the dominant floor. Going higher has diminishing returns and makes static-split variance worse (one slow spec file is a larger % of a smaller shard).

## Why this approach (vs. ci-queue / knapsack_pro)

- No gem, no SaaS, no Redis coordinator — ~10 lines of bash.
- Deterministic: reproducing a failing shard locally is just `SHARD_INDEX=N SHARD_TOTAL=8 <split> | xargs bundle exec rspec`.
- Known tradeoff: splits by filename, not by runtime. If shards drift apart in wall time as the suite grows, revisit — ci-queue (free, OSS) would be the natural next step, and migration cost is low since the current change is self-contained.

## Next real speedups (follow-ups, not this PR)

Once at 8 shards, per-shard setup time is the bottleneck, not the split. Higher-leverage follow-ups:

- Cache `libpoppler-glib-dev` / `libpq-dev` (apt installs every run).
- Cache yarn build artifacts keyed by JS/CSS source hashes.
- Prebuilt Docker image with system deps baked in.

## Tuning

Bumping parallelism is a two-line change: extend `matrix.shard` and update `SHARD_TOTAL` to match.

## Test plan

- [ ] CI runs and all 8 shards pass.
- [ ] Each shard's log shows a non-empty spec file count (`Running N spec files on shard X/8`).
- [ ] Total spec count across shards equals the pre-change count (no file dropped by the split).
- [ ] `simplecov-report-shard-{1..8}` artifacts all upload successfully.
- [ ] Slowest shard's wall time is meaningfully lower than the pre-change single-runner wall time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)