### PR TITLE
Fix FIRST controller specs failing after Worlds cutoff

### DIFF
--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe "Users::FirstController", type: :request do
     let(:affiliation_metadata) { { "league" => "frc", "team_number" => "9999" } }
     let(:user_role) { "student_member" }
 
+    # The contest-window cards (AirPods raffle, Request to join, etc.) are
+    # gated by `Date.current < Date.new(2026, 5, 3)` in the view. Freeze time
+    # to inside the FIRST Worlds 2026 window so those cards still render.
+    before { travel_to(Date.new(2026, 4, 30)) }
+    after  { travel_back }
+
     before do
       user.affiliations.create!(name: "first", metadata: affiliation_metadata.merge("role" => user_role))
 

--- a/spec/requests/users/first_request_org_invite_spec.rb
+++ b/spec/requests/users/first_request_org_invite_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Users::FirstController, type: :controller do
   end
 
   describe "POST #request_org_invite" do
+    # The endpoint is gated by `Date.current >= Date.new(2026, 5, 3)` in the
+    # controller. Freeze time to inside the FIRST Worlds 2026 window so the
+    # endpoint still serves its happy path.
+    before { travel_to(Date.new(2026, 4, 30)) }
+    after  { travel_back }
+
     it "creates a pending OrganizerPositionInvite::Request for the matching event" do
       give_user_first_affiliation
       event = event_with_first_affiliation
@@ -51,6 +57,9 @@ RSpec.describe Users::FirstController, type: :controller do
       create_session(user, verified: true)
 
       post(:request_org_invite)
+      # Time is frozen for the contest-window date gate, so the 0-second link
+      # is right at its expiry boundary. Nudge past it to read as expired.
+      travel(1.second)
 
       link = OrganizerPositionInvite::Request.where(requester: user).last.link
       expect(link.active?).to eq(false),


### PR DESCRIPTION
## Summary
- The view at `app/views/users/first/index.html.erb:82` and the controller at `app/controllers/users/first_controller.rb:39` gate the AirPods raffle card, the "Request to join" card, and the `request_org_invite` endpoint on `Date.current < Date.new(2026, 5, 3)`.
- Once that date passed, **every PR** started failing the same 7 specs (3 in shard 6/8, 4 in shard 8/8) — see e.g. [run 25346033329](https://github.com/hackclub/hcb/actions/runs/25346033329).
- This freezes time to **2026-04-30** in the affected describe blocks via `travel_to` so the specs continue to exercise the in-window behavior.
- One test (`creates an OrganizerPositionInvite::Link that is expired immediately`) needed an extra `travel(1.second)` because `travel_to` froze time exactly at link creation, putting the 0-second link right on its expiry boundary instead of past it.

No production code changed. The contest-window code paths remain live as designed; only the specs are affected.

## Test plan
- [x] `bundle exec rspec spec/requests/users/first_controller_spec.rb spec/requests/users/first_request_org_invite_spec.rb` — 23/23 pass locally
- [ ] CI shards 6/8 and 8/8 pass on this PR