### PR TITLE
[CI] Set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+# Default to least-privilege for the GITHUB_TOKEN. Individual jobs that
+# need to write back to the repo (e.g. posting PR review suggestions)
+# widen their own permissions block below.
+permissions:
+  contents: read
 jobs:
   rubocop:
     name: Rubocop
@@ -26,6 +31,11 @@ jobs:
     name: 'Suggest lint changes'
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
+    # parkerbxyz/suggest-changes posts review comments with suggested
+    # edits, which requires write access to the PR.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Default to no permissions at the workflow level. The job below grants
+# itself exactly what the Claude Code action needs.
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/stripe_ips.yml
+++ b/.github/workflows/stripe_ips.yml
@@ -4,9 +4,18 @@ on:
   schedule:
     - cron: "0 0 * * *" # https://crontab.guru/#0_0_*_*_*
 
+# Default to no permissions. The one job below opts into exactly what
+# peter-evans/create-pull-request needs.
+permissions: {}
+
 jobs:
   update-and-commit:
     runs-on: "ubuntu-latest"
+    # peter-evans/create-pull-request pushes a branch and opens a PR,
+    # which requires write access to both scopes.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: "actions/checkout@v6"
       - name: "Sync with Stripe"


### PR DESCRIPTION
## Summary

Declares explicit least-privilege `permissions:` blocks in every workflow file so the `GITHUB_TOKEN` never defaults to broad write access.

### `ci.yml`
- Top-level default: `contents: read` — all jobs inherit read-only.
- Per-job override on `suggest_lint_changes`: `pull-requests: write` — required by `parkerbxyz/suggest-changes@v3.0.3`, which posts review comments with suggested edits.
- All other jobs (rubocop, erblint, eslint, prettier, rspec, annotate, zeitwerk, reversible_migrations, brakeman) inherit the read-only default.

### `claude.yml`
- Top-level default: `permissions: {}` — future jobs added to this file can't silently inherit broad scopes.
- Pre-existing per-job permissions on the `claude` job are unchanged.

### `stripe_ips.yml`
- Top-level default: `permissions: {}` (the file previously had no permissions block at all).
- Per-job grant of `contents: write` + `pull-requests: write` on `update-and-commit`, which is the minimum needed by `peter-evans/create-pull-request@v8` to push a branch and open the auto-update PR.

### `browserslist-update-action.yml`
- Already declared scoped top-level permissions (`contents: write`, `pull-requests: write`) for its auto-PR job. No change needed.

## Why

Without an explicit `permissions:` block, GitHub Actions hands the `GITHUB_TOKEN` broad write scopes (contents, issues, pull-requests, checks, packages, etc.) to every job. If any third-party action pulled in by these workflows were ever compromised, it could push commits, close issues, or modify PRs.

Declaring least-privilege scopes and widening only where needed is the recommended GitHub Actions hardening posture and resolves all of the CodeQL **"Workflow does not contain permissions"** warnings currently open on these files.

## Test plan

- [ ] CI runs on this PR and all jobs pass with the tighter defaults.
- [ ] `suggest_lint_changes` can still post review comments on a PR with intentional lint violations.
- [ ] CodeQL no longer reports `actions/missing-workflow-permissions` on `ci.yml` or `stripe_ips.yml`.
- [ ] Manual spot-check after merge: the next scheduled run of `stripe_ips.yml` and `browserslist-update-action.yml` successfully creates its auto-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)