### PR TITLE
[GSuiteAccount] Allow disconnecting from HCB management

### DIFF
--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -33,6 +33,8 @@ class GSuiteAccount < ApplicationRecord
 
   include Rejectable
 
+  attr_accessor :skip_gsuite_sync
+
   after_update :attempt_notify_user_of_password_change
 
   paginates_per 50
@@ -105,6 +107,35 @@ class GSuiteAccount < ApplicationRecord
     self.save
   end
 
+  # Engineer-only via Rails console. Disconnects this account from HCB
+  # management, leaving the Google Workspace user (and its aliases) intact.
+  # Intended for use in the Rails console when a user's account is being
+  # transferred to the unmanaged hackclub.com domain from an HCB managed domain
+  # (e.g., events.hackclub.com).
+  def disconnect!(confirm:)
+    raise ArgumentError, "confirm must match address" unless confirm == address
+
+    # Materialize once so the in-memory `skip_gsuite_sync` we set below
+    # survives — a later reload would drop the flag and re-trigger the
+    # Google Workspace alias deletion callback.
+    aliases = g_suite_aliases.reload.to_a
+
+    Rails.logger.info(
+      "[GSuiteAccount#disconnect!] disconnecting " \
+      "id=#{id} address=#{address} g_suite_id=#{g_suite_id} " \
+      "aliases=#{aliases.size}"
+    )
+
+    transaction do
+      aliases.each do |gsa|
+        gsa.skip_gsuite_sync = true
+        gsa.destroy!
+      end
+      self.skip_gsuite_sync = true
+      destroy!
+    end
+  end
+
   private
 
   def notify_user_of_password_change(first_password = false)
@@ -130,6 +161,8 @@ class GSuiteAccount < ApplicationRecord
   end
 
   def sync_delete_to_gsuite
+    return if skip_gsuite_sync
+
     unless Rails.env.production?
       puts "☣️ In production, we would currently be syncing the GSuite account deletion ☣️"
       return

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -107,12 +107,12 @@ class GSuiteAccount < ApplicationRecord
     self.save
   end
 
-  # Engineer-only via Rails console. Disconnects this account from HCB
+  # Engineer-only via Rails console. Removes this account from HCB
   # management, leaving the Google Workspace user (and its aliases) intact.
   # Intended for use in the Rails console when a user's account is being
   # transferred to the unmanaged hackclub.com domain from an HCB managed domain
   # (e.g., events.hackclub.com).
-  def disconnect!(confirm:)
+  def unmanage!(confirm:)
     raise ArgumentError, "confirm must match address" unless confirm == address
 
     # Materialize once so the in-memory `skip_gsuite_sync` we set below
@@ -121,7 +121,7 @@ class GSuiteAccount < ApplicationRecord
     aliases = g_suite_aliases.reload.to_a
 
     Rails.logger.info(
-      "[GSuiteAccount#disconnect!] disconnecting " \
+      "[GSuiteAccount#unmanage!] unmanaging " \
       "id=#{id} address=#{address} g_suite_id=#{g_suite_id} " \
       "aliases=#{aliases.size}"
     )

--- a/app/models/g_suite_alias.rb
+++ b/app/models/g_suite_alias.rb
@@ -19,6 +19,8 @@
 #  fk_rails_...  (g_suite_account_id => g_suite_accounts.id)
 #
 class GSuiteAlias < ApplicationRecord
+  has_paper_trail
+
   attr_accessor :skip_gsuite_sync
 
   belongs_to :g_suite_account

--- a/app/models/g_suite_alias.rb
+++ b/app/models/g_suite_alias.rb
@@ -19,6 +19,8 @@
 #  fk_rails_...  (g_suite_account_id => g_suite_accounts.id)
 #
 class GSuiteAlias < ApplicationRecord
+  attr_accessor :skip_gsuite_sync
+
   belongs_to :g_suite_account
   has_one :g_suite, through: :g_suite_account
 
