### PR TITLE
[CI] Speed up yarn install with caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Set up Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -48,7 +49,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
         # With node_modules already on disk, `--frozen-lockfile` is a
         # fast consistency check; on cache miss it installs the full
@@ -81,6 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -89,7 +91,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
         run: yarn install --frozen-lockfile --prefer-offline
       - name: Run ESLint
@@ -101,6 +103,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -109,7 +112,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
         run: yarn install --frozen-lockfile --prefer-offline
       - name: Run Prettier
@@ -152,6 +155,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -162,7 +166,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
         # With node_modules already on disk, `--frozen-lockfile` is a
         # fast consistency check; on cache miss it installs the full
@@ -244,6 +248,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -254,7 +259,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
         # With node_modules already on disk, `--frozen-lockfile` is a
         # fast consistency check; on cache miss it installs the full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,20 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-      - name: Install Yarn
-        run: yarn install
+          # Built-in yarn cache replaces the older `actions/cache` +
+          # `yarn cache dir` dance; it handles the download cache
+          # automatically, keyed on yarn.lock.
+          cache: yarn
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Install JS packages
+        # With node_modules already on disk, `--frozen-lockfile` is a
+        # fast consistency check; on cache miss it installs the full
+        # tree. Either way we end up with a lockfile-matching tree.
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Run Lint
         run: bin/lint -c
       - name: Comment suggested changes
@@ -73,7 +85,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-      - run: yarn install
+          cache: yarn
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Install JS packages
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Run ESLint
         run: yarn lint
   prettier:
@@ -86,7 +105,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-      - run: yarn install
+          cache: yarn
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+      - name: Install JS packages
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Run Prettier
         run: yarn format:check
   rspec:
@@ -130,19 +156,20 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - name: JS package cache
+          # Built-in yarn cache replaces the older `actions/cache` +
+          # `yarn cache dir` dance; it handles the download cache
+          # automatically, keyed on yarn.lock.
+          cache: yarn
+      - name: Cache node_modules
         uses: actions/cache@v5
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
-        run: |
-          yarn install --pure-lockfile
+        # With node_modules already on disk, `--frozen-lockfile` is a
+        # fast consistency check; on cache miss it installs the full
+        # tree. Either way we end up with a lockfile-matching tree.
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Install postgres client
         run: sudo apt-get install libpq-dev
       - name: Build App
@@ -222,19 +249,20 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - name: JS package cache
+          # Built-in yarn cache replaces the older `actions/cache` +
+          # `yarn cache dir` dance; it handles the download cache
+          # automatically, keyed on yarn.lock.
+          cache: yarn
+      - name: Cache node_modules
         uses: actions/cache@v5
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
       - name: Install JS packages
-        run: |
-          yarn install --pure-lockfile
+        # With node_modules already on disk, `--frozen-lockfile` is a
+        # fast consistency check; on cache miss it installs the full
+        # tree. Either way we end up with a lockfile-matching tree.
+        run: yarn install --frozen-lockfile --prefer-offline
       - name: Run zeitwerk:check
         env:
           RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-          # Built-in yarn cache replaces the older `actions/cache` +
-          # `yarn cache dir` dance; it handles the download cache
-          # automatically, keyed on yarn.lock.
+          # Handles the yarn download cache automatically, keyed on
+          # yarn.lock — no separate actions/cache step needed for it.
           cache: yarn
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -156,9 +155,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-          # Built-in yarn cache replaces the older `actions/cache` +
-          # `yarn cache dir` dance; it handles the download cache
-          # automatically, keyed on yarn.lock.
+          # Handles the yarn download cache automatically, keyed on
+          # yarn.lock — no separate actions/cache step needed for it.
           cache: yarn
       - name: Cache node_modules
         uses: actions/cache@v5
@@ -249,9 +247,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-          # Built-in yarn cache replaces the older `actions/cache` +
-          # `yarn cache dir` dance; it handles the download cache
-          # automatically, keyed on yarn.lock.
+          # Handles the yarn download cache automatically, keyed on
+          # yarn.lock — no separate actions/cache step needed for it.
           cache: yarn
       - name: Cache node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary of the problem

CI was reinstalling JS packages from scratch on every run. `setup-node`'s `cache: yarn` (and the equivalent manual block) only stores the download tarballs — every job still had to extract and link them into `node_modules`. ESLint and Prettier had no JS cache at all and cold-installed (~20s) every run.

## Describe your changes

Cache `node_modules` directly in each yarn-using job:

- Add `cache: yarn` to `setup-node` (replacing the manual `yarn cache dir` + `actions/cache` block where present).
- Add `actions/cache` on `node_modules` keyed on `runner.os` + resolved Node version (from `steps.setup-node.outputs.node-version`) + `yarn.lock` hash. OS and Node cover native-binary ABI; `yarn.lock` covers the dependency set.
- Use `yarn install --frozen-lockfile --prefer-offline` — fast consistency check on hit, full install on miss.

### Benchmark (measured)

Compared latest main run vs this branch's warm-cache run:

| Job | main | branch (warm) | Δ |
|---|---|---|---|
| ESLint | 30s | **20s** | -33% |
| Prettier | 32s | **21s** | -34% |
| Zeitwerk | 1m15s | **56s** | -25% |
| RSpec shard (each) | ~25s yarn-related | **~5s yarn-related** | -80% |

`yarn install` itself drops from 8–23s to 0–1s across the board. Critical-path CI wall time drops ~15–20s (set by RSpec, whose own variance is similar), but the jobs previously dominated by yarn install (ESLint, Prettier, Zeitwerk) see the clearer 25–35% drop.

On a first PR run (cold cache), a few early-starting jobs race each other and cold-install; once the first finishes and saves, everything after hits. Subsequent runs with unchanged `yarn.lock` hit everywhere.