### PR TITLE
[FIRST] Add earnable extra tickets to MacBook raffle for referring more people

### DIFF
--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -105,26 +105,26 @@ module Users
       program = "first-worlds-2026-macbook" if ["student_leader", "student_member"].include?(user_params.dig(:affiliations_attributes, "0", "role"))
 
       unless User.where(email: user_params[:email]).exists?
-        user_referral = Raffle.find_by_hashid(user_ref_params[:user_referral]) if user_ref_params[:user_referral].present?
-        if user_referral.nil?
-          flash[:error] = "We couldn't find that referral link!"
+        user_referral = nil
+        if user_ref_params[:user_referral].present?
+          user_referral = Raffle.find_by_hashid(user_ref_params[:user_referral])
 
-          redirect_to welcome_first_index_path and return
-        end
-        # case that should never happen because users should not be able to get a link if program or user is not eligible for referral link
-        # however still adding here because it could eventually be possible that a user becomes ineligible or a program becomes ineligible
-        if !user_referral.program_allows_referrals? || !user_referral.user_allows_referrals?
-          flash[:error] = "We couldn't find that referral link!"
+          # the referral not being eligible should never happen because users should not be able to get a link if program or user is not eligible for referral link
+          # however still adding here because it could eventually be possible that a user becomes ineligible or a program becomes ineligible
+          if user_referral.nil? || !user_referral.program_allows_referrals? || !user_referral.user_allows_referrals?
+            flash[:error] = "We couldn't find that referral link!"
 
-          redirect_to welcome_first_index_path and return
+            redirect_to welcome_first_index_path and return
+          end
         end
+
         @user = User.new(user_params)
         @user.creation_method = :first_robotics_form
         @user.save!
 
         if program.present?
           raf = Raffle.find_or_create_by!(user: @user, program:)
-          raf.update!(referring_raffle: user_referral)
+          raf.update!(referring_raffle: user_referral) if user_referral.present?
         end
 
         create_session(user: @user, verified: false)

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -85,7 +85,9 @@ module Users
       return redirect_to first_index_path if signed_in?(allow_unverified: true)
 
       @referral_link_slug = Referral::Link.find_by(slug: params[:referral])&.slug if params[:referral].present?
+      @user_referral = params[:referred_by] if params[:referred_by].present?
       @user = User.new(affiliations: [Event::Affiliation.new])
+
     end
 
     def verify_email
@@ -103,11 +105,27 @@ module Users
       program = "first-worlds-2026-macbook" if ["student_leader", "student_member"].include?(user_params.dig(:affiliations_attributes, "0", "role"))
 
       unless User.where(email: user_params[:email]).exists?
+        user_referral = Raffle.find_by_hashid(user_ref_params[:user_referral]) if user_ref_params[:user_referral].present?
+        if user_referral.nil?
+          flash[:error] = "We couldn't find that referral link!"
+
+          redirect_to welcome_first_index_path and return
+        end
+        # case that should never happen because users should not be able to get a link if program or user is not eligible for referral link
+        # however still adding here because it could eventually be possible that a user becomes ineligible or a program becomes ineligible
+        if !user_referral.program_allows_referrals? || !user_referral.user_allows_referrals?
+          flash[:error] = "We couldn't find that referral link!"
+
+          redirect_to welcome_first_index_path and return
+        end
         @user = User.new(user_params)
         @user.creation_method = :first_robotics_form
         @user.save!
 
-        Raffle.find_or_create_by!(user: @user, program:) if program.present?
+        if program.present?
+          raf = Raffle.find_or_create_by!(user: @user, program:)
+          raf.update!(referring_raffle: user_referral)
+        end
 
         create_session(user: @user, verified: false)
 
@@ -130,6 +148,10 @@ module Users
 
     def user_params
       params.require(:user).permit(:email, :full_name, affiliations_attributes: [:league, :team_number, :name, :team_name, :role])
+    end
+
+    def user_ref_params
+      params.permit(:user_referral)
     end
 
     def load_team_community

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -144,6 +144,30 @@ module Users
       render :new, status: :unprocessable_entity
     end
 
