### PR TITLE
[TX Engine] Add preloading for type filter

### DIFF
--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -17,6 +17,13 @@ module Api
         @settled_transactions = TransactionGroupingEngine::Transaction::All.new(**filters).run
         @pending_transactions = PendingTransactionEngine::PendingTransaction::All.new(**filters).run
 
+        # `filter_transaction_type` reads `t.local_hcb_code.<predicate>?` for every settled
+        # row. Without preloading, that's a SELECT per row — multi-second N+1 on large orgs.
+        if params[:type].present? && @settled_transactions.any?
+          hcb_codes_by_code = HcbCode.where(hcb_code: @settled_transactions.map(&:hcb_code)).index_by(&:hcb_code)
+          @settled_transactions.each { |t| t.local_hcb_code = hcb_codes_by_code[t.hcb_code] }
+        end
+
         type_results = ::EventsController.filter_transaction_type(params[:type], settled_transactions: @settled_transactions, pending_transactions: @pending_transactions)
         @settled_transactions = type_results[:settled_transactions]
         @pending_transactions = type_results[:pending_transactions]

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -17,42 +17,10 @@ module Api
         @settled_transactions = TransactionGroupingEngine::Transaction::All.new(**filters).run
         @pending_transactions = PendingTransactionEngine::PendingTransaction::All.new(**filters).run
 
-        # `filter_transaction_type` reads `t.local_hcb_code.<predicate>?` for every settled
-        # row. Without preloading, that's a SELECT per row — multi-second N+1 on large orgs.
-        if params[:type].present? && @settled_transactions.any?
-          hcb_codes_by_code = HcbCode.where(hcb_code: @settled_transactions.map(&:hcb_code)).index_by(&:hcb_code)
-          @settled_transactions.each { |t| t.local_hcb_code = hcb_codes_by_code[t.hcb_code] }
-
-          # The card_charge filter reads `t.raw_stripe_transaction` which walks
-          # `ct -> transaction_source` — both lazy lookups per row. Bulk-load
-          # the CTs (and their stripe sources) and assign once.
-          if params[:type] == "card_charge"
-            ct_ids = @settled_transactions.flat_map(&:canonical_transaction_ids)
-            cts_by_id = CanonicalTransaction.where(id: ct_ids).index_by(&:id)
-            stripe_source_ids = cts_by_id.values.select { |ct| ct.transaction_source_type == RawStripeTransaction.name }.map(&:transaction_source_id)
-            rsts_by_id = RawStripeTransaction.where(id: stripe_source_ids).index_by(&:id)
-            cts_by_id.each_value do |ct|
-              ct.raw_stripe_transaction = rsts_by_id[ct.transaction_source_id] if ct.transaction_source_type == RawStripeTransaction.name
-            end
-            @settled_transactions.each do |t|
-              t.canonical_transactions = t.canonical_transaction_ids.filter_map { |id| cts_by_id[id] }
-                                                                    .sort_by { |ct| [ct.date, ct.id] }.reverse
-            end
-          end
-
-          # The hcb_transfer filter also reads `outgoing_disbursement` /
-          # `incoming_disbursement` on each row, which are otherwise unmemoized
-          # `Disbursement.find_by`s. Bulk-load + assign once.
-          if params[:type] == "hcb_transfer"
-            disbursement_hcb_codes = hcb_codes_by_code.values.select { |hc| hc.outgoing_disbursement? || hc.incoming_disbursement? }
-            disbursements_by_id = Disbursement.where(id: disbursement_hcb_codes.map(&:hcb_i2)).index_by(&:id)
-            disbursement_hcb_codes.each do |hc|
-              disbursement = disbursements_by_id[hc.hcb_i2.to_i]
-              hc.outgoing_disbursement = disbursement&.outgoing_disbursement if hc.outgoing_disbursement?
-              hc.incoming_disbursement = disbursement&.incoming_disbursement if hc.incoming_disbursement?
-            end
-          end
-        end
+        TransactionGroupingEngine::Transaction::FilterTypePreloader.new(
+          settled_transactions: @settled_transactions,
+          type: params[:type]
+        ).run!
 
         type_results = ::EventsController.filter_transaction_type(params[:type], settled_transactions: @settled_transactions, pending_transactions: @pending_transactions)
         @settled_transactions = type_results[:settled_transactions]

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -22,6 +22,19 @@ module Api
         if params[:type].present? && @settled_transactions.any?
           hcb_codes_by_code = HcbCode.where(hcb_code: @settled_transactions.map(&:hcb_code)).index_by(&:hcb_code)
           @settled_transactions.each { |t| t.local_hcb_code = hcb_codes_by_code[t.hcb_code] }
