### PR TITLE
Fix donations menu not closing when modal opens

### DIFF
--- a/app/views/hcb_codes/_meatballs.html.erb
+++ b/app/views/hcb_codes/_meatballs.html.erb
@@ -40,13 +40,13 @@
         <% end %>
       <% end %>
       <% if open_invoice %>
-        <%= link_to "#", data: { behavior: "modal_trigger", modal: "manually_mark_as_paid" }, class: "flex items-center" do %>
+        <%= link_to "#", data: { behavior: "modal_trigger", action: "menu#close", modal: "manually_mark_as_paid" }, class: "flex items-center" do %>
           <%= inline_icon "checkmark", size: 24 %>
           Manually mark as paid
         <% end %>
       <% end %>
       <% if hcb_code.donation? %>
-        <%= link_to "#", data: { behavior: "modal_trigger", modal: "update" }, class: "flex items-center" do %>
+        <%= link_to "#", data: { behavior: "modal_trigger", action: "menu#close", modal: "update" }, class: "flex items-center" do %>
           <%= inline_icon "person", size: 24 %>
           Edit donor
         <% end %>


### PR DESCRIPTION
## Summary

- When clicking "Edit donor" or "Manually mark as paid" from the meatballs (⋯) menu on a donation transaction, the dropdown menu stayed open with no way to dismiss it (required a page refresh to close).
- Added `data-action="menu#close"` to both modal trigger links in `_meatballs.html.erb`.

## Root cause

`menu_controller.js` has a guard in its `close()` method that skips closing when a click originates from inside the menu content — intentionally, to allow things like search inputs to stay open. The escape hatch is: if the clicked element's `data-action` contains `"menu#close"`, the guard is bypassed and the menu closes.

The "Edit donor" and "Manually mark as paid" links were missing this attribute. The fix follows the exact same pattern already used in `_create_tag.html.erb`.

## Test plan

- [ ] Click on a donation transaction
- [ ] Click the ⋯ menu → "Edit donor"
- [ ] Close the modal without submitting (ESC, click overlay, or close button)
- [ ] Verify the dropdown menu is gone
- [ ] Repeat for any transaction with an open invoice → "Manually mark as paid"

Fixes #13539

https://claude.ai/code/session_01WVjSqJwxg8NgvzvwjT1A6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVjSqJwxg8NgvzvwjT1A6f)_