### PR TITLE
[v4][Code Quality] Create 'object_shape' helper to follow new v4 standards

### DIFF
--- a/app/helpers/api/v4/application_helper.rb
+++ b/app/helpers/api/v4/application_helper.rb
@@ -8,6 +8,13 @@ module Api
 
       attr_reader :current_user, :current_token
 
+      def object_shape(json, object, object_name: nil, created_at: true, &block)
+        json.id object.public_id
+        json.object object_name || object.model_name.element
+        block.call
+        json.created_at object.created_at if created_at
+      end
+
       def pagination_metadata(json)
         json.total_count @total_count
         json.has_more @has_more

--- a/app/helpers/api/v4/application_helper.rb
+++ b/app/helpers/api/v4/application_helper.rb
@@ -10,7 +10,7 @@ module Api
 
       def object_shape(json, object, object_name: nil, created_at: true, &block)
         json.id object.public_id
-        json.object object_name || object.model_name.element
+        json.object object_name || object.model_name.singular
         block.call
         json.created_at object.created_at if created_at
       end

--- a/app/views/api/v4/card_grants/_card_grant.json.jbuilder
+++ b/app/views/api/v4/card_grants/_card_grant.json.jbuilder
@@ -1,25 +1,26 @@
-json.id card_grant.public_id
-json.user card_grant.user, partial: "api/v4/users/user", as: :user if expand?(:user)
-json.organization card_grant.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
-json.call(
-  card_grant,
-  :amount_cents,
-  :merchant_lock,
-  :category_lock,
-  :keyword_lock,
-  :allowed_merchants,
-  :allowed_categories,
-  :purpose,
-  :one_time_use,
-  :pre_authorization_required,
-  :email
-)
-json.expires_on card_grant.expiration_at
-json.balance_cents card_grant.balance.cents if expand?(:balance_cents)
-json.status card_grant.status
-if expand?(:disbursements)
-  json.disbursements card_grant.disbursements.order(created_at: :desc) do |disbursement|
-    json.partial! "api/v4/transactions/disbursement", disbursement:
+object_shape(json, card_grant) do
+  json.user card_grant.user, partial: "api/v4/users/user", as: :user if expand?(:user)
+  json.organization card_grant.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
+  json.call(
+    card_grant,
+    :amount_cents,
+    :merchant_lock,
+    :category_lock,
+    :keyword_lock,
+    :allowed_merchants,
+    :allowed_categories,
+    :purpose,
+    :one_time_use,
+    :pre_authorization_required,
+    :email
+  )
+  json.expires_on card_grant.expiration_at
+  json.balance_cents card_grant.balance.cents if expand?(:balance_cents)
+  json.status card_grant.status
+  if expand?(:disbursements)
+    json.disbursements card_grant.disbursements.order(created_at: :desc) do |disbursement|
+      json.partial! "api/v4/transactions/disbursement", disbursement:
+    end
   end
+  json.card_id card_grant.stripe_card&.public_id
 end
-json.card_id card_grant.stripe_card&.public_id

--- a/app/views/api/v4/check_deposits/_check_deposit.json.jbuilder
+++ b/app/views/api/v4/check_deposits/_check_deposit.json.jbuilder
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-json.id check_deposit.public_id
-json.status check_deposit.state_text.parameterize(separator: "_")
-json.amount_cents check_deposit.amount_cents
-json.created_at check_deposit.created_at
-json.updated_at check_deposit.updated_at
+object_shape(json, check_deposit) do
+  json.status check_deposit.state_text.parameterize(separator: "_")
+  json.amount_cents check_deposit.amount_cents
+  json.updated_at check_deposit.updated_at
 
-if check_deposit.rejected? && check_deposit.rejection_reason.present?
-  json.rejection do
-    json.reason check_deposit.rejection_reason
-    json.description check_deposit.rejection_description
+  if check_deposit.rejected? && check_deposit.rejection_reason.present?
+    json.rejection do
+      json.reason check_deposit.rejection_reason
+      json.description check_deposit.rejection_description
+    end
   end
-end
 
-json.estimated_arrival_date check_deposit.estimated_arrival_date
+  json.estimated_arrival_date check_deposit.estimated_arrival_date
 
-if policy(check_deposit).view_image?
-  json.front_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.front) if check_deposit.front.attached?
-  json.back_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.back) if check_deposit.back.attached?
-end
+  if policy(check_deposit).view_image?
+    json.front_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.front) if check_deposit.front.attached?
+    json.back_url Rails.application.routes.url_helpers.rails_blob_url(check_deposit.back) if check_deposit.back.attached?
+  end
 
-json.submitter do
-  if check_deposit.created_by.present?
-    json.partial! "api/v4/users/user", user: check_deposit.created_by
-  else
-    json.nil!
+  json.submitter do
+    if check_deposit.created_by.present?
+      json.partial! "api/v4/users/user", user: check_deposit.created_by
+    else
+      json.nil!
+    end
   end
 end