+
+          # The hcb_transfer filter also reads `outgoing_disbursement` /
+          # `incoming_disbursement` on each row, which are otherwise unmemoized
+          # `Disbursement.find_by`s. Bulk-load + assign once.
+          if params[:type] == "hcb_transfer"
+            disbursement_hcb_codes = hcb_codes_by_code.values.select { |hc| hc.outgoing_disbursement? || hc.incoming_disbursement? }
+            disbursements_by_id = Disbursement.where(id: disbursement_hcb_codes.map(&:hcb_i2)).index_by(&:id)
+            disbursement_hcb_codes.each do |hc|
+              disbursement = disbursements_by_id[hc.hcb_i2.to_i]
+              hc.outgoing_disbursement = disbursement&.outgoing_disbursement if hc.outgoing_disbursement?
+              hc.incoming_disbursement = disbursement&.incoming_disbursement if hc.incoming_disbursement?
+            end
+          end
         end
 
         type_results = ::EventsController.filter_transaction_type(params[:type], settled_transactions: @settled_transactions, pending_transactions: @pending_transactions)

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -23,6 +23,23 @@ module Api
           hcb_codes_by_code = HcbCode.where(hcb_code: @settled_transactions.map(&:hcb_code)).index_by(&:hcb_code)
           @settled_transactions.each { |t| t.local_hcb_code = hcb_codes_by_code[t.hcb_code] }
 
+          # The card_charge filter reads `t.raw_stripe_transaction` which walks
+          # `ct -> transaction_source` — both lazy lookups per row. Bulk-load
+          # the CTs (and their stripe sources) and assign once.
+          if params[:type] == "card_charge"
+            ct_ids = @settled_transactions.flat_map(&:canonical_transaction_ids)
+            cts_by_id = CanonicalTransaction.where(id: ct_ids).index_by(&:id)
+            stripe_source_ids = cts_by_id.values.select { |ct| ct.transaction_source_type == RawStripeTransaction.name }.map(&:transaction_source_id)
+            rsts_by_id = RawStripeTransaction.where(id: stripe_source_ids).index_by(&:id)
+            cts_by_id.each_value do |ct|
+              ct.raw_stripe_transaction = rsts_by_id[ct.transaction_source_id] if ct.transaction_source_type == RawStripeTransaction.name
+            end
+            @settled_transactions.each do |t|
+              t.canonical_transactions = t.canonical_transaction_ids.filter_map { |id| cts_by_id[id] }
+                                                                    .sort_by { |ct| [ct.date, ct.id] }.reverse
+            end
+          end
+
           # The hcb_transfer filter also reads `outgoing_disbursement` /
           # `incoming_disbursement` on each row, which are otherwise unmemoized
           # `Disbursement.find_by`s. Bulk-load + assign once.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -199,6 +199,11 @@ class EventsController < ApplicationController
       @all_transactions.reject!(&:likely_account_verification_related?)
     end
 
+    TransactionGroupingEngine::Transaction::FilterTypePreloader.new(
+      settled_transactions: @all_transactions,
+      type: @type
+    ).run!
+
     type_results = self.class.filter_transaction_type(@type, settled_transactions: @all_transactions, pending_transactions: @pending_transactions)
     @all_transactions = type_results[:settled_transactions]
     @pending_transactions = type_results[:pending_transactions]

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -452,16 +452,20 @@ class HcbCode < ApplicationRecord
     end
   end
 
+  attr_writer :incoming_disbursement, :outgoing_disbursement
+
   def incoming_disbursement
     return nil unless incoming_disbursement?
+    return @incoming_disbursement if defined?(@incoming_disbursement)
 
-    Disbursement.find_by(id: hcb_i2)&.incoming_disbursement
+    @incoming_disbursement = Disbursement.find_by(id: hcb_i2)&.incoming_disbursement
   end
 
   def outgoing_disbursement
     return nil unless outgoing_disbursement?
+    return @outgoing_disbursement if defined?(@outgoing_disbursement)
 
-    Disbursement.find_by(id: hcb_i2)&.outgoing_disbursement
+    @outgoing_disbursement = Disbursement.find_by(id: hcb_i2)&.outgoing_disbursement
   end
 
   def card_grant

