### PR TITLE
[Policy][Code Quality] Consolidate auditor? and admin? methods

### DIFF
--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -2,7 +2,7 @@
 
 class AchTransferPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def new?
@@ -31,19 +31,19 @@ class AchTransferPolicy < ApplicationPolicy
   end
 
   def start_approval?
-    user&.admin?
+    admin?
   end
 
   def approve?
-    user&.admin?
+    admin?
   end
 
   def reject?
-    user&.admin?
+    admin?
   end
 
   def toggle_speed?
-    user&.admin?
+    admin?
   end
 
   private
@@ -53,15 +53,15 @@ class AchTransferPolicy < ApplicationPolicy
   end
 
   def auditor_or_user?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def admin_or_user?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def is_public?

--- a/app/policies/announcement/block_policy.rb
+++ b/app/policies/announcement/block_policy.rb
@@ -28,10 +28,6 @@ class Announcement
       admin? || manager?
     end
 
-    def admin?
-      user&.admin?
-    end
-
     def manager?
       OrganizerPosition.role_at_least?(user, record.event, :manager)
     end

--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -33,14 +33,6 @@ class AnnouncementPolicy < ApplicationPolicy
 
   private
 
-  def admin?
-    user&.admin?
-  end
-
-  def auditor?
-    user&.auditor?
-  end
-
   def manager?
     OrganizerPosition.role_at_least?(user, record.event, :manager)
   end

--- a/app/policies/api_token_policy.rb
+++ b/app/policies/api_token_policy.rb
@@ -2,7 +2,7 @@
 
 class ApiTokenPolicy < ApplicationPolicy
   def make_eternal?
-    user&.admin?
+    admin?
   end
 
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -54,4 +54,14 @@ class ApplicationPolicy
 
   end
 
+  private
+
+  def admin?
+    user&.admin?
+  end
+
+  def auditor?
+    user&.auditor?
+  end
+
 end

--- a/app/policies/bank_account_policy.rb
+++ b/app/policies/bank_account_policy.rb
@@ -2,27 +2,27 @@
 
 class BankAccountPolicy < ApplicationPolicy
   def index?
-    user.auditor?
+    auditor?
   end
 
   def new?
-    user.admin?
+    admin?
   end
 
   def update?
-    user.admin?
+    admin?
   end
 
   def create?
-    user.admin?
+    admin?
   end
 
   def show?
-    user.auditor?
+    auditor?
   end
 
   def reauthenticate?
-    user.admin?
+    admin?
   end
 
 end

--- a/app/policies/canonical_pending_transaction_policy.rb
+++ b/app/policies/canonical_pending_transaction_policy.rb
@@ -14,17 +14,17 @@ class CanonicalPendingTransactionPolicy < ApplicationPolicy
   end
 
   def set_category?
-    user&.admin?
+    admin?
   end
 
   private
 
   def admin_or_teammember
-    user&.admin? || record&.event&.users&.include?(user)
+    admin? || record&.event&.users&.include?(user)
   end
 
   def auditor_or_teammember
-    user&.auditor? || record&.event&.users&.include?(user)
+    auditor? || record&.event&.users&.include?(user)
   end
 
 end

--- a/app/policies/canonical_transaction_policy.rb
+++ b/app/policies/canonical_transaction_policy.rb
@@ -14,7 +14,7 @@ class CanonicalTransactionPolicy < ApplicationPolicy
   end
 
   def set_category?
-    user&.admin?
+    admin?
   end
 
   def export?
@@ -22,25 +22,25 @@ class CanonicalTransactionPolicy < ApplicationPolicy
   end
 
   def waive_fee?
-    user&.admin?
+    admin?
   end
 
   def unwaive_fee?
-    user&.admin?
+    admin?
   end
 
   def mark_bank_fee?
-    user&.admin?
+    admin?
   end
 
   private
 
   def auditor_or_teammember
-    user&.auditor? || record&.event&.users&.include?(user)
+    auditor? || record&.event&.users&.include?(user)
   end
 
   def admin_or_teammember
-    user&.admin? || record&.event&.users&.include?(user)
+    admin? || record&.event&.users&.include?(user)
   end
 
 end

--- a/app/policies/card_grant/pre_authorization_policy.rb
+++ b/app/policies/card_grant/pre_authorization_policy.rb
@@ -3,23 +3,23 @@
 class CardGrant
   class PreAuthorizationPolicy < ApplicationPolicy
     def show?
-      user&.auditor? || record.user == user || user_in_event?
+      auditor? || record.user == user || user_in_event?
     end
 
     def update?
-      user&.admin? || record.user == user || user_in_event?
+      admin? || record.user == user || user_in_event?
     end
 
     def clear_screenshots?
-      user&.auditor? || record.user == user || user_in_event?
+      auditor? || record.user == user || user_in_event?
     end
 
     def organizer_approve?
-      user&.admin? || manager_in_event?
+      admin? || manager_in_event?
     end
 
     def organizer_reject?
-      user&.admin? || manager_in_event?
+      admin? || manager_in_event?
     end
 
     private

--- a/app/policies/card_grant_policy.rb
+++ b/app/policies/card_grant_policy.rb
@@ -10,15 +10,15 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || cardholder? || user_in_event?
+    auditor? || cardholder? || user_in_event?
   end
 
   def transactions?
-    user&.auditor? || cardholder? || user_in_event?
+    auditor? || cardholder? || user_in_event?
   end
 
   def spending?
-    record.event.is_public? || user&.auditor? || user_in_event?
+    record.event.is_public? || auditor? || user_in_event?
   end
 
   def edit_actions?
@@ -54,7 +54,7 @@ class CardGrantPolicy < ApplicationPolicy
   end
 
   def activate?
-    (user&.admin? || (cardholder? && authorized_to_activate?)) && record.active?
+    (admin? || (cardholder? && authorized_to_activate?)) && record.active?
   end
 
   def cancel?
@@ -96,15 +96,15 @@ class CardGrantPolicy < ApplicationPolicy
   private
 
   def admin_or_user?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def auditor_or_manager?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def sender_admin_or_manager?

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -29,14 +29,6 @@ class CheckDepositPolicy < ApplicationPolicy
 
   private
 
