### PR TITLE
[CI] Drop `apt-get update` from `setup-ruby`

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -5,9 +5,10 @@ runs:
   steps:
     - name: Install Poppler
       shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt -y install libpoppler-glib-dev
+      # ubuntu-latest ships with recent enough apt indexes to resolve
+      # libpoppler-glib-dev without a fresh `apt-get update` (~30 s).
+      # Re-add one here if a future runner image breaks that.
+      run: sudo apt-get install -y libpoppler-glib-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Summary of the problem

`ubuntu-latest` ships with recent enough apt indexes to resolve `libpoppler-glib-dev` without a fresh `apt-get update`.

## Describe your changes

Drop `apt-get update` from the `setup-ruby` composite action. If a future runner image breaks this assumption, the install step will fail loudly with `Unable to locate package` and the inline comment points at the fix.

## Measured impact

Aggregated across two CI runs per side (13 common jobs × 2 runs = 26 samples each):

| Metric | Main | This branch | Δ |
|---|---:|---:|---:|
| Avg `setup-ruby` step duration | 30.0 s | 22.3 s | **−7.7 s (−26%)** |
| Min `setup-ruby` step duration | 24 s | 17 s | −7 s |
| Max `setup-ruby` step duration | 37 s | 36 s | −1 s |

The per-invocation savings is the right thing to measure here — `apt-get update` hits external mirrors and has high variance, so averaging across ~26 samples is more honest than a single-run headline.

<details>
<summary>Per-job <code>setup-ruby</code> step duration, per run</summary>

| Job | Main #1 | Main #2 | Branch #1 | Branch #2 |
|---|---:|---:|---:|---:|
| Rubocop | 24 s | 28 s | 17 s | 19 s |
| ERB Lint | 31 s | 37 s | 24 s | 20 s |
| Annotate | 24 s | 28 s | 26 s | 20 s |
| Zeitwerk | 32 s | 33 s | 24 s | 21 s |
| Brakeman | 30 s | 27 s | 20 s | 27 s |
| RSpec shard 1 | 33 s | 29 s | 22 s | 27 s |
| RSpec shard 2 | 35 s | 26 s | 19 s | 36 s |
| RSpec shard 3 | 25 s | 26 s | 20 s | 20 s |
| RSpec shard 4 | 30 s | 33 s | 18 s | 19 s |
| RSpec shard 5 | 31 s | 34 s | 23 s | 23 s |
| RSpec shard 6 | 26 s | 37 s | 21 s | 17 s |
| RSpec shard 7 | 32 s | 30 s | 22 s | 36 s |
| RSpec shard 8 | 30 s | 29 s | 18 s | 21 s |
| **Avg** | **29.5 s** | **30.5 s** | **21.1 s** | **23.5 s** |

Main run #1: [24829851410](https://github.com/hackclub/hcb/actions/runs/24829851410) (base commit `de794090e`)
Main run #2: [24832643653](https://github.com/hackclub/hcb/actions/runs/24832643653) (base commit `634c292dc`)
Branch run #1: [24831990978](https://github.com/hackclub/hcb/actions/runs/24831990978)
Branch run #2: [24832654121](https://github.com/hackclub/hcb/actions/runs/24832654121)
</details>

### Critical-path impact

Comparing only the base-commit-matched pair (`de794090e` vs this PR's first run), the slowest job — RSpec shard 2 — dropped from 168 s to 148 s, a **−20 s critical-path improvement**. ~16 s of that came from `setup-ruby` on that specific shard (which happened to draw a slow apt on main); the remaining ~4 s is within single-run noise on other steps.

Main's more recent run (#2) includes an unrelated DB schema cache (#13560) that this branch hasn't rebased over, so comparing total run times against that run would conflate two optimizations. The `setup-ruby` step comparison above is unaffected by that change.