### PR TITLE
[Card Locking] Fix duplicate warning notification bug

### DIFF
--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -13,19 +13,23 @@ module UserService
       future_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE).count
 
       if current_count.in?([5, 7, 9])
-        CardLockingMailer.warning(user: @user).deliver_later
+        if Rails.cache.write("card_locking_warning:#{@user.id}:#{current_count}", true, expires_in: 24.hours, unless_exist: true)
+          CardLockingMailer.warning(user: @user).deliver_later
 
-        if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You now have #{current_count} transactions missing receipts from more than a day ago. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          if @user.phone_number.present? && @user.phone_number_verified?
+            message = "You now have #{current_count} transactions missing receipts from more than a day ago. If you have ten or more missing receipts, your cards will be locked. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
-          TwilioMessageService::Send.new(@user, message).run!
+            TwilioMessageService::Send.new(@user, message).run!
+          end
         end
 
       elsif future_count >= 10
         if @user.phone_number.present? && @user.phone_number_verified?
-          message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+          if Rails.cache.write("card_locking_pre_lock_sms:#{@user.id}", true, expires_in: 24.hours, unless_exist: true)
+            message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
-          TwilioMessageService::Send.new(@user, message).run!
+            TwilioMessageService::Send.new(@user, message).run!
+          end
         end
       end
     end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -13,7 +13,7 @@ module UserService
       future_count = @user.transactions_missing_receipt(from: Receipt::CARD_LOCKING_START_DATE).count
 
       if current_count.in?([5, 7, 9])
-        if Rails.cache.write("card_locking_warning:#{@user.id}:#{current_count}", true, expires_in: 24.hours, unless_exist: true)
+        if Rails.cache.write("card_locking_warning:#{@user.id}:#{current_count}", true, expires_in: 25.hours, unless_exist: true)
           CardLockingMailer.warning(user: @user).deliver_later
 
           if @user.phone_number.present? && @user.phone_number_verified?
@@ -25,7 +25,7 @@ module UserService
 
       elsif future_count >= 10
         if @user.phone_number.present? && @user.phone_number_verified?
-          if Rails.cache.write("card_locking_pre_lock_sms:#{@user.id}", true, expires_in: 24.hours, unless_exist: true)
+          if Rails.cache.write("card_locking_pre_lock_sms:#{@user.id}", true, expires_in: 25.hours, unless_exist: true)
             message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
             TwilioMessageService::Send.new(@user, message).run!

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -24,12 +24,10 @@ module UserService
         end
 
       elsif future_count >= 10
-        if @user.phone_number.present? && @user.phone_number_verified?
-          if Rails.cache.write("card_locking_pre_lock_sms:#{@user.id}", true, expires_in: 25.hours, unless_exist: true)
-            message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
+        if @user.phone_number.present? && @user.phone_number_verified? && Rails.cache.write("card_locking_pre_lock_sms:#{@user.id}", true, expires_in: 25.hours, unless_exist: true)
+          message = "You have ten or more transactions missing receipts. In the next twenty-four hours, your cards will be locked unless receipts are uploaded for these transactions. You can manage your receipts at #{Rails.application.routes.url_helpers.my_inbox_url}."
 
-            TwilioMessageService::Send.new(@user, message).run!
-          end
+          TwilioMessageService::Send.new(@user, message).run!
         end
       end
     end

