### PR TITLE
[CI] Build Event#plan with target type up front in factory

### DIFF
--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -8,13 +8,23 @@ FactoryBot.define do
       organizers { [] }
     end
 
-    after(:create) do |event, context|
-      event.plan.update!(type: context.plan_type) if context.plan_type.present?
+    # Build the plan with the factory's `plan_type` up front. Without this,
+    # `Event#before_validation` builds a plan of the fallback type (Standard)
+    # and `after(:create)` had to UPDATE the plan to the desired type
+    # afterwards — an extra INSERT + UPDATE round trip on every
+    # `create(:event)`, paid on all ~250 event creations per suite run.
+    after(:build) do |event, context|
+      event.build_plan(type: context.plan_type.to_s) if context.plan_type.present? && event.plan.nil?
+    end
 
+    after(:create) do |event, context|
       context.organizers.each do |user|
         create(:organizer_position, event:, user:)
       end
 
+      # Reload to clear cached associations (e.g. `plan`) that other tests
+      # rely on being fresh after various callbacks run — see
+      # spec/models/event_spec.rb "uses the standard plan as a fallback".
       event.reload
     end
 

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -8,11 +8,10 @@ FactoryBot.define do
       organizers { [] }
     end
 
-    # Build the plan with the factory's `plan_type` up front. Without this,
-    # `Event#before_validation` builds a plan of the fallback type (Standard)
-    # and `after(:create)` had to UPDATE the plan to the desired type
-    # afterwards — an extra INSERT + UPDATE round trip on every
-    # `create(:event)`, paid on all ~250 event creations per suite run.
+    # Set the plan type up front. `Event#before_validation` builds a
+    # plan with the fallback type (Event::Plan::Standard) when none is
+    # set, so building the plan here saves an UPDATE + reload per
+    # `create(:event)` — hit on ~250 event creations per suite run.
     after(:build) do |event, context|
       event.build_plan(type: context.plan_type.to_s) if context.plan_type.present? && event.plan.nil?
     end
@@ -22,9 +21,9 @@ FactoryBot.define do
         create(:organizer_position, event:, user:)
       end
 
-      # Reload to clear cached associations (e.g. `plan`) that other tests
-      # rely on being fresh after various callbacks run — see
-      # spec/models/event_spec.rb "uses the standard plan as a fallback".
+      # Clear cached associations (e.g. `plan`) so specs like
+      # spec/models/event_spec.rb "uses the standard plan as a fallback"
+      # see post-callback state rather than the factory's in-memory copy.
       event.reload
     end
 


### PR DESCRIPTION
## Summary

Tightens `spec/factories/event_factory.rb` so that `create(:event, plan_type: ...)` no longer does an INSERT-then-UPDATE-then-reload dance for the plan.

### Before

```ruby
after(:create) do |event, context|
  event.plan.update!(type: context.plan_type) if context.plan_type.present?
  ...
  event.reload
end
```

Flow per `create(:event, plan_type: :some_type)`:
1. Event saves.
2. `Event#before_validation` sees no plan, builds one with the fallback type (`Event::Plan::Standard`) and inserts it.
3. Factory's `after(:create)` then runs `event.plan.update!(type: ...)` — a second SQL UPDATE on the plan row just to swap the `type`.
4. `event.reload` refreshes cached associations.

### After

```ruby
after(:build) do |event, context|
  event.build_plan(type: context.plan_type.to_s) if context.plan_type.present? && event.plan.nil?
end

after(:create) do |event, context|
  ...
  event.reload
end
```

Flow per `create(:event, plan_type: :some_type)`:
1. Factory's `after(:build)` attaches an in-memory plan with the correct type before the event is saved.
2. `Event#before_validation` sees a plan already set and doesn't build a fallback.
3. Event + plan save together; no follow-up UPDATE.
4. `event.reload` is still needed so specs that assert on `event.plan` after factory callbacks see post-save state rather than the factory's in-memory copy (e.g. `spec/models/event_spec.rb` "uses the standard plan as a fallback").

## Why

The factory is hit on ~250 event creations per suite run, so cutting one UPDATE per call is a modest but free RSpec wall-time win.

## Test plan

- [ ] Full RSpec suite passes with the factory change.
- [ ] Specs that exercise non-default plan types (e.g. `plan_type: :unapproved`, `:hack_club_affiliate`) still see the correct `event.plan.type` after `create(:event, plan_type: ...)`.
- [ ] `spec/models/event_spec.rb` "uses the standard plan as a fallback" still passes — this was the motivating case for keeping `event.reload` in `after(:create)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)