### PR TITLE
[Reimbursements] Make both settings checkboxes use toggle switches

### DIFF
--- a/app/views/events/settings/_reimbursements.html.erb
+++ b/app/views/events/settings/_reimbursements.html.erb
@@ -8,17 +8,22 @@
     <% unless event.unapproved? %>
       <% if event.users.size > 1 %>
         <div class="field field--checkbox">
-          <%= form.check_box :reimbursements_require_organizer_peer_review, disabled:, switch: true %>
-          <%= form.label :reimbursements_require_organizer_peer_review, "Require a peer review for reports submitted by managers." %>
+          <span>Require a peer review for reports submitted by managers.</span>
+          <div class="field--checkbox--switch ml-auto" style="flex-shrink:0">
+            <%= form.label :reimbursements_require_organizer_peer_review do %>
+              <%= form.check_box :reimbursements_require_organizer_peer_review, disabled:, switch: true %>
+              <span class="slider"></span>
+            <% end %>
+          </div>
         </div>
       <% end %>
       <div class="field field--checkbox mb-2">
-        <%= form.label :public_reimbursement_page_enabled, "Enable public reimbursement page", class: "flex-1", style: "font-weight: 700" %>
+        <span class="flex-1" style="font-weight: 700">Enable public reimbursement page</span>
         <div class="field--checkbox--switch" style="flex-shrink:0">
-          <%= form.check_box :public_reimbursement_page_enabled,
-            disabled:,
-            switch: true %>
-          <span class="slider"></span>
+          <%= form.label :public_reimbursement_page_enabled do %>
+            <%= form.check_box :public_reimbursement_page_enabled, disabled:, switch: true %>
+            <span class="slider"></span>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/events/settings/_reimbursements.html.erb
+++ b/app/views/events/settings/_reimbursements.html.erb
@@ -8,7 +8,7 @@
     <% unless event.unapproved? %>
       <% if event.users.size > 1 %>
         <div class="field field--checkbox">
-          <span style="font-weight: 700">Require a peer review for reports submitted by managers.</span>
+          <span class="flex-1" style="font-weight: 700">Require a peer review for reports submitted by managers.</span>
           <div class="field--checkbox--switch ml-auto shrink-0">
             <%= form.label :reimbursements_require_organizer_peer_review do %>
               <%= form.check_box :reimbursements_require_organizer_peer_review, disabled:, switch: true %>

--- a/app/views/events/settings/_reimbursements.html.erb
+++ b/app/views/events/settings/_reimbursements.html.erb
@@ -8,8 +8,8 @@
     <% unless event.unapproved? %>
       <% if event.users.size > 1 %>
         <div class="field field--checkbox">
-          <span>Require a peer review for reports submitted by managers.</span>
-          <div class="field--checkbox--switch ml-auto" style="flex-shrink:0">
+          <span style="font-weight: 700">Require a peer review for reports submitted by managers.</span>
+          <div class="field--checkbox--switch ml-auto shrink-0">
             <%= form.label :reimbursements_require_organizer_peer_review do %>
               <%= form.check_box :reimbursements_require_organizer_peer_review, disabled:, switch: true %>
               <span class="slider"></span>
@@ -19,7 +19,7 @@
       <% end %>
       <div class="field field--checkbox mb-2">
         <span class="flex-1" style="font-weight: 700">Enable public reimbursement page</span>
-        <div class="field--checkbox--switch" style="flex-shrink:0">
+        <div class="field--checkbox--switch shrink-0">
           <%= form.label :public_reimbursement_page_enabled do %>
             <%= form.check_box :public_reimbursement_page_enabled, disabled:, switch: true %>
             <span class="slider"></span>


### PR DESCRIPTION
## Summary

- The "Enable public reimbursement page" switch wasn't toggling when clicking the visual slider — the `<span class="slider">` was a sibling of the checkbox rather than inside a wrapping `<label>`, so CSS clicks on the slider didn't propagate to the input
- Fixed by wrapping both the `check_box` and `<span class="slider">` inside a `form.label do` block, matching the pattern used elsewhere in the codebase (e.g. `edit_security.html.erb`)
- Also converted the "Require peer review" field from a plain checkbox layout to the same switch pattern

## Test plan

- [ ] Go to an org's reimbursement settings
- [ ] Click the visual toggle (not the label text) for "Enable public reimbursement page" — it should now toggle
- [ ] If the org has >1 member, the peer review option should now render as a switch and toggle correctly
- [ ] Saving should persist the correct value in both cases

https://claude.ai/code/session_01LM9HGuDZtgyQKnGvZYfKcm


---
_Generated by [Claude Code](https://claude.ai/code/session_01LM9HGuDZtgyQKnGvZYfKcm)_