@@ -31,6 +33,8 @@ class GSuiteAlias < ApplicationRecord
   end
 
   before_destroy do
+    next if skip_gsuite_sync
+
     delete_alias_with_google
   end
 

--- a/spec/factories/g_suite_account_factory.rb
+++ b/spec/factories/g_suite_account_factory.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :g_suite_account do
+    association :g_suite
+    association :creator, factory: :user
+    address { "#{Faker::Internet.username(specifier: 5..10)}@#{g_suite.domain}" }
+    backup_email { Faker::Internet.email }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    accepted_at { Time.current }
+  end
+end

--- a/spec/factories/g_suite_alias_factory.rb
+++ b/spec/factories/g_suite_alias_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :g_suite_alias do
+    association :g_suite_account
+    address { "#{Faker::Internet.username(specifier: 5..10)}@#{g_suite_account.g_suite.domain}" }
+  end
+end

--- a/spec/models/g_suite_account_spec.rb
+++ b/spec/models/g_suite_account_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GSuiteAccount, type: :model do
+  let(:g_suite) { create(:g_suite, domain: "example.com") }
+  let(:g_suite_account) { create(:g_suite_account, g_suite:) }
+
+  describe "#disconnect!" do
+    let(:gsuite_service) { instance_double(GsuiteService, delete_gsuite_user: true) }
+
+    before do
+      allow_any_instance_of(::Partners::Google::GSuite::CreateUserAlias).to receive(:run).and_return(true)
+      allow_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).to receive(:run).and_return(true)
+      allow(GsuiteService).to receive(:instance).and_return(gsuite_service)
+    end
+
+    context "when confirm does not match address" do
+      it "raises ArgumentError and does not destroy the account" do
+        expect do
+          g_suite_account.disconnect!(confirm: "wrong@example.com")
+        end.to raise_error(ArgumentError, /confirm must match address/)
+
+        expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
+      end
+
+      it "does not destroy aliases" do
+        create(:g_suite_alias, g_suite_account:)
+        g_suite_account.reload
+
+        expect do
+          g_suite_account.disconnect!(confirm: "wrong@example.com") rescue nil
+        end.not_to change(GSuiteAlias, :count)
+      end
+    end
+
+    context "when confirm matches address" do
+      context "with no aliases" do
+        it "destroys the account" do
+          id = g_suite_account.id
+
+          g_suite_account.disconnect!(confirm: g_suite_account.address)
+
+          expect(GSuiteAccount.exists?(id)).to be false
+        end
+
+        it "does not call Google Workspace to delete the user" do
+          allow(Rails.env).to receive(:production?).and_return(true)
+
+          g_suite_account.disconnect!(confirm: g_suite_account.address)
+
+          expect(gsuite_service).not_to have_received(:delete_gsuite_user)
+        end
+      end
+
+      context "with aliases" do
+        before do
+          create_list(:g_suite_alias, 2, g_suite_account:)
+          g_suite_account.reload
+        end
+
+        it "destroys the account and its aliases" do
+          account_id = g_suite_account.id
+          alias_ids = g_suite_account.g_suite_aliases.map(&:id)
+
+          g_suite_account.disconnect!(confirm: g_suite_account.address)
+
+          expect(GSuiteAccount.exists?(account_id)).to be false
+          expect(GSuiteAlias.where(id: alias_ids)).to be_empty
+        end
+
+        it "does not call Google Workspace to delete any alias" do
+          expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).not_to receive(:run)
+
+          g_suite_account.disconnect!(confirm: g_suite_account.address)
+        end
+
+        it "rolls back the destroy when an alias destroy fails" do
+          allow_any_instance_of(GSuiteAlias).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed.new("boom"))
+
+          expect do
+            g_suite_account.disconnect!(confirm: g_suite_account.address)
+          end.to raise_error(ActiveRecord::RecordNotDestroyed)
+
+          expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
+          expect(g_suite_account.g_suite_aliases.reload.count).to eq(2)
+        end
+
+        it "does not call Google Workspace on the rollback path" do
+          allow(Rails.env).to receive(:production?).and_return(true)
+          allow_any_instance_of(GSuiteAlias).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed.new("boom"))
+          expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).not_to receive(:run)
+
+          expect do
+            g_suite_account.disconnect!(confirm: g_suite_account.address)
+          end.to raise_error(ActiveRecord::RecordNotDestroyed)
+
+          expect(gsuite_service).not_to have_received(:delete_gsuite_user)
+        end
+      end
+
+      it "logs a structured disconnect line before destroying" do
+        create_list(:g_suite_alias, 2, g_suite_account:)
+        g_suite_account.reload
+
+        expect(Rails.logger).to receive(:info).with(
+          a_string_including(
+            "[GSuiteAccount#disconnect!]",
+            "id=#{g_suite_account.id}",
+            "address=#{g_suite_account.address}",
+            "g_suite_id=#{g_suite_account.g_suite_id}",
+            "aliases=2"
+          )
+        )
+
+        g_suite_account.disconnect!(confirm: g_suite_account.address)
+      end
+    end
+  end
+
+  describe "#sync_delete_to_gsuite (callback)" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it "calls GsuiteService.delete_gsuite_user on a normal destroy" do
+      gsuite_service = instance_double(GsuiteService, delete_gsuite_user: true)
+      allow(GsuiteService).to receive(:instance).and_return(gsuite_service)
+
+      g_suite_account.destroy!
+
+      expect(gsuite_service).to have_received(:delete_gsuite_user).with(g_suite_account.address)
+    end
+
+    it "does not call GsuiteService when skip_gsuite_sync is true" do
+      gsuite_service = instance_double(GsuiteService, delete_gsuite_user: true)
+      allow(GsuiteService).to receive(:instance).and_return(gsuite_service)
+
+      g_suite_account.skip_gsuite_sync = true
+      g_suite_account.destroy!
+
+      expect(gsuite_service).not_to have_received(:delete_gsuite_user)
+    end
+  end
+end