--- a/app/views/api/v4/comments/_comment.json.jbuilder
+++ b/app/views/api/v4/comments/_comment.json.jbuilder
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-json.id comment.public_id
-json.created_at comment.created_at
-json.user comment.user, partial: "api/v4/users/user", as: :user
-json.content comment.content
-json.file rails_blob_url(comment.file) if comment.file.attached?
+object_shape(json, comment) do
+  json.user comment.user, partial: "api/v4/users/user", as: :user
+  json.content comment.content
+  json.file rails_blob_url(comment.file) if comment.file.attached?
 
-if comment.admin_only
-  json.admin_only true
+  if comment.admin_only
+    json.admin_only true
+  end
 end

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -1,40 +1,40 @@
 # frozen_string_literal: true
 
-json.created_at event.created_at
-json.id event.public_id
-json.parent_id event.parent&.public_id
-json.name event.name
-json.country event.country
-json.slug event.slug
-json.financially_frozen event.financially_frozen?
-json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
-json.donation_page_available event.donation_page_available?
-json.playground_mode event.demo_mode?
-json.playground_mode_meeting_requested nil # This field is deprecated and will be removed
-json.transparent event.is_public?
-json.fee_percentage event.revenue_fee.to_f
-json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
+object_shape(json, event, object_name: "organization") do
+  json.parent_id event.parent&.public_id
+  json.name event.name
+  json.country event.country
+  json.slug event.slug
+  json.financially_frozen event.financially_frozen?
+  json.icon event.logo.attached? ? Rails.application.routes.url_helpers.url_for(event.logo) : nil
+  json.donation_page_available event.donation_page_available?
+  json.playground_mode event.demo_mode?
+  json.playground_mode_meeting_requested nil # This field is deprecated and will be removed
+  json.transparent event.is_public?
+  json.fee_percentage event.revenue_fee.to_f
+  json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
 
-if expand?(:balance_cents)
-  json.balance_cents event.balance_available
-  json.fee_balance_cents event.fronted_fee_balance_v2_cents
-end
+  if expand?(:balance_cents)
+    json.balance_cents event.balance_available
+    json.fee_balance_cents event.fronted_fee_balance_v2_cents
+  end
 
-if expand?(:reporting)
-  json.total_spent_cents event.total_spent_cents
-  json.total_raised_cents event.total_raised
-end
+  if expand?(:reporting)
+    json.total_spent_cents event.total_spent_cents
+    json.total_raised_cents event.total_raised
+  end
 
-if policy(event).account_number? && expand?(:account_number)
-  json.account_number event.account_number
-  json.routing_number event.routing_number
-  json.swift_bic_code event.bic_code
-end
+  if policy(event).account_number? && expand?(:account_number)
+    json.account_number event.account_number
+    json.routing_number event.routing_number
+    json.swift_bic_code event.bic_code
+  end
 
-if expand?(:users)
-  json.users event.organizer_positions.includes(:user).order(created_at: :desc) do |op|
-    json.partial! "api/v4/users/user", user: op.user, show_email: shares_org_with?(op.user)
-    json.joined_at op.created_at
-    json.role op.role
+  if expand?(:users)
+    json.users event.organizer_positions.includes(:user).order(created_at: :desc) do |op|
+      json.partial! "api/v4/users/user", user: op.user, show_email: shares_org_with?(op.user)
+      json.joined_at op.created_at
+      json.role op.role
+    end
   end
 end

--- a/app/views/api/v4/invitations/_invitation.json.jbuilder
+++ b/app/views/api/v4/invitations/_invitation.json.jbuilder
@@ -1,6 +1,6 @@
-json.id invitation.public_id
-json.created_at invitation.created_at
-json.accepted invitation.accepted?
-json.sender { json.partial! "api/v4/users/user", user: invitation.sender }
-json.organization { json.partial! "api/v4/events/event", event: invitation.event }
-json.role invitation.role
+object_shape(json, invitation) do
+  json.accepted invitation.accepted?
+  json.sender { json.partial! "api/v4/users/user", user: invitation.sender }
+  json.organization { json.partial! "api/v4/events/event", event: invitation.event }
+  json.role invitation.role
+end

--- a/app/views/api/v4/invoices/_invoice.json.jbuilder
+++ b/app/views/api/v4/invoices/_invoice.json.jbuilder
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-json.id invoice.public_id
-json.status invoice.state_text
-json.created_at invoice.created_at
-json.to invoice.sponsor.name
-json.amount_due invoice.amount_due
-if policy(invoice).show_in_v4?
-  json.memo invoice.memo
-  json.due_date invoice.due_date
-  json.item_amount invoice.item_amount
-  json.item_description invoice.item_description
-  json.sponsor_id invoice.sponsor_id
+object_shape(json, invoice) do
+  json.status invoice.state_text
+  json.to invoice.sponsor.name
+  json.amount_due invoice.amount_due
+  if policy(invoice).show_in_v4?
+    json.memo invoice.memo
+    json.due_date invoice.due_date
+    json.item_amount invoice.item_amount
+    json.item_description invoice.item_description
+    json.sponsor_id invoice.sponsor_id
+  end
 end

