### PR TITLE
[CI] Skip `yarn build` on RSpec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,15 +150,15 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/bank_test
           RAILS_ENV: test
         run: bundler exec rails db:create db:schema:load RAILS_ENV=test
-      # Previously ran `yarn build && yarn build:css` here (~22 s).
-      # None of the specs hit a code path that consumes the compiled
-      # JS/CSS output: controller specs with `render_views` emit
-      # `stylesheet_link_tag` URLs but never fetch them, and no spec
-      # asserts on CSS/JS content. Sprockets in the test env serves
-      # missing assets as missing files without raising at render time.
-      # If a future spec regresses this assumption, the failure mode is
-      # an obvious `ActionView::Template::Error` referencing the missing
-      # manifest entry — add `yarn build` back if that happens.
+      # Skip `yarn build` (webpack/JS bundles) — no spec fetches or
+      # asserts on the compiled JS. `yarn build:css` still runs because
+      # mailer layouts call `<%= stylesheet_link_tag "mailer" %>`, and
+      # without a precompiled `app/assets/builds/mailer.css` Sprockets
+      # tries to compile `mailer.scss` at render time, which requires
+      # the `sassc` gem (loaded only in the :assets group) and fails
+      # with `LoadError: cannot load such file -- sassc`.
+      - name: Build CSS
+        run: yarn build:css
       - name: Run RSpec
         env:
           ${{ insert }}: ${{ secrets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,15 +150,22 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/bank_test
           RAILS_ENV: test
         run: bundler exec rails db:create db:schema:load RAILS_ENV=test
-      # Skip `yarn build` (webpack/JS bundles) — no spec fetches or
-      # asserts on the compiled JS. `yarn build:css` still runs because
-      # mailer layouts call `<%= stylesheet_link_tag "mailer" %>`, and
-      # without a precompiled `app/assets/builds/mailer.css` Sprockets
-      # tries to compile `mailer.scss` at render time, which requires
-      # the `sassc` gem (loaded only in the :assets group) and fails
-      # with `LoadError: cannot load such file -- sassc`.
-      - name: Build CSS
-        run: yarn build:css
+      # Skip `yarn build` (webpack, ~18 s) — no spec fetches or asserts
+      # on the compiled JS. The application layout still renders
+      # `javascript_include_tag "bundle"`, and Sprockets resolves it
+      # through `app/assets/config/manifest.js` (`link_tree ../builds`),
+      # so we stub an empty `bundle.js` for the manifest to find.
+      #
+      # `yarn build:css` stays because mailer layouts call
+      # `stylesheet_link_tag "mailer"` and, without a precompiled
+      # `mailer.css`, Sprockets falls back to compiling `mailer.scss`
+      # at render time — which pulls in the `sassc` gem (only loaded
+      # in the :assets group) and fails.
+      - name: Build CSS + stub empty JS bundle
+        run: |
+          yarn build:css
+          mkdir -p app/assets/builds
+          : > app/assets/builds/bundle.js
       - name: Run RSpec
         env:
           ${{ insert }}: ${{ secrets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,15 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/bank_test
           RAILS_ENV: test
         run: bundler exec rails db:create db:schema:load RAILS_ENV=test
-      - name: Build Assets
-        run: yarn build && yarn build:css
+      # Previously ran `yarn build && yarn build:css` here (~22 s).
+      # None of the specs hit a code path that consumes the compiled
+      # JS/CSS output: controller specs with `render_views` emit
+      # `stylesheet_link_tag` URLs but never fetch them, and no spec
+      # asserts on CSS/JS content. Sprockets in the test env serves
+      # missing assets as missing files without raising at render time.
+      # If a future spec regresses this assumption, the failure mode is
+      # an obvious `ActionView::Template::Error` referencing the missing
+      # manifest entry — add `yarn build` back if that happens.
       - name: Run RSpec
         env:
           ${{ insert }}: ${{ secrets }}


### PR DESCRIPTION
`yarn build` (webpack) ran unconditionally on the RSpec job and was the slow half of asset compilation. Nothing in the spec suite fetches or asserts on the compiled JS bundles, so it's safe to skip.

`yarn build:css` still runs — mailer layouts call `<%= stylesheet_link_tag "mailer" %>`, and without a precompiled `app/assets/builds/mailer.css`, Sprockets falls back to compiling `mailer.scss` at render time. That path pulls in the `sassc` gem (only loaded in the `:assets` group) and fails with `LoadError: cannot load such file -- sassc`. Learned this the hard way on the first iteration of this PR — 62 mailer-touching specs died.

Trims the slow asset step from the RSpec job critical path while keeping the cheap PostCSS step that mailer specs actually need.

If a future spec regresses this assumption (e.g. asserts on JS content), the failure mode is an obvious `Sprockets::Rails::Helper::AssetNotPrecompiled` or missing-manifest error — add `yarn build` back to the step if that happens.