### PR TITLE
Use HCB deprecator for model disbursement methods

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -288,7 +288,7 @@ class CanonicalPendingTransaction < ApplicationRecord
   end
 
   def disbursement
-    Rails.error.unexpected "CanonicalPendingTransaction#disbursement accessed"
+    Rails.application.deprecators[:hcb].warn "CanonicalPendingTransaction#disbursement accessed"
     return nil unless raw_pending_outgoing_disbursement_transaction || raw_pending_incoming_disbursement_transaction
 
     (outgoing_disbursement || incoming_disbursement)&.disbursement

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -429,7 +429,7 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def disbursement
-    Rails.error.unexpected "CanonicalTransaction#disbursement accessed"
+    Rails.application.deprecators[:hcb].warn "CanonicalTransaction#disbursement accessed"
     (outgoing_disbursement || incoming_disbursement)&.disbursement
   end
 

--- a/app/models/canonical_transaction_grouped.rb
+++ b/app/models/canonical_transaction_grouped.rb
@@ -130,7 +130,7 @@ class CanonicalTransactionGrouped
   end
 
   def disbursement
-    Rails.error.unexpected "CanonicalTransactionGrouped#disbursement accessed"
+    Rails.application.deprecators[:hcb].warn "CanonicalTransactionGrouped#disbursement accessed"
     Disbursement.find(hcb_i2)
   end
 

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -437,7 +437,8 @@ class HcbCode < ApplicationRecord
   end
 
   def disbursement
-    Rails.error.unexpected "HcbCode#disbursement accessed"
+    Rails.application.deprecators[:hcb].warn("HcbCode#disbursement accessed")
+
     return nil unless disbursement?
 
     @disbursement ||= begin

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -437,7 +437,7 @@ class HcbCode < ApplicationRecord
   end
 
   def disbursement
-    Rails.application.deprecators[:hcb].warn("HcbCode#disbursement accessed")
+    Rails.application.deprecators[:hcb].warn "HcbCode#disbursement accessed"
 
     return nil unless disbursement?
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13442 changed `HcbCode#disbursement?` to use the new ActiveSupport HCB deprecator - but there's also other `disbursement` methods that should be using it as well.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change `disbursement` methods to use the new deprecator

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