--- a/app/views/api/v4/receipts/_receipt.json.jbuilder
+++ b/app/views/api/v4/receipts/_receipt.json.jbuilder
@@ -1,12 +1,12 @@
-json.id receipt.public_id
-json.created_at receipt.created_at
-json.url receipt.url
-json.preview_url receipt.preview(only_path: false)
-json.filename receipt.file.blob.filename
-json.uploader do
-  if receipt.user.present?
-    json.partial! "api/v4/users/user", user: receipt.user
-  else
-    json.nil!
+object_shape(json, receipt) do
+  json.url receipt.url
+  json.preview_url receipt.preview(only_path: false)
+  json.filename receipt.file.blob.filename
+  json.uploader do
+    if receipt.user.present?
+      json.partial! "api/v4/users/user", user: receipt.user
+    else
+      json.nil!
+    end
   end
 end

--- a/app/views/api/v4/sponsors/_sponsor.json.jbuilder
+++ b/app/views/api/v4/sponsors/_sponsor.json.jbuilder
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-json.id sponsor.public_id
-json.address_city sponsor.address_city
-json.address_country sponsor.address_country
-json.address_line1 sponsor.address_line1
-json.address_line2 sponsor.address_line2
-json.address_postal_code sponsor.address_postal_code
-json.address_state sponsor.address_state
-json.contact_email sponsor.contact_email
-json.name sponsor.name
-json.slug sponsor.slug
-json.created_at sponsor.created_at
-json.event_id sponsor.event_id
-json.stripe_customer_id sponsor.stripe_customer_id
+object_shape(json, sponsor) do
+  json.address_city sponsor.address_city
+  json.address_country sponsor.address_country
+  json.address_line1 sponsor.address_line1
+  json.address_line2 sponsor.address_line2
+  json.address_postal_code sponsor.address_postal_code
+  json.address_state sponsor.address_state
+  json.contact_email sponsor.contact_email
+  json.name sponsor.name
+  json.slug sponsor.slug
+  json.event_id sponsor.event_id
+  json.stripe_customer_id sponsor.stripe_customer_id
+end

--- a/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
+++ b/app/views/api/v4/stripe_cards/_stripe_card.json.jbuilder
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
-json.created_at stripe_card.created_at
-json.id stripe_card.public_id
-json.type stripe_card.card_type
-json.status stripe_card.status_text.parameterize(separator: "_")
-json.name stripe_card.name
+object_shape(json, stripe_card) do
+  json.type stripe_card.card_type
+  json.status stripe_card.status_text.parameterize(separator: "_")
+  json.name stripe_card.name
 
-if stripe_card.initially_activated?
-  json.last4 stripe_card.last4
-  json.exp_month stripe_card.stripe_exp_month
-  json.exp_year stripe_card.stripe_exp_year
-else
-  json.last4 nil
-end
-
-json.total_spent_cents stripe_card.total_spent if expand?(:total_spent_cents)
-json.balance_available stripe_card.balance_available if expand?(:balance_available)
-
-json.organization stripe_card.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
-json.user         stripe_card.user,  partial: "api/v4/users/user",   as: :user  if expand?(:user)
-json.last_frozen_by stripe_card.last_frozen_by, partial: "api/v4/users/user", as: :user if expand?(:last_frozen_by)
-
-if stripe_card.physical?
-  json.personalization do
-    json.color stripe_card.personalization_design.color
-    json.logo_url rails_blob_url(stripe_card.personalization_design.logo)
+  if stripe_card.initially_activated?
+    json.last4 stripe_card.last4
+    json.exp_month stripe_card.stripe_exp_month
+    json.exp_year stripe_card.stripe_exp_year
+  else
+    json.last4 nil
   end
-  json.shipping if policy(stripe_card).shipping? do
-    json.status stripe_card.remote_shipping_status
-    json.eta stripe_card.shipping_eta
-    json.address do
-      json.line1 stripe_card.stripe_shipping_address_line1
-      json.line2 stripe_card.stripe_shipping_address_line2
-      json.city stripe_card.stripe_shipping_address_city
-      json.state stripe_card.stripe_shipping_address_state
-      json.country stripe_card.stripe_shipping_address_country
-      json.postal_code stripe_card.stripe_shipping_address_postal_code
+
+  json.total_spent_cents stripe_card.total_spent if expand?(:total_spent_cents)
+  json.balance_available stripe_card.balance_available if expand?(:balance_available)
+
+  json.organization stripe_card.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
+  json.user         stripe_card.user,  partial: "api/v4/users/user",   as: :user  if expand?(:user)
+  json.last_frozen_by stripe_card.last_frozen_by, partial: "api/v4/users/user", as: :user if expand?(:last_frozen_by)
+
+  if stripe_card.physical?
+    json.personalization do
+      json.color stripe_card.personalization_design.color
+      json.logo_url rails_blob_url(stripe_card.personalization_design.logo)
+    end
+    json.shipping if policy(stripe_card).shipping? do
+      json.status stripe_card.remote_shipping_status
+      json.eta stripe_card.shipping_eta
+      json.address do
+        json.line1 stripe_card.stripe_shipping_address_line1
+        json.line2 stripe_card.stripe_shipping_address_line2
+        json.city stripe_card.stripe_shipping_address_city
+        json.state stripe_card.stripe_shipping_address_state
+        json.country stripe_card.stripe_shipping_address_country
+        json.postal_code stripe_card.stripe_shipping_address_postal_code
+      end
     end
   end
 end