-  def admin?
-    user&.admin?
-  end
-
-  def auditor?
-    user&.auditor?
-  end
-
   def user?
     OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
@@ -53,8 +45,5 @@ class CheckDepositPolicy < ApplicationPolicy
     auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
-  def user_who_can_transfer?
-    EventPolicy.new(user, record.event).create_transfer?
-  end
 
 end

--- a/app/policies/check_deposit_policy.rb
+++ b/app/policies/check_deposit_policy.rb
@@ -45,5 +45,8 @@ class CheckDepositPolicy < ApplicationPolicy
     auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
+  def user_who_can_transfer?
+    EventPolicy.new(user, record.event).create_transfer?
+  end
 
 end

--- a/app/policies/check_policy.rb
+++ b/app/policies/check_policy.rb
@@ -8,7 +8,7 @@ class CheckPolicy < ApplicationPolicy
   private
 
   def auditor_or_user
-    user&.auditor? || record.lob_address.event.users.include?(user)
+    auditor? || record.lob_address.event.users.include?(user)
   end
 
   def is_public

--- a/app/policies/column/account_number_policy.rb
+++ b/app/policies/column/account_number_policy.rb
@@ -4,11 +4,11 @@ module Column
   class AccountNumberPolicy < ApplicationPolicy
     def create?
       # Usually, we don't allow auditors to create. However, this is needed for account numbers because we create them on-demand during page load.
-      user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+      auditor? || OrganizerPosition.role_at_least?(user, record.event, :manager)
     end
 
     def update?
-      user&.admin?
+      admin?
     end
 
   end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -3,7 +3,7 @@
 class CommentPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user.auditor?
+      if auditor?
         scope.all
       else
         scope.not_admin_only
@@ -13,21 +13,21 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def new?
-    user.auditor? || users.include?(user)
+    auditor? || users.include?(user)
   end
 
   def create?
-    return false if record.admin_only && !user.auditor?
+    return false if record.admin_only && !auditor?
 
-    user.auditor? || users.include?(user)
+    auditor? || users.include?(user)
   end
 
   def edit?
-    user.admin? || (users.include?(user) && record.user == user) || (user.auditor? && record.user == user)
+    admin? || (users.include?(user) && record.user == user) || (auditor? && record.user == user)
   end
 
   def update?
-    user.admin? || (users.include?(user) && record.user == user) || (user.auditor? && record.user == user)
+    admin? || (users.include?(user) && record.user == user) || (auditor? && record.user == user)
   end
 
   def react?
@@ -35,11 +35,11 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || (users.include?(user) && !record.admin_only)
+    auditor? || (users.include?(user) && !record.admin_only)
   end
 
   def destroy?
-    user.admin? || (users.include?(user) && record.user == user) || (user.auditor? && record.user == user)
+    admin? || (users.include?(user) && record.user == user) || (auditor? && record.user == user)
   end
 
 

--- a/app/policies/contract/party_policy.rb
+++ b/app/policies/contract/party_policy.rb
@@ -4,7 +4,7 @@ class Contract
   class PartyPolicy < ApplicationPolicy
     def show?
       if record.user.present?
-        return true if record.role == "hcb" && user&.admin?
+        return true if record.role == "hcb" && admin?
 
         return record.user == user
       end
@@ -13,7 +13,7 @@ class Contract
     end
 
     def resend?
-      user&.admin?
+      admin?
     end
 
     alias_method :completed?, :show?

--- a/app/policies/contract_policy.rb
+++ b/app/policies/contract_policy.rb
@@ -2,15 +2,15 @@
 
 class ContractPolicy < ApplicationPolicy
   def create?
-    user&.admin?
+    admin?
   end
 
   def void?
-    user&.admin?
+    admin?
   end
 
   def reissue?
-    user&.admin?
+    admin?
   end
 
 end

--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -2,11 +2,11 @@
 
 class DisbursementPolicy < ApplicationPolicy
   def show?
-    user.auditor?
+    auditor?
   end
 
   def can_send?(role: :manager)
-    return true if user&.admin?
+    return true if admin?
     return true if record.source_event.nil?
     return true if OrganizerPosition.role_at_least?(user, record.source_event, role)
 
@@ -14,7 +14,7 @@ class DisbursementPolicy < ApplicationPolicy
   end
 
   def can_receive?(role: :manager)
-    return true if user&.admin?
+    return true if admin?
     return true if record.source_event&.plan&.unrestricted_disbursements_enabled?
     return true if record.destination_event.nil?
     return true if OrganizerPosition.role_at_least?(user, record.destination_event, role)
@@ -23,7 +23,7 @@ class DisbursementPolicy < ApplicationPolicy
   end
 
   def new?
-    user&.auditor? || can_send?(role: :reader) && can_receive?(role: :reader)
+    auditor? || can_send?(role: :reader) && can_receive?(role: :reader)
   end
 
   def create?
@@ -35,37 +35,37 @@ class DisbursementPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.admin?
+    admin?
   end
 
   def update?
-    user.admin?
+    admin?
   end
 
   def cancel?
-    user.admin?
+    admin?
   end
 
   def mark_fulfilled?
-    user.admin?
+    admin?
   end
 
   def reject?
-    user.admin?
+    admin?
   end
 
   def pending_disbursements?
-    user.admin?
+    admin?
   end
 
   def set_transaction_categories?
-    user.admin?
+    admin?
   end
 
   private
 
   def auditor_or_user?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -2,52 +2,52 @@
 
 class DocumentPolicy < ApplicationPolicy
   def common_index?
-    user.auditor?
+    auditor?
   end
 
   def index?
     # `record` in this context is an Event
-    user.auditor? || OrganizerPosition.role_at_least?(user, record, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record, :reader)
   end
 
   def new?
-    user.admin?
+    admin?
   end
 
   def create?
-    user.admin?
+    admin?
   end
 
   def show?
-    user.auditor?
+    auditor?
   end
 
   def edit?
