### PR TITLE
[FIRST] Fix iteration error in heuristic referral backfill

### DIFF
--- a/app/tasks/maintenance/heuristic_backfill_referral_attributions_task.rb
+++ b/app/tasks/maintenance/heuristic_backfill_referral_attributions_task.rb
@@ -34,11 +34,17 @@ module Maintenance
     # attribution that already has a user_id.
     WINDOW = 24.hours
 
+    # Returns an Array (not a Relation) so we can sort by anchor time.
+    # JobIteration's cursor iteration cannot support ORDER BY, but the
+    # greedy claim depends on processing earliest signups first.
     def collection
       User
         .where("EXISTS (SELECT 1 FROM event_affiliations ea WHERE ea.affiliable_type = 'User' AND ea.affiliable_id = users.id AND ea.name = 'first')")
         .where("NOT EXISTS (SELECT 1 FROM referral_attributions ra WHERE ra.user_id = users.id)")
-        .order(:created_at)
+        .map { |u| [u, anchor_for(u)] }
+        .reject { |_, anchor| anchor.nil? }
+        .sort_by { |_, anchor| anchor }
+        .map(&:first)
     end
 
     def process(user)


### PR DESCRIPTION
## Summary

Fixes `JobIteration::ActiveRecordCursor::ConditionNotSupportedError` raised by `Maintenance::HeuristicBackfillReferralAttributionsTask` (introduced in #13611). The task errored on launch in prod without processing any rows.

## Root cause

The MaintenanceTasks gem iterates `Task#collection` via JobIteration's `ActiveRecordCursor`, which rejects relations with `ORDER BY` because the cursor pagination uses primary-key ordering internally. The original `collection` method returned a Relation ending in `.order(:created_at)`, so the first iteration tick raised before any row was processed.

## Fix

The greedy claim still needs to process earliest signups first (otherwise late signups can steal closer orphans from early signups). Return a sorted Array (~800 entries, negligible memory) instead of a Relation. The Array path is supported by the gem and preserves our anchor-time ordering through iteration.

No safety implications from the previous failed run — it processed 0 of 817 items, so no rows were mutated.

## Test plan
- [x] Verified locally end-to-end via `MaintenanceTasks::TaskJob.perform_now` against a fresh prod dump: collection returns Array of 851 users, task status `succeeded`, processed 817/817, 99.7% coverage on team links (886/889 affiliated users attributed)
- [ ] Run via `/maintenance_tasks` UI in prod and confirm it finishes without erroring