### PR TITLE
Revert "[Command Bar] Improve navigation for events"

### DIFF
--- a/app/javascript/components/command_bar/CommandBar.js
+++ b/app/javascript/components/command_bar/CommandBar.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types:0 */
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   KBarProvider,
   KBarPortal,
@@ -22,7 +22,6 @@ export default function CommandBar({
   admin_override_pretend = false,
   adminUrls = {},
   has_followed_events = false,
-  current_event_slug = null,
 }) {
   return (
     <div style={{ position: 'relative', zIndex: '100000000' }}>
@@ -41,7 +40,6 @@ export default function CommandBar({
         }}
       >
         <ButtonTrigger />
-        <EventRootSetter current_event_slug={current_event_slug} />
         <KBarPortal>
           <KBarPositioner
             style={{ zIndex: 1000, backgroundColor: 'var(--kbar-dim)' }}
@@ -52,26 +50,6 @@ export default function CommandBar({
       </KBarProvider>
     </div>
   )
-}
-
-function EventRootSetter({ current_event_slug }) {
-  const { query, visualState } = useKBar(state => ({
-    visualState: state.visualState,
-  }))
-  const prevVisualState = useRef(null)
-
-  useEffect(() => {
-    if (
-      current_event_slug &&
-      visualState !== 'hidden' &&
-      prevVisualState.current === 'hidden'
-    ) {
-      query.setCurrentRootAction(current_event_slug)
-    }
-    prevVisualState.current = visualState
-  }, [visualState, current_event_slug, query])
-
-  return null
 }
 
 const ButtonTrigger = () => {
@@ -137,8 +115,7 @@ function SearchAndResults() {
         const response = await fetch('/events.json')
         if (response.ok) {
           const data = await response.json()
-          const eventActions = generateEventActions(data)
-          setActions([...actions, ...eventActions])
+          setActions([...actions, ...generateEventActions(data)])
         }
       } catch (error) {
         console.error('Error:', error)

--- a/app/javascript/components/command_bar/input.js
+++ b/app/javascript/components/command_bar/input.js
@@ -3,7 +3,6 @@
 import { RichTextarea, createRegexRenderer } from 'rich-textarea'
 import React, { useState, useEffect } from 'react'
 import { useKBar } from 'kbar'
-import Icon from '@hackclub/icons'
 
 const renderer = createRegexRenderer([
   [
@@ -125,34 +124,15 @@ export function KBarInput(props) {
     )
   }, [actions, currentRootActionId, defaultPlaceholder, placeholder])
 
-  const parent =
-    currentRootActionId && actions[currentRootActionId]
-      ? actions[currentRootActionId].parent
-      : undefined
-
   return (
     <div
-      style={{
-        borderBottom: '1px solid var(--kbar-border)',
-        marginBottom: 10,
-        display: 'flex',
-        alignItems: 'center',
-        height: '50px',
-      }}
+      style={{ borderBottom: '1px solid var(--kbar-border)', marginBottom: 10 }}
     >
-      {currentRootActionId && (
-        <button
-          onClick={() => query.setCurrentRootAction(parent)}
-          className="pop ml-3 w-7 h-7 -mr-2 z-10"
-          aria-label="Go back"
-        >
-          <Icon glyph="view-back" size={20} />
-        </button>
-      )}
       <RichTextarea
         {...rest}
         style={{
-          padding: '0px 20px',
+          padding: '10px 20px',
+          paddingBottom: '5px',
           width: '100%',
           boxSizing: 'border-box',
           outline: 'none',

--- a/app/views/application/_command_bar.html.erb
+++ b/app/views/application/_command_bar.html.erb
@@ -13,5 +13,5 @@
         "Google Workspace Waitlist" => "https://airtable.com/appEzv7w2IBMoxxHe/tbl9CkfZHKZYrXf1T/viwgfJvrrD9Jn9VLj"
       } : {} %>
 
-   <%= react_component "command_bar/CommandBar", { admin: auditor_signed_in?, admin_override_pretend: current_user.admin_override_pretend?, adminUrls: @admin_urls, has_followed_events: current_user.followed_events.any?, current_event_slug: @event&.slug }, { camelize_props: false } %>
+   <%= react_component "command_bar/CommandBar", { admin: auditor_signed_in?, admin_override_pretend: current_user.admin_override_pretend?, adminUrls: @admin_urls, has_followed_events: current_user.followed_events.any? }, { camelize_props: false } %>
 <% end %>


### PR DESCRIPTION
Reverts hackclub/hcb#13521

When opening command bar from inside an org, there's a 2-3 second delay before the list populates. this is confusing
<img width="678" height="304" alt="image" src="https://github.com/user-attachments/assets/39d4932e-fb41-4e02-9dcb-61383368b5a7" />

2-3 seconds later:

<img width="653" height="517" alt="image" src="https://github.com/user-attachments/assets/785a3026-f2c2-4e31-be98-86628008162a" />