--- a/spec/services/user_service/send_card_locking_notification_spec.rb
+++ b/spec/services/user_service/send_card_locking_notification_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserService::SendCardLockingNotification, type: :service do
+  let(:user) { create(:user) }
+  let(:service) { described_class.new(user:) }
+
+  around do |example|
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rails.cache = original
+  end
+
+  before do
+    Flipper.enable(:card_locking_2025_06_09, user)
+  end
+
+  def stub_counts(current:, future: current)
+    allow(user).to receive(:transactions_missing_receipt)
+      .with(from: Receipt::CARD_LOCKING_START_DATE, to: kind_of(ActiveSupport::TimeWithZone))
+      .and_return(double("Relation", count: current))
+    allow(user).to receive(:transactions_missing_receipt)
+      .with(from: Receipt::CARD_LOCKING_START_DATE)
+      .and_return(double("Relation", count: future))
+  end
+
+  describe "warning email dedup" do
+    it "enqueues a warning email the first time count hits 5" do
+      stub_counts(current: 5)
+
+      expect { service.run }.to have_enqueued_mail(CardLockingMailer, :warning).once
+    end
+
+    it "does not re-enqueue if count is still 5 on a subsequent run" do
+      stub_counts(current: 5)
+      service.run
+
+      expect { service.run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
+    end
+
+    it "sends a fresh email when count advances from 5 to 7" do
+      stub_counts(current: 5)
+      service.run
+
+      stub_counts(current: 7)
+      expect { service.run }.to have_enqueued_mail(CardLockingMailer, :warning).once
+    end
+
+    it "sends at each of 5, 7, and 9 exactly once even with repeat runs between" do
+      stub_counts(current: 5)
+      expect { 3.times { service.run } }.to have_enqueued_mail(CardLockingMailer, :warning).once
+
+      stub_counts(current: 7)
+      expect { 3.times { service.run } }.to have_enqueued_mail(CardLockingMailer, :warning).once
+
+      stub_counts(current: 9)
+      expect { 3.times { service.run } }.to have_enqueued_mail(CardLockingMailer, :warning).once
+    end
+
+    it "does not notify at off-threshold counts (6, 8)" do
+      stub_counts(current: 6)
+      expect { service.run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
+
+      stub_counts(current: 8)
+      expect { service.run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
+    end
+
+    it "re-notifies at the same count after the 24h cache window elapses" do
+      stub_counts(current: 5)
+      service.run
+
+      travel_to(25.hours.from_now) do
+        expect { service.run }.to have_enqueued_mail(CardLockingMailer, :warning).once
+      end
+    end
+
+    it "dedupes per-user" do
+      other_user = create(:user)
+      Flipper.enable(:card_locking_2025_06_09, other_user)
+
+      stub_counts(current: 5)
+      service.run
+
+      allow(other_user).to receive(:transactions_missing_receipt)
+        .with(from: Receipt::CARD_LOCKING_START_DATE, to: kind_of(ActiveSupport::TimeWithZone))
+        .and_return(double("Relation", count: 5))
+      allow(other_user).to receive(:transactions_missing_receipt)
+        .with(from: Receipt::CARD_LOCKING_START_DATE)
+        .and_return(double("Relation", count: 5))
+
+      expect {
+        described_class.new(user: other_user).run
+      }.to have_enqueued_mail(CardLockingMailer, :warning).once
+    end
+  end
+
+  describe "warning SMS dedup" do
+    let(:twilio_send) { instance_double(TwilioMessageService::Send, run!: true) }
+
+    before do
+      allow(user).to receive(:phone_number).and_return("+15555555555")
+      allow(user).to receive(:phone_number_verified?).and_return(true)
+      allow(TwilioMessageService::Send).to receive(:new).and_return(twilio_send)
+    end
+
+    it "sends the warning SMS once per threshold and no more" do
+      stub_counts(current: 5)
+      service.run
+      service.run
+
+      expect(TwilioMessageService::Send).to have_received(:new).once
+      expect(twilio_send).to have_received(:run!).once
+    end
+  end
+
+  describe "pre-lock SMS dedup" do
+    let(:twilio_send) { instance_double(TwilioMessageService::Send, run!: true) }
+
+    before do
+      allow(user).to receive(:phone_number).and_return("+15555555555")
+      allow(user).to receive(:phone_number_verified?).and_return(true)
+      allow(TwilioMessageService::Send).to receive(:new).and_return(twilio_send)
+    end
+
+    it "sends the pre-lock SMS once while future_count is >= 10 and current_count is not a warning threshold" do
+      stub_counts(current: 3, future: 11)
+
+      service.run
+      service.run
+      service.run
+
+      expect(twilio_send).to have_received(:run!).once
+    end
+
+    it "re-sends after 24h" do
+      stub_counts(current: 3, future: 11)
+      service.run
+
+      travel_to(25.hours.from_now) do
+        service.run
+      end
+
+      expect(twilio_send).to have_received(:run!).twice
+    end
+
+    it "does not send when phone is unverified" do
+      allow(user).to receive(:phone_number_verified?).and_return(false)
+      stub_counts(current: 3, future: 11)
+
+      service.run
+
+      expect(TwilioMessageService::Send).not_to have_received(:new)
+    end
+  end
+
+  describe "feature flag" do
+    it "is a no-op when the flag is disabled for the user" do
+      Flipper.disable(:card_locking_2025_06_09, user)
+      stub_counts(current: 5)
+
+      expect { service.run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
+    end
+  end
+end

--- a/spec/services/user_service/send_card_locking_notification_spec.rb
+++ b/spec/services/user_service/send_card_locking_notification_spec.rb
@@ -68,11 +68,11 @@ RSpec.describe UserService::SendCardLockingNotification, type: :service do
       expect { service.run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
     end
 
-    it "re-notifies at the same count after the 24h cache window elapses" do
+    it "re-notifies at the same count after the 25h cache window elapses" do
       stub_counts(current: 5)
       service.run
 
-      travel_to(25.hours.from_now) do
+      travel_to(26.hours.from_now) do
         expect { service.run }.to have_enqueued_mail(CardLockingMailer, :warning).once
       end
     end
@@ -135,11 +135,11 @@ RSpec.describe UserService::SendCardLockingNotification, type: :service do
       expect(twilio_send).to have_received(:run!).once
     end
 
-    it "re-sends after 24h" do
+    it "re-sends after 25h" do
       stub_counts(current: 3, future: 11)
       service.run
 
-      travel_to(25.hours.from_now) do
+      travel_to(26.hours.from_now) do
         service.run
       end
 


### PR DESCRIPTION
## Summary of the problem

Within the card locking feature, we queue multiple jobs (when an authentication hits, and 24 hrs afterwards) to check whether a user is in compliance and to send warning emails.

There exists a bug that Zach ran into, where duplicate warning notifications are sent. This happens when multiple `UserService::SendCardLockingNotification` jobs run during the period the user has exactly 5, 7, or 9 missing receipts (our warning intervals).

## Describe your changes

As a minimalistic fix, I'm just using `Rails.cache` to dedup these warning notifications. I'm planning to completely overhaul this system soon, so there's no point in sinking more time into this old system.

https://github.com/hackclub/hcb/issues/13194

Cons of this implementation: For each warning notification interval (5, 7, and 9 missing receipts), you'll receive an email max once every 24 hr. This means, if in the span of 24 hrs, you go above X missing receipts (e.g. 9), get notified, go below X, and cross back over X again, you'll only be notified once when you really should be notified twice.