### PR TITLE
[FIRST] Attribute referral clicks for existing users on form

### DIFF
--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -137,6 +137,11 @@ module Users
       end
 
       @user = User.find_by!(email: user_params[:email])
+
+      current_session.referral_attributions.where(user_id: nil).find_each do |attribution|
+        attribution.update!(user: @user)
+      end
+
       @login = Login.create!(state: { purpose: "first", return_to: first_index_path, user_params:, raffle: program }, user: @user)
 
       cookies.signed["browser_token_#{@login.hashid}"] = { value: @login.browser_token, expires: Login::EXPIRATION.from_now }

--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe "Users::FirstController", type: :request do
         new_user = User.find_by!(email: valid_form[:user][:email])
         expect(Referral::Attribution.where(link: [link, other_link]).pluck(:user_id)).to all(eq(new_user.id))
       end
+
+      it "associates the click attribution with an existing user when the form is submitted with their email" do
+        existing = create(:user, verified: true)
+
+        get "/referrals/#{link.slug}"
+        attribution = Referral::Attribution.find_by!(link:)
+        expect(attribution.user_id).to be_nil
+
+        params = valid_form.deep_dup
+        params[:user][:email] = existing.email
+        post "/first", params: params
+
+        expect(attribution.reload.user_id).to eq(existing.id)
+      end
     end
 
     it "completes signup successfully when the visitor's session has no referral attributions" do


### PR DESCRIPTION
The existing-user branch of Users::FirstController#create created the Login row and redirected to email verification without ever binding the visitor's pending Referral::Attribution rows to the user, so any signup through the existing-account path left its click attribution orphaned. Mirror the same backfill the new-user branch already runs, after locating the user but before opening the Login.