--- a/spec/models/g_suite_account_spec.rb
+++ b/spec/models/g_suite_account_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GSuiteAccount, type: :model do
   let(:g_suite) { create(:g_suite, domain: "example.com") }
   let(:g_suite_account) { create(:g_suite_account, g_suite:) }
 
-  describe "#disconnect!" do
+  describe "#unmanage!" do
     let(:gsuite_service) { instance_double(GsuiteService, delete_gsuite_user: true) }
 
     before do
@@ -18,7 +18,7 @@ RSpec.describe GSuiteAccount, type: :model do
     context "when confirm does not match address" do
       it "raises ArgumentError and does not destroy the account" do
         expect do
-          g_suite_account.disconnect!(confirm: "wrong@example.com")
+          g_suite_account.unmanage!(confirm: "wrong@example.com")
         end.to raise_error(ArgumentError, /confirm must match address/)
 
         expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
@@ -29,7 +29,7 @@ RSpec.describe GSuiteAccount, type: :model do
         g_suite_account.reload
 
         expect do
-          g_suite_account.disconnect!(confirm: "wrong@example.com") rescue nil
+          g_suite_account.unmanage!(confirm: "wrong@example.com") rescue nil
         end.not_to change(GSuiteAlias, :count)
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe GSuiteAccount, type: :model do
         it "destroys the account" do
           id = g_suite_account.id
 
-          g_suite_account.disconnect!(confirm: g_suite_account.address)
+          g_suite_account.unmanage!(confirm: g_suite_account.address)
 
           expect(GSuiteAccount.exists?(id)).to be false
         end
@@ -47,7 +47,7 @@ RSpec.describe GSuiteAccount, type: :model do
         it "does not call Google Workspace to delete the user" do
           allow(Rails.env).to receive(:production?).and_return(true)
 
-          g_suite_account.disconnect!(confirm: g_suite_account.address)
+          g_suite_account.unmanage!(confirm: g_suite_account.address)
 
           expect(gsuite_service).not_to have_received(:delete_gsuite_user)
         end