--- a/app/services/transaction_grouping_engine/transaction/filter_type_preloader.rb
+++ b/app/services/transaction_grouping_engine/transaction/filter_type_preloader.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module TransactionGroupingEngine
+  module Transaction
+    # Preloads associations that `EventsController.filter_transaction_type`
+    # reads on each settled row. Without this, each lambda walks
+    # `t.local_hcb_code.<predicate>?` (and, for some types, deeper lazy
+    # lookups) once per row — an N+1 that takes seconds on large orgs.
+    #
+    # Mutates the passed-in transactions in place. No-op when `type` is blank.
+    class FilterTypePreloader
+      def initialize(settled_transactions:, type:)
+        @settled_transactions = settled_transactions
+        @type = type
+      end
+
+      def run!
+        return if @type.blank? || @settled_transactions.none?
+
+        preload_local_hcb_code!
+        preload_disbursements! if @type == "hcb_transfer"
+        preload_canonical_transactions! if @type == "card_charge"
+      end
+
+      private
+
+      def preload_local_hcb_code!
+        @hcb_codes_by_code = ::HcbCode.where(hcb_code: @settled_transactions.map(&:hcb_code)).index_by(&:hcb_code)
+        @settled_transactions.each { |t| t.local_hcb_code = @hcb_codes_by_code[t.hcb_code] }
+      end
+
+      # `hcb_transfer` reads `outgoing_disbursement` / `incoming_disbursement`,
+      # both of which are otherwise unmemoized `Disbursement.find_by` calls.
+      def preload_disbursements!
+        disbursement_hcb_codes = @hcb_codes_by_code.values.select { |hc| hc.outgoing_disbursement? || hc.incoming_disbursement? }
+        disbursements_by_id = ::Disbursement.where(id: disbursement_hcb_codes.map(&:hcb_i2)).index_by(&:id)
+        disbursement_hcb_codes.each do |hc|
+          disbursement = disbursements_by_id[hc.hcb_i2.to_i]
+          hc.outgoing_disbursement = disbursement&.outgoing_disbursement if hc.outgoing_disbursement?
+          hc.incoming_disbursement = disbursement&.incoming_disbursement if hc.incoming_disbursement?
+        end
+      end
+
+      # `card_charge` reads `t.raw_stripe_transaction`, which walks
+      # `ct -> transaction_source` — both lazy lookups per row.
+      def preload_canonical_transactions!
+        ct_ids = @settled_transactions.flat_map(&:canonical_transaction_ids)
+        cts_by_id = ::CanonicalTransaction.where(id: ct_ids).index_by(&:id)
+        stripe_source_ids = cts_by_id.values.select { |ct| ct.transaction_source_type == ::RawStripeTransaction.name }.map(&:transaction_source_id)
+        rsts_by_id = ::RawStripeTransaction.where(id: stripe_source_ids).index_by(&:id)
+        cts_by_id.each_value do |ct|
+          ct.raw_stripe_transaction = rsts_by_id[ct.transaction_source_id] if ct.transaction_source_type == ::RawStripeTransaction.name
+        end
+        @settled_transactions.each do |t|
+          t.canonical_transactions = t.canonical_transaction_ids.filter_map { |id| cts_by_id[id] }
+                                      .sort_by { |ct| [ct.date, ct.id] }.reverse
+        end
+      end
+
+    end
+  end
+end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -36,6 +36,76 @@ RSpec.describe HcbCode, type: :model do
       end
     end
 
+    describe "#outgoing_disbursement" do
+      it "returns nil for non-disbursement codes" do
+        hcb_code = HcbCode.find_or_create_by(hcb_code: "HCB-100-1")
+        expect(hcb_code.outgoing_disbursement).to be_nil
+      end
+
+      it "memoizes the result so repeated calls do not query" do
+        disbursement = create(:disbursement)
+        hcb_code = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+        hcb_code.outgoing_disbursement # populate
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        hcb_code.outgoing_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+
+      it "memoizes nil results too (so a missing disbursement doesn't re-query)" do
+        hcb_code = HcbCode.find_or_create_by(hcb_code: "HCB-500-0")
+        expect(hcb_code.outgoing_disbursement).to be_nil
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        hcb_code.outgoing_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+
+      it "honors the writer (used by FilterTypePreloader)" do
+        disbursement = create(:disbursement)
+        hcb_code = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+
+        sentinel = Object.new
+        hcb_code.outgoing_disbursement = sentinel
+        expect(hcb_code.outgoing_disbursement).to equal(sentinel)
+      end
+    end
+
+    describe "#incoming_disbursement" do
+      it "returns nil for non-disbursement codes" do
+        hcb_code = HcbCode.find_or_create_by(hcb_code: "HCB-100-1")
+        expect(hcb_code.incoming_disbursement).to be_nil
+      end
+
+      it "memoizes the result so repeated calls do not query" do
+        disbursement = create(:disbursement)
+        hcb_code = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+        hcb_code.incoming_disbursement # populate
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        hcb_code.incoming_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+
+      it "memoizes nil results too" do
+        hcb_code = HcbCode.find_or_create_by(hcb_code: "HCB-550-0")
+        expect(hcb_code.incoming_disbursement).to be_nil
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        hcb_code.incoming_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+
+      it "honors the writer (used by FilterTypePreloader)" do
+        disbursement = create(:disbursement)
+        hcb_code = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+
+        sentinel = Object.new
+        hcb_code.incoming_disbursement = sentinel
+        expect(hcb_code.incoming_disbursement).to equal(sentinel)
+      end
+    end
+
     # The goal is to deprecate this method entirely with the disbursement splitting work
     describe "#events" do
       context "with a disbursement that has canonical pending transactions" do

--- a/spec/services/transaction_grouping_engine/transaction/filter_type_preloader_spec.rb
+++ b/spec/services/transaction_grouping_engine/transaction/filter_type_preloader_spec.rb
@@ -157,5 +157,150 @@ RSpec.describe TransactionGroupingEngine::Transaction::FilterTypePreloader do
         expect(RawStripeTransaction).not_to have_received(:find)
       end
     end
