### PR TITLE
[User] Send security email when phone number is cleared

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,7 +246,7 @@ class User < ApplicationRecord
       User::SecurityMailer.security_configuration_changed(user: self, change:).deliver_later
     end
 
-    if phone_number_previously_changed? && phone_number.present?
+    if phone_number_previously_changed? && phone_number.present? && phone_number_previously_was.present?
       User::SecurityMailer.security_configuration_changed(user: self, change: "Phone number was changed to #{phone_number}").deliver_later
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -249,6 +249,15 @@ class User < ApplicationRecord
     if phone_number_previously_changed? && phone_number.present? && phone_number_previously_was.present?
       User::SecurityMailer.security_configuration_changed(user: self, change: "Phone number was changed to #{phone_number}").deliver_later
     end
+
+    if phone_number_previously_changed? && phone_number.blank? && phone_number_previously_was.present?
+      change = if Current.session&.impersonated?
+        "Phone number was removed by HCB support"
+      else
+        "Phone number was removed"
+      end
+      User::SecurityMailer.security_configuration_changed(user: self, change:).deliver_later
+    end
   end
 
   scope :last_seen_within, ->(ago) { joins(:user_sessions).where(user_sessions: { impersonated_by_id: nil, last_seen_at: ago.. }).distinct }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -285,12 +285,26 @@ RSpec.describe User, type: :model do
         }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
       end
 
-      it "does not send an email when phone_number changes from a value to nil" do
+      it "sends an email when the user clears their own phone_number" do
         user = create(:user, phone_number: "+18556254225")
 
         expect {
           user.update!(phone_number: nil)
-        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+          .with(user:, change: "Phone number was removed")
+      end
+
+      it "sends an admin-initiated email when an impersonating admin clears the phone_number" do
+        admin = create(:user, :make_admin)
+        user = create(:user, phone_number: "+18556254225")
+        Current.session = build(:user_session, user:, impersonated_by: admin)
+
+        expect {
+          user.update!(phone_number: nil)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+          .with(user:, change: "Phone number was removed by HCB support")
+      ensure
+        Current.session = nil
       end
 
       it "does not send an email when phone_number is not changed" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -319,6 +319,15 @@ RSpec.describe User, type: :model do
           user.update!(use_sms_auth: false)
         }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
       end
+
+      it "does not send an email when use_sms_auth is not changed" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        user.update!(use_sms_auth: true)
+
+        expect {
+          user.update!(full_name: "New Name")
+        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
     end
 
     describe "use_two_factor_authentication changes" do
@@ -339,6 +348,16 @@ RSpec.describe User, type: :model do
         expect {
           user.update!(use_two_factor_authentication: false)
         }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "does not send an email when use_two_factor_authentication is not changed" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        user.update!(use_sms_auth: true)
+        user.update!(use_two_factor_authentication: true)
+
+        expect {
+          user.update!(full_name: "New Name")
+        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -267,6 +267,82 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "security configuration change emails" do
+    describe "phone_number changes" do
+      it "does not send an email when phone_number changes from nil to a value (signup)" do
+        user = create(:user, phone_number: nil)
+
+        expect {
+          user.update!(phone_number: "+18556254225")
+        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "sends an email when phone_number changes from one value to another" do
+        user = create(:user, phone_number: "+18556254225")
+
+        expect {
+          user.update!(phone_number: "+14155550123")
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "does not send an email when phone_number changes from a value to nil" do
+        user = create(:user, phone_number: "+18556254225")
+
+        expect {
+          user.update!(phone_number: nil)
+        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "does not send an email when phone_number is not changed" do
+        user = create(:user, phone_number: "+18556254225")
+
+        expect {
+          user.update!(full_name: "New Name")
+        }.not_to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+    end
+
+    describe "use_sms_auth changes" do
+      it "sends an email when SMS authentication is enabled" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+
+        expect {
+          user.update!(use_sms_auth: true)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "sends an email when SMS authentication is disabled" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        user.update!(use_sms_auth: true)
+
+        expect {
+          user.update!(use_sms_auth: false)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+    end
+
+    describe "use_two_factor_authentication changes" do
+      it "sends an email when two-factor authentication is enabled" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        user.update!(use_sms_auth: true)
+
+        expect {
+          user.update!(use_two_factor_authentication: true)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+
+      it "sends an email when two-factor authentication is disabled" do
+        user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        user.update!(use_sms_auth: true)
+        user.update!(use_two_factor_authentication: true)
+
+        expect {
+          user.update!(use_two_factor_authentication: false)
+        }.to have_enqueued_mail(User::SecurityMailer, :security_configuration_changed)
+      end
+    end
+  end
+
   describe ".search_name" do
     it "finds user by ID" do
       user = create(:user)


### PR DESCRIPTION
## Summary
- Send the "Security settings changed" email when a user's phone number is cleared (value → nil). Clearing the phone number removes SMS 2FA capability, so the account owner should be notified.
- When the change is made by an admin via impersonation (`Current.session&.impersonated?`), the email uses alternate copy: "Phone number was removed by HCB support" (vs. "Phone number was removed" for user-initiated clears) so the user isn't confused by a notification for an action they didn't take.

## Notes
- Based on `garyhtou/user-phone-number-security-email` (issue #13507 fix) — please merge that first.
- Admin-initiated detection uses impersonation since there's no admin UI that directly edits a user's phone number; admins operate via impersonation.

## Test plan
- [x] New specs in `spec/models/user_spec.rb`:
  - sends an email when the user clears their own phone_number (with "Phone number was removed")
  - sends an admin-initiated email when an impersonating admin clears the phone_number (with "Phone number was removed by HCB support")
- [x] Existing security-email specs still pass (11 examples, 0 failures)
- [ ] Manually verify email copy in the mailer preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)