+    def macbook_qr_code
+      raffle = current_user.raffles.find_by(program: "first-worlds-2026-macbook")
+
+      if raffle.nil?
+        head :not_found
+        return
+      end
+
+      qrcode = RQRCode::QRCode.new(raffle.referral_link)
+
+      png = qrcode.as_png(
+        bit_depth: 1,
+        border_modules: 2,
+        color_mode: ChunkyPNG::COLOR_GRAYSCALE,
+        color: "black",
+        fill: "white",
+        module_px_size: 6,
+        size: 300
+      )
+
+      send_data png, filename: "MacBook Raffle Referral.png",
+        type: "image/png", disposition: "inline"
+    end
+
     private
 
     def user_params

--- a/app/mailers/raffle_mailer.rb
+++ b/app/mailers/raffle_mailer.rb
@@ -7,4 +7,5 @@ class RaffleMailer < ApplicationMailer
 
     mail to: @user.email_address_with_name, subject: "You've earned an extra raffle ticket!"
   end
+
 end

--- a/app/mailers/raffle_mailer.rb
+++ b/app/mailers/raffle_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RaffleMailer < ApplicationMailer
+  def extra_ticket_earned
+    @raffle = params[:raffle]
+    @user = @raffle.user
+
+    mail to: @user.email_address_with_name, subject: "You've earned an extra raffle ticket!"
+  end
+end

--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -4,31 +4,46 @@
 #
 # Table name: raffles
 #
-#  id            :bigint           not null, primary key
-#  confirmed     :boolean          default(TRUE), not null
-#  program       :string           not null
-#  ticket_number :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  user_id       :bigint           not null
+#  id                  :bigint           not null, primary key
+#  confirmed           :boolean          default(TRUE), not null
+#  program             :string           not null
+#  ticket_number       :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  referring_raffle_id :bigint
+#  user_id             :bigint           not null
 #
 # Indexes
 #
 #  index_raffles_on_program_and_user_id  (program,user_id) UNIQUE
+#  index_raffles_on_referring_raffle_id  (referring_raffle_id)
 #  index_raffles_on_ticket_number        (ticket_number) UNIQUE
 #
 # Foreign Keys
 #
+#  fk_rails_...  (referring_raffle_id => raffles.id)
 #  fk_rails_...  (user_id => users.id)
 #
 class Raffle < ApplicationRecord
+  include Hashid::Rails
+
   TICKET_NUMBER_LENGTH = 6
+  REFERRAL_TICKET_TIERS = [1, 3, 8].freeze
 
   PROGRAMS_REQUIRING_CONFIRMATION = ["first-worlds-2026-airpods"].freeze
+  PROGRAMS_ALLOWING_REFERRALS = ["first-worlds-2026-macbook"].freeze
 
   belongs_to :user
+  has_many :referred_raffle_entries, class_name: "Raffle", foreign_key: "referring_raffle_id", inverse_of: :referring_raffle
+  belongs_to :referring_raffle, class_name: "Raffle", optional: true
   validates :program, presence: true
   validates :ticket_number, uniqueness: true, allow_nil: true
+
+  after_create_commit do
+    if referring_raffle.present? && referring_raffle.tier_progress == 0
+      RaffleMailer.with(raffle: referring_raffle).extra_ticket_earned.deliver_later
+    end
+  end
 
   before_validation do
     self.ticket_number = self.class.generate_ticket_number if self.ticket_number.blank?
@@ -53,6 +68,50 @@ class Raffle < ApplicationRecord
     return if confirmed?
 
     update!(confirmed: true)
+  end
+
+  def tickets
+    1 + extra_tickets
+  end
+
+  def extra_tickets
+    referrals = referred_raffle_entries.count
+    tickets = 0
+    REFERRAL_TICKET_TIERS.each do |t|
+      tickets += 1 if (referrals >= t)
+    end
+    referrals -= REFERRAL_TICKET_TIERS[tickets - 1]
+    tickets += referrals.to_i / 10.to_i
+    tickets
+  end
+
+  def referrals_needed_for_next_ticket
+    tix = extra_tickets
+    tix > REFERRAL_TICKET_TIERS.length - 1 ? 10 : REFERRAL_TICKET_TIERS[tix]
+  end
+
+  def tier_progress
+    referrals = referred_raffle_entries.count
+    tix = extra_tickets
+    if tix >= REFERRAL_TICKET_TIERS.length
+      referrals - REFERRAL_TICKET_TIERS.last - ((tix - REFERRAL_TICKET_TIERS.length) * 10)
+    else
+      referrals - REFERRAL_TICKET_TIERS[tix]
+    end
+  end
+
+  def referral_link
+    return Rails.application.routes.url_helpers.welcome_first_index_url(referred_by: self.hashid) if program_allows_referrals? && user_allows_referrals?
+
+    nil
+  end
+
+  def program_allows_referrals?
+    PROGRAMS_ALLOWING_REFERRALS.include? program
+  end
+
+  def user_allows_referrals?
+    user.verified?
   end
 
   private

