### PR TITLE
[FIRST] Attribute referral link clicks to new users on signup

### DIFF
--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -122,6 +122,10 @@ module Users
         @user.creation_method = :first_robotics_form
         @user.save!
 
+        current_session.referral_attributions.where(user_id: nil).find_each do |attribution|
+          attribution.update!(user: @user)
+        end
+
         if program.present?
           raf = Raffle.find_or_create_by!(user: @user, program:)
           raf.update!(referring_raffle: user_referral) if user_referral.present?

--- a/app/tasks/maintenance/backfill_referral_attribution_users_task.rb
+++ b/app/tasks/maintenance/backfill_referral_attribution_users_task.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillReferralAttributionUsersTask < MaintenanceTasks::Task
+    # Sets Referral::Attribution#user_id from the bound user on the
+    # attribution's User::Session, for rows where user_id is nil but the
+    # session is already associated with a user. User::Session#user_id is
+    # set-once (see User::Session#create_login_activity), so the join is
+    # unambiguous.
+    def collection
+      Referral::Attribution
+        .where(user_id: nil)
+        .where.not(user_session_id: nil)
+        .joins(:user_session)
+        .where.not(user_sessions: { user_id: nil })
+        .select("referral_attributions.*, user_sessions.user_id AS resolved_user_id")
+    end
+
+    def process(attribution)
+      attribution.update_columns(user_id: attribution.resolved_user_id, updated_at: Time.current)
+    end
+
+  end
+end

--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -54,6 +54,50 @@ RSpec.describe "Users::FirstController", type: :request do
                               "this discrepancy lets an attacker enumerate registered emails."
     end
 
+    context "when the visitor's session has Referral::Attribution rows from prior link clicks" do
+      let(:creator) { create(:user, verified: true) }
+      let(:program) do
+        Referral::Program.create!(
+          name: "FIRST referral test program",
+          redirect_to: "https://hcb.hackclub.com/first/welcome",
+          creator:
+        )
+      end
+      let(:link)       { program.links.create!(name: "Primary",   creator:) }
+      let(:other_link) { program.links.create!(name: "Secondary", creator:) }
+
+      it "associates a single click attribution with the new user" do
+        get "/referrals/#{link.slug}"
+        attribution = Referral::Attribution.find_by!(link:)
+        expect(attribution.user_id).to be_nil
+        expect(attribution.user_session_id).to be_present
+
+        post "/first", params: valid_form
+
+        new_user = User.find_by!(email: valid_form[:user][:email])
+        expect(attribution.reload.user_id).to eq(new_user.id)
+      end
+
+      it "associates every attribution accumulated on the session, across multiple links" do
+        get "/referrals/#{link.slug}"
+        get "/referrals/#{other_link.slug}"
+        expect(Referral::Attribution.where(link: [link, other_link]).pluck(:user_id)).to all(be_nil)
+
+        post "/first", params: valid_form
+
+        new_user = User.find_by!(email: valid_form[:user][:email])
+        expect(Referral::Attribution.where(link: [link, other_link]).pluck(:user_id)).to all(eq(new_user.id))
+      end
+    end
+
+    it "completes signup successfully when the visitor's session has no referral attributions" do
+      params = valid_form.deep_dup
+      params[:user][:email] = "no-referral-#{SecureRandom.hex(4)}@example.invalid"
+
+      expect { post "/first", params: params }.to change { User.count }.by(1)
+      expect(response.status).to eq(302)
+    end
+
   end
 
   describe "DELETE /first/sign_out" do


### PR DESCRIPTION
Users::FirstController#create now mirrors LoginsController#create by binding the visitor's pending Referral::Attribution rows to the new user before swapping in the authenticated session. Without this, any signup that came through the FIRST form path left its attributions orphaned (user_id nil), so per-link signup metrics undercounted.

Adds Maintenance::BackfillReferralAttributionUsersTask to repair existing orphans by resolving user_id from the attribution's User::Session, which is set-once and therefore unambiguous.
