### PR TITLE
[Applications] Don't redirect to an archived application

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -21,9 +21,9 @@ class Event
     def apply
       skip_authorization
 
-      if signed_in? && current_user.applications.draft.one?
-        redirect_to application_path(current_user.applications.draft.first)
-      elsif signed_in? && current_user.applications.any?
+      if signed_in? && current_user.applications.not_archived.draft.one?
+        redirect_to application_path(current_user.applications.not_archived.draft.first)
+      elsif signed_in? && current_user.applications.not_archived.any?
         redirect_to applications_path(ref: params[:ref])
       else
         redirect_to new_application_path(ref: params[:ref])


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We don't display them on the dashboard, and we shouldn't be redirecting `/apply` to them.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use `not_archived` scope to prevent redirecting to archived applications

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

