### PR TITLE
Add ops delay warning due FIRST Championship

### DIFF
--- a/app/views/application/_ooo_callout.html.erb
+++ b/app/views/application/_ooo_callout.html.erb
@@ -9,7 +9,7 @@
 
 <% if Date.today <= Date.new(2026, 5, 4) %>
   <% championship = Date.new(2026, 4, 28)..Date.new(2026, 5, 2) %>
-  <% at_championship = championship === Date.today %>
+  <% at_championship = championship.cover?(Date.today) %>
   <% upcoming = Date.today < championship.first %>
   <% is_first_org = @event.respond_to?(:affiliations) && @event.affiliations.any?(&:is_first?) %>
   <%= render "application/callout", type: "warning", title: upcoming ? "Upcoming delays in transfer processing" : "Delayed transfer processing", class: "mt-2 mb-0" do %>

--- a/app/views/application/_ooo_callout.html.erb
+++ b/app/views/application/_ooo_callout.html.erb
@@ -6,3 +6,25 @@
     Transfers will be reviewed on the <span class="tooltipped" aria-label="<%= Time.first_business_day(Date.today).strftime("%b %e, %Y") %>">next business day</span>.
   <% end %>
 <% end %>
+
+<% if Date.today <= Date.new(2026, 5, 4) %>
+  <% upcoming = Date.today < Date.new(2026, 3, 28) %>
+  <% championship = Date.new(2026, 4, 28)..Date.new(2026, 5, 2) %>
+  <% at_championship = championship === Date.today %>
+  <% before_championship = Date.today < championship.first %>
+  <% is_first_org = @event.respond_to?(:affiliations) && @event.affiliations.any?(&:is_first?) %>
+  <%= render "application/callout", type: "warning", title: upcoming ? "Upcoming delays in transfer processing" : "Delayed transfer processing", class: "mt-2 mb-0" do %>
+    <% if is_first_org && at_championship %>
+      Our team is at the FIRST Championship in Houston through May 2 — come say hi in the Expo hall!
+      Transfer approvals may take 2–3 business days through May 4.
+    <% elsif is_first_org && before_championship %>
+      Our team will be at the FIRST Championship in Houston April 28–May 2 — come say hi in the Expo hall!
+      Transfer approvals may take 2–3 business days through May 4.
+    <% elsif upcoming %>
+      From March 28 to May 4, our team will have limited availability.
+      Transfers submitted during that window may take 2–3 business days to approve.
+    <% else %>
+      Our team has limited availability through May 4. Transfer approvals may take 2–3 business days.
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/application/_ooo_callout.html.erb
+++ b/app/views/application/_ooo_callout.html.erb
@@ -8,20 +8,19 @@
 <% end %>
 
 <% if Date.today <= Date.new(2026, 5, 4) %>
-  <% upcoming = Date.today < Date.new(2026, 3, 28) %>
   <% championship = Date.new(2026, 4, 28)..Date.new(2026, 5, 2) %>
   <% at_championship = championship === Date.today %>
-  <% before_championship = Date.today < championship.first %>
+  <% upcoming = Date.today < championship.first %>
   <% is_first_org = @event.respond_to?(:affiliations) && @event.affiliations.any?(&:is_first?) %>
   <%= render "application/callout", type: "warning", title: upcoming ? "Upcoming delays in transfer processing" : "Delayed transfer processing", class: "mt-2 mb-0" do %>
     <% if is_first_org && at_championship %>
       Our team is at the FIRST Championship in Houston through May 2 — come say hi in the Expo hall!
       Transfer approvals may take 2–3 business days through May 4.
-    <% elsif is_first_org && before_championship %>
+    <% elsif is_first_org && upcoming %>
       Our team will be at the FIRST Championship in Houston April 28–May 2 — come say hi in the Expo hall!
       Transfer approvals may take 2–3 business days through May 4.
     <% elsif upcoming %>