--- a/app/views/api/v4/tags/_tag.json.jbuilder
+++ b/app/views/api/v4/tags/_tag.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-json.id tag.public_id
-json.label tag.label
-json.color tag.color
-json.emoji tag.emoji
-json.created_at tag.created_at
+object_shape(json, tag) do
+  json.label tag.label
+  json.color tag.color
+  json.emoji tag.emoji
+end

--- a/app/views/api/v4/transactions/_ach_transfer.json.jbuilder
+++ b/app/views/api/v4/transactions/_ach_transfer.json.jbuilder
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-json.recipient_name ach_transfer.recipient_name
-json.recipient_email ach_transfer.recipient_email
-json.bank_name ach_transfer.bank_name
+object_shape(json, ach_transfer) do
+  json.recipient_name ach_transfer.recipient_name
+  json.recipient_email ach_transfer.recipient_email
+  json.bank_name ach_transfer.bank_name
 
-if policy(ach_transfer).view_account_routing_numbers?
-  json.account_number_last4 ach_transfer.account_number.slice(-4, 4)
-  json.routing_number ach_transfer.routing_number
-end
+  if policy(ach_transfer).view_account_routing_numbers?
+    json.account_number_last4 ach_transfer.account_number.slice(-4, 4)
+    json.routing_number ach_transfer.routing_number
+  end
 
-json.payment_for ach_transfer.payment_for
-json.sender do
-  if ach_transfer.creator.present?
-    json.partial! "api/v4/users/user", user: ach_transfer.creator
-  else
-    json.nil!
+  json.payment_for ach_transfer.payment_for
+  json.sender do
+    if ach_transfer.creator.present?
+      json.partial! "api/v4/users/user", user: ach_transfer.creator
+    else
+      json.nil!
+    end
   end
 end

--- a/app/views/api/v4/transactions/_check.json.jbuilder
+++ b/app/views/api/v4/transactions/_check.json.jbuilder
@@ -1,23 +1,23 @@
-json.id check.public_id
+object_shape(json, check) do
+  if policy(check.local_hcb_code).show?
+    json.address_city check.is_a?(IncreaseCheck) ? check.address_city : nil
+    json.address_line1 check.is_a?(IncreaseCheck) ? check.address_line1 : nil
+    json.address_line2 check.is_a?(IncreaseCheck) ? check.address_line2 : nil
+    json.address_state check.is_a?(IncreaseCheck) ? check.address_state : nil
+    json.address_zip check.is_a?(IncreaseCheck) ? check.address_zip : nil
+    json.recipient_email check.is_a?(IncreaseCheck) ? check.recipient_email : nil
+    json.check_number check.check_number
+  end
 
-if policy(check.local_hcb_code).show?
-  json.address_city check.is_a?(IncreaseCheck) ? check.address_city : nil
-  json.address_line1 check.is_a?(IncreaseCheck) ? check.address_line1 : nil
-  json.address_line2 check.is_a?(IncreaseCheck) ? check.address_line2 : nil
-  json.address_state check.is_a?(IncreaseCheck) ? check.address_state : nil
-  json.address_zip check.is_a?(IncreaseCheck) ? check.address_zip : nil
-  json.recipient_email check.is_a?(IncreaseCheck) ? check.recipient_email : nil
-  json.check_number check.check_number
-end
-
-json.status check.is_a?(IncreaseCheck) ? check.state_text.parameterize(separator: "_") : nil # TODO: handle statuses for old Lob checks
-json.recipient_name check.is_a?(IncreaseCheck) ? check.recipient_name : nil
-json.memo check.memo
-json.payment_for check.payment_for
-json.sender do
-  if check.try(:creator) || check.try(:user)
-    json.partial! "api/v4/users/user", user: check.try(:creator) || check.try(:user)
-  else
-    json.nil!
+  json.status check.is_a?(IncreaseCheck) ? check.state_text.parameterize(separator: "_") : nil # TODO: handle statuses for old Lob checks
+  json.recipient_name check.is_a?(IncreaseCheck) ? check.recipient_name : nil
+  json.memo check.memo
+  json.payment_for check.payment_for
+  json.sender do
+    if check.try(:creator) || check.try(:user)
+      json.partial! "api/v4/users/user", user: check.try(:creator) || check.try(:user)
+    else
+      json.nil!
+    end
   end
 end

--- a/app/views/api/v4/transactions/_disbursement.json.jbuilder
+++ b/app/views/api/v4/transactions/_disbursement.json.jbuilder
@@ -1,34 +1,35 @@
 # frozen_string_literal: true
 
-json.id disbursement.public_id
-json.memo disbursement.local_hcb_code.memo
-json.status disbursement.v4_api_state
+object_shape(json, disbursement) do
+  json.memo disbursement.local_hcb_code.memo
+  json.status disbursement.v4_api_state
 