+
+    # Accuracy / data-integrity guarantees: the preloader must attach the
+    # *exact same* records the lazy path would have loaded — anything else
+    # could surface as a financial data leak.
+    describe "preload accuracy" do
+      it "attaches the same local_hcb_code (by id) the lazy path would load" do
+        3.times { create(:canonical_event_mapping, event:, canonical_transaction: create(:canonical_transaction)) }
+
+        baseline = settled_for(event)
+        baseline_ids_by_code = baseline.to_h { |t| [t.hcb_code, t.local_hcb_code.id] }
+
+        preloaded = settled_for(event)
+        described_class.new(settled_transactions: preloaded, type: "ach_transfer").run!
+
+        preloaded.each do |t|
+          local = t.instance_variable_get(:@local_hcb_code)
+          expect(local.id).to eq(baseline_ids_by_code.fetch(t.hcb_code))
+          expect(local.hcb_code).to eq(t.hcb_code)
+        end
+      end
+
+      context "with type: 'hcb_transfer'" do
+        it "attaches the same Disbursement (by id) the lazy path would load" do
+          # one outgoing + one incoming row to exercise both writers
+          outgoing_disb = create(:disbursement, source_event: event, event: create(:event))
+          incoming_disb = create(:disbursement, source_event: create(:event), event: event)
+          make_disbursement_settled_tx(event, outgoing_disb,
+                                       hcb_code: outgoing_disb.outgoing_hcb_code,
+                                       amount_cents: -outgoing_disb.amount)
+          make_disbursement_settled_tx(event, incoming_disb,
+                                       hcb_code: incoming_disb.incoming_hcb_code,
+                                       amount_cents: incoming_disb.amount)
+
+          baseline = settled_for(event)
+          baseline_disb_ids = baseline.to_h do |t|
+            local = t.local_hcb_code
+            disb_id =
+              if local.outgoing_disbursement?
+                local.outgoing_disbursement&.disbursement&.id
+              elsif local.incoming_disbursement?
+                local.incoming_disbursement&.disbursement&.id
+              end
+            [t.hcb_code, disb_id]
+          end
+
+          preloaded = settled_for(event)
+          described_class.new(settled_transactions: preloaded, type: "hcb_transfer").run!
+
+          preloaded.each do |t|
+            local = t.instance_variable_get(:@local_hcb_code)
+            attached =
+              if local.outgoing_disbursement?
+                local.outgoing_disbursement&.disbursement&.id
+              elsif local.incoming_disbursement?
+                local.incoming_disbursement&.disbursement&.id
+              end
+            expect(attached).to eq(baseline_disb_ids.fetch(t.hcb_code))
+          end
+        end
+
+        it "never assigns outgoing_disbursement onto an incoming HcbCode (or vice versa)" do
+          outgoing_disb = create(:disbursement, source_event: event, event: create(:event))
+          incoming_disb = create(:disbursement, source_event: create(:event), event: event)
+          make_disbursement_settled_tx(event, outgoing_disb,
+                                       hcb_code: outgoing_disb.outgoing_hcb_code,
+                                       amount_cents: -outgoing_disb.amount)
+          make_disbursement_settled_tx(event, incoming_disb,
+                                       hcb_code: incoming_disb.incoming_hcb_code,
+                                       amount_cents: incoming_disb.amount)
+
+          settled = settled_for(event)
+          described_class.new(settled_transactions: settled, type: "hcb_transfer").run!
+
+          settled.each do |t|
+            local = t.instance_variable_get(:@local_hcb_code)
+            outgoing_iv = local.instance_variable_defined?(:@outgoing_disbursement) ? local.instance_variable_get(:@outgoing_disbursement) : :unset
+            incoming_iv = local.instance_variable_defined?(:@incoming_disbursement) ? local.instance_variable_get(:@incoming_disbursement) : :unset
+
+            if local.outgoing_disbursement?
+              expect(outgoing_iv).not_to eq(:unset), "outgoing HcbCode should have outgoing_disbursement preloaded"
+              expect(incoming_iv).to eq(:unset), "outgoing HcbCode must NOT have incoming_disbursement assigned"
+            elsif local.incoming_disbursement?
+              expect(incoming_iv).not_to eq(:unset), "incoming HcbCode should have incoming_disbursement preloaded"
+              expect(outgoing_iv).to eq(:unset), "incoming HcbCode must NOT have outgoing_disbursement assigned"
+            end
+          end
+        end
+      end
+
+      context "with type: 'card_charge'" do
+        it "attaches the same canonical_transactions and raw_stripe_transactions (by id) the lazy path would load" do
+          rst1 = create(:raw_stripe_transaction)
+          rst2 = create(:raw_stripe_transaction)
+          ct1 = create(:canonical_transaction, transaction_source: rst1)
+          ct2 = create(:canonical_transaction, transaction_source: rst2)
+          create(:canonical_event_mapping, event:, canonical_transaction: ct1)
+          create(:canonical_event_mapping, event:, canonical_transaction: ct2)
+
+          baseline_settled = settled_for(event)
+          baseline_by_hcb_code = baseline_settled.to_h do |t|
+            [t.hcb_code, {
+              ct_ids: t.canonical_transactions.map(&:id).sort,
+              rst_id: t.canonical_transactions.first.raw_stripe_transaction&.id,
+            }]
+          end
+
+          preloaded = settled_for(event)
+          described_class.new(settled_transactions: preloaded, type: "card_charge").run!
+
+          preloaded.each do |t|
+            attached_ct_ids = t.canonical_transactions.map(&:id).sort
+            attached_rst_id = t.canonical_transactions.first.raw_stripe_transaction&.id
+            expected = baseline_by_hcb_code.fetch(t.hcb_code)
+            expect(attached_ct_ids).to eq(expected[:ct_ids])
+            expect(attached_rst_id).to eq(expected[:rst_id])
+          end
+        end
+      end
+
+      it "never attaches another event's HcbCode to a settled row" do
+        # Two events with disbursement-flavored rows of similar shape.
+        other_event = create(:event)
+        disb_a = create(:disbursement, source_event: event, event: create(:event))
+        disb_b = create(:disbursement, source_event: other_event, event: create(:event))
+        make_disbursement_settled_tx(event, disb_a,
+                                     hcb_code: disb_a.outgoing_hcb_code,
+                                     amount_cents: -disb_a.amount)
+        make_disbursement_settled_tx(other_event, disb_b,
+                                     hcb_code: disb_b.outgoing_hcb_code,
+                                     amount_cents: -disb_b.amount)
+
+        settled = settled_for(event)
+        # Sanity: the engine itself only returned event A's rows.
+        expect(settled.map(&:hcb_code)).to contain_exactly(disb_a.outgoing_hcb_code)
+
+        described_class.new(settled_transactions: settled, type: "hcb_transfer").run!
+
+        settled.each do |t|
+          local = t.instance_variable_get(:@local_hcb_code)
+          # The HcbCode for disb_b must never be attached to a row from event A.
+          expect(local.hcb_code).not_to eq(disb_b.outgoing_hcb_code)
+          expect(local.hcb_code).to eq(t.hcb_code)
+        end
+      end
+    end
   end
 end