@@ -63,7 +63,7 @@ RSpec.describe GSuiteAccount, type: :model do
           account_id = g_suite_account.id
           alias_ids = g_suite_account.g_suite_aliases.map(&:id)
 
-          g_suite_account.disconnect!(confirm: g_suite_account.address)
+          g_suite_account.unmanage!(confirm: g_suite_account.address)
 
           expect(GSuiteAccount.exists?(account_id)).to be false
           expect(GSuiteAlias.where(id: alias_ids)).to be_empty
@@ -72,14 +72,14 @@ RSpec.describe GSuiteAccount, type: :model do
         it "does not call Google Workspace to delete any alias" do
           expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).not_to receive(:run)
 
-          g_suite_account.disconnect!(confirm: g_suite_account.address)
+          g_suite_account.unmanage!(confirm: g_suite_account.address)
         end
 
         it "rolls back the destroy when an alias destroy fails" do
           allow_any_instance_of(GSuiteAlias).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed.new("boom"))
 
           expect do
-            g_suite_account.disconnect!(confirm: g_suite_account.address)
+            g_suite_account.unmanage!(confirm: g_suite_account.address)
           end.to raise_error(ActiveRecord::RecordNotDestroyed)
 
           expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
@@ -92,7 +92,7 @@ RSpec.describe GSuiteAccount, type: :model do
           expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).not_to receive(:run)
 
           expect do
-            g_suite_account.disconnect!(confirm: g_suite_account.address)
+            g_suite_account.unmanage!(confirm: g_suite_account.address)
           end.to raise_error(ActiveRecord::RecordNotDestroyed)
 
           expect(gsuite_service).not_to have_received(:delete_gsuite_user)
@@ -105,7 +105,8 @@ RSpec.describe GSuiteAccount, type: :model do
 
         expect(Rails.logger).to receive(:info).with(
           a_string_including(
-            "[GSuiteAccount#disconnect!]",
+            "[GSuiteAccount#unmanage!]",
+            "unmanaging",
             "id=#{g_suite_account.id}",
             "address=#{g_suite_account.address}",
             "g_suite_id=#{g_suite_account.g_suite_id}",
@@ -113,7 +114,7 @@ RSpec.describe GSuiteAccount, type: :model do
           )
         )
 
-        g_suite_account.disconnect!(confirm: g_suite_account.address)
+        g_suite_account.unmanage!(confirm: g_suite_account.address)
       end
     end
   end

--- a/spec/models/g_suite_alias_spec.rb
+++ b/spec/models/g_suite_alias_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GSuiteAlias, type: :model do
+  let(:g_suite_account) { create(:g_suite_account) }
+
+  before do
+    allow_any_instance_of(::Partners::Google::GSuite::CreateUserAlias).to receive(:run).and_return(true)
+  end
+
+  describe "before_destroy (sync to Google Workspace)" do
+    let(:g_suite_alias) { create(:g_suite_alias, g_suite_account:) }
+
+    it "calls Partners::Google::GSuite::DeleteUserAlias on a normal destroy" do
+      expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).to receive(:run).and_return(true)
+
+      g_suite_alias.destroy!
+    end
+
+    it "does not call Partners::Google::GSuite::DeleteUserAlias when skip_gsuite_sync is true" do
+      expect_any_instance_of(::Partners::Google::GSuite::DeleteUserAlias).not_to receive(:run)
+
+      g_suite_alias.skip_gsuite_sync = true
+      g_suite_alias.destroy!
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

We want to be able to convert an HCB-managed Google Workspace Account (e.g. `example@event.hackclub.com`) into an unmanaged Google Workspace Account so that we can transfer it to the unmanaged `hackclub.com` domain.


## Describe your changes

This PR adds a `GSuiteAccount#disconnect!` method that deletes the records from HCB while preserving everything on Google Workspace; effectively "unmanaging" this Google Workspace Account.