### PR TITLE
[v4] Disbursements call same hcb code twice

### DIFF
--- a/app/views/api/v4/transactions/_disbursement.json.jbuilder
+++ b/app/views/api/v4/transactions/_disbursement.json.jbuilder
@@ -3,10 +3,14 @@
 json.id disbursement.public_id
 json.memo disbursement.local_hcb_code.memo
 json.status disbursement.v4_api_state
+
+outgoing_hcb_code = disbursement.outgoing_disbursement.local_hcb_code
+incoming_hcb_code = disbursement.incoming_disbursement.local_hcb_code
+
 # `transaction_id` will eventually be deprecated
-json.transaction_id disbursement.outgoing_disbursement.local_hcb_code.public_id
-json.outgoing_transaction_id disbursement.outgoing_disbursement.local_hcb_code.public_id
-json.incoming_transaction_id disbursement.incoming_disbursement.local_hcb_code.public_id
+json.transaction_id outgoing_hcb_code.public_id
+json.outgoing_transaction_id outgoing_hcb_code.public_id
+json.incoming_transaction_id incoming_hcb_code.public_id
 json.amount_cents disbursement.amount
 
 json.from do


### PR DESCRIPTION
## Summary of the problem
We are calling `disbursement.outgoing_disbursement.local_hcb_code` twice


## Describe your changes
Use variables to reuse the value.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

