### PR TITLE
[IncreaseCheck] Remove reissuing

### DIFF
--- a/app/controllers/increase_checks_controller.rb
+++ b/app/controllers/increase_checks_controller.rb
@@ -5,7 +5,7 @@ class IncreaseChecksController < ApplicationController
   include Admin::TransferApprovable
 
   before_action :set_event, only: %i[new create]
-  before_action :set_check, only: %i[approve reject stop reissue]
+  before_action :set_check, only: %i[approve reject stop]
 
   def new
     @check = @event.increase_checks.build
@@ -72,14 +72,6 @@ class IncreaseChecksController < ApplicationController
     @check.stop!
 
     redirect_back_or_to url_for(@check.local_hcb_code), flash: { success: "Check has been stopped." }
-  end
-
-  def reissue
-    authorize @check
-
-    @check.reissue!
-
-    redirect_back_or_to url_for(@check.reissued_as.local_hcb_code), flash: { success: "Check has been reissued!" }
   end
 
   private

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -49,6 +49,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class IncreaseCheck < ApplicationRecord
+  self.ignored_columns += ["reissued_for_id"]
   # [@garyhtou] `IncreaseCheck` superseded `Check` starting March 2023.
   # On January 2024, we switched check printing & mailing services from
   # Increase to Column. This model, although still named `IncreaseCheck`, now

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -129,8 +129,6 @@ class IncreaseCheck < ApplicationRecord
 
   belongs_to :event
   belongs_to :user, optional: true
-  belongs_to :reissued_for, class_name: "IncreaseCheck", optional: true
-  has_one :reissued_as, class_name: "IncreaseCheck", foreign_key: :reissued_for_id, inverse_of: :reissued_for
 
   def payment_recipient_attributes
     %i[address_line1 address_line2 address_city address_state address_zip]
@@ -338,35 +336,6 @@ class IncreaseCheck < ApplicationRecord
     #   column_status: column_check["status"],
     #   column_delivery_status: column_check["delivery_status"],
     # )
-  end
-
-  def reissue!
-    raise ArgumentError, "Reissuing checks is not yet supported"
-
-    # stop! unless column_stopped? || column_pending_stop?
-
-    # reissued_check = event.increase_checks.build(
-    #   user_id:,
-    #   memo:,
-    #   amount:,
-    #   payment_for:,
-    #   recipient_name:,
-    #   address_line1:,
-    #   address_line2:,
-    #   address_city:,
-    #   address_state:,
-    #   recipient_email:,
-    #   send_email_notification:,
-    #   address_zip:,
-    #   payment_recipient_id:,
-    #   reissued_for_id: id,
-    # )
-
-    # reissued_check.save!
-
-    # Receipt.reupload(old_receiptable: local_hcb_code, new_receiptable: reissued_check.local_hcb_code)
-
-    # reissued_check.send_check!
   end
 
   private

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -30,7 +30,6 @@
 #  event_id                :bigint           not null
 #  increase_id             :string
 #  payment_recipient_id    :bigint
-#  reissued_for_id         :bigint
 #  user_id                 :bigint
 #
 # Indexes

--- a/app/policies/increase_check_policy.rb
+++ b/app/policies/increase_check_policy.rb
@@ -17,10 +17,6 @@ class IncreaseCheckPolicy < ApplicationPolicy
     user_who_can_transfer? && record.can_stop?
   end
 
-  def reissue?
-    user&.admin?
-  end
-
   def reject?
     user_who_can_transfer?
   end

--- a/app/views/hcb_codes/transaction_types/_increase_check.html.erb
+++ b/app/views/hcb_codes/transaction_types/_increase_check.html.erb
@@ -136,10 +136,6 @@
             <%= stop_button %>
           </div>
         <% end %>
-
-        <% admin_tool("flex gap-3") do %>
-          <%= button_to "Reissue", reissue_increase_check_path(@hcb_code.increase_check), class: "btn bg-muted", target: "_blank", data: { turbo_confirm: "This action will stop the current check and issue a new one for the same amount." }, disabled: !policy(@hcb_code.increase_check).reissue? %>
-        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/increase_check_mailer/notify_recipient.html.erb
+++ b/app/views/increase_check_mailer/notify_recipient.html.erb
@@ -2,20 +2,11 @@
   Hi <%= @check.recipient_name %>,
 </p>
 
