### PR TITLE
[Referrals] Drop unique (user_id, referral_link_id) constraint

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -33,11 +33,7 @@ class LoginsController < ApplicationController
     @user = User.create_with(creation_method: @login.for_application? ? :application_form : :login).find_or_create_by!(email: params[:email])
 
     current_session.referral_attributions.each do |attribution|
-      begin
-        attribution.update!(user: @user)
-      rescue ActiveRecord::RecordNotUnique
-        attribution.destroy!
-      end
+      attribution.update!(user: @user)
     end
 
     @login.user = @user

--- a/app/models/referral/attribution.rb
+++ b/app/models/referral/attribution.rb
@@ -14,11 +14,10 @@
 #
 # Indexes
 #
-#  index_referral_attributions_on_referral_link_id              (referral_link_id)
-#  index_referral_attributions_on_referral_program_id           (referral_program_id)
-#  index_referral_attributions_on_user_id                       (user_id)
-#  index_referral_attributions_on_user_id_and_referral_link_id  (user_id,referral_link_id) UNIQUE
-#  index_referral_attributions_on_user_session_id               (user_session_id)
+#  index_referral_attributions_on_referral_link_id     (referral_link_id)
+#  index_referral_attributions_on_referral_program_id  (referral_program_id)
+#  index_referral_attributions_on_user_id              (user_id)
+#  index_referral_attributions_on_user_session_id      (user_session_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260429010000_remove_unique_referral_attributions_user_link_index.rb
+++ b/db/migrate/20260429010000_remove_unique_referral_attributions_user_link_index.rb
@@ -1,0 +1,10 @@
+class RemoveUniqueReferralAttributionsUserLinkIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :referral_attributions,
+                 [:user_id, :referral_link_id],
+                 unique: true,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_29_005850) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_29_010000) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2136,7 +2136,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_29_005850) do
     t.bigint "user_session_id"
     t.index ["referral_link_id"], name: "index_referral_attributions_on_referral_link_id"
     t.index ["referral_program_id"], name: "index_referral_attributions_on_referral_program_id"
-    t.index ["user_id", "referral_link_id"], name: "index_referral_attributions_on_user_id_and_referral_link_id", unique: true
     t.index ["user_id"], name: "index_referral_attributions_on_user_id"
     t.index ["user_session_id"], name: "index_referral_attributions_on_user_session_id"
   end


### PR DESCRIPTION
## Summary of the problem

Errors of the form

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: duplicate key value violates unique constraint "index_referral_attributions_on_user_id_and_referral_link_id"
```

were being reported from `Referral::LinksController#show` whenever a signed-in user clicked the same referral link more than once. `Rails.error.handle` swallowed the exception so the redirect still worked, but every repeat click filed a noisy report.

Beyond the noise, this made click tracking inconsistent:

- Anonymous clicks each created a row (in PG, `NULL` values are distinct in unique indexes).
- Signed-in users contributed exactly one row per link regardless of how many times they actually clicked.

The unique index dates from #12916, when attributions tracked completed signups. #13551 made `user_id` nullable so the table could track clicks instead — but the index was never updated. The admin page (`app/views/admin/referral_programs.html.erb:14`) already labels `program.attributions.size` as "click", so the data model and the UI disagreed.

## Describe your changes

- New migration drops `index_referral_attributions_on_user_id_and_referral_link_id` (concurrent, no downtime).
- Re-annotated `Referral::Attribution`.
- Removed the now-unreachable `rescue ActiveRecord::RecordNotUnique => attribution.destroy!` block in `logins_controller.rb`. Under the new semantics, that rescue would have destroyed legitimate click data when an anonymous click was associated with a user who had already clicked the same link.

## Stat accuracy on `admin/referral_programs`

Verified each statistic on the page still reads correctly after this change:

| Stat | Source | Effect |
| --- | --- | --- |
| `program.attributions.size` ("click") | raw row count | now actually counts every click — was undercounting repeat signed-in clicks |
| `program.users.size` ("user") | `has_many :users, -> { distinct }, through: :attributions` | inner-join on `users.id = user_id` filters NULLs; `distinct` collapses duplicates |
| `program.new_users.size` ("new user") | `attributions.joins(:user)…map(&:user).uniq` | `.uniq` already handles repeat attributions per user |
| `link.attributions.count` ("attribution") | raw row count | each click is an attribution row |

Caveat: historical "click" totals will be a mix until enough new clicks accrue, since pre-PR data undercounted repeat clicks by signed-in users. That's an unavoidable consequence of the schema change, not something to fix in code.