### PR TITLE
[Raffles] Fix extra ticket raffle email

### DIFF
--- a/app/models/raffle.rb
+++ b/app/models/raffle.rb
@@ -40,8 +40,8 @@ class Raffle < ApplicationRecord
   validates :program, presence: true
   validates :ticket_number, uniqueness: true, allow_nil: true
 
-  after_create_commit do
-    if referring_raffle.present? && referring_raffle.tier_progress == 0
+  after_save_commit do
+    if referring_raffle_id_previously_changed? && referring_raffle.present? && referring_raffle.tier_progress == 0
       RaffleMailer.with(raffle: referring_raffle).extra_ticket_earned.deliver_later
     end
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
In FIRST controller, we update the raffle entry after creating it, so we can't use `after_create_commit`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Switch to `after_save_commit`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