-    user.admin?
+    admin?
   end
 
   def update?
-    user.admin?
+    admin?
   end
 
   def destroy?
-    user.admin?
+    admin?
   end
 
   def download?
-    user.auditor? || record.event.nil? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    auditor? || record.event.nil? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def fiscal_sponsorship_letter?
-    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || user.auditor?)
+    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || auditor?)
   end
 
   def verification_letter?
-    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || user.auditor?) && record.account_number.present?
+    !(record&.unapproved? || record&.pending?) && !record.demo_mode? && (OrganizerPosition.role_at_least?(user, record, :reader) || auditor?) && record.account_number.present?
   end
 
   def toggle_archive?
-    user.admin?
+    admin?
   end
 
 end

--- a/app/policies/donation_policy.rb
+++ b/app/policies/donation_policy.rb
@@ -2,11 +2,11 @@
 
 class DonationPolicy < ApplicationPolicy
   def show?
-    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || auditor?
   end
 
   def create?
-    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.admin?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || admin?
   end
 
   def start_donation?
@@ -18,23 +18,23 @@ class DonationPolicy < ApplicationPolicy
   end
 
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def export?
-    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || auditor?
   end
 
   def export_donors?
-    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || auditor?
   end
 
   def update?
-    OrganizerPosition.role_at_least?(user, record.event, :manager) || user&.admin?
+    OrganizerPosition.role_at_least?(user, record.event, :manager) || admin?
   end
 
   def refund?
-    user&.admin?
+    admin?
   end
 
 end

--- a/app/policies/emburse_card_policy.rb
+++ b/app/policies/emburse_card_policy.rb
@@ -2,11 +2,11 @@
 
 class EmburseCardPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def show?
-    OrganizerPosition.role_at_least?(user, record.event, :reader) || user&.auditor?
+    OrganizerPosition.role_at_least?(user, record.event, :reader) || auditor?
   end
 
 end

--- a/app/policies/emburse_card_request_policy.rb
+++ b/app/policies/emburse_card_request_policy.rb
@@ -2,15 +2,15 @@
 
 class EmburseCardRequestPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def show?
-    user&.auditor?
+    auditor?
   end
 
   def export?
-    user&.auditor?
+    auditor?
   end
 
 end

--- a/app/policies/emburse_transaction_policy.rb
+++ b/app/policies/emburse_transaction_policy.rb
@@ -2,19 +2,19 @@
 
 class EmburseTransactionPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def edit?
-    user&.admin?
+    admin?
   end
 
   def update?
-    user&.admin?
+    admin?
   end
 
   private

--- a/app/policies/employee/payment_policy.rb
+++ b/app/policies/employee/payment_policy.rb
@@ -3,30 +3,22 @@
 class Employee
   class PaymentPolicy < ApplicationPolicy
     def new?
-      employee || admin || manager
+      employee || admin? || manager
     end
 
     def create?
-      employee || admin || manager
+      employee || admin? || manager
     end
 
     def review?
-      admin || manager
+      admin? || manager
     end
 
     def stub?
-      employee || admin || manager || auditor
+      employee || admin? || manager || auditor?
     end
 
     private
-
-    def admin
-      user&.admin?
-    end
-
-    def auditor
-      user&.auditor?
-    end
 
     def manager
       OrganizerPosition.role_at_least?(user, record.employee.event, :manager)

--- a/app/policies/employee_policy.rb
+++ b/app/policies/employee_policy.rb
@@ -2,38 +2,30 @@
 
 class EmployeePolicy < ApplicationPolicy
   def new?
-    admin || team_member
+    admin? || team_member
   end
 
   def create?
-    !record.event.demo_mode && (admin || manager)
+    !record.event.demo_mode && (admin? || manager)
   end
 
   def show?
-    team_member || admin || employee || auditor
+    team_member || admin? || employee || auditor?
   end
 
   def onboard?
-    admin
+    admin?
   end
 
   def terminate?
-    admin || manager
+    admin? || manager
   end
 
   def destroy?
-    (manager || admin) && record.onboarding?
+    (manager || admin?) && record.onboarding?
   end
 
   private
-
-  def admin
-    user&.admin?
-  end
-
-  def auditor
-    user&.auditor?
-  end
 
   def manager
     OrganizerPosition.role_at_least?(user, record.event, :manager)

--- a/app/policies/event/affiliation_policy.rb
+++ b/app/policies/event/affiliation_policy.rb
@@ -3,19 +3,19 @@
 class Event
   class AffiliationPolicy < ApplicationPolicy
     def create?
-      return true if user.admin?
+      return true if admin?
       return OrganizerPosition.role_at_least?(user, record, :manager) if record.is_a?(Event)
       return user == record.user if record.is_a?(Event::Application)
     end
 
     def update?
-      return true if user.admin?
+      return true if admin?
       return OrganizerPosition.role_at_least?(user, record.affiliable, :manager) if record.affiliable.is_a?(Event)
       return user == record.affiliable.user if record.affiliable.is_a?(Event::Application)
     end
 
     def destroy?
-      return true if user.admin?
+      return true if admin?
       return OrganizerPosition.role_at_least?(user, record.affiliable, :manager) if record.affiliable.is_a?(Event)
       return user == record.affiliable.user if record.affiliable.is_a?(Event::Application)
     end

--- a/app/policies/event/application_policy.rb
+++ b/app/policies/event/application_policy.rb
@@ -7,38 +7,38 @@ class Event
     end
 
     def show?
-      record.user == user || user.auditor?
+      record.user == user || auditor?
     end
 
     def airtable?
-      user.auditor?
+      auditor?
     end
 
     def admin_approve?
-      user.admin?
+      admin?
     end
 
     def admin_reject?
-      user.admin?
+      admin?
     end
 
     def admin_activate?
-      user.admin?
+      admin?
     end
 
     def edit?
-      user.admin?
+      admin?
     end
 
     def update?
-      return true if user.admin?
+      return true if admin?
       return record.user == user if record.draft?
 
       false
     end
 
     def archive?
