### PR TITLE
Fix creating too many session public activities

### DIFF
--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -60,7 +60,7 @@ class User
     scope :verified, -> { where(verified: true) }
     scope :unverified, -> { where(verified: false) }
 
-    after_save :create_login_activity, if: -> { user_id_before_last_save.nil? && user.present? }
+    after_save :create_login_activity, if: -> { user_id_before_last_save.nil? && user(allow_unverified: true).present? }
 
     after_create_commit do
       next if impersonated?

--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -51,7 +51,6 @@ class User
     validate :verified_matches_user_verified
 
     include PublicActivity::Model
-    tracked owner: proc { |controller, record| record.impersonated_by || record.user(allow_unverified: true) }, recipient: proc { |controller, record| record.impersonated_by || record.user(allow_unverified: true) }, only: [:create]
 
     scope :impersonated, -> { where.not(impersonated_by_id: nil) }
     scope :not_impersonated, -> { where(impersonated_by_id: nil) }
@@ -60,6 +59,8 @@ class User
     scope :recently_expired_within, ->(date) { expired.where("expiration_at >= ?", date) }
     scope :verified, -> { where(verified: true) }
     scope :unverified, -> { where(verified: false) }
+
+    after_save_commit :create_login_activity, if: -> { user_id_before_last_save.nil? && user.present? }
 
     after_create_commit do
       next if impersonated?
@@ -183,6 +184,11 @@ class User
     # @return [ActiveSupport::TimeWithZone, nil]
     def last_authenticated_at
       logins.complete.max_by(&:created_at)&.created_at
+    end
+
+    def create_login_activity
+      activity_user = impersonated_by || user(allow_unverified: true)
+      create_activity key: "user_session.create", owner: activity_user, recipient: activity_user
     end
 
   end

--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -60,7 +60,7 @@ class User
     scope :verified, -> { where(verified: true) }
     scope :unverified, -> { where(verified: false) }
 
-    after_save_commit :create_login_activity, if: -> { user_id_before_last_save.nil? && user.present? }
+    after_save :create_login_activity, if: -> { user_id_before_last_save.nil? && user.present? }
 
     after_create_commit do
       next if impersonated?

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -152,6 +152,42 @@ RSpec.describe User::Session, type: :model do
       expect(activity.owner_id).to eq(user.id)
       expect(activity.owner_type).to eq("User")
     end
+
+    specify "does not create an activity for a session with no associated user" do
+      PublicActivity.with_tracking do
+        User::Session.create!(
+          user: nil,
+          verified: false,
+          session_token: SecureRandom.urlsafe_base64,
+          expiration_at: 1.week.from_now,
+        )
+      end
+
+      expect(PublicActivity::Activity.count).to eq(0)
+    end
+
+    specify "creates an activity when a user is later assigned to a previously anonymous session" do
+      user = create(:user, full_name: "Hack Clubber")
+
+      session = PublicActivity.with_tracking do
+        User::Session.create!(
+          user: nil,
+          verified: false,
+          session_token: SecureRandom.urlsafe_base64,
+          expiration_at: 1.week.from_now,
+        )
+      end
+
+      expect(PublicActivity::Activity.count).to eq(0)
+
+      PublicActivity.with_tracking do
+        session.update!(user:, verified: true)
+      end
+
+      activity = PublicActivity::Activity.sole
+      expect(activity.owner_id).to eq(user.id)
+      expect(activity.owner_type).to eq("User")
+    end
   end
 
   describe "verified/unverified mismatch validation" do


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Now that we're creating a session without a user on all requests, we shouldn't be creating public activity records for them until a user is associated with it.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Switch from using the `tracked` helper to a custom callback that checks if a user was created before creating the public activity

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