--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -28,7 +28,7 @@ class Raffle < ApplicationRecord
   include Hashid::Rails
 
   TICKET_NUMBER_LENGTH = 6
-  REFERRAL_TICKET_TIERS = [1, 3, 8].freeze
+  REFERRAL_TICKET_TIERS = [1, 2, 5].freeze
 
   PROGRAMS_REQUIRING_CONFIRMATION = ["first-worlds-2026-airpods"].freeze
   PROGRAMS_ALLOWING_REFERRALS = ["first-worlds-2026-macbook"].freeze
@@ -78,9 +78,13 @@ class Raffle < ApplicationRecord
     referrals = referred_raffle_entries.count
     tickets = 0
     REFERRAL_TICKET_TIERS.each do |t|
-      tickets += 1 if (referrals >= t)
+      if referrals >= t
+        tickets += 1
+        referrals -= t
+      else
+        break
+      end
     end
-    referrals -= REFERRAL_TICKET_TIERS[tickets - 1]
     tickets += referrals.to_i / 10.to_i
     tickets
   end
@@ -92,12 +96,21 @@ class Raffle < ApplicationRecord
 
   def tier_progress
     referrals = referred_raffle_entries.count
-    tix = extra_tickets
-    if tix >= REFERRAL_TICKET_TIERS.length
-      referrals - REFERRAL_TICKET_TIERS.last - ((tix - REFERRAL_TICKET_TIERS.length) * 10)
-    else
-      referrals - REFERRAL_TICKET_TIERS[tix]
+    tickets = 0
+    REFERRAL_TICKET_TIERS.each do |t|
+      if referrals >= t
+        tickets += 1
+        referrals -= t
+      else
+        break
+      end
     end
+    if (referrals >= 10)
+      tens = referrals.to_i / 10.to_i
+      tickets += tens
+      referrals -= tens * 10
+    end
+    referrals
   end
 
   def referral_link

--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -28,7 +28,7 @@ class Raffle < ApplicationRecord
   include Hashid::Rails
 
   TICKET_NUMBER_LENGTH = 6
-  REFERRAL_TICKET_TIERS = [1, 2, 5].freeze
+  REFERRAL_TICKET_TIERS = [1, 2].freeze
 
   PROGRAMS_REQUIRING_CONFIRMATION = ["first-worlds-2026-airpods"].freeze
   PROGRAMS_ALLOWING_REFERRALS = ["first-worlds-2026-macbook"].freeze
@@ -85,13 +85,13 @@ class Raffle < ApplicationRecord
         break
       end
     end
-    tickets += referrals.to_i / 10.to_i
+    tickets += referrals.to_i / 5.to_i
     tickets
   end
 
   def referrals_needed_for_next_ticket
     tix = extra_tickets
-    tix > REFERRAL_TICKET_TIERS.length - 1 ? 10 : REFERRAL_TICKET_TIERS[tix]
+    tix > REFERRAL_TICKET_TIERS.length - 1 ? 5 : REFERRAL_TICKET_TIERS[tix]
   end
 
   def tier_progress
@@ -105,10 +105,10 @@ class Raffle < ApplicationRecord
         break
       end
     end
-    if (referrals >= 10)
-      tens = referrals.to_i / 10.to_i
-      tickets += tens
-      referrals -= tens * 10
+    if referrals >= 5
+      fives = referrals.to_i / 5.to_i
+      tickets += fives
+      referrals -= fives * 5
     end
     referrals
   end

--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -29,6 +29,7 @@ class Raffle < ApplicationRecord
 
   TICKET_NUMBER_LENGTH = 6
   REFERRAL_TICKET_TIERS = [1, 2].freeze
+  REFERRAL_TICKET_FINAL_TIER = 5
 
   PROGRAMS_REQUIRING_CONFIRMATION = ["first-worlds-2026-airpods"].freeze
   PROGRAMS_ALLOWING_REFERRALS = ["first-worlds-2026-macbook"].freeze