-      user.admin? || record.user == user
+      admin? || record.user == user
     end
 
     alias_method :unarchive?, :archive?
@@ -46,7 +46,7 @@ class Event
     def resend_to_cosigner?
       return false if record.contract&.party(:cosigner).nil?
 
-      record.contract.party(:cosigner).pending? && (record.user == user || user.admin?)
+      record.contract.party(:cosigner).pending? && (record.user == user || admin?)
     end
 
     alias_method :personal_info?, :show?
@@ -56,11 +56,11 @@ class Event
     alias_method :review?, :show?
 
     def mark_videos_watched?
-      user.admin? || record.user == user
+      admin? || record.user == user
     end
 
     def submission?
-      (record.user == user && !record.draft?) || user.auditor?
+      (record.user == user && !record.draft?) || auditor?
     end
 
     alias_method :submit?, :update?

--- a/app/policies/event/scoped_tag_policy.rb
+++ b/app/policies/event/scoped_tag_policy.rb
@@ -21,7 +21,7 @@ class Event
     private
 
     def admin_or_manager?
-      user&.admin? || OrganizerPosition.role_at_least?(user, record.parent_event, :manager)
+      admin? || OrganizerPosition.role_at_least?(user, record.parent_event, :manager)
     end
 
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -35,15 +35,15 @@ class EventPolicy < ApplicationPolicy
   alias_method :merchants_filter?, :transactions?
 
   def toggle_hidden?
-    user&.admin?
+    admin?
   end
 
   def new?
-    user&.admin?
+    admin?
   end
 
   def create?
-    user&.admin?
+    admin?
   end
 
   def balance_by_date?
@@ -84,7 +84,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user&.admin? && record.demo_mode?
+    admin? && record.demo_mode?
   end
 
   def team?
@@ -220,7 +220,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def toggle_event_tag?
-    user.admin?
+    admin?
   end
 
   def receive_grant?
@@ -228,11 +228,11 @@ class EventPolicy < ApplicationPolicy
   end
 
   def audit_log?
-    user.auditor?
+    auditor?
   end
 
   def termination?
-    user&.auditor?
+    auditor?
   end
 
   def can_invite_user?
@@ -240,15 +240,15 @@ class EventPolicy < ApplicationPolicy
   end
 
   def claim_point_of_contact?
-    user&.admin?
+    admin?
   end
 
   def activation_flow?
-    user&.admin? && record.demo_mode?
+    admin? && record.demo_mode?
   end
 
   def activate?
-    user&.admin? && record.demo_mode?
+    admin? && record.demo_mode?
   end
 
   def toggle_scoped_tag?
@@ -267,14 +267,6 @@ class EventPolicy < ApplicationPolicy
 
   def auditor_or_member?
     auditor? || member?
-  end
-
-  def admin?
-    user&.admin?
-  end
-
-  def auditor?
-    user&.auditor?
   end
 
   def reader?

--- a/app/policies/event_tag_policy.rb
+++ b/app/policies/event_tag_policy.rb
@@ -2,15 +2,15 @@
 
 class EventTagPolicy < ApplicationPolicy
   def create?
-    user.admin?
+    admin?
   end
 
   def destroy?
-    user.admin?
+    admin?
   end
 
   def toggle_event_tag?
-    user.admin?
+    admin?
   end
 
 end

--- a/app/policies/fee_policy.rb
+++ b/app/policies/fee_policy.rb
@@ -2,7 +2,7 @@
 
 class FeePolicy < ApplicationPolicy
   def create?
-    user&.admin?
+    admin?
   end
 
 end

--- a/app/policies/g_suite/revocation_policy.rb
+++ b/app/policies/g_suite/revocation_policy.rb
@@ -3,11 +3,11 @@
 class GSuite
   class RevocationPolicy < ApplicationPolicy
     def create?
-      user.admin?
+      admin?
     end
 
     def destroy?
-      user.admin?
+      admin?
     end
 
   end

--- a/app/policies/g_suite_account_policy.rb
+++ b/app/policies/g_suite_account_policy.rb
@@ -2,7 +2,7 @@
 
 class GSuiteAccountPolicy < ApplicationPolicy
   def index?
-    user.auditor?
+    auditor?
   end
 
   def create?
@@ -10,7 +10,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
   end
 
   def show?
-    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.g_suite.revocation.present?)
+    auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.g_suite.revocation.present?)
   end
 
   def reset_password?
@@ -18,11 +18,11 @@ class GSuiteAccountPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.admin?
+    admin?
   end
 
   def update?
-    user.admin?
+    admin?
   end
 
   def destroy?
@@ -30,7 +30,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
   end
 
   def reject?
-    user.admin?
+    admin?
   end
 
   def toggle_suspension?
@@ -40,7 +40,7 @@ class GSuiteAccountPolicy < ApplicationPolicy
   private
 
   def admin_or_manager?
-    return true if user&.admin?
+    return true if admin?
 
     revocation = record.is_a?(GSuite) ? record.revocation : record&.g_suite&.revocation
     OrganizerPosition.role_at_least?(user, record.event, :manager) && !revocation&.revoked?

--- a/app/policies/g_suite_alias_policy.rb
+++ b/app/policies/g_suite_alias_policy.rb
@@ -12,7 +12,7 @@ class GSuiteAliasPolicy < ApplicationPolicy
   private
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.g_suite.event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, record.g_suite.event, :manager)
   end
 
 end

--- a/app/policies/g_suite_policy.rb
+++ b/app/policies/g_suite_policy.rb
@@ -2,31 +2,31 @@
 
 class GSuitePolicy < ApplicationPolicy
   def index?
-    user.auditor?
+    auditor?
   end
 
   def create?
-    user.admin?
+    admin?
   end
 
   def show?
-    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
+    auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
   end
 
   def edit?
-    user.admin?
+    admin?
   end
 
   def update?
-    user.admin?
+    admin?
   end
 
   def destroy?
-    user.admin?
+    admin?
   end
 
   def status?
-    user.auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
+    auditor? || (OrganizerPosition.role_at_least?(user, record.event, :reader) && !record.revocation.present?)
   end
 
 end