-outgoing_hcb_code = disbursement.outgoing_disbursement.local_hcb_code
-incoming_hcb_code = disbursement.incoming_disbursement.local_hcb_code
+  outgoing_hcb_code = disbursement.outgoing_disbursement.local_hcb_code
+  incoming_hcb_code = disbursement.incoming_disbursement.local_hcb_code
 
-# `transaction_id` will eventually be deprecated
-json.transaction_id outgoing_hcb_code.public_id
-json.outgoing_transaction_id outgoing_hcb_code.public_id
-json.incoming_transaction_id incoming_hcb_code.public_id
-json.amount_cents disbursement.amount
+  # `transaction_id` will eventually be deprecated
+  json.transaction_id outgoing_hcb_code.public_id
+  json.outgoing_transaction_id outgoing_hcb_code.public_id
+  json.incoming_transaction_id incoming_hcb_code.public_id
+  json.amount_cents disbursement.amount
 
-json.from do
-  json.partial! "api/v4/events/event", event: disbursement.source_event
-end
-
-json.to do
-  json.partial! "api/v4/events/event", event: disbursement.destination_event
-end
-
-json.sender do
-  if disbursement.requested_by.present?
-    json.partial! "api/v4/users/user", user: disbursement.requested_by
-  else
-    json.nil!
+  json.from do
+    json.partial! "api/v4/events/event", event: disbursement.source_event
   end
-end
 
-if disbursement.card_grant.present?
-  json.card_grant_id disbursement.card_grant&.public_id
+  json.to do
+    json.partial! "api/v4/events/event", event: disbursement.destination_event
+  end
+
+  json.sender do
+    if disbursement.requested_by.present?
+      json.partial! "api/v4/users/user", user: disbursement.requested_by
+    else
+      json.nil!
+    end
+  end
+
+  if disbursement.card_grant.present?
+    json.card_grant_id disbursement.card_grant&.public_id
+  end
 end

--- a/app/views/api/v4/transactions/_donation.json.jbuilder
+++ b/app/views/api/v4/transactions/_donation.json.jbuilder
@@ -1,31 +1,32 @@
 # frozen_string_literal: true
 
-json.id donation.public_id
-json.recurring donation.recurring?
-json.donor do
-  json.name donation.name
-  json.email donation.email
-  json.recurring_donor_id donation.recurring_donation.hashid if donation.recurring?
+object_shape(json, donation) do
+  json.recurring donation.recurring?
+  json.donor do
+    json.name donation.name
+    json.email donation.email
+    json.recurring_donor_id donation.recurring_donation.hashid if donation.recurring?
+  end
+  json.attribution do
+    json.referrer donation.referrer
+    json.utm_source donation.utm_source
+    json.utm_medium donation.utm_medium
+    json.utm_campaign donation.utm_campaign
+    json.utm_term donation.utm_term
+    json.utm_content donation.utm_content
+  end
+  json.payment_method do
+    json.type donation.payment_method_type
+    json.brand donation.payment_method_card_brand
+    json.last4 donation.payment_method_card_last4
+    json.funding donation.payment_method_card_funding
+    json.exp_month donation.payment_method_card_exp_month
+    json.exp_year donation.payment_method_card_exp_year
+    json.country donation.payment_method_card_country
+  end
+  json.message donation.message
+  json.donated_at donation.donated_at
+  json.refunded donation.refunded?
+  json.deposited donation.deposited?
+  json.in_transit donation.in_transit?
 end
-json.attribution do
-  json.referrer donation.referrer
-  json.utm_source donation.utm_source
-  json.utm_medium donation.utm_medium
-  json.utm_campaign donation.utm_campaign
-  json.utm_term donation.utm_term
-  json.utm_content donation.utm_content
-end
-json.payment_method do
-  json.type donation.payment_method_type
-  json.brand donation.payment_method_card_brand
-  json.last4 donation.payment_method_card_last4
-  json.funding donation.payment_method_card_funding
-  json.exp_month donation.payment_method_card_exp_month
-  json.exp_year donation.payment_method_card_exp_year
-  json.country donation.payment_method_card_country
-end
-json.message donation.message
-json.donated_at donation.donated_at
-json.refunded donation.refunded?
-json.deposited donation.deposited?
-json.in_transit donation.in_transit?

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -7,7 +7,7 @@ is_cpt = tx.is_a?(CanonicalPendingTransaction)
 is_hcb_code = tx.is_a?(HcbCode)
 amount = transaction_amount(tx, event: @event)
 
-object_shape(json, hcb_code, object_name: "transaction") do
+object_shape(json, hcb_code, object_name: "transaction", created_at: false) do
   json.date tx.date
   json.amount_cents amount
   json.memo hcb_code.memo(event: @event)

--- a/app/views/api/v4/transactions/_transaction.json.jbuilder
+++ b/app/views/api/v4/transactions/_transaction.json.jbuilder
@@ -7,43 +7,44 @@ is_cpt = tx.is_a?(CanonicalPendingTransaction)
 is_hcb_code = tx.is_a?(HcbCode)
 amount = transaction_amount(tx, event: @event)
 
