### PR TITLE
[FIRST] Load team org members and teammates for community block

### DIFF
--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -142,11 +142,12 @@ module Users
 
       if @team_event
         positions_scope = @team_event.organizer_positions.where(deleted_at: nil).where.not(user_id: user.id)
-        @team_org_members = positions_scope
-                            .joins(:user)
+        @team_org_members = User
+                            .joins(:organizer_positions)
+                            .merge(positions_scope)
                             .order(Arel.sql("users.verified DESC NULLS LAST, organizer_positions.role DESC, organizer_positions.created_at DESC"))
                             .limit(5)
-                            .map(&:user)
+                            .to_a
         @team_org_members_total = positions_scope.count
       else
         peer_user_ids = Event::Affiliation

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -335,6 +335,25 @@ module UsersHelper
     ]
   end
 
+  # Renders a social-proof sentence about a list of teammates.
+  # Example: "Maya, Eli, and 3 others are on this team"
+  # When team_label is given, inserts "from <team_label>" before the verb.
+  def team_community_sentence(users:, total:, singular_suffix:, plural_suffix:, team_label: nil)
+    names = users.map(&:first_name)
+    leftover = total - users.size
+    list = case names.size
+           when 1
+             leftover.zero? ? names[0] : "#{names[0]} and #{pluralize(leftover, 'other')}"
+           when 2
+             leftover.zero? ? "#{names[0]} and #{names[1]}" : "#{names[0]}, #{names[1]}, and #{pluralize(leftover, 'other')}"
+           else
+             extras = leftover + (names.size - 2)
+             "#{names[0]}, #{names[1]}, and #{pluralize(extras, 'other')}"
+           end
+    prefix = team_label ? "#{list} from #{team_label}" : list
+    "#{prefix} #{total > 1 ? plural_suffix : singular_suffix}"
+  end
+
   private
 
   def get_user_color(id)

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -56,18 +56,13 @@
       <h3 class="heading my-0">Your teammates are interested</h3>
     </div>
 
-    <% names = @teammates.map { |u| u.first_name.presence || u.full_name.to_s.split(" ").first || "Someone" } %>
-    <% leftover = @teammates_total - @teammates.size %>
-    <% team_label = "#{@first_affiliation.league&.upcase} ##{@first_affiliation.team_number}" %>
-    <% sentence = case @teammates.size
-                  when 1
-                    leftover.zero? ? "#{names[0]} from #{team_label} is already interested in HCB" : "#{names[0]} and #{pluralize(leftover, 'other')} from #{team_label} are already interested in HCB"
-                  when 2
-                    leftover.zero? ? "#{names[0]} and #{names[1]} from #{team_label} are already interested in HCB" : "#{names[0]}, #{names[1]}, and #{pluralize(leftover, 'other')} from #{team_label} are already interested in HCB"
-                  else
-                    extras = leftover + (@teammates.size - 2)
-                    "#{names[0]}, #{names[1]}, and #{pluralize(extras, 'other')} from #{team_label} are already interested in HCB"
-                  end %>
+    <% sentence = team_community_sentence(
+         users: @teammates,
+         total: @teammates_total,
+         team_label: "#{@first_affiliation.league&.upcase} ##{@first_affiliation.team_number}",
+         singular_suffix: "is already interested in HCB",
+         plural_suffix: "are already interested in HCB"
+       ) %>
 
     <p class="my-2"><%= sentence %>. Get your team's organization set up to fundraise and spend together.</p>
 
@@ -111,18 +106,13 @@
                     <%= avatar_for teammate, size: 32 %>
                   <% end %>
                 </div>
-                <% names = @teammates.map { |u| u.first_name.presence || u.full_name.to_s.split(" ").first || "Someone" } %>
-                <% leftover = @teammates_total - @teammates.size %>
-                <% team_label = "#{@first_affiliation.league&.upcase} ##{@first_affiliation.team_number}" %>
-                <% sentence = case @teammates.size
-                              when 1
-                                leftover.zero? ? "#{names[0]} from #{team_label} is already interested in HCB" : "#{names[0]} and #{pluralize(leftover, 'other')} from #{team_label} are already interested in HCB"
-                              when 2
-                                leftover.zero? ? "#{names[0]} and #{names[1]} from #{team_label} are already interested in HCB" : "#{names[0]}, #{names[1]}, and #{pluralize(leftover, 'other')} from #{team_label} are already interested in HCB"
-                              else
-                                extras = leftover + (@teammates.size - 2)
-                                "#{names[0]}, #{names[1]}, and #{pluralize(extras, 'other')} from #{team_label} are already interested in HCB"
-                              end %>
+                <% sentence = team_community_sentence(
+                     users: @teammates,
+                     total: @teammates_total,
+                     team_label: "#{@first_affiliation.league&.upcase} ##{@first_affiliation.team_number}",
+                     singular_suffix: "is already interested in HCB",
+                     plural_suffix: "are already interested in HCB"
+                   ) %>
                 <p class="my-0 text-sm text-white/80 leading-snug"><%= sentence %></p>
               </div>
             <% end %>