--- a/app/policies/hcb_code/tag/suggestion_policy.rb
+++ b/app/policies/hcb_code/tag/suggestion_policy.rb
@@ -14,7 +14,7 @@ class HcbCode
       private
 
       def admin_or_user?
-        user&.admin? || OrganizerPosition.role_at_least?(user, record.tag.event, :member)
+        admin? || OrganizerPosition.role_at_least?(user, record.tag.event, :member)
       end
 
     end

--- a/app/policies/hcb_code_policy.rb
+++ b/app/policies/hcb_code_policy.rb
@@ -2,11 +2,11 @@
 
 class HcbCodePolicy < ApplicationPolicy
   def show?
-    user&.auditor? || present_in_events? || (record.stripe_cardholder.present? && record.stripe_cardholder.user == user)
+    auditor? || present_in_events? || (record.stripe_cardholder.present? && record.stripe_cardholder.user == user)
   end
 
   def memo_frame?
-    user&.admin?
+    admin?
   end
 
   def edit?
@@ -22,11 +22,11 @@ class HcbCodePolicy < ApplicationPolicy
   end
 
   def attach_receipt?
-    user&.admin? || gte_member_in_events? || user_made_purchase?
+    admin? || gte_member_in_events? || user_made_purchase?
   end
 
   def send_receipt_sms?
-    user&.admin?
+    admin?
   end
 
   def dispute?
@@ -64,7 +64,7 @@ class HcbCodePolicy < ApplicationPolicy
   # if users have permissions greater than or equal to member in events
   def gte_member_in_events?
     return false if user.nil? # dont run checks if the user isnt signed in
-    return true if user&.admin?
+    return true if admin?
 
     record.events.any? do |e|
       OrganizerPosition.role_at_least?(user, e, :member)

--- a/app/policies/increase_check_policy.rb
+++ b/app/policies/increase_check_policy.rb
@@ -10,7 +10,7 @@ class IncreaseCheckPolicy < ApplicationPolicy
   end
 
   def approve?
-    user&.admin?
+    admin?
   end
 
   def stop?
@@ -18,7 +18,7 @@ class IncreaseCheckPolicy < ApplicationPolicy
   end
 
   def reissue?
-    user&.admin?
+    admin?
   end
 
   def reject?
@@ -27,16 +27,17 @@ class IncreaseCheckPolicy < ApplicationPolicy
 
   private
 
-  def auditor_or_user?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
-  def admin_or_user?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
   def user_who_can_transfer?
     EventPolicy.new(user, record.event).create_transfer?
   end
+
+  def auditor_or_user?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
+  def admin_or_user?
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
 
 end

--- a/app/policies/increase_check_policy.rb
+++ b/app/policies/increase_check_policy.rb
@@ -27,9 +27,6 @@ class IncreaseCheckPolicy < ApplicationPolicy
 
   private
 
-  def user_who_can_transfer?
-    EventPolicy.new(user, record.event).create_transfer?
-  end
 
   def auditor_or_user?
     auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
@@ -39,5 +36,8 @@ class IncreaseCheckPolicy < ApplicationPolicy
     admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
+  def user_who_can_transfer?
+    EventPolicy.new(user, record.event).create_transfer?
+  end
 
 end

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -2,7 +2,7 @@
 
 class InvoicePolicy < ApplicationPolicy
   def index?
-    return true if user&.auditor?
+    return true if auditor?
 
     event_ids = record.map(&:sponsor).map(&:event).pluck(:id)
     same_event = event_ids.uniq.size == 1 # same_event is a sanity check that all the records are from the same event
@@ -49,7 +49,7 @@ class InvoicePolicy < ApplicationPolicy
   end
 
   def refund?
-    user&.admin?
+    admin?
   end
 
   def show_in_v4?
@@ -57,11 +57,11 @@ class InvoicePolicy < ApplicationPolicy
   end
 
   def auditor_or_reader?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, event, :reader)
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, event, :manager)
   end
 
   private

--- a/app/policies/ledger/item_policy.rb
+++ b/app/policies/ledger/item_policy.rb
@@ -7,7 +7,7 @@ class Ledger
         LedgerPolicy.new(user, record.primary_ledger).show?
       else
         # Item is unampped, only admins can see it
-        user&.admin?
+        admin?
       end
     end
 

--- a/app/policies/ledger_policy.rb
+++ b/app/policies/ledger_policy.rb
@@ -2,7 +2,7 @@
 
 class LedgerPolicy < ApplicationPolicy
   def show?
-    user&.auditor?
+    auditor?
   end
 
 end

--- a/app/policies/organizer_position/spending/control/allowance_policy.rb
+++ b/app/policies/organizer_position/spending/control/allowance_policy.rb
@@ -9,7 +9,7 @@ class OrganizerPosition
         end
 
         def create?
-          user.admin? ||
+          admin? ||
             OrganizerPosition.role_at_least?(user, record.event, :manager)
         end
 

--- a/app/policies/organizer_position/spending/control_policy.rb
+++ b/app/policies/organizer_position/spending/control_policy.rb
@@ -4,13 +4,13 @@ class OrganizerPosition
   module Spending
     class ControlPolicy < ApplicationPolicy
       def index?