@@ -85,13 +86,13 @@ class Raffle < ApplicationRecord
         break
       end
     end
-    tickets += referrals.to_i / 5.to_i
+    tickets += referrals.to_i / REFERRAL_TICKET_FINAL_TIER.to_i
     tickets
   end
 
   def referrals_needed_for_next_ticket
     tix = extra_tickets
-    tix > REFERRAL_TICKET_TIERS.length - 1 ? 5 : REFERRAL_TICKET_TIERS[tix]
+    tix > REFERRAL_TICKET_TIERS.length - 1 ? REFERRAL_TICKET_FINAL_TIER : REFERRAL_TICKET_TIERS[tix]
   end
 
   def tier_progress
@@ -105,10 +106,10 @@ class Raffle < ApplicationRecord
         break
       end
     end
-    if referrals >= 5
-      fives = referrals.to_i / 5.to_i
-      tickets += fives
-      referrals -= fives * 5
+    if referrals >= REFERRAL_TICKET_FINAL_TIER
+      times = referrals.to_i / REFERRAL_TICKET_FINAL_TIER.to_i
+      tickets += times
+      referrals -= times * REFERRAL_TICKET_FINAL_TIER
     end
     referrals
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,8 @@ class User < ApplicationRecord
   has_many :referral_programs, class_name: "Referral::Program", inverse_of: :creator
   has_many :referral_links, class_name: "Referral::Link", inverse_of: :creator
 
+  has_many :raffles
+
   has_many :messages, class_name: "Ahoy::Message", as: :user
 
   has_many :events, through: :organizer_positions

--- a/app/views/raffle_mailer/extra_ticket_earned.html.erb
+++ b/app/views/raffle_mailer/extra_ticket_earned.html.erb
@@ -1,0 +1,15 @@
+<p>
+  Hey <%= @user.name %>,
+</p>
+
+<p>You just earned an extra ticket in the raffle for a MacBook Neo! You now have <%= @raffle.tickets %> entries in the raffle.</p>
+
+<p>
+  To get another extra entry, keep sharing your <%= link_to "your unique raffle link", @raffle.referral_link %> with your teammates and friends in FIRST robotics.
+  We'll be drawing the raffle Friday afternoon!
+</p>
+
+<p>
+  Best,<br>
+  The HCB Team
+</p>

--- a/app/views/users/first/_raffle.html.erb
+++ b/app/views/users/first/_raffle.html.erb
@@ -3,7 +3,15 @@
 <div class="my-4 flex rounded-lg bg-white dark:bg-black overflow-hidden border-2 border-dashed border-blue">
   <div class="flex-1 p-5">
     <% if raffle.confirmed? %>
-      <p class="text-xs uppercase muted mt-0 mb-3">🎟 Raffle Entry Confirmed</p>
+      <% if raffle.program_allows_referrals? %>
+        <p class="text-xs uppercase muted mt-0 mb-3">
+          🎟 <span class="font-bold <%= "text-green" if raffle.tickets > 1 %>"><%= raffle.tickets %></span> <%= "raffle entry".pluralize(raffle.tickets) %> Confirmed
+        </p>
+      <% else %>
+        <p class="text-xs uppercase muted mt-0 mb-3">
+          🎟 Raffle Entry Confirmed
+        </p>
+      <% end %>
     <% else %>
       <p class="text-xs uppercase muted mt-0 mb-3">🎟 Raffle Entry Pending</p>
     <% end %>

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -71,6 +71,36 @@
 <% end %>
 
 <% if @macbook_raffle.present? %>