-json.id hcb_code.public_id
-json.date tx.date
-json.amount_cents amount
-json.memo hcb_code.memo(event: @event)
-json.has_custom_memo hcb_code.custom_memo.present?
-json.pending (is_cpt && tx.unsettled?) || (is_hcb_code && !tx.pt&.fronted? && tx.pt&.unsettled?)
-json.declined (is_cpt && tx.declined?) || (is_hcb_code && tx.pt&.declined?)
-json.reversed (is_cpt && tx.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") == "reversed") || (is_hcb_code && tx.stripe_reversed_by_merchant?)
-json.tags hcb_code.tags do |tag|
-  json.id tag.public_id
-  json.label tag.label
-  json.color tag.color
-  json.emoji tag.emoji
-end
-json.code hcb_code.hcb_i1
-json.missing_receipt hcb_code.missing_receipt?(@event)
-json.lost_receipt hcb_code.no_or_lost_receipt?
-json.appearance hcb_code.incoming_disbursement.special_appearance_name if hcb_code.incoming_disbursement&.special_appearance?
-
-if current_user&.auditor?
-  json._debug do
-    json.hcb_code hcb_code.hcb_code
+object_shape(json, hcb_code, object_name: "transaction") do
+  json.date tx.date
+  json.amount_cents amount
+  json.memo hcb_code.memo(event: @event)
+  json.has_custom_memo hcb_code.custom_memo.present?
+  json.pending (is_cpt && tx.unsettled?) || (is_hcb_code && !tx.pt&.fronted? && tx.pt&.unsettled?)
+  json.declined (is_cpt && tx.declined?) || (is_hcb_code && tx.pt&.declined?)
+  json.reversed (is_cpt && tx.raw_pending_stripe_transaction&.stripe_transaction&.dig("status") == "reversed") || (is_hcb_code && tx.stripe_reversed_by_merchant?)
+  json.tags hcb_code.tags do |tag|
+    json.id tag.public_id
+    json.label tag.label
+    json.color tag.color
+    json.emoji tag.emoji
   end
-end
+  json.code hcb_code.hcb_i1
+  json.missing_receipt hcb_code.missing_receipt?(@event)
+  json.lost_receipt hcb_code.no_or_lost_receipt?
+  json.appearance hcb_code.incoming_disbursement.special_appearance_name if hcb_code.incoming_disbursement&.special_appearance?
 
-if policy(hcb_code).show?
-  json.card_charge    { json.partial! "api/v4/transactions/card_charge",    hcb_code:                                                   } if hcb_code.stripe_card? || hcb_code.stripe_force_capture?
-  json.donation       { json.partial! "api/v4/transactions/donation",       donation:       hcb_code.donation                           } if hcb_code.donation?
-  json.expense_payout { json.partial! "api/v4/transactions/expense_payout", expense_payout: hcb_code.reimbursement_expense_payout       } if hcb_code.reimbursement_expense_payout?
-  json.invoice        { json.partial! "api/v4/transactions/invoice",        invoice:        hcb_code.invoice                            } if hcb_code.invoice?
-  json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.check                              } if hcb_code.check?
-  json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.increase_check                     } if hcb_code.increase_check?
-  json.transfer       { json.partial! "api/v4/transactions/disbursement",   disbursement:   hcb_code.incoming_disbursement.disbursement } if hcb_code.incoming_disbursement?
-  json.transfer       { json.partial! "api/v4/transactions/disbursement",   disbursement:   hcb_code.outgoing_disbursement.disbursement } if hcb_code.outgoing_disbursement?
-  json.ach_transfer   { json.partial! "api/v4/transactions/ach_transfer",   ach_transfer:   hcb_code.ach_transfer                       } if hcb_code.ach_transfer?
-  json.check_deposit  { json.partial! "api/v4/transactions/check_deposit",  check_deposit:  hcb_code.check_deposit                      } if hcb_code.check_deposit?
-  json.wise_transfer  { json.partial! "api/v4/transactions/wise_transfer",  wise_transfer:  hcb_code.wise_transfer                      } if hcb_code.wise_transfer?
-end
+  if current_user&.auditor?
+    json._debug do
+      json.hcb_code hcb_code.hcb_code
+    end
+  end
 