-        user.auditor? || (
+        auditor? || (
           current_user_manager? || own_control?
         )
       end
 
       def create?
-        user.admin? || (
+        admin? || (
            current_user_manager? &&
            !record.organizer_position.manager?
            # Don't have to make sure you're not setting the control on yourself as
@@ -20,7 +20,7 @@ class OrganizerPosition
       end
 
       def destroy?
-        user.admin? || current_user_manager?
+        admin? || current_user_manager?
       end
 
       private

--- a/app/policies/organizer_position_deletion_request_policy.rb
+++ b/app/policies/organizer_position_deletion_request_policy.rb
@@ -2,7 +2,7 @@
 
 class OrganizerPositionDeletionRequestPolicy < ApplicationPolicy
   def index?
-    user.auditor?
+    auditor?
   end
 
   def new?
@@ -15,19 +15,19 @@ class OrganizerPositionDeletionRequestPolicy < ApplicationPolicy
     target_is_in_event = record.event.organizer_positions.include?(record.organizer_position)
     target_has_no_pending_request = record.organizer_position.organizer_position_deletion_requests.under_review.none?
 
-    user.admin? || (target_is_in_event && target_has_no_pending_request && current_user_is_manager? || current_user_is_the_user?)
+    admin? || (target_is_in_event && target_has_no_pending_request && current_user_is_manager? || current_user_is_the_user?)
   end
 
   def show?
-    user.auditor?
+    auditor?
   end
 
   def close?
-    user.admin?
+    admin?
   end
 
   def open?
-    user.admin?
+    admin?
   end
 
   private

--- a/app/policies/organizer_position_invite/link_policy.rb
+++ b/app/policies/organizer_position_invite/link_policy.rb
@@ -24,10 +24,6 @@ class OrganizerPositionInvite
 
     private
 
-    def admin?
-      user&.admin?
-    end
-
     def manager?
       OrganizerPosition.role_at_least?(user, record.event, :manager)
     end

--- a/app/policies/organizer_position_invite/request_policy.rb
+++ b/app/policies/organizer_position_invite/request_policy.rb
@@ -16,10 +16,6 @@ class OrganizerPositionInvite
 
     private
 
-    def admin?
-      user&.admin?
-    end
-
     def manager?
       OrganizerPosition.role_at_least?(user, record.link.event, :manager)
     end

--- a/app/policies/organizer_position_invite_policy.rb
+++ b/app/policies/organizer_position_invite_policy.rb
@@ -2,7 +2,7 @@
 
 class OrganizerPositionInvitePolicy < ApplicationPolicy
   def index?
-    user&.auditor? || record.event&.users&.include?(user)
+    auditor? || record.event&.users&.include?(user)
   end
 
   def new?
@@ -14,7 +14,7 @@ class OrganizerPositionInvitePolicy < ApplicationPolicy
   end
 
   def show?
-    user&.auditor? || record.user == user
+    auditor? || record.user == user
   end
 
   def accept?
@@ -42,13 +42,13 @@ class OrganizerPositionInvitePolicy < ApplicationPolicy
   end
 
   def send_contract?
-    user&.admin?
+    admin?
   end
 
   private
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
 end

--- a/app/policies/organizer_position_policy.rb
+++ b/app/policies/organizer_position_policy.rb
@@ -26,18 +26,18 @@ class OrganizerPositionPolicy < ApplicationPolicy
   end
 
   def view_allowances?
-    admin_or_manager? || record.user == user || user&.auditor?
+    admin_or_manager? || record.user == user || auditor?
   end
 
   private
 
   def admin_or_manager?
-    user&.admin? ||
+    admin? ||
       OrganizerPosition.role_at_least?(user, record.event, :manager) # This is not just `record`!
   end
 
   def admin_or_contract_signee?
-    user&.admin? || OrganizerPosition.find_by(user:, event: record.event)&.is_signee
+    admin? || OrganizerPosition.find_by(user:, event: record.event)&.is_signee
   end
 
 end

--- a/app/policies/paypal_transfer_policy.rb
+++ b/app/policies/paypal_transfer_policy.rb
@@ -10,7 +10,7 @@ class PaypalTransferPolicy < ApplicationPolicy
   end
 
   def approve?
-    user&.admin?
+    admin?
   end
 
   def reject?
@@ -18,7 +18,7 @@ class PaypalTransferPolicy < ApplicationPolicy
   end
 
   def mark_failed?
-    user&.admin?
+    admin?
   end
 
   private

--- a/app/policies/receipt_policy.rb
+++ b/app/policies/receipt_policy.rb
@@ -3,7 +3,7 @@
 class ReceiptPolicy < ApplicationPolicy
   def destroy?
     return false if record.nil?
-    return true if user&.admin?
+    return true if admin?
 
     # the receipt is in receipt bin.
     if record.receiptable.nil?

--- a/app/policies/receiptable_policy.rb
+++ b/app/policies/receiptable_policy.rb
@@ -2,7 +2,7 @@
 
 class ReceiptablePolicy < ApplicationPolicy
   def upload?
-    user&.admin? || present_in_events? || Pundit.policy(user, record).try(:receiptable_upload?)
+    admin? || present_in_events? || Pundit.policy(user, record).try(:receiptable_upload?)
   end
 
   def link?
@@ -10,7 +10,7 @@ class ReceiptablePolicy < ApplicationPolicy
   end
 
   def link_modal?
-    upload? || user&.auditor?
+    upload? || auditor?
   end
 
   def mark_no_or_lost?

--- a/app/policies/referral/link_policy.rb
+++ b/app/policies/referral/link_policy.rb
@@ -7,7 +7,7 @@ module Referral
     end
 
     def create?
-      user.auditor?
+      auditor?
     end
 
   end

--- a/app/policies/referral/program_policy.rb
+++ b/app/policies/referral/program_policy.rb
@@ -3,7 +3,7 @@
 module Referral
   class ProgramPolicy < ApplicationPolicy
     def create?
-      user.auditor?
+      auditor?
     end
 
   end

--- a/app/policies/reimbursement/expense_policy.rb
+++ b/app/policies/reimbursement/expense_policy.rb
@@ -3,27 +3,27 @@
 module Reimbursement
   class ExpensePolicy < ApplicationPolicy
     def create?
-      unlocked && (admin || manager || creator)
+      unlocked && (admin? || manager || creator)
     end
 
     def edit?
-      unlocked && (admin || manager || creator) && !record.is_fee?
+      unlocked && (admin? || manager || creator) && !record.is_fee?
     end
 
     def update?
-      unlocked && (admin || manager || creator) && !record.is_fee?
+      unlocked && (admin? || manager || creator) && !record.is_fee?
     end
 
     def destroy?
-      unlocked && (admin || manager || creator) && !record.is_fee?
+      unlocked && (admin? || manager || creator) && !record.is_fee?
     end
 
     def approve?
-      (admin || (manager && !creator)) && record.report.submitted?
+      (admin? || (manager && !creator)) && record.report.submitted?
     end
 
     def unapprove?
-      (admin || (manager && !creator)) && record.report.submitted?
+      (admin? || (manager && !creator)) && record.report.submitted?
     end
 
     def user_made_expense?
@@ -33,10 +33,6 @@ module Reimbursement
     alias receiptable_upload? user_made_expense?
 
     private
-
-    def admin
-      user&.admin?
-    end
 
     def manager
       record.event && OrganizerPosition.role_at_least?(user, record.event, :manager)

--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -3,15 +3,15 @@
 module Reimbursement
   class ReportPolicy < ApplicationPolicy
     def new?
-      admin || reader
+      admin? || reader
     end
 
     def create?
-      !record.event.demo_mode && (record.event.public_reimbursement_page_available? || admin || OrganizerPosition.role_at_least?(user, record.event, :member))
+      !record.event.demo_mode && (record.event.public_reimbursement_page_available? || admin? || OrganizerPosition.role_at_least?(user, record.event, :member))
     end
 
     def show?
-      admin || reader || creator || auditor
+      admin? || reader || creator || auditor?
     end
 
     def wise_transfer_quote?
@@ -23,70 +23,62 @@ module Reimbursement
     end
 
     def edit?
-      admin || manager || (creator && unlocked)
+      admin? || manager || (creator && unlocked)
     end
 
     def update?
-      admin || manager || (creator && open)
+      admin? || manager || (creator && open)
     end
 
     def submit?
-      unlocked && (admin || manager || creator)
+      unlocked && (admin? || manager || creator)
     end
 
     def draft?
-      ((admin || manager || creator) && open) || ((admin || manager) && record.rejected?)
+      ((admin? || manager || creator) && open) || ((admin? || manager) && record.rejected?)
     end
 
     def request_reimbursement?
-      (admin || (manager && !creator)) && open
+      (admin? || (manager && !creator)) && open
     end
 
     def convert_to_wise_transfer?
-      admin && !record.event.financially_frozen?
+      admin? && !record.event.financially_frozen?
     end
 
     def request_changes?
-      (admin || manager) && open
+      (admin? || manager) && open
     end
 
     def approve_all_expenses?
-      (admin || (manager && !creator)) && open
+      (admin? || (manager && !creator)) && open
     end
 
     def reject?
-      (admin || manager) && open
+      (admin? || manager) && open
     end
 
     def update_currency?
-      (admin || manager || creator) && open && record.mismatched_currency?
+      (admin? || manager || creator) && open && record.mismatched_currency?
     end
 
     def admin_approve?
-      admin && open
+      admin? && open
     end
 
     def admin_send_wise_transfer?
-      admin
+      admin?
     end
 
     def reverse?
-      admin
+      admin?
     end
 
     def destroy?
-      ((manager || creator) && record.draft?) || (admin && !record.reimbursed?)
+      ((manager || creator) && record.draft?) || (admin? && !record.reimbursed?)
     end
 
     private
-
-    def admin
-      user&.admin?
-    end
-
-    def auditor
-      user&.auditor?
-    end
 
     def manager
       record.event && OrganizerPosition.role_at_least?(user, record.event, :manager)

--- a/app/policies/sponsor_policy.rb
+++ b/app/policies/sponsor_policy.rb
@@ -43,7 +43,7 @@ class SponsorPolicy < ApplicationPolicy
       :id
     ]
 
-    attrs << :event_id if user&.admin?
+    attrs << :event_id if admin?
 
     attrs
   end
@@ -51,11 +51,11 @@ class SponsorPolicy < ApplicationPolicy
   private
 
   def auditor_or_reader?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
   end
 
   def admin_or_member?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record&.event, :member)
+    admin? || OrganizerPosition.role_at_least?(user, record&.event, :member)
   end
 
 end

--- a/app/policies/stripe_card/personalization_design_policy.rb
+++ b/app/policies/stripe_card/personalization_design_policy.rb
@@ -3,15 +3,15 @@
 class StripeCard
   class PersonalizationDesignPolicy < ApplicationPolicy
     def show?
-      user&.auditor?
+      auditor?
     end
 
     def make_common?
-      user&.admin?
+      admin?
     end
 
     def make_unlisted?
-      user&.admin?
+      admin?
     end
 
   end

--- a/app/policies/stripe_card_policy.rb
+++ b/app/policies/stripe_card_policy.rb
@@ -2,11 +2,11 @@
 
 class StripeCardPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def shipping?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
   def freeze?
@@ -25,11 +25,11 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def activate?
-    (user&.admin? || member_and_cardholder?) && !record.canceled? && !record.event&.financially_frozen?
+    (admin? || member_and_cardholder?) && !record.canceled? && !record.event&.financially_frozen?
   end
 
   def show?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || grantee?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || grantee?
   end
 
   def edit?
@@ -41,7 +41,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def transactions?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || cardholder?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader) || cardholder?
   end
 
   def ephemeral_keys?