+  <div class="card my-4 flex flex-col">
+    <h3 class="heading my-0">Earn additional tickets for the MacBook Neo raffle!</h3>
+
+    <p>
+      Share your <%= @macbook_raffle.referral_link.present? ? link_to("unique raffle link", @macbook_raffle.referral_link) : "unique raffle link" %> with your teammates and friends in FIRST robotics,
+      and you'll earn extra raffle tickets for the MacBook Neo!
+      You currently have <%= pluralize(@macbook_raffle.tickets, "ticket") %> for the MacBook Neo raffle.
+      <em>We may</em>
+    </p>
+
+    <% referrals_needed = @macbook_raffle.referrals_needed_for_next_ticket - @macbook_raffle.tier_progress %>
+    <p class="mb-0 text-center italic">Refer <%= referrals_needed %> more <%= "person".pluralize(referrals_needed) %> for your next ticket</p>
+    <div class="h-3 bg-gray-200 dark:bg-neutral-700 rounded mt-2 overflow-hidden">
+      <div class="h-full bg-primary rounded" style="width: <%= [1 + (@macbook_raffle.tier_progress.to_f / @macbook_raffle.referrals_needed_for_next_ticket) * 100, 100].min %>%;"></div>
+    </div>
+
+    <% if current_user(allow_unverified: true).verified? %>
+      <button class="btn mt-3" data-controller="clipboard" data-clipboard-text-value="<%= @macbook_raffle.referral_link %>" data-clipboard-confirm-text-value="Copied!" data-action="click->clipboard#copy">
+        Copy referral link to clipboard
+      </button>
+    <% else %>
+      <%= link_to verify_email_first_index_path, method: :post, class: "btn mt-3" do %>
+        <%= inline_icon "email-exclamation" %>
+        Verify your email to get your link
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @macbook_raffle.present? %>
   <%= render "users/first/raffle", raffle: @macbook_raffle, raffle_name: "MacBook Neo" %>
 <% end %>
 

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -78,11 +78,11 @@
       Share your <%= @macbook_raffle.referral_link.present? ? link_to("unique raffle link", @macbook_raffle.referral_link) : "unique raffle link" %> with your teammates and friends in FIRST robotics,
       and you'll earn extra raffle tickets for the MacBook Neo!
       You currently have <%= pluralize(@macbook_raffle.tickets, "ticket") %> for the MacBook Neo raffle.
-      <em>We may</em>
+      <em>We may disqualify extra tickets if referrals are fraudulent.</em>
     </p>
 
     <% referrals_needed = @macbook_raffle.referrals_needed_for_next_ticket - @macbook_raffle.tier_progress %>
-    <p class="mb-0 text-center italic">Refer <%= referrals_needed %> more <%= "person".pluralize(referrals_needed) %> for your next ticket</p>
+    <p class="mb-0 text-center">Refer <%= referrals_needed %> more <%= "person".pluralize(referrals_needed) %> for your next ticket!</p>
     <div class="h-3 bg-gray-200 dark:bg-neutral-700 rounded mt-2 overflow-hidden">
       <div class="h-full bg-primary rounded" style="width: <%= [1 + (@macbook_raffle.tier_progress.to_f / @macbook_raffle.referrals_needed_for_next_ticket) * 100, 100].min %>%;"></div>
     </div>

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -390,7 +390,7 @@
   <%= modal_header "MacBook Neo Raffle" %>
 
   <div class="flex flex-col items-center justify-center gap-1">
-    <img src="<%= macbook_qr_code_first_index_url %>" alt="QR code" class="rounded-md" />
+    <img src="<%= macbook_qr_code_first_index_url %>" alt="QR code" class="rounded-md">
     <%= link_to @macbook_raffle.referral_link, @macbook_raffle.referral_link, class: "text-center" %>
   </div>
 </section>

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -88,9 +88,12 @@
     </div>
 
     <% if current_user(allow_unverified: true).verified? %>
-      <button class="btn mt-3" data-controller="clipboard" data-clipboard-text-value="<%= @macbook_raffle.referral_link %>" data-clipboard-confirm-text-value="Copied!" data-action="click->clipboard#copy">
-        Copy referral link to clipboard
-      </button>
+      <div class="grid grid-cols-1 md:grid-cols-2 mt-3 gap-2">
+        <button class="btn flex-grow" data-controller="clipboard" data-clipboard-text-value="<%= @macbook_raffle.referral_link %>" data-clipboard-confirm-text-value="Copied!" data-action="click->clipboard#copy">
+          Copy referral link to clipboard
+        </button>
+        <button class="btn flex-grow" data-behavior="modal_trigger" data-modal="qr_code">View QR Code</button>
+      </div>
     <% else %>
       <%= link_to verify_email_first_index_path, method: :post, class: "btn mt-3" do %>
         <%= inline_icon "email-exclamation" %>
@@ -381,4 +384,13 @@
 
   <br>
   <i class="muted">Must be 18 years of age or younger and have CCd <%= mail_to @advisor_email_cc %> in your email to be eligible.</i>
