### PR TITLE
[Application] Fix `application_ready_to_submit?` for adults

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -410,7 +410,7 @@ class Event
       end
 
       unless teen_led?
-        required_fields += ["planning_duration", "team_size", "annual_budget", "committed_amount"]
+        required_fields += ["planning_duration", "team_size", "annual_budget_cents", "committed_amount_cents"]
 
         if committed_amount&.positive?
           required_fields.push("funding_source")


### PR DESCRIPTION
## Summary of the problem

Since we're using `self[field]` syntax, it accesses the DB columns; bypassing model methods. This means that `annual_budget` and `committed_amount` always return `nil` since the columns are `annual_budget_cents` and `committed_amount_cents`.


## Describe your changes

Use the `_cents` columns.