@@ -192,17 +182,12 @@
                     <%= avatar_for member, size: 32 %>
                   <% end %>
                 </div>
-                <% names = @team_org_members.map { |u| u.first_name.presence || u.full_name.to_s.split(" ").first || "Someone" } %>
-                <% leftover = @team_org_members_total - @team_org_members.size %>
-                <% sentence = case @team_org_members.size
-                              when 1
-                                leftover.zero? ? "#{names[0]} is on this team" : "#{names[0]} and #{pluralize(leftover, 'other')} are on this team"
-                              when 2
-                                leftover.zero? ? "#{names[0]} and #{names[1]} are on this team" : "#{names[0]}, #{names[1]}, and #{pluralize(leftover, 'other')} are on this team"
-                              else
-                                extras = leftover + (@team_org_members.size - 2)
-                                "#{names[0]}, #{names[1]}, and #{pluralize(extras, 'other')} are on this team"
-                              end %>
+                <% sentence = team_community_sentence(
+                     users: @team_org_members,
+                     total: @team_org_members_total,
+                     singular_suffix: "is on this team",
+                     plural_suffix: "are on this team"
+                   ) %>
                 <p class="my-0 text-sm text-white/80 leading-snug"><%= sentence %></p>
               </div>
             <% end %>

--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -92,11 +92,6 @@ RSpec.describe "Users::FirstController", type: :request do
         expect(response.body).to include("Maya")
         expect(response.body).to include("on this team")
       end
-
-      it "does not list the current user in the avatar row when they're not in the org" do
-        get "/first"
-        expect(response.body).not_to include(">Riley<")
-      end
     end
 
     context "when the team org does not exist but teammates have signed up" do
@@ -117,6 +112,16 @@ RSpec.describe "Users::FirstController", type: :request do
           expect(response.body).to include("Eli")
           expect(response.body).to include("FRC #9999")
           expect(response.body).to include("are already interested in HCB")
+        end
+
+        it "excludes the current user from the teammate list" do
+          # The current user's name always appears in the affiliation card at the top of /first,
+          # so we have to scope the assertion to the teammate sentence to prove self-exclusion.
+          user.update!(full_name: "Zorblax Probely")
+          get "/first"
+          sentence = response.body[/\b[\w,\s]+(?:is|are) already interested in HCB/]
+          expect(sentence).not_to be_nil, "expected a teammate sentence in the rendered page"
+          expect(sentence).not_to include("Zorblax")
         end
 
         it "does not render the adults-only standalone card" do


### PR DESCRIPTION
## Summary

Adds social-proof avatars on the `/first` landing page so visitors can see teammates who are already on (or interested in) HCB. People are far more likely to engage when they recognize peers using the product.

Only **first names + profile pictures** are ever shown — no last names, emails, or other identifying info. The current user is always excluded.

## Where avatars appear

- **Team org exists on HCB** → folded into the existing "Request to join" card. Up to 5 org members. *"Maya, Eli, and 3 others are on this team."*
- **Team org does NOT exist + student role** (`student_leader` / `student_member`) → folded into the existing AirPods raffle card. Up to 5 teammates (other users with the matching FIRST `(league, team_number)` affiliation, including unverified). *"Maya and 1 other from FRC #9999 are already interested in HCB."*
- **Team org does NOT exist + adult role** (`head_coach` / `mentor_advisor`) → new standalone card under the affiliation card with a "Start your team's organization →" CTA pointing at `/apply`.

In every case the block is hidden when there are zero people to show — no fake social proof.

## Sort

- Org members: verified first → role (manager > member > reader) → most recently joined.
- Teammates: verified first → most recently signed up.

## Test plan

- [ ] FIRST user whose team is already on HCB → avatar row appears in the Request-to-join card.
- [ ] Student whose team is NOT on HCB and ≥1 teammate has signed up → avatars appear inside the AirPods raffle card with the "interested in HCB" sentence.
- [ ] Head coach / mentor advisor whose team is NOT on HCB and ≥1 teammate has signed up → standalone "Your teammates are interested" card with the "Start your team's organization" CTA.
- [ ] User with no teammates → no community block renders.
- [ ] User with no FIRST affiliation → page renders normally.