@@ -51,7 +51,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def enable_cash_withdrawal?
-    user&.admin?
+    admin?
   end
 
   private
@@ -69,7 +69,7 @@ class StripeCardPolicy < ApplicationPolicy
   end
 
   def admin_or_manager?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
   def grantee?

--- a/app/policies/stripe_cardholder_policy.rb
+++ b/app/policies/stripe_cardholder_policy.rb
@@ -2,19 +2,19 @@
 
 class StripeCardholderPolicy < ApplicationPolicy
   def new?
-    user&.admin? || record&.user = user
+    admin? || record&.user = user
   end
 
   def create?
-    user&.admin? || record&.user = user
+    admin? || record&.user = user
   end
 
   def update?
-    user&.admin? || record&.event&.users&.include?(user)
+    admin? || record&.event&.users&.include?(user)
   end
 
   def update_profile?
-    user&.admin? || record&.user == user
+    admin? || record&.user == user
   end
 
 end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -23,10 +23,6 @@ class TagPolicy < ApplicationPolicy
 
   private
 
-  def auditor?
-    user&.auditor?
-  end
-
   def reader?
     OrganizerPosition.role_at_least?(user, record.event, :reader)
   end

--- a/app/policies/transaction_policy.rb
+++ b/app/policies/transaction_policy.rb
@@ -2,11 +2,11 @@
 
 class TransactionPolicy < ApplicationPolicy
   def index?
