### PR TITLE
[Applications] Fix contract status text on submission

### DIFF
--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -47,7 +47,9 @@
             <p>
               <strong>Contract status</strong>
               <span>
-                <% if @application.contract.parties.not_hcb.all?(&:signed?) %>
+                <% if @application.contract.signed? %>
+                  Signed by all parties
+                <% elsif @application.contract.parties.not_hcb.all?(&:signed?) %>
                   Ready for HCB signature
                 <% else %>
                   Waiting on <%= @application.contract.parties.not_hcb.pending.map(&:role).to_sentence %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The contract status field didn't have a case for if the contract was fully signed! This is a little confusing to admins looking at the submission page after its been signed.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add case for if contract is signed

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

