### PR TITLE
Add comment_policy test and fix unique index_ledger_items_on_short_code violation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,12 @@ jobs:
         run: |
           specs=$(find spec -name '*_spec.rb' | sort | awk -v i="$SHARD_INDEX" -v n="$SHARD_TOTAL" 'NR % n == (i - 1) % n { print }')
           echo "Running $(echo "$specs" | wc -l) spec files on shard $SHARD_INDEX/$SHARD_TOTAL"
-          bundle exec rspec --tag ~skip $specs
+          seed=$RANDOM
+          cmd="bundle exec rspec --seed $seed --tag '~skip' $(echo $specs | tr '\n' ' ')"
+          echo "To reproduce locally, run:"
+          echo "  RAILS_ENV=test bundle exec rails db:drop db:create db:schema:load && \\"
+          echo "  $cmd"
+          eval "$cmd"
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:

--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -163,7 +163,8 @@ class CanonicalPendingTransaction < ApplicationRecord
 
   after_create_commit unless: -> { ledger_item.present? } do
     safely do
-      update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      update(ledger_item: li)
     end
   end
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -137,7 +137,8 @@ class CanonicalTransaction < ApplicationRecord
 
   after_create_commit unless: -> { ledger_item.present? } do
     safely do
-      update(ledger_item: create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code))
+      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      update(ledger_item: li)
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ email = Rails.env.staging? ? "staging@bank.engineering" : "admin@bank.engineerin
 
 if user.nil?
   puts "Woah there, there aren't any users! Creating an user (#{email})."
-  user = User.create!(email:, full_name: "Stagey McStageface", phone_number: "+19064225632")
+  user = User.create!(email:, full_name: "Stagey McStageface", phone_number: "+19064225632", verified: true)
 end
 
 puts "Continuing with #{user.email}..."
@@ -15,7 +15,7 @@ user.make_admin! unless user.admin?
 
 Governance::Admin::Transfer::Limit.create(user_id: user.id, amount_cents: 1000000000)
 
