### PR TITLE
[Subevents] Add live duplicate check for sub-organization name

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -797,6 +797,28 @@ class EventsController < ApplicationController
     redirect_to subevent
   end
 
+  def check_sub_organization_name
+    authorize @event, :create_sub_organization?
+
+    name = params[:name].to_s.strip
+
+    if name.blank?
+      return render json: { duplicate: false }
+    end
+
+    duplicate = @event.descendants.find_by("lower(name) = ?", name.downcase)
+
+    if duplicate
+      render json: {
+        duplicate: true,
+        org_name: duplicate.name,
+        org_url: event_path(duplicate)
+      }
+    else
+      render json: { duplicate: false }
+    end
+  end
+
   def toggle_hidden
     authorize @event
 

--- a/app/javascript/controllers/sub_org_name_check_controller.js
+++ b/app/javascript/controllers/sub_org_name_check_controller.js
@@ -9,6 +9,12 @@ export default class extends Controller {
     this.check = debounce(this._check, 400)
   }
 
+  hideWarning() {
+    this.warningTarget.hidden = true
+    this.linkTarget.textContent = ''
+    this.linkTarget.href = ''
+  }
+
   async _check(e) {
     const name = e.target.value.trim()
 
@@ -27,9 +33,7 @@ export default class extends Controller {
       })
 
       if (!response.ok) {
-        this.warningTarget.hidden = true
-        this.linkTarget.textContent = ''
-        this.linkTarget.href = ''
+        this.hideWarning()
         return
       }
 

--- a/app/javascript/controllers/sub_org_name_check_controller.js
+++ b/app/javascript/controllers/sub_org_name_check_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from '@hotwired/stimulus'
+import { debounce } from 'lodash/function'
+
+export default class extends Controller {
+  static values = { url: String }
+  static targets = ['warning', 'link']
+
+  initialize() {
+    this.check = debounce(this._check, 400)
+  }
+
+  async _check(e) {
+    const name = e.target.value.trim()
+
+    if (!name) {
+      this.warningTarget.hidden = true
+      return
+    }
+
+    const url = new URL(this.urlValue, window.location.origin)
+    url.searchParams.set('name', name)
+
+    let data
+    try {
+      data = await fetch(url, { headers: { Accept: 'application/json' } }).then(r => r.json())
+    } catch {
+      return
+    }
+
+    if (data.duplicate) {
+      this.linkTarget.textContent = data.org_name
+      this.linkTarget.href = data.org_url
+      this.warningTarget.hidden = false
+    } else {
+      this.warningTarget.hidden = true
+    }
+  }
+}

--- a/app/javascript/controllers/sub_org_name_check_controller.js
+++ b/app/javascript/controllers/sub_org_name_check_controller.js
@@ -22,7 +22,9 @@ export default class extends Controller {
 
     let data
     try {
-      data = await fetch(url, { headers: { Accept: 'application/json' } }).then(r => r.json())
+      data = await fetch(url, { headers: { Accept: 'application/json' } }).then(
+        r => r.json()
+      )
     } catch {
       return
     }

--- a/app/javascript/controllers/sub_org_name_check_controller.js
+++ b/app/javascript/controllers/sub_org_name_check_controller.js
@@ -22,10 +22,22 @@ export default class extends Controller {
 
     let data
     try {
-      data = await fetch(url, { headers: { Accept: 'application/json' } }).then(
-        r => r.json()
-      )
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!response.ok) {
+        this.warningTarget.hidden = true
+        this.linkTarget.textContent = ''
+        this.linkTarget.href = ''
+        return
+      }
+
+      data = await response.json()
     } catch {
+      this.warningTarget.hidden = true
+      this.linkTarget.textContent = ''
+      this.linkTarget.href = ''
       return
     }
 

--- a/app/javascript/controllers/sub_org_name_check_controller.js
+++ b/app/javascript/controllers/sub_org_name_check_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
     const name = e.target.value.trim()
 
     if (!name) {
-      this.warningTarget.hidden = true
+      this.hideWarning()
       return
     }
 
@@ -39,9 +39,7 @@ export default class extends Controller {
 
       data = await response.json()
     } catch {
-      this.warningTarget.hidden = true
-      this.linkTarget.textContent = ''
-      this.linkTarget.href = ''
+      this.hideWarning()
       return
     }
 
@@ -50,7 +48,7 @@ export default class extends Controller {
       this.linkTarget.href = data.org_url
       this.warningTarget.hidden = false
     } else {
-      this.warningTarget.hidden = true
+      this.hideWarning()
     }
   }
 }

--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -9,9 +9,18 @@
     </p>
   </div>
 
-  <div class="field">
+  <div class="field"
+    data-controller="sub-org-name-check"
+    data-sub-org-name-check-url-value="<%= check_sub_organization_name_event_path(event) %>">
     <%= form.label :name, "Project name", class: "bold" %>
-    <%= form.text_field :name, placeholder: "#{possessive(event.name)} latest project", value: params[:name] %>
+    <%= form.text_field :name, placeholder: "#{possessive(event.name)} latest project", value: params[:name],
+        data: { action: "input->sub-org-name-check#check" } %>
+    <div data-sub-org-name-check-target="warning" hidden class="card border b--warning mt1">
+      <div class="flex items-center warning">
+        <%= inline_icon "important", size: 20, class: "mr1 flex-shrink-0" %>
+        <span>A sub-organization named <strong><a data-sub-org-name-check-target="link" href="#"></a></strong> already exists under this organization.</span>
+      </div>
+    </div>
   </div>
 
   <div class="field">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1055,6 +1055,7 @@ Rails.application.routes.draw do
       post "validate_slug"
       get "termination"
       post "permit_merchant"
+      get "sub_organizations/check_name", to: "events#check_sub_organization_name", as: :check_sub_organization_name
 
       get "settings(/:tab)", to: "events#edit", as: :edit
     end


### PR DESCRIPTION
This pull request closes #13606 by introducing a new banner that checks for duplicate sub-organization names in real time when creating a sub-organization under an event

## Preview 
<img width="603" height="722" alt="image" src="https://github.com/user-attachments/assets/5736e47d-b2b6-418e-80fa-bdd59fd6ded1" />