-json.organization hcb_code.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
+  if policy(hcb_code).show?
+    json.card_charge    { json.partial! "api/v4/transactions/card_charge",    hcb_code:                                                   } if hcb_code.stripe_card? || hcb_code.stripe_force_capture?
+    json.donation       { json.partial! "api/v4/transactions/donation",       donation:       hcb_code.donation                           } if hcb_code.donation?
+    json.expense_payout { json.partial! "api/v4/transactions/expense_payout", expense_payout: hcb_code.reimbursement_expense_payout       } if hcb_code.reimbursement_expense_payout?
+    json.invoice        { json.partial! "api/v4/transactions/invoice",        invoice:        hcb_code.invoice                            } if hcb_code.invoice?
+    json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.check                              } if hcb_code.check?
+    json.check          { json.partial! "api/v4/transactions/check",          check:          hcb_code.increase_check                     } if hcb_code.increase_check?
+    json.transfer       { json.partial! "api/v4/transactions/disbursement",   disbursement:   hcb_code.incoming_disbursement.disbursement } if hcb_code.incoming_disbursement?
+    json.transfer       { json.partial! "api/v4/transactions/disbursement",   disbursement:   hcb_code.outgoing_disbursement.disbursement } if hcb_code.outgoing_disbursement?
+    json.ach_transfer   { json.partial! "api/v4/transactions/ach_transfer",   ach_transfer:   hcb_code.ach_transfer                       } if hcb_code.ach_transfer?
+    json.check_deposit  { json.partial! "api/v4/transactions/check_deposit",  check_deposit:  hcb_code.check_deposit                      } if hcb_code.check_deposit?
+    json.wise_transfer  { json.partial! "api/v4/transactions/wise_transfer",  wise_transfer:  hcb_code.wise_transfer                      } if hcb_code.wise_transfer?
+  end
+
+  json.organization hcb_code.event, partial: "api/v4/events/event", as: :event if expand?(:organization)
+end

--- a/app/views/api/v4/transactions/_wise_transfer.json.jbuilder
+++ b/app/views/api/v4/transactions/_wise_transfer.json.jbuilder
@@ -1,27 +1,26 @@
 # frozen_string_literal: true
 
-json.id wise_transfer.public_id
+object_shape(json, wise_transfer) do
+  json.recipient_name wise_transfer.recipient_name
+  json.recipient_email wise_transfer.recipient_email
+  json.recipient_country wise_transfer.recipient_country
 
-json.recipient_name wise_transfer.recipient_name
-json.recipient_email wise_transfer.recipient_email
-json.recipient_country wise_transfer.recipient_country
+  json.payment_for wise_transfer.payment_for
+  json.currency wise_transfer.currency
+  json.amount_cents wise_transfer.amount_cents
+  json.usd_amount_cents wise_transfer.usd_amount_cents if wise_transfer.usd_amount_cents.present?
+  json.state wise_transfer.aasm_state
+  json.organization_id wise_transfer.event_id
 
-json.payment_for wise_transfer.payment_for
-json.currency wise_transfer.currency
-json.amount_cents wise_transfer.amount_cents
-json.usd_amount_cents wise_transfer.usd_amount_cents if wise_transfer.usd_amount_cents.present?
-json.state wise_transfer.aasm_state
-json.organization_id wise_transfer.event_id
+  json.return_reason wise_transfer.return_reason if wise_transfer.return_reason.present?
 
-json.return_reason wise_transfer.return_reason if wise_transfer.return_reason.present?
+  json.sent_at wise_transfer.sent_at if wise_transfer.sent_at.present?
 
-json.sent_at wise_transfer.sent_at if wise_transfer.sent_at.present?
-json.created_at wise_transfer.created_at
-
-json.sender do
-  if wise_transfer.user.present?
-    json.partial! "api/v4/users/user", user: wise_transfer.user
-  else
-    json.nil!
+  json.sender do
+    if wise_transfer.user.present?
+      json.partial! "api/v4/users/user", user: wise_transfer.user
+    else
+      json.nil!
+    end
   end
 end

--- a/app/views/api/v4/users/_user.json.jbuilder
+++ b/app/views/api/v4/users/_user.json.jbuilder
@@ -1,37 +1,39 @@
 # frozen_string_literal: true
 
 # attributes suitable for public consumption:
-json.id user.public_id
-json.avatar profile_picture_for(user, params[:avatar_size].presence&.to_i || 24)
-json.admin user.admin?
-json.auditor user.auditor?
-json.name user.initial_name
+object_shape(json, user, created_at: false) do
+  json.avatar profile_picture_for(user, params[:avatar_size].presence&.to_i || 24)
+  json.admin user.admin?
+  json.auditor user.auditor?
+  json.name user.initial_name
 
-# those which we'd like to expose less of:
-expand_pii(override_if: user == current_user || local_assigns[:show_email]) do
-  json.email user.email
-end
-
-expand_pii(override_if: user == current_user) do
-  json.birthday user.birthday
-  if expand?(:shipping_address)
-    json.shipping_address do
-      json.address_line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
-      json.address_line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
-      json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
-      json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
-      json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country
-      json.postal_code user&.stripe_cards&.physical&.last&.stripe_shipping_address_postal_code
-    end
+  # those which we'd like to expose less of:
+  expand_pii(override_if: user == current_user || local_assigns[:show_email]) do
+    json.email user.email
   end