-system_user = User.create_with(email: User::SYSTEM_USER_EMAIL).create_or_find_by!(id: User::SYSTEM_USER_ID)
+system_user = User.create_with(email: User::SYSTEM_USER_EMAIL, verified: true).create_or_find_by!(id: User::SYSTEM_USER_ID)
 system_user.make_admin! unless system_user.admin?
 
 # DEMO

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommentPolicy, type: :policy do
+  def create_hcb_code_for_event(event)
+    disbursement = create(:disbursement, source_event: event)
+    disbursement.outgoing_disbursement.local_hcb_code
+  end
+
+  describe "#users" do
+    context "when commentable responds to :events" do
+      it "includes both direct users and ancestor users" do
+        parent_event = create(:event)
+        ancestor_user = create(:user)
+        create(:organizer_position, event: parent_event, user: ancestor_user)
+
+        child_event = create(:event, parent: parent_event)
+        direct_user = create(:user)
+        create(:organizer_position, event: child_event, user: direct_user)
+
+        hcb_code = create_hcb_code_for_event(child_event)
+        comment = create(:comment, commentable: hcb_code)
+        policy = described_class.new(direct_user, comment)
+        policy_users = policy.send(:users)
+
+        expect(policy_users).to include(direct_user)
+        expect(policy_users).to include(ancestor_user)
+      end
+    end
+  end
+
+  describe "#show?" do
+    context "when commentable responds to :events" do
+      it "allows organizers of the event to view comments" do
+        event = create(:event)
+        user = create(:user)
+        create(:organizer_position, event: event, user: user)
+
+        hcb_code = create_hcb_code_for_event(event)
+        comment = create(:comment, commentable: hcb_code, admin_only: false)
+        policy = described_class.new(user, comment)
+
+        expect(policy.show?).to eq(true)
+      end
+    end
+  end
+
+  describe "#create?" do
+    context "when commentable responds to :events" do
+      it "allows organizers to create comments" do
+        event = create(:event)
+        user = create(:user)
+        create(:organizer_position, event: event, user: user)
+
+        hcb_code = create_hcb_code_for_event(event)
+        comment = build(:comment, commentable: hcb_code, admin_only: false)
+        policy = described_class.new(user, comment)
+
+        expect(policy.create?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CommentPolicy, type: :policy do
   end
 
   describe "#users" do
-    context "when commentable responds to :events" do
+    context "when commentable responds to :events (HcbCode)" do
       it "includes both direct users and ancestor users" do
         parent_event = create(:event)
         ancestor_user = create(:user)
@@ -22,43 +22,107 @@ RSpec.describe CommentPolicy, type: :policy do
         hcb_code = create_hcb_code_for_event(child_event)
         comment = create(:comment, commentable: hcb_code)
         policy = described_class.new(direct_user, comment)
-        policy_users = policy.send(:users)
 
-        expect(policy_users).to include(direct_user)
-        expect(policy_users).to include(ancestor_user)
+        expect(policy.send(:users)).to include(direct_user, ancestor_user)
+      end
+    end
+
+    context "when commentable is a Reimbursement::Report" do
+      it "includes the report user and event organizers" do
+        event = create(:event)
+        organizer = create(:user)
+        create(:organizer_position, event: event, user: organizer)
+        report_user = create(:user)
+        report = create(:reimbursement_report, user: report_user, event: event)
+
+        comment = create(:comment, commentable: report)
+        policy = described_class.new(report_user, comment)
+
+        expect(policy.send(:users)).to include(report_user, organizer)
+      end
+    end
+
+    context "when commentable is a Disbursement" do
+      it "includes users from both source and destination events" do
+        source_user = create(:user)
+        destination_user = create(:user)
+        disbursement = create(:disbursement)
+        create(:organizer_position, event: disbursement.source_event, user: source_user)
+        create(:organizer_position, event: disbursement.destination_event, user: destination_user)
+
+        comment = create(:comment, commentable: disbursement)
+        policy = described_class.new(source_user, comment)
+
+        expect(policy.send(:users)).to include(source_user, destination_user)
+      end
+    end
+
+    context "when commentable is an Event" do
+      it "returns no users" do
+        event = create(:event)
+        user = create(:user)
+        create(:organizer_position, event: event, user: user)
+
+        comment = create(:comment, commentable: event)
+        policy = described_class.new(user, comment)
+
+        expect(policy.send(:users)).to be_empty
+      end
+    end
+
+    context "when commentable falls through to the default branch (AchTransfer)" do
+      it "returns the event's users" do
+        event = create(:event, :with_positive_balance)
+        user = create(:user)
+        create(:organizer_position, event: event, user: user)
+        ach_transfer = create(:ach_transfer, event: event)
+
+        comment = create(:comment, commentable: ach_transfer)
+        policy = described_class.new(user, comment)
+
+        expect(policy.send(:users)).to include(user)
+      end
+    end
+
+    context "when commentable responds to :author" do
+      it "includes the author" do
+        author = create(:user)
+        disbursement = create(:disbursement, requested_by: author)
+        hcb_code = disbursement.outgoing_disbursement.local_hcb_code
+
+        comment = create(:comment, commentable: hcb_code)
+        policy = described_class.new(author, comment)
+
+        expect(policy.send(:users)).to include(author)
       end
     end
   end
 
   describe "#show?" do
-    context "when commentable responds to :events" do
-      it "allows organizers of the event to view comments" do
-        event = create(:event)
-        user = create(:user)
-        create(:organizer_position, event: event, user: user)
+    it "allows organizers of the event to view comments" do
+      event = create(:event)
+      user = create(:user)
+      create(:organizer_position, event: event, user: user)
 
-        hcb_code = create_hcb_code_for_event(event)
-        comment = create(:comment, commentable: hcb_code, admin_only: false)
-        policy = described_class.new(user, comment)
+      hcb_code = create_hcb_code_for_event(event)
+      comment = create(:comment, commentable: hcb_code, admin_only: false)
+      policy = described_class.new(user, comment)
 
-        expect(policy.show?).to eq(true)
-      end
+      expect(policy.show?).to eq(true)
     end
   end
 
   describe "#create?" do
-    context "when commentable responds to :events" do
-      it "allows organizers to create comments" do
-        event = create(:event)
-        user = create(:user)
-        create(:organizer_position, event: event, user: user)
+    it "allows organizers to create comments" do
+      event = create(:event)
+      user = create(:user)
+      create(:organizer_position, event: event, user: user)
 
-        hcb_code = create_hcb_code_for_event(event)
-        comment = build(:comment, commentable: hcb_code, admin_only: false)
-        policy = described_class.new(user, comment)
+      hcb_code = create_hcb_code_for_event(event)
+      comment = build(:comment, commentable: hcb_code, admin_only: false)
+      policy = described_class.new(user, comment)
 
-        expect(policy.create?).to eq(true)
-      end
+      expect(policy.create?).to eq(true)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,6 +100,16 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 
+  # Pin Kernel#rand to RSpec's seed so PRNG-driven code paths (e.g.
+  # HcbCodeService::Generate::ShortCode) are deterministic per run.
+  # Pass --seed N to reproduce a specific failure; the seed is printed below.
+  config.before(:suite) do
+    seed = RSpec.configuration.seed
+    Kernel.srand(seed)
+    Faker::Config.random = Random.new(seed)
+    puts "Kernel.srand + Faker seeded with: #{seed}"
+  end
+
   # Uncomment to allow the test suite to make network calls
   # WebMock.allow_net_connect!
 end


### PR DESCRIPTION
Originally added this test in https://github.com/hackclub/hcb/pull/13248 and saw an unrelated failure

Turns out if we run the specific test group in https://github.com/hackclub/hcb/pull/13643/commits/4ccb307f17d659b63f18bc7eef7cc824287fb3bf with a fresh database, we ended up having a race + collision on the unique index due to postgres sequences

The fix is to use an existing ledger item associated to an hcbcode if there is one

This should also fix an existing issue with db:seed https://hackclub.slack.com/archives/C047Y01MHJQ/p1772390834586969

After the fix, added some more cases to comment_policy_spec. If we had them from the beginning, we wouldn't surface the unique index collison