-<% if @check.reissued_for.nil? %>
-  <p>
-    <%= @check.event.name %> has just mailed you a
-    <%= render_money(@check.amount) %> check for
-    <i>"<%= @check.payment_for %>"</i>.
-  </p>
-<% else %>
-  <p>
-    Your <%= render_money(@check.amount) %> check for
-    <i>"<%= @check.payment_for %>"</i> from <%= @check.event.name %>
-    has been reissued with a new check number of <b><%= @check.check_number %></b>.
-    The previous check is no longer valid and should be disposed of if received.
-  </p>
-<% end %>
+<p>
+  <%= @check.event.name %> has just mailed you a
+  <%= render_money(@check.amount) %> check for
+  <i>"<%= @check.payment_for %>"</i>.
+</p>
 
 <p>You must deposit this check within <%= IncreaseCheck::VALID_DURATION.inspect %>. It will expire on <%= (@check.approved_at + IncreaseCheck::VALID_DURATION).strftime("%b %e, %Y") %>.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -450,7 +450,6 @@ Rails.application.routes.draw do
       post "approve"
       post "reject"
       post "stop"
-      post "reissue"
     end
   end
 

--- a/spec/controllers/increase_checks_controller_spec.rb
+++ b/spec/controllers/increase_checks_controller_spec.rb
@@ -75,66 +75,6 @@ RSpec.describe IncreaseChecksController do
   #   end
   # end
 
-  # describe "reissue" do
-  #   it "copies all attributes to the reissued check" do
-  #     user = create(:user, :make_admin)
-  #     event = create(:event, :with_positive_balance)
-  #     check = event.increase_checks.create!(
-  #       build_check_attributes(column_id: "col_original", column_status: "issued")
-  #     )
-
-  #     sign_in(user)
-
-  #     allow(ColumnService).to receive(:post)
-  #       .with("/transfers/checks/col_original/stop-payment", idempotency_key: "stop_col_original")
-  #       .and_return({ "status" => "stopped", "delivery_status" => "failed" })
-
-  #     allow(ColumnService).to receive(:post)
-  #       .with(match(/\/account-numbers\z/), anything)
-  #       .and_return({ "id" => "acno_test", "account_number" => "123", "routing_number" => "456", "bic" => "789" })
-
-  #     allow(ColumnService).to receive(:post)
-  #       .with("/transfers/checks/issue", anything)
-  #       .and_return({
-  #                     "id"              => "col_new",
-  #                     "check_number"    => "1002",
-  #                     "status"          => "issued",
-  #                     "delivery_status" => "created",
-  #                   })
-
-  #     post(:reissue, params: { id: check.id })
-
-  #     new_check = check.reload.reissued_as
-  #     expect(response).to redirect_to(hcb_code_path(new_check.local_hcb_code))
-
-  #     columns_that_differ = %w[
-  #       id created_at updated_at approved_at aasm_state reissued_for_id
-  #       column_id column_status column_delivery_status column_object check_number
-  #     ]
-
-  #     columns_to_compare = check.attributes.keys - columns_that_differ
-
-  #     expect(new_check.attributes.slice(*columns_to_compare))
-  #       .to eq(check.attributes.slice(*columns_to_compare))
-  #   end
-
-  #   it "denies non-admins" do
-  #     user = create(:user)
-  #     event = create(:event, :with_positive_balance)
-  #     create(:organizer_position, user:, event:)
-  #     check = event.increase_checks.create!(
-  #       build_check_attributes(column_id: "col_test_deny", column_status: "issued")
-  #     )
-
-  #     sign_in(user)
-
-  #     post(:reissue, params: { id: check.id })
-
-  #     expect(response).to redirect_to(root_path)
-  #     expect(flash[:error]).to be_present
-  #   end
-  # end
-
   describe "create" do
     def increase_check_params
       {


### PR DESCRIPTION
# Now that stopping is supported, the new flow is:
- org manager sends check
- hcb ops approves check
- org manager stops check (they can now do this even after hcb approval and it is sent on column)
- org manager sends new check
- hcb ops approves new check

This way, hcb ops only has to deal with the existing flow of approving checks rather than a special flow just to reissue.

# What if it's a reimbursement?
- reimbursee reachs out to hcb ops
- hcb ops stops check
- reimbursement report now shows as failed
- hcb ops clicks edit payout info and then presses save (no need to change any data)
- reimbursement service sends new check

Closes #13650