### PR TITLE
[OrganizerPositionInvite] Clarify member role access

### DIFF
--- a/app/views/organizer_position_invites/_role_and_control_form.html.erb
+++ b/app/views/organizer_position_invites/_role_and_control_form.html.erb
@@ -19,7 +19,7 @@
           </li>
           <li>Not transfer money</li>
           <li>Not change the organization's settings</li>
-          <li>View transactions & finances</li>
+          <li>View transactions and finances</li>
         </ul>
       </div>
       <p class="muted mb-0"><span class="bold info">Readers</span> have read-only access to the organization.</p>

--- a/app/views/organizer_position_invites/_role_and_control_form.html.erb
+++ b/app/views/organizer_position_invites/_role_and_control_form.html.erb
@@ -19,6 +19,7 @@
           </li>
           <li>Not transfer money</li>
           <li>Not change the organization's settings</li>
+          <li>View transactions & finances</li>
         </ul>
       </div>
       <p class="muted mb-0"><span class="bold info">Readers</span> have read-only access to the organization.</p>

--- a/app/views/organizer_position_invites/_role_and_control_form.html.erb
+++ b/app/views/organizer_position_invites/_role_and_control_form.html.erb
@@ -15,11 +15,11 @@
       <div class="muted mb1">
         <p class="m0"><span class="bold info">Members</span> can:</p>
         <ul class="m0">
+          <li>View transactions and finances</li>
           <li>Create & use cards (with a limit if spending controls are enabled)
           </li>
           <li>Not transfer money</li>
           <li>Not change the organization's settings</li>
-          <li>View transactions and finances</li>
         </ul>
       </div>
       <p class="muted mb-0"><span class="bold info">Readers</span> have read-only access to the organization.</p>


### PR DESCRIPTION
Closes #13451 by clarifying member role access to view transactions

<img width="345" height="435" alt="image" src="https://github.com/user-attachments/assets/e8a2f266-8938-40d2-b689-41e61503a07d" />

> <img width="626" height="860" alt="image" src="https://github.com/user-attachments/assets/1e7f9c06-a31f-4d4f-9638-6c5d1a9116c4" />