+</section>
+
+<section id="qr_code" class="modal modal--scroll bg-snow" data-behavior="modal" data-controller="email-compose" role="dialog">
+  <%= modal_header "MacBook Neo Raffle" %>
+
+  <div class="flex flex-col items-center justify-center gap-1">
+    <img src="<%= macbook_qr_code_first_index_url %>" alt="QR code" class="rounded-md" />
+    <%= link_to @macbook_raffle.referral_link, @macbook_raffle.referral_link, class: "text-center" %>
+  </div>
 </section>

--- a/app/views/users/first/index.html.erb
+++ b/app/views/users/first/index.html.erb
@@ -386,11 +386,13 @@
   <i class="muted">Must be 18 years of age or younger and have CCd <%= mail_to @advisor_email_cc %> in your email to be eligible.</i>
 </section>
 
-<section id="qr_code" class="modal modal--scroll bg-snow" data-behavior="modal" data-controller="email-compose" role="dialog">
-  <%= modal_header "MacBook Neo Raffle" %>
+<% if @macbook_raffle.present? %>
+  <section id="qr_code" class="modal modal--scroll bg-snow" data-behavior="modal" data-controller="email-compose" role="dialog">
+    <%= modal_header "MacBook Neo Raffle" %>
 
-  <div class="flex flex-col items-center justify-center gap-1">
-    <img src="<%= macbook_qr_code_first_index_url %>" alt="QR code" class="rounded-md">
-    <%= link_to @macbook_raffle.referral_link, @macbook_raffle.referral_link, class: "text-center" %>
-  </div>
-</section>
+    <div class="flex flex-col items-center justify-center gap-1">
+      <img src="<%= macbook_qr_code_first_index_url %>" alt="QR code" class="rounded-md">
+      <%= link_to @macbook_raffle.referral_link, @macbook_raffle.referral_link, class: "text-center" %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/users/first/new.html.erb
+++ b/app/views/users/first/new.html.erb
@@ -125,6 +125,8 @@
 
         <%= hidden_field_tag :referral_link_slug, @referral_link_slug %>
 
+        <%= hidden_field_tag :user_referral, @user_referral %>
+
         <%= invisible_captcha :remember_me %>
 
         <div class="card card--sunken flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Rails.application.routes.draw do
         post "verify_email", to: "first#verify_email"
         post "request_org_invite", to: "first#request_org_invite"
         delete "sign_out", to: "first#sign_out"
+        get "macbook_qr_code"
       end
     end
 

--- a/db/migrate/20260430043657_add_referring_raffle_id_raffle.rb
+++ b/db/migrate/20260430043657_add_referring_raffle_id_raffle.rb
@@ -1,0 +1,7 @@
+class AddReferringRaffleIdRaffle < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :raffles, :referring_raffle, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20260430044254_add_referring_raffle_id_foreign_key_raffle.rb
+++ b/db/migrate/20260430044254_add_referring_raffle_id_foreign_key_raffle.rb
@@ -1,0 +1,5 @@
+class AddReferringRaffleIdForeignKeyRaffle < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :raffles, :raffles, column: :referring_raffle_id, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_29_153343) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1898,10 +1898,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_29_153343) do
     t.boolean "confirmed", default: true, null: false
     t.datetime "created_at", null: false
     t.string "program", null: false
+    t.bigint "referring_raffle_id"
     t.string "ticket_number"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["program", "user_id"], name: "index_raffles_on_program_and_user_id", unique: true
+    t.index ["referring_raffle_id"], name: "index_raffles_on_referring_raffle_id"
     t.index ["ticket_number"], name: "index_raffles_on_ticket_number", unique: true
   end
 
@@ -2937,6 +2939,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_29_153343) do
   add_foreign_key "payment_recipients", "events"
   add_foreign_key "paypal_transfers", "events"
   add_foreign_key "paypal_transfers", "users"
+  add_foreign_key "raffles", "raffles", column: "referring_raffle_id", validate: false
   add_foreign_key "raffles", "users"
   add_foreign_key "raw_pending_incoming_disbursement_transactions", "disbursements"
   add_foreign_key "raw_pending_outgoing_disbursement_transactions", "disbursements"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We want to encourage users to share HCB with their teammates and friends at FIRST Worlds! Let's give out some extra raffle tickets on a tiered system when users send their unique raffle link to others who fill out the FIRST form.

<img width="985" height="268" alt="image" src="https://github.com/user-attachments/assets/dfe46285-4f04-4506-b609-8ad41b4c27ac" />