-    user&.auditor?
+    auditor?
   end
 
   def export?
-    user&.auditor? ||
+    auditor? ||
       record.all? { |r| r.event.users.include? user }
   end
 
@@ -27,7 +27,7 @@ class TransactionPolicy < ApplicationPolicy
   private
 
   def auditor_or_teammember
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
+    auditor? || OrganizerPosition.role_at_least?(user, record&.event, :reader)
   end
 
   def admin_or_teammember

--- a/app/policies/user/email_update_policy.rb
+++ b/app/policies/user/email_update_policy.rb
@@ -3,11 +3,11 @@
 class User
   class EmailUpdatePolicy < ApplicationPolicy
     def verify?
-      user.admin? || record.user == user
+      admin? || record.user == user
     end
 
     def authorize_change?
-      user.admin? || record.user == user
+      admin? || record.user == user
     end
 
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,27 +2,27 @@
 
 class UserPolicy < ApplicationPolicy
   def show?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def impersonate?
-    user.admin?
+    admin?
   end
 
   def edit?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def generate_totp?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def enable_totp?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def disable_totp?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def generate_backup_codes?
@@ -34,87 +34,87 @@ class UserPolicy < ApplicationPolicy
   end
 
   def disable_backup_codes?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def edit_address?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_payout?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_featurepreviews?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_security?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_notifications?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_integrations?
-    user.auditor? || record == user
+    auditor? || record == user
   end
 
   def edit_admin?
-    user.auditor? || (record == user && user.admin_override_pretend?)
+    auditor? || (record == user && user.admin_override_pretend?)
   end
 
   def admin_details?
-    user.auditor?
+    auditor?
   end
 
   def admin_details_stripe_transactions?
-    user.auditor?
+    auditor?
   end
 
   def update?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def delete_profile_picture?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def toggle_sms_auth?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def start_sms_auth_verification?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def complete_sms_auth_verification?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def receipt_report?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def enable_feature?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def disable_feature?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def logout_session?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def logout_all?
-    user.admin? || record == user
+    admin? || record == user
   end
 
   def toggle_pretend_is_not_admin?
-    user.auditor? || (record == user && user.admin_override_pretend?)
+    auditor? || (record == user && user.admin_override_pretend?)
   end
 
 end

--- a/app/policies/webauthn_credential_policy.rb
+++ b/app/policies/webauthn_credential_policy.rb
@@ -2,7 +2,7 @@
 
 class WebauthnCredentialPolicy < ApplicationPolicy
   def destroy?
-    user.admin? || record.user == user
+    admin? || record.user == user
   end
 
 end

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -10,11 +10,11 @@ class WirePolicy < ApplicationPolicy
   end
 
   def approve?
-    user&.admin?
+    admin?
   end
 
   def send_wire?
-    user&.admin?
+    admin?
   end
 
   def reject?
@@ -22,25 +22,26 @@ class WirePolicy < ApplicationPolicy
   end
 
   def edit?
-    user&.admin?
+    admin?
   end
 
   def update?
-    user&.admin?
+    admin?
   end
 
   private
 
-  def auditor_or_user?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
-  def admin_or_user?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
   def user_who_can_transfer?
     EventPolicy.new(user, record.event).create_transfer?
   end
+
+  def auditor_or_user?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
+  def admin_or_user?
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
 
 end

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -31,9 +31,6 @@ class WirePolicy < ApplicationPolicy
 
   private
 
-  def user_who_can_transfer?
-    EventPolicy.new(user, record.event).create_transfer?
-  end
 
   def auditor_or_user?
     auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
@@ -43,5 +40,8 @@ class WirePolicy < ApplicationPolicy
     admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
+  def user_who_can_transfer?
+    EventPolicy.new(user, record.event).create_transfer?
+  end
 
 end

--- a/app/policies/wise_transfer_policy.rb
+++ b/app/policies/wise_transfer_policy.rb
@@ -35,10 +35,6 @@ class WiseTransferPolicy < ApplicationPolicy
 
   private
 
-  def user_who_can_transfer?
-    EventPolicy.new(user, record.event).create_transfer?
-  end
-
   def auditor_or_user?
     auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
@@ -47,5 +43,8 @@ class WiseTransferPolicy < ApplicationPolicy
     admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
   end
 
+  def user_who_can_transfer?
+    EventPolicy.new(user, record.event).create_transfer?
+  end
 
 end

--- a/app/policies/wise_transfer_policy.rb
+++ b/app/policies/wise_transfer_policy.rb
@@ -10,7 +10,7 @@ class WiseTransferPolicy < ApplicationPolicy
   end
 
   def approve?
-    user&.admin?
+    admin?
   end
 
   def reject?
@@ -18,11 +18,11 @@ class WiseTransferPolicy < ApplicationPolicy
   end
 
   def update?
-    user&.admin?
+    admin?
   end
 
   def mark_sent?
-    user&.admin?
+    admin?
   end
 
   def mark_failed?
@@ -30,21 +30,22 @@ class WiseTransferPolicy < ApplicationPolicy
   end
 
   def generate_quote?
-    user&.auditor? || user.events.any?
+    auditor? || user.events.any?
   end
 
   private
 
-  def auditor_or_user?
-    user&.auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
-  def admin_or_user?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
-  end
-
   def user_who_can_transfer?
     EventPolicy.new(user, record.event).create_transfer?
   end
+
+  def auditor_or_user?
+    auditor? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
+  def admin_or_user?
+    admin? || OrganizerPosition.role_at_least?(user, record.event, :reader)
+  end
+
 
 end


### PR DESCRIPTION
## Summary of the problem
It would be cleaner to standardize use of `admin?` and `auditor?` methods without having to define them in every policy file. 


## Describe your changes
Since they're widely used we should define them in the parent policy then we can reference them through inheritance


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

