### PR TITLE
[FIRST] Backfill orphaned referral attributions

### DIFF
--- a/app/tasks/maintenance/heuristic_backfill_referral_attributions_task.rb
+++ b/app/tasks/maintenance/heuristic_backfill_referral_attributions_task.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class HeuristicBackfillReferralAttributionsTask < MaintenanceTasks::Task
+    # Heuristic second-pass backfill for Referral::Attribution rows that
+    # BackfillReferralAttributionUsersTask cannot recover.
+    #
+    # Background: until the controller fix shipped, Users::FirstController
+    # never bound Referral::Attribution rows to the new user. The new-user
+    # branch called SessionsHelper#create_session, which builds a fresh
+    # User::Session for the new user instead of binding user_id onto the
+    # existing anonymous session. The anonymous session's user_id stayed
+    # NULL forever, so the FK-based backfill (which joins on
+    # user_sessions.user_id) skips these rows. The existing-user branch
+    # never touched attributions at all.
+    #
+    # Strategy: iterate unattributed /first/welcome signups in time order
+    # and, for each, claim the closest preceding orphan attribution within
+    # WINDOW. Bind every orphan from the same anonymous session so that a
+    # visitor who clicked multiple referral links in one sitting gets all
+    # their clicks attributed correctly.
+    #
+    # The anchor event is whichever moment best approximates "they
+    # submitted /first/welcome":
+    #   - new-user branch: users.created_at (account is created on submit)
+    #   - existing-user branch: the first Login row with
+    #     state->>'purpose' = 'first', which Users::FirstController#create
+    #     opens before redirecting to email verification.
+    #
+    # Caveat: this is heuristic. Two people signing up within seconds of
+    # each other can have their clicks swapped. Aggregate per-team counts
+    # are still close to truth because each user gets exactly one attribution
+    # claimed. The task is safe to re-run; it never overwrites an
+    # attribution that already has a user_id.
+    WINDOW = 24.hours
+
+    def collection
+      User
+        .where("EXISTS (SELECT 1 FROM event_affiliations ea WHERE ea.affiliable_type = 'User' AND ea.affiliable_id = users.id AND ea.name = 'first')")
+        .where("NOT EXISTS (SELECT 1 FROM referral_attributions ra WHERE ra.user_id = users.id)")
+        .order(:created_at)
+    end
+
+    def process(user)
+      anchor = anchor_for(user)
+      return unless anchor
+
+      closest = Referral::Attribution
+                .where(user_id: nil)
+                .where(created_at: (anchor - WINDOW)..anchor)
+                .order(created_at: :desc)
+                .first
+      return unless closest
+
+      Referral::Attribution
+        .where(user_id: nil, user_session_id: closest.user_session_id)
+        .update_all(user_id: user.id, updated_at: Time.current)
+    end
+
+    private
+
+    def anchor_for(user)
+      if user.first_robotics_form?
+        user.created_at
+      else
+        Login.where(user: user).where("state->>'purpose' = ?", "first").minimum(:created_at)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Maintenance::HeuristicBackfillReferralAttributionsTask` (heuristic), the second-pass companion to the existing `BackfillReferralAttributionUsersTask` (FK-based). Recovers `Referral::Attribution` rows whose anonymous `User::Session` was abandoned by `SessionsHelper#create_session` and therefore can't be reached by the FK pass.

## Why

The two `Users::FirstController#create` fixes (#13609, #13610) prevent new orphans, but they don't repair the historical gap. For `/first/welcome` new-user signups, the anonymous click session has its `user_id` left at NULL forever — the controller calls `create_session(user: @user, …)` which builds a brand-new session row instead of binding the existing one. The FK-based backfill (which joins on `user_sessions.user_id`) skips these rows; in prod that's ~1,455 of 1,504 orphans.

## How it works

For each user with a `name='first'` user-affiliation who has zero referral attributions, in `users.created_at` order:
1. Compute an "anchor" timestamp — `users.created_at` for `first_robotics_form` signups, otherwise the earliest `Login` with `state->>'purpose'='first'` (the existing-user branch).
2. Find the single closest `user_id IS NULL` attribution row in `[anchor - 24h, anchor]`.
3. Claim that row plus every sibling orphan sharing its `user_session_id` (covers visitors who clicked multiple referral links in the same sitting).

Already-attributed rows are never overwritten because the lookup filters on `user_id: nil`. Re-running is a no-op.

## Validation

Local run against a fresh prod dump:
- **99.7% coverage** — 886 of 889 affiliated users attributed to one of the 5 team referral links
- 815 of 817 candidates matched in ~6s
- The 2 unmatched users have no orphan in their backward window and are the earliest signups in the campaign (4/29 11:28 and 12:41 UTC)
- Empirical bucket data: 80% of users have a click within 1 minute of signup, 95% within 5 min, 99% within 1 hour, 100% within 24 hours — the 24h window is well-justified.

## Risks

- **Greedy claim mis-attribution** (low single-digit %): an early signup can claim a click that "belongs" to a later, slower-converting signup. Doesn't affect aggregate per-team counts.
- **Race vs. live `FirstController` writes** (tiny but real): if a live signup completes mid-task, the controller's update could be silently lost. Mitigation: run off-peak.
- **Reversibility**: only marker is `updated_at`, indistinguishable from the FK task's writes. If results look wrong, rollback requires nulling rows updated during the task's run window.

## Run plan

```
1. Run `Maintenance::BackfillReferralAttributionUsersTask` (FK pass) — recovers ~50 rows.
2. Run `Maintenance::HeuristicBackfillReferralAttributionsTask` (this PR's heuristic) — recovers ~1,400 more.
```

Both via `/maintenance_tasks`.

## Test plan
- [ ] Run task in `/maintenance_tasks` against staging or off-peak prod
- [ ] Verify per-team Blazer queries show coverage near the affiliated total (~889)
- [ ] Confirm re-run processes 0 rows (idempotent)
