### PR TITLE
[CI] Make donation notification spec less flaky

### DIFF
--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Donation, type: :model do
 
       donation.status = "succeeded"
       donation.save
-    end.to change(enqueued_jobs, :size).by(1)
+    end.to have_enqueued_mail(DonationMailer, :first_donation_notification).once
   end
 
   it "does not send email notifications for non-succeeded donations" do


### PR DESCRIPTION
## Summary
- The "Donation does not send multiple email notifications" spec was failing intermittently in CI (e.g. RSpec shard 7/8 on `8df69e5fb` failed, then a re-run of the same commit passed).
- The original assertion measured the delta of the total `enqueued_jobs.size`, so any unrelated job that enqueues during the block (mailer, sidekiq side-effect, etc.) inflates the count and turns a transient enqueue into a hard test failure.
- Switched to `have_enqueued_mail(DonationMailer, :first_donation_notification).once` — counts only the specific mailer this test cares about. If `Donation#send_notification` is ever genuinely fired twice, the test still fails, with a clearer message naming the mailer.

This is the spec-only fix. If the underlying behavior turns out to be a real model-level double-fire (e.g. `after_commit` firing on a no-op `save` with stale `previous_changes`), tightening `Donation#send_notification` with an in-memory idempotency guard is the follow-up.

## Test plan
- [x] `bundle exec rspec spec/models/donation_spec.rb` — 4 examples, 0 failures locally.
- [x] CI runs green across all 8 shards.