-      From March 28 to May 4, our team will have limited availability.
+      From April 28 to May 4, our team will have limited availability.
       Transfers submitted during that window may take 2–3 business days to approve.
     <% else %>
       Our team has limited availability through May 4. Transfer approvals may take 2–3 business days.

--- a/app/views/event/applications/_review_delay_callout.html.erb
+++ b/app/views/event/applications/_review_delay_callout.html.erb
@@ -1,0 +1,11 @@
+<% if Date.today <= Date.new(2026, 5, 4) %>
+  <% upcoming = Date.today < Date.new(2026, 3, 28) %>
+  <%= render "application/callout", type: "warning", title: upcoming ? "Upcoming delays in application reviews" : "Delayed application reviews", class: "mt-2 mb-4" do %>
+    <% if upcoming %>
+      From March 28 to May 4, our team will have limited availability.
+      Applications submitted during that window may take about 1 week to review.
+    <% else %>
+      Our team has limited availability through May 4. Application reviews may take about 1 week.
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/event/applications/_review_delay_callout.html.erb
+++ b/app/views/event/applications/_review_delay_callout.html.erb
@@ -1,8 +1,8 @@
 <% if Date.today <= Date.new(2026, 5, 4) %>
-  <% upcoming = Date.today < Date.new(2026, 3, 28) %>
+  <% upcoming = Date.today < Date.new(2026, 4, 28) %>
   <%= render "application/callout", type: "warning", title: upcoming ? "Upcoming delays in application reviews" : "Delayed application reviews", class: "mt-2 mb-4" do %>
     <% if upcoming %>
-      From March 28 to May 4, our team will have limited availability.
+      From April 28 to May 4, our team will have limited availability.
       Applications submitted during that window may take about 1 week to review.
     <% else %>
       Our team has limited availability through May 4. Application reviews may take about 1 week.

--- a/app/views/event/applications/review.html.erb
+++ b/app/views/event/applications/review.html.erb
@@ -13,6 +13,7 @@
 
 <div class="flex flex-col items-center flex-grow">
   <div class="md:max-w-[600px] w-full mt-7 space-y-8 pb-5">
+    <%= render "event/applications/review_delay_callout" %>
     <%= render "event/applications/summary", application: @application, allow_edits: true %>
   </div>
 </div>

--- a/app/views/event/applications/show.html.erb
+++ b/app/views/event/applications/show.html.erb
@@ -31,6 +31,12 @@
       <% end %>
     </h2>
 
+    <% unless @application.approved? %>
+      <div class="w-full md:max-w-2xl">
+        <%= render "event/applications/review_delay_callout" %>
+      </div>
+    <% end %>
+
     <h3 class="m-0 muted">
       <% if !@application.approved? || @application.contract&.party(:signee)&.pending? || @application.contract&.party(:cosigner)&.pending? %>
         Here's what's next for <%= @application.name %>


### PR DESCRIPTION
## Summary of the problem

We're attending FIRST Championships. There will be a decrease in the operation team's capacity, and thus delays.


## Describe your changes

### Transfers

Context: FIRST Championships ends on May 2nd

For normal organizations (and for everyone after May 2nd)
<img width="1250" height="972" alt="image" src="https://github.com/user-attachments/assets/6dac9c32-3a67-435f-8ede-47db1fcacd04" />

For FIRST orgs before May 2nd
<img width="500" height="269" alt="image" src="https://github.com/user-attachments/assets/282d2865-bdf0-4f6e-92f5-a474b9e7e06b" />
<img width="453" height="227" alt="image" src="https://github.com/user-attachments/assets/7d7f097d-81fd-4f08-b231-9ec105987c8f" />


### Applications
<img width="1405" height="639" alt="image" src="https://github.com/user-attachments/assets/106b66f7-d9e4-4721-861f-69dd52416f96" />

<img width="1419" height="878" alt="image" src="https://github.com/user-attachments/assets/61b9d729-5947-4d59-96ff-1db1218832be" />

<img width="855" height="363" alt="image" src="https://github.com/user-attachments/assets/4fe699b9-1ad9-45bd-baf6-bd685358bc20" />

