### PR TITLE
[Command Bar] Improve navigation for events

### DIFF
--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -111,7 +111,7 @@ function EmptyState() {
   )
 }
 
-function SearchAndResults({ current_event_slug }) {
+function SearchAndResults() {
   const [actions, setActions] = useState([])
   const { search, searching, searched, searchedFor, currentRootActionId } =
     useKBar(state => {

--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -46,7 +46,7 @@ export default function CommandBar({
           <KBarPositioner
             style={{ zIndex: 1000, backgroundColor: 'var(--kbar-dim)' }}
           >
-            <SearchAndResults current_event_slug={current_event_slug} />
+            <SearchAndResults />
           </KBarPositioner>
         </KBarPortal>
       </KBarProvider>

--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types:0 */
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import {
   KBarProvider,
   KBarPortal,
@@ -22,6 +22,7 @@ export default function CommandBar({
   admin_override_pretend = false,
   adminUrls = {},
   has_followed_events = false,
+  current_event_slug = null,
 }) {
   return (
     <div style={{ position: 'relative', zIndex: '100000000' }}>
@@ -40,16 +41,37 @@ export default function CommandBar({
         }}
       >
         <ButtonTrigger />
+        <EventRootSetter current_event_slug={current_event_slug} />
         <KBarPortal>
           <KBarPositioner
             style={{ zIndex: 1000, backgroundColor: 'var(--kbar-dim)' }}
           >
-            <SearchAndResults />
+            <SearchAndResults current_event_slug={current_event_slug} />
           </KBarPositioner>
         </KBarPortal>
       </KBarProvider>
     </div>
   )
+}
+
+function EventRootSetter({ current_event_slug }) {
+  const { query, visualState } = useKBar(state => ({
+    visualState: state.visualState,
+  }))
+  const prevVisualState = useRef(null)
+
+  useEffect(() => {
+    if (
+      current_event_slug &&
+      visualState !== 'hidden' &&
+      prevVisualState.current === 'hidden'
+    ) {
+      query.setCurrentRootAction(current_event_slug)
+    }
+    prevVisualState.current = visualState
+  }, [visualState, current_event_slug, query])
+
+  return null
 }
 
 const ButtonTrigger = () => {
@@ -89,9 +111,9 @@ function EmptyState() {
   )
 }
 
-function SearchAndResults() {
+function SearchAndResults({ current_event_slug }) {
   const [actions, setActions] = useState([])
-  const { search, searching, searched, searchedFor, currentRootActionId } =
+  const { query, search, searching, searched, searchedFor, currentRootActionId } =
     useKBar(state => {
       return {
         state,
@@ -115,7 +137,21 @@ function SearchAndResults() {
         const response = await fetch('/events.json')
         if (response.ok) {
           const data = await response.json()
-          setActions([...actions, ...generateEventActions(data)])
+          const eventActions = generateEventActions(data)
+          const browseAllActions = current_event_slug
+            ? [
+                {
+                  id: `${current_event_slug}-browse-all`,
+                  name: 'Browse all organizations',
+                  icon: <Icon glyph="explore" size={16} />,
+                  parent: current_event_slug,
+                  priority: Priority.HIGH,
+                  perform: () => query.setCurrentRootAction(null),
+                  section: 'Navigation',
+                },
+              ]
+            : []
+          setActions([...actions, ...eventActions, ...browseAllActions])
         }
       } catch (error) {
         console.error('Error:', error)

--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -113,27 +113,21 @@ function EmptyState() {
 
 function SearchAndResults({ current_event_slug }) {
   const [actions, setActions] = useState([])
-  const {
-    query,
-    search,
-    searching,
-    searched,
-    searchedFor,
-    currentRootActionId,
-  } = useKBar(state => {
-    return {
-      state,
-      search: state.currentRootActionId?.startsWith('search')
-        ? state.searchQuery
-        : null,
-      searching: state.currentRootActionId?.startsWith('search'),
-      searched: state.currentRootActionId?.startsWith('results:'),
-      searchedFor: state.currentRootActionId?.startsWith('results:')
-        ? state.currentRootActionId?.replace('results: ', '')
-        : '',
-      currentRootActionId: state.currentRootActionId,
-    }
-  })
+  const { search, searching, searched, searchedFor, currentRootActionId } =
+    useKBar(state => {
+      return {
+        state,
+        search: state.currentRootActionId?.startsWith('search')
+          ? state.searchQuery
+          : null,
+        searching: state.currentRootActionId?.startsWith('search'),
+        searched: state.currentRootActionId?.startsWith('results:'),
+        searchedFor: state.currentRootActionId?.startsWith('results:')
+          ? state.currentRootActionId?.replace('results: ', '')
+          : '',
+        currentRootActionId: state.currentRootActionId,
+      }
+    })
 
   useRegisterActions(actions, [actions])
 

--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -113,21 +113,27 @@ function EmptyState() {
 
 function SearchAndResults({ current_event_slug }) {
   const [actions, setActions] = useState([])
-  const { query, search, searching, searched, searchedFor, currentRootActionId } =
-    useKBar(state => {
-      return {
-        state,
-        search: state.currentRootActionId?.startsWith('search')
-          ? state.searchQuery
-          : null,
-        searching: state.currentRootActionId?.startsWith('search'),
-        searched: state.currentRootActionId?.startsWith('results:'),
-        searchedFor: state.currentRootActionId?.startsWith('results:')
-          ? state.currentRootActionId?.replace('results: ', '')
-          : '',
-        currentRootActionId: state.currentRootActionId,
-      }
-    })
+  const {
+    query,
+    search,
+    searching,
+    searched,
+    searchedFor,
+    currentRootActionId,
+  } = useKBar(state => {
+    return {
+      state,
+      search: state.currentRootActionId?.startsWith('search')
+        ? state.searchQuery
+        : null,
+      searching: state.currentRootActionId?.startsWith('search'),
+      searched: state.currentRootActionId?.startsWith('results:'),
+      searchedFor: state.currentRootActionId?.startsWith('results:')
+        ? state.currentRootActionId?.replace('results: ', '')
+        : '',
+      currentRootActionId: state.currentRootActionId,
+    }
+  })
 
   useRegisterActions(actions, [actions])
 
@@ -138,20 +144,7 @@ function SearchAndResults({ current_event_slug }) {
         if (response.ok) {
           const data = await response.json()
           const eventActions = generateEventActions(data)
-          const browseAllActions = current_event_slug
-            ? [
-                {
-                  id: `${current_event_slug}-browse-all`,
-                  name: 'Browse all organizations',
-                  icon: <Icon glyph="explore" size={16} />,
-                  parent: current_event_slug,
-                  priority: Priority.HIGH,
-                  perform: () => query.setCurrentRootAction(null),
-                  section: 'Navigation',
-                },
-              ]
-            : []
-          setActions([...actions, ...eventActions, ...browseAllActions])
+          setActions([...actions, ...eventActions])
         }
       } catch (error) {
         console.error('Error:', error)

--- a/app/javascript/components/command_bar/input.js
+++ b/app/javascript/components/command_bar/input.js
@@ -143,7 +143,7 @@ export function KBarInput(props) {
       {currentRootActionId && (
         <button
           onClick={() => query.setCurrentRootAction(parent)}
-          class="pop ml-3 w-7 h-7 -mr-2 z-10"
+          className="pop ml-3 w-7 h-7 -mr-2 z-10"
           aria-label="Go back"
         >
           <Icon glyph="view-back" size={20} />

--- a/app/javascript/components/command_bar/input.js
+++ b/app/javascript/components/command_bar/input.js
@@ -3,6 +3,7 @@
 import { RichTextarea, createRegexRenderer } from 'rich-textarea'
 import React, { useState, useEffect } from 'react'
 import { useKBar } from 'kbar'
+import Icon from '@hackclub/icons'
 
 const renderer = createRegexRenderer([
   [
@@ -124,15 +125,34 @@ export function KBarInput(props) {
     )
   }, [actions, currentRootActionId, defaultPlaceholder, placeholder])
 
+  const parent =
+    currentRootActionId && actions[currentRootActionId]
+      ? actions[currentRootActionId].parent
+      : undefined
+
   return (
     <div
-      style={{ borderBottom: '1px solid var(--kbar-border)', marginBottom: 10 }}
+      style={{
+        borderBottom: '1px solid var(--kbar-border)',
+        marginBottom: 10,
+        display: 'flex',
+        alignItems: 'center',
+        height: '50px',
+      }}
     >
+      {currentRootActionId && (
+        <button
+          onClick={() => query.setCurrentRootAction(parent)}
+          class="pop ml-3 w-7 h-7 -mr-2 z-10"
+          aria-label="Go back"
+        >
+          <Icon glyph="view-back" size={20} />
+        </button>
+      )}
       <RichTextarea
         {...rest}
         style={{
-          padding: '10px 20px',
-          paddingBottom: '5px',
+          padding: '0px 20px',
           width: '100%',
           boxSizing: 'border-box',
           outline: 'none',

--- a/app/views/application/_command_bar.html.erb
+++ b/app/views/application/_command_bar.html.erb
@@ -13,5 +13,5 @@
         "Google Workspace Waitlist" => "https://airtable.com/appEzv7w2IBMoxxHe/tbl9CkfZHKZYrXf1T/viwgfJvrrD9Jn9VLj"
       } : {} %>
 
-   <%= react_component "command_bar/CommandBar", { admin: auditor_signed_in?, admin_override_pretend: current_user.admin_override_pretend?, adminUrls: @admin_urls, has_followed_events: current_user.followed_events.any? }, { camelize_props: false } %>
+   <%= react_component "command_bar/CommandBar", { admin: auditor_signed_in?, admin_override_pretend: current_user.admin_override_pretend?, adminUrls: @admin_urls, has_followed_events: current_user.followed_events.any?, current_event_slug: @event&.slug }, { camelize_props: false } %>
 <% end %>


### PR DESCRIPTION
This PR improves command bar navigation by: 
* Opening event-specific pages when you're in an org page
* Adding a back button next to the search bar, similar to Raycast
