### PR TITLE
[UI] Fix `.bg-warning` contrast for buttons

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -158,10 +158,18 @@ input[type='submit'],
 
   &.bg-warning {
     background-color: map-get($palette, warning);
+    &:hover {
+      background-color: darken(map-get($palette, warning), 5%) !important;
+    }
+    &:active,
+    &:focus {
+      background-color: darken(map-get($palette, warning), 10%) !important;
+    }
+
     color: darken(map-get($palette, warning), 33.3%) !important;
 
     html[data-dark='true'] & {
-      color: darken(map-get($palette, warning), 33.3%) !important;
+      color: darken(map-get($palette, warning), 40.3%) !important;
     }
   }
 


### PR DESCRIPTION
Closes #13476


### Before
<img width="376" height="98" alt="image" src="https://github.com/user-attachments/assets/21f0b581-bd5f-46a0-a466-c001f21ef4c4" />

### After
<img width="292" height="115" alt="image" src="https://github.com/user-attachments/assets/3b2b0ebf-5ec3-450c-bcba-66c256a04c3b" />