--- a/spec/services/transaction_grouping_engine/transaction/filter_type_preloader_spec.rb
+++ b/spec/services/transaction_grouping_engine/transaction/filter_type_preloader_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransactionGroupingEngine::Transaction::FilterTypePreloader do
+  let(:event) { create(:event) }
+
+  def settled_for(event)
+    TransactionGroupingEngine::Transaction::All.new(event_id: event.id).run
+  end
+
+  def hcb_code_query_count(&block)
+    count = 0
+    callback = ->(*, payload) { count += 1 if payload[:sql].include?(%("hcb_codes")) }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    count
+  end
+
+  describe "#run!" do
+    context "when type is blank" do
+      it "is a no-op (does not assign local_hcb_code)" do
+        create(:canonical_event_mapping, event:, canonical_transaction: create(:canonical_transaction))
+        settled = settled_for(event)
+
+        described_class.new(settled_transactions: settled, type: nil).run!
+
+        expect(settled.first.instance_variable_get(:@local_hcb_code)).to be_nil
+      end
+    end
+
+    context "when settled_transactions is empty" do
+      it "does not raise" do
+        expect {
+          described_class.new(settled_transactions: [], type: "card_charge").run!
+        }.not_to raise_error
+      end
+    end
+
+    it "assigns local_hcb_code on every row" do
+      2.times { create(:canonical_event_mapping, event:, canonical_transaction: create(:canonical_transaction)) }
+      settled = settled_for(event)
+
+      described_class.new(settled_transactions: settled, type: "ach_transfer").run!
+
+      settled.each do |t|
+        local = t.instance_variable_get(:@local_hcb_code)
+        expect(local).to be_a(HcbCode)
+        expect(local.hcb_code).to eq(t.hcb_code)
+      end
+    end
+
+    it "loads hcb_codes in a single query regardless of row count" do
+      4.times { create(:canonical_event_mapping, event:, canonical_transaction: create(:canonical_transaction)) }
+      settled = settled_for(event)
+
+      count = hcb_code_query_count do
+        described_class.new(settled_transactions: settled, type: "ach_transfer").run!
+      end
+
+      expect(count).to eq(1)
+    end
+
+    # `CanonicalTransaction#after_create :write_hcb_code` and
+    # `CanonicalEventMapping#after_create` (which calls write_hcb_code on the
+    # mapping's CT) both recompute hcb_code from the row's source, so passing
+    # `hcb_code:` to the factory doesn't stick. Use `update_column` after both
+    # are created and ensure the matching HcbCode row exists.
+    def make_disbursement_settled_tx(event, disbursement, hcb_code:, amount_cents:)
+      ct = create(:canonical_transaction, amount_cents:)
+      create(:canonical_event_mapping, event:, canonical_transaction: ct)
+      ct.update_column(:hcb_code, hcb_code)
+      HcbCode.find_or_create_by(hcb_code:)
+      ct
+    end
+
+    %w[card_charge hcb_transfer ach_transfer donation invoice].each do |type|
+      it "produces the same filter result as without preload (type=#{type})" do
+        # Mix of plain CTs and a disbursement-flavored row, to exercise the
+        # different code paths.
+        4.times { create(:canonical_event_mapping, event:, canonical_transaction: create(:canonical_transaction)) }
+
+        disbursement = create(:disbursement, source_event: event, event: create(:event))
+        make_disbursement_settled_tx(event, disbursement,
+                                     hcb_code: disbursement.outgoing_hcb_code,
+                                     amount_cents: -disbursement.amount)
+
+        baseline = ::EventsController.filter_transaction_type(
+          type,
+          settled_transactions: settled_for(event),
+          pending_transactions: []
+        )[:settled_transactions].map(&:hcb_code).sort
+
+        preloaded_settled = settled_for(event)
+        described_class.new(settled_transactions: preloaded_settled, type:).run!
+        preloaded = ::EventsController.filter_transaction_type(
+          type,
+          settled_transactions: preloaded_settled,
+          pending_transactions: []
+        )[:settled_transactions].map(&:hcb_code).sort
+
+        expect(preloaded).to eq(baseline)
+      end
+    end
+
+    context "with type: 'hcb_transfer'" do
+      it "preloads outgoing_disbursement so subsequent reads do not query" do
+        disbursement = create(:disbursement, source_event: event, event: create(:event))
+        make_disbursement_settled_tx(event, disbursement,
+                                     hcb_code: disbursement.outgoing_hcb_code,
+                                     amount_cents: -disbursement.amount)
+
+        settled = settled_for(event)
+        described_class.new(settled_transactions: settled, type: "hcb_transfer").run!
+
+        local = settled.first.instance_variable_get(:@local_hcb_code)
+        expect(local.outgoing_disbursement?).to be true
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        local.outgoing_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+
+      it "preloads incoming_disbursement so subsequent reads do not query" do
+        disbursement = create(:disbursement, source_event: create(:event), event: event)
+        make_disbursement_settled_tx(event, disbursement,
+                                     hcb_code: disbursement.incoming_hcb_code,
+                                     amount_cents: disbursement.amount)
+
+        settled = settled_for(event)
+        described_class.new(settled_transactions: settled, type: "hcb_transfer").run!
+
+        local = settled.first.instance_variable_get(:@local_hcb_code)
+        expect(local.incoming_disbursement?).to be true
+
+        allow(Disbursement).to receive(:find_by).and_call_original
+        local.incoming_disbursement
+        expect(Disbursement).not_to have_received(:find_by)
+      end
+    end
+
+    context "with type: 'card_charge'" do
+      it "preloads canonical_transactions and their raw_stripe_transaction" do
+        rst = create(:raw_stripe_transaction)
+        ct = create(:canonical_transaction, transaction_source: rst)
+        create(:canonical_event_mapping, event:, canonical_transaction: ct)
+
+        settled = settled_for(event)
+        described_class.new(settled_transactions: settled, type: "card_charge").run!
+
+        cts = settled.first.canonical_transactions
+        expect(cts.map(&:id)).to eq([ct.id])
+
+        # The writer should have set @raw_stripe_transaction directly, so
+        # accessing it doesn't go back to the DB.
+        allow(RawStripeTransaction).to receive(:find).and_call_original
+        expect(cts.first.raw_stripe_transaction.id).to eq(rst.id)
+        expect(RawStripeTransaction).not_to have_received(:find)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> heavily done by Claude

