### PR TITLE
[v4] Save donation message

### DIFF
--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -22,6 +22,7 @@ module Api
                                    in_person: true,
                                    name: params[:name].presence,
                                    email: params[:email].presence,
+                                   message: params[:message].presence,
                                    anonymous: !!params[:anonymous],
                                    tax_deductible: params[:tax_deductible].nil? || params[:tax_deductible],
                                    fee_covered: !!params[:fee_covered] && @event.config.cover_donation_fees

--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V4::DonationsController do
   render_views
 
   describe "#create" do
-    it "persists the message and echoes it back in the response" do
+    it "creates a donation" do
       user  = create(:user)
       event = create(:event)
       create(:organizer_position, user:, event:)
@@ -26,10 +26,25 @@ RSpec.describe Api::V4::DonationsController do
       }, as: :json
 
       expect(response).to have_http_status(:created)
-      expect(response.parsed_body["message"]).to eq(message)
+      donation = event.donations.sole
 
-      donation = Donation.find_by_public_id(response.parsed_body["id"])
-      expect(donation.message).to eq(message)
+      expect(response.parsed_body).to include(
+        {
+          "id"         => donation.public_id,
+          "object"     => "donation",
+          "recurring"  => false,
+          "donor"      => {
+            "name"  => "Donor",
+            "email" => "donor@example.com",
+          },
+          "message"    => message,
+          "donated_at" => donation.donated_at.iso8601(3),
+          "refunded"   => false,
+          "deposited"  => false,
+          "in_transit" => false,
+          "created_at" => donation.created_at.iso8601(3),
+        }
+      )
     end
   end
 end

--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::DonationsController do
+  render_views
+
+  describe "#create" do
+    it "persists the message and echoes it back in the response" do
+      user  = create(:user)
+      event = create(:event)
+      create(:organizer_position, user:, event:)
+
+      token = create(:api_token, user:)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+
+      message = "Thanks for the great work — keep it up!"
+
+      post :create, params: {
+        event_id: event.public_id,
+        amount_cents: 900,
+        name: "Donor",
+        email: "donor@example.com",
+        message:,
+        tax_deductible: false,
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body["message"]).to eq(message)
+
+      donation = Donation.find_by_public_id(response.parsed_body["id"])
+      expect(donation.message).to eq(message)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
Currently, HCB Mobile's Tap to pay donation feature cannot provide messages. As I use it for fundraising, it would be helpful to keep track of what each transaction is selling. I am building a web ui to go along with this.

I am making a PR to HCB Mobile to use this functionality as well.

## Describe your changes
Save message on v4 donation API. I made a test too but TBH I am not super familiar with rails so I don't know if there's issues in it.



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

