### PR TITLE
[Raffles] Make pending raffles yellow

### DIFF
--- a/app/views/users/first/_raffle.html.erb
+++ b/app/views/users/first/_raffle.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (raffle:, raffle_name:) %>
 
-<div class="my-4 flex rounded-lg bg-white dark:bg-black overflow-hidden border-2 border-dashed border-blue">
+<div class="my-4 flex rounded-lg bg-white overflow-hidden border-2 border-dashed <%= raffle.confirmed? ? "border-blue dark:bg-black" : "border-yellow bg-yellow !bg-opacity-20" %>">
   <div class="flex-1 p-5">
     <% if raffle.confirmed? %>
       <% if raffle.program_allows_referrals? %>
@@ -24,7 +24,7 @@
     <% end %>
     <p class="text-xs muted mb-0">Entered <%= raffle.created_at.strftime("%B %-d, %Y") %></p>
   </div>
-  <div class="border-0 border-l-2 border-dashed self-stretch border-blue"></div>
+  <div class="border-0 border-l-2 border-dashed self-stretch <%= raffle.confirmed? ? "border-blue" : "border-yellow" %>"></div>
   <div class="w-32 p-5 flex flex-col items-center justify-center text-center gap-1 shrink-0">
     <p class="text-xs uppercase tracking-widest muted mt-0 mb-1">Ticket No.</p>
     <p class="font-mono font-bold text-2xl my-0 <%= "muted" unless raffle.confirmed? %>"><%= raffle.ticket_number || "——" %></p>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It should be more obvious to the user that a raffle entry isn't confirmed yet - let's make pending raffles yellow.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="974" height="216" alt="image" src="https://github.com/user-attachments/assets/c025e085-2dc4-4319-ba2e-505f5c8becdf" />