-  if expand?(:billing_address)
-    json.billing_address do
-      json.address_line1 user&.stripe_cardholder&.stripe_billing_address_line1
-      json.address_line2 user&.stripe_cardholder&.stripe_billing_address_line2
-      json.city user&.stripe_cardholder&.stripe_billing_address_city
-      json.state user&.stripe_cardholder&.stripe_billing_address_state
-      json.country user&.stripe_cardholder&.stripe_billing_address_country
-      json.postal_code user&.stripe_cardholder&.stripe_billing_address_postal_code
+
+  expand_pii(override_if: user == current_user) do
+    json.created_at user.created_at
+    json.birthday user.birthday
+    if expand?(:shipping_address)
+      json.shipping_address do
+        json.address_line1 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line1
+        json.address_line2 user&.stripe_cards&.physical&.last&.stripe_shipping_address_line2
+        json.city user&.stripe_cards&.physical&.last&.stripe_shipping_address_city
+        json.state user&.stripe_cards&.physical&.last&.stripe_shipping_address_state
+        json.country user&.stripe_cards&.physical&.last&.stripe_shipping_address_country
+        json.postal_code user&.stripe_cards&.physical&.last&.stripe_shipping_address_postal_code
+      end
+    end
+    if expand?(:billing_address)
+      json.billing_address do
+        json.address_line1 user&.stripe_cardholder&.stripe_billing_address_line1
+        json.address_line2 user&.stripe_cardholder&.stripe_billing_address_line2
+        json.city user&.stripe_cardholder&.stripe_billing_address_city
+        json.state user&.stripe_cardholder&.stripe_billing_address_state
+        json.country user&.stripe_cardholder&.stripe_billing_address_country
+        json.postal_code user&.stripe_cardholder&.stripe_billing_address_postal_code
+      end
     end
   end
 end

--- a/app/views/api/v4/users/_user.json.jbuilder
+++ b/app/views/api/v4/users/_user.json.jbuilder
@@ -13,7 +13,6 @@ object_shape(json, user, created_at: false) do
   end
 
   expand_pii(override_if: user == current_user) do
-    json.created_at user.created_at
     json.birthday user.birthday
     if expand?(:shipping_address)
       json.shipping_address do

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Api::V4::CardGrantsController do
                 "avatar"   => "https://gravatar.com/avatar/stubbed",
                 "birthday" => nil,
               },
-              "created_at" => disbursement.created_at.iso8601(3)
+              "created_at"              => disbursement.created_at.iso8601(3)
             }
           ],
           "organization"               => serialized_event,
@@ -110,7 +110,7 @@ RSpec.describe Api::V4::CardGrantsController do
             "auditor" => false,
             "avatar"  => "https://gravatar.com/avatar/stubbed",
           },
-          "created_at"=> card_grant.created_at.iso8601(3)
+          "created_at"                 => card_grant.created_at.iso8601(3)
         }
       )
     end

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -42,24 +42,26 @@ RSpec.describe Api::V4::CardGrantsController do
 
       serialized_event = {
         "id"                                => event.public_id,
+        "object"                            => "organization",
         "parent_id"                         => nil,
         "name"                              => "Test Event",
         "slug"                              => "test-event",
         "background_image"                  => nil,
         "country"                           => nil,
-        "created_at"                        => event.created_at.iso8601(3),
         "fee_percentage"                    => 0.0,
         "financially_frozen"                => false,
         "icon"                              => nil,
         "donation_page_available"           => true,
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => nil,
-        "transparent"                       => true
+        "transparent"                       => true,
+        "created_at"                        => event.created_at.iso8601(3)
       }
 
       expect(response.parsed_body).to eq(
         {
           "id"                         => card_grant.public_id,
+          "object"                     => "card_grant",
           "amount_cents"               => 123_45,
           "card_id"                    => nil,
           "one_time_use"               => true,
@@ -76,6 +78,7 @@ RSpec.describe Api::V4::CardGrantsController do
           "disbursements"              => [
             {
               "id"                      => disbursement.public_id,
+              "object"                  => "disbursement",
               "memo"                    => "Grant to recipient",
               "status"                  => "completed",
               "transaction_id"          => disbursement.local_hcb_code.public_id,
@@ -87,6 +90,7 @@ RSpec.describe Api::V4::CardGrantsController do
               "to"                      => serialized_event,
               "sender"                  => {
                 "id"       => user.public_id,
+                "object"   => "user",
                 "name"     => "Orpheus D",
                 "email"    => "orpheus@hackclub.com",
                 "admin"    => false,
@@ -94,16 +98,19 @@ RSpec.describe Api::V4::CardGrantsController do
                 "avatar"   => "https://gravatar.com/avatar/stubbed",
                 "birthday" => nil,
               },
+              "created_at" => disbursement.created_at.iso8601(3)
             }
           ],
           "organization"               => serialized_event,
           "user"                       => {
             "id"      => recipient.public_id,
+            "object"  => "user",
             "name"    => "recipient",
             "admin"   => false,
             "auditor" => false,
             "avatar"  => "https://gravatar.com/avatar/stubbed",
           },
+          "created_at"=> card_grant.created_at.iso8601(3)
         }
       )
     end


### PR DESCRIPTION
## Summary of the problem
We're not compliant with our own standards 😨 


## Describe your changes
Create the object_shape helper we defined in our v4 standards and apply it to existing routes. Couple things to notice:

1. event partial has custom object name of "organization"
2. user partial doesn't have `created_at` field for privacy reasons