## Summary

The `?type=` filter on the v4 `/api/v4/organizations/:id/transactions` endpoint and on the web `EventsController#ledger` action was an unguarded N+1 against the *full* settled-transaction set for the org. For large orgs (Hack Club HQ, Reimbursement Clearinghouse, etc.) this was tens of seconds per request and was hitting the upstream router timeout — that's the slowness reported on the API by `grant-gun`. `EventsController.filter_transaction_type` evaluates a lambda per settled row that walks `t.local_hcb_code.<predicate>?` (and, for some types, `outgoing_disbursement` / `raw_stripe_transaction`). None of those were preloaded, so each row triggered 1–3 sequential `find_by`s.

## What changed

A new `TransactionGroupingEngine::Transaction::FilterTypePreloader` service preloads exactly what `filter_transaction_type` reads, in a small fixed number of queries, then mutates the `CanonicalTransactionGrouped` / `HcbCode` objects in place so the existing lambdas see preloaded data. Both controllers call it right before `filter_transaction_type`.

Three preload passes inside the service:
- `local_hcb_code` for every row (helps every type).
- `Disbursement` for every disbursement row (only when
  `type=hcb_transfer`). Required adding `attr_writer` +
  memoization to `HcbCode#outgoing_disbursement` and
  `HcbCode#incoming_disbursement` so the preloaded value sticks.
- `CanonicalTransaction` + their `RawStripeTransaction` source (only
  when `type=card_charge`).

No public API change. No view template changes. The render path is untouched — this only affects the work that happens *before* pagination / association-preloading for the page.

## Original report: YSWS - Blueprint (Event 8762)

