### PR TITLE
Fix Sign the agreement email's button text align

### DIFF
--- a/app/views/contract/party_mailer/remind_signee.html.erb
+++ b/app/views/contract/party_mailer/remind_signee.html.erb
@@ -5,7 +5,7 @@
   It only takes a couple minutes to sign the agreement and get started on HCB!
 </p>
 
-<%= link_to("Sign the agreement →", @contract.contractable.is_a?(Event::Application) ? agreement_application_url(@contract.contractable) : contract_party_url(@party), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-flex; font-size: 1rem; font-weight: 600; justify-content: center; align-items: center; height: 36px; letter-spacing: 0; overflow: hidden; padding: 0 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; min-height: 36px; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;") %>
+<%= link_to("Sign the agreement →", @contract.contractable.is_a?(Event::Application) ? agreement_application_url(@contract.contractable) : contract_party_url(@party), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-flex; font-size: 1rem; font-weight: 600; justify-content: center; align-items: center; align-items: anchor-center; height: 36px; letter-spacing: 0; overflow: hidden; padding: 0 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; min-height: 36px; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;") %>
 
 <p>If you have any questions, we're here to help! Just reply to this email or reach out to <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %>.</p>
 

--- a/app/views/contract/party_mailer/remind_signee.html.erb
+++ b/app/views/contract/party_mailer/remind_signee.html.erb
@@ -5,7 +5,7 @@
   It only takes a couple minutes to sign the agreement and get started on HCB!
 </p>
 
-<%= link_to("Sign the agreement →", @contract.contractable.is_a?(Event::Application) ? agreement_application_url(@contract.contractable) : contract_party_url(@party), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-flex; font-size: 1rem; font-weight: 600; justify-content: center; align-items: center; align-items: anchor-center; height: 36px; letter-spacing: 0; overflow: hidden; padding: 0 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; min-height: 36px; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;") %>
+<%= link_to("Sign the agreement →", @contract.contractable.is_a?(Event::Application) ? agreement_application_url(@contract.contractable) : contract_party_url(@party), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-flex; font-size: 1rem; font-weight: 600; justify-content: center; align-items: anchor-center; height: 36px; letter-spacing: 0; overflow: hidden; padding: 0 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; min-height: 36px; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;") %>
 
 <p>If you have any questions, we're here to help! Just reply to this email or reach out to <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %>.</p>
 


### PR DESCRIPTION
## Summary of the problem
The "Sign the agreement" button in the contract reminder email had a wrong text alignment.

## Describe your changes
Fixed the text alignment property in `app/views/contract/party_mailer/remind_signee.html.erb` to correctly center the button text.

<img width="465" height="432.5" alt="image" src="https://github.com/user-attachments/assets/c992ee29-b19e-4189-b0ff-f3fdf6fc0fb3" />


Closes #13524