The bug report came from the `grant-gun` consumer timing out against [YSWS - Blueprint](https://hcb.hackclub.com/ysws-blueprint) — 8,293 settled mappings, ~1,700 card grants. Small enough that one-off requests *almost* fit inside the upstream timeout, large enough that the consumer's full-walk pagination reliably blew through it. Numbers below are from the same data-layer benchmark used for the broader table further down (engine + preloader + filter + first-page `AssociationPreloader`).

| Type | API: before → after (×) | Ledger: before → after (×) | Filtered |
|---|---|---|---:|
| `card_charge` | 7,803 → **883 ms** (8.8×) | 7,477 → **881 ms** (8.5×) | 406 |
| `hcb_transfer` | 11,524 → **1,068 ms** (10.8×) | 12,983 → **1,098 ms** (11.8×) | 83 |
| `ach_transfer` | 6,486 → **813 ms** (8.0×) | 6,717 → **757 ms** (8.9×) | 3 |
| `donation` | 7,094 → **835 ms** (8.5×) | 6,700 → **809 ms** (8.3×) | 51 |
| `invoice` | 5,332 → **774 ms** (6.9×) | 4,923 → **732 ms** (6.7×) | 0 |

## Performance

Benchmarked against 8 production-shape orgs (5 deliberately picked across a range of sizes, 3 randomly sampled from orgs with >500 canonical event mappings). Ran the full data-layer flow (engine + preloader + filter + first-page `AssociationPreloader`) for each of the 5 type filters, against both controllers. 40 (event × type) cases per controller, 80 measurements total.

| Event | Settled mappings | Type | API: before → after (×) | Ledger: before → after (×) | Filtered |
|---|---:|---|---|---|---:|
| 183 Hack Club HQ | 21,661 | card_charge | 76,056 → **2,657 ms** (28.6×) | 69,396 → **2,757 ms** (25.2×) | 9,811 |
| 183 Hack Club HQ | 21,661 | hcb_transfer | 57,896 → **1,939 ms** (29.9×) | 56,405 → **1,997 ms** (28.2×) | 2,861 |
| 183 Hack Club HQ | 21,661 | ach_transfer | 53,416 → **1,717 ms** (31.1×) | 53,604 → **1,822 ms** (29.4×) | 865 |
| 183 Hack Club HQ | 21,661 | donation | 56,428 → **1,961 ms** (28.8×) | 54,939 → **1,858 ms** (29.6×) | 1,004 |
| 183 Hack Club HQ | 21,661 | invoice | 53,348 → **1,845 ms** (28.9×) | 50,511 → **1,758 ms** (28.7×) | 150 |
| 999 [redacted] | 10,274 | card_charge | 23,967 → **1,099 ms** (21.8×) | 26,625 → **1,114 ms** (23.9×) | 0 |
| 999 [redacted] | 10,274 | hcb_transfer | 28,860 → **1,009 ms** (28.6×) | 29,071 → **895 ms** (32.5×) | 0 |
| 999 [redacted] | 10,274 | ach_transfer | 13,514 → **1,048 ms** (12.9×) | 16,712 → **892 ms** (18.7×) | 0 |
| 999 [redacted] | 10,274 | donation | 12,307 → **978 ms** (12.6×) | 12,896 → **897 ms** (14.4×) | 0 |
| 999 [redacted] | 10,274 | invoice | 18,411 → **880 ms** (20.9×) | 18,248 → **927 ms** (19.7×) | 0 |
| 4318 [redacted] | 26,916 | card_charge | 57,480 → **2,659 ms** (21.6×) | 48,921 → **2,679 ms** (18.3×) | 0 |
| 4318 [redacted] | 26,916 | hcb_transfer | 53,309 → **2,208 ms** (24.1×) | 90,309 → **2,067 ms** (43.7×) | 15 |
| 4318 [redacted] | 26,916 | ach_transfer | 80,222 → **2,107 ms** (38.1×) | 59,450 → **2,132 ms** (27.9×) | 12,073 |
| 4318 [redacted] | 26,916 | donation | 29,787 → **2,043 ms** (14.6×) | 50,926 → **2,295 ms** (22.2×) | 1 |
| 4318 [redacted] | 26,916 | invoice | 28,996 → **2,106 ms** (13.8×) | 35,718 → **1,856 ms** (19.2×) | 0 |
| 689 [redacted] | 3,381 | card_charge | 4,074 → **739 ms** (5.5×) | 3,988 → **704 ms** (5.7×) | 0 |
| 689 [redacted] | 3,381 | hcb_transfer | 7,747 → **799 ms** (9.7×) | 7,828 → **784 ms** (10.0×) | 2,803 |
| 689 [redacted] | 3,381 | ach_transfer | 4,059 → **696 ms** (5.8×) | 4,577 → **672 ms** (6.8×) | 2 |
| 689 [redacted] | 3,381 | donation | 4,257 → **663 ms** (6.4×) | 4,627 → **644 ms** (7.2×) | 0 |
| 689 [redacted] | 3,381 | invoice | 4,538 → **639 ms** (7.1×) | 4,820 → **745 ms** (6.5×) | 0 |
| 3349 [redacted] | 1,015 | card_charge | 1,317 → **542 ms** (2.4×) | 1,277 → **520 ms** (2.5×) | 0 |
| 3349 [redacted] | 1,015 | hcb_transfer | 2,824 → **582 ms** (4.9×) | 2,972 → **623 ms** (4.8×) | 997 |
| 3349 [redacted] | 1,015 | ach_transfer | 1,515 → **516 ms** (2.9×) | 1,383 → **526 ms** (2.6×) | 0 |
| 3349 [redacted] | 1,015 | donation | 1,691 → **520 ms** (3.3×) | 1,406 → **532 ms** (2.6×) | 0 |
| 3349 [redacted] | 1,015 | invoice | 1,479 → **548 ms** (2.7×) | 1,477 → **526 ms** (2.8×) | 0 |
| 8223 Jumpstart | 621 | card_charge | 379 → **197 ms** (1.9×) | 402 → **188 ms** (2.1×) | 5 |
| 8223 Jumpstart | 621 | hcb_transfer | 684 → **226 ms** (3.0×) | 587 → **199 ms** (2.9×) | 9 |
| 8223 Jumpstart | 621 | ach_transfer | 305 → **157 ms** (1.9×) | 375 → **163 ms** (2.3×) | 0 |
| 8223 Jumpstart | 621 | donation | 371 → **182 ms** (2.0×) | 427 → **182 ms** (2.3×) | 28 |
| 8223 Jumpstart | 621 | invoice | 358 → **162 ms** (2.2×) | 376 → **162 ms** (2.3×) | 0 |
| 4460 [redacted] | 1,023 | card_charge | 1,266 → **548 ms** (2.3×) | 1,165 → **540 ms** (2.2×) | 6 |
| 4460 [redacted] | 1,023 | hcb_transfer | 1,136 → **483 ms** (2.4×) | 1,369 → **508 ms** (2.7×) | 0 |
| 4460 [redacted] | 1,023 | ach_transfer | 1,258 → **485 ms** (2.6×) | 1,133 → **518 ms** (2.2×) | 0 |
| 4460 [redacted] | 1,023 | donation | 1,199 → **552 ms** (2.2×) | 1,395 → **534 ms** (2.6×) | 684 |
| 4460 [redacted] | 1,023 | invoice | 1,209 → **528 ms** (2.3×) | 1,175 → **538 ms** (2.2×) | 0 |
| 7954 Athena Initiative | 2,226 | card_charge | 2,329 → **647 ms** (3.6×) | 2,211 → **634 ms** (3.5×) | 418 |
| 7954 Athena Initiative | 2,226 | hcb_transfer | 2,512 → **601 ms** (4.2×) | 2,327 → **595 ms** (3.9×) | 16 |
| 7954 Athena Initiative | 2,226 | ach_transfer | 1,672 → **583 ms** (2.9×) | 1,752 → **576 ms** (3.0×) | 2 |
| 7954 Athena Initiative | 2,226 | donation | 1,599 → **570 ms** (2.8×) | 1,666 → **572 ms** (2.9×) | 11 |
| 7954 Athena Initiative | 2,226 | invoice | 1,753 → **556 ms** (3.2×) | 1,681 → **572 ms** (2.9×) | 0 |

Headline wins (production-shape data, dev DB):
- HCB Reimbursement Clearinghouse, `type=ach_transfer`: **80 s → 2.1 s** (38×)
- Hack Club HQ, `type=ach_transfer`: **53 s → 1.7 s** (31×)
- Hack Club HQ, `type=card_charge`: **76 s → 2.7 s** (28×)

Speedup scales with org size. Tiny orgs see ~2×; 20k+ mapping orgs see 25–40×. The remaining floor (~600 ms small orgs, ~2 s on 20k+ orgs) is the engine query plus per-page `AssociationPreloader` — work this PR doesn't touch.

The unfiltered path (no `?type=`) is unchanged within noise (YSWS - Blueprint 8762: 693 → 682 ms; the preloader early-returns when `type` is blank).

## Regression testing

For each of the 40 (event × type) combinations on each controller, the benchmark script compared the *filtered output* with and without the preloader (sorted hcb_codes for both settled and pending). All **80 cases match exactly** — no behavioural change, just no N+1.

No regressions detected. All 40 (event, type) cases produce identical filtered output. Same comparison was also run on the original Event 8762 report across all 5 type filters before each of the four commits was made.

Specs cover `FilterTypePreloader` directly (no-op when type is blank, single-query `local_hcb_code` preload, identical filter result vs. unpreloaded baseline for each of the 5 types, and the `hcb_transfer` / `card_charge` deep preloads), plus the new `HcbCode#outgoing_disbursement` / `#incoming_disbursement` memoization + writer.

## Test plan
- [ ] CI green
- [ ] Spot-check one large org from the table on staging with the
      `?type=card_charge` and `?type=hcb_transfer` filters
- [ ] Confirm the web ledger renders correctly with each `?type=` for
      one large org and one small org
