### PR TITLE
[Admin] AI-powered BI query generator dashboard

### DIFF
--- a/app/controllers/admin/ai_queries_controller.rb
+++ b/app/controllers/admin/ai_queries_controller.rb
@@ -5,7 +5,8 @@ module Admin
     before_action :set_query, only: [:show, :destroy]
 
     def index
-      @queries = Blazer::Query
+      @queries =
+        Blazer::Query
         .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
         .order(created_at: :desc)
     end
@@ -44,7 +45,8 @@ module Admin
     private
 
     def set_query
-      @query = Blazer::Query
+      @query =
+        Blazer::Query
         .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
         .find(params[:id])
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/admin/ai_queries_controller.rb
+++ b/app/controllers/admin/ai_queries_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Admin
+  class AiQueriesController < BaseController
+    before_action :set_query, only: [:show, :destroy]
+
+    def index
+      @queries = Blazer::Query
+        .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
+        .order(created_at: :desc)
+    end
+
+    def new
+      @prompt = params[:prompt]
+    end
+
+    def create
+      prompt = params[:prompt].to_s.strip
+
+      if prompt.blank?
+        flash.now[:error] = "Please enter a prompt."
+        return render :new, status: :unprocessable_entity
+      end
+
+      result = Admin::GenerateAiQuery.new(prompt:, user: current_user).run
+
+      if result.success?
+        redirect_to admin_ai_query_path(result.query), notice: "Query generated successfully!"
+      else
+        flash.now[:error] = result.error
+        @prompt = prompt
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def show
+    end
+
+    def destroy
+      @query.destroy
+      redirect_to admin_ai_queries_path, notice: "Query deleted."
+    end
+
+    private
+
+    def set_query
+      @query = Blazer::Query
+        .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
+        .find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to admin_ai_queries_path, alert: "Query not found."
+    end
+  end
+end

--- a/app/controllers/admin/ai_queries_controller.rb
+++ b/app/controllers/admin/ai_queries_controller.rb
@@ -2,13 +2,10 @@
 
 module Admin
   class AiQueriesController < BaseController
-    before_action :set_query, only: [:show, :destroy]
+    before_action :set_ai_query, only: [:show, :destroy]
 
     def index
-      @queries =
-        Blazer::Query
-        .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
-        .order(created_at: :desc)
+      @ai_queries = AiQuery.order(created_at: :desc).includes(:blazer_query, :creator)
     end
 
     def new
@@ -23,34 +20,25 @@ module Admin
         return render :new, status: :unprocessable_entity
       end
 
-      result = Admin::GenerateAiQuery.new(prompt:, user: current_user).run
+      @ai_query = AiQuery.create!(prompt:, creator: current_user)
+      AiQueryGenerationJob.perform_later(@ai_query.id)
 
-      if result.success?
-        redirect_to admin_ai_query_path(result.query), notice: "Query generated successfully!"
-      else
-        flash.now[:error] = result.error
-        @prompt = prompt
-        render :new, status: :unprocessable_entity
-      end
+      redirect_to admin_ai_query_path(@ai_query)
     end
 
     def show
     end
 
     def destroy
-      @query.destroy
+      @ai_query.blazer_query&.destroy
+      @ai_query.destroy
       redirect_to admin_ai_queries_path, notice: "Query deleted."
     end
 
     private
 
-    def set_query
-      @query =
-        Blazer::Query
-        .where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%")
-        .find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      redirect_to admin_ai_queries_path, alert: "Query not found."
+    def set_ai_query
+      @ai_query = AiQuery.find(params[:id])
     end
   end
 end

--- a/app/controllers/admin/ai_queries_controller.rb
+++ b/app/controllers/admin/ai_queries_controller.rb
@@ -40,5 +40,6 @@ module Admin
     def set_ai_query
       @ai_query = AiQuery.find(params[:id])
     end
+
   end
 end

--- a/app/jobs/ai_query_generation_job.rb
+++ b/app/jobs/ai_query_generation_job.rb
@@ -34,8 +34,9 @@ class AiQueryGenerationJob < ApplicationJob
       else
         history = ai_query.conversation_history + [
           { "role" => "assistant", "content" => "```sql\n#{sql}\n```" },
-          { "role" => "user",
-            "content" => "That query failed with: #{error}\n\nPlease fix it and return only the corrected SQL." }
+          { "role"    => "user",
+            "content" => "That query failed with: #{error}\n\nPlease fix it and return only the corrected SQL."
+          }
         ]
         ai_query.update!(conversation_history: history)
       end
@@ -54,4 +55,5 @@ class AiQueryGenerationJob < ApplicationJob
     ]
     ai_query.update!(conversation_history: history)
   end
+
 end

--- a/app/jobs/ai_query_generation_job.rb
+++ b/app/jobs/ai_query_generation_job.rb
@@ -17,6 +17,12 @@ class AiQueryGenerationJob < ApplicationJob
       if sql.blank?
         ai_query.record_attempt!(sql: "", error: "AI returned no SQL")
         ai_query.broadcast_generation_update
+        history = ai_query.conversation_history + [
+          { "role"    => "user",
+            "content" => "You returned an empty response. Please return only a valid PostgreSQL SELECT query with no explanation."
+          }
+        ]
+        ai_query.update!(conversation_history: history)
         next
       end
 

--- a/app/jobs/ai_query_generation_job.rb
+++ b/app/jobs/ai_query_generation_job.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class AiQueryGenerationJob < ApplicationJob
+  queue_as :default
+
+  def perform(ai_query_id)
+    ai_query = AiQuery.find(ai_query_id)
+
+    ai_query.update!(status: :generating)
+    ai_query.broadcast_generation_update
+
+    build_initial_conversation!(ai_query) if ai_query.conversation_history.empty?
+
+    AiQuery::MAX_GENERATION_ATTEMPTS.times do
+      sql = Admin::GenerateAiQuery.call_openai(ai_query.conversation_history)
+
+      if sql.blank?
+        ai_query.record_attempt!(sql: "", error: "AI returned no SQL")
+        ai_query.broadcast_generation_update
+        next
+      end
+
+      error = Admin::GenerateAiQuery.validate_sql(sql)
+      ai_query.record_attempt!(sql:, error:)
+      ai_query.broadcast_generation_update
+
+      if error.nil?
+        name = Admin::GenerateAiQuery.generate_name(ai_query.prompt)
+        ai_query.update!(generated_name: name)
+        ai_query.sync_to_blazer!
+        ai_query.update!(status: :success)
+        ai_query.broadcast_generation_update
+        return
+      else
+        history = ai_query.conversation_history + [
+          { "role" => "assistant", "content" => "```sql\n#{sql}\n```" },
+          { "role" => "user",
+            "content" => "That query failed with: #{error}\n\nPlease fix it and return only the corrected SQL." }
+        ]
+        ai_query.update!(conversation_history: history)
+      end
+    end
+
+    ai_query.update!(status: :failed)
+    ai_query.broadcast_generation_update
+  end
+
+  private
+
+  def build_initial_conversation!(ai_query)
+    history = [
+      { "role" => "system", "content" => Admin::GenerateAiQuery::SYSTEM_PROMPT },
+      { "role" => "user", "content" => ai_query.prompt }
+    ]
+    ai_query.update!(conversation_history: history)
+  end
+end

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -336,7 +336,7 @@ module Admin
           make_item(
             name: "AI Queries",
             path: admin_ai_queries_path,
-            count: ->{ Blazer::Query.where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%").count },
+            count: ->{ AiQuery.count },
             count_type: :records
           ),
           make_item(

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -334,6 +334,12 @@ module Admin
         name: "Misc",
         items: [
           make_item(
+            name: "AI Queries",
+            path: admin_ai_queries_path,
+            count: ->{ Blazer::Query.where("name LIKE ?", "#{Admin::GenerateAiQuery::AI_QUERY_PREFIX}%").count },
+            count_type: :records
+          ),
+          make_item(
             name: "Blazer",
             path: blazer_path,
             count: ->{ Blazer::Query.count },

--- a/app/models/ai_query.rb
+++ b/app/models/ai_query.rb
@@ -4,16 +4,16 @@
 #
 # Table name: ai_queries
 #
-#  id                    :bigint           not null, primary key
-#  attempts              :jsonb            not null
-#  conversation_history  :jsonb            not null
-#  generated_name        :string
-#  prompt                :text             not null
-#  status                :string           default("pending"), not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  blazer_query_id       :bigint
-#  creator_id            :bigint
+#  id                   :bigint           not null, primary key
+#  attempts             :jsonb            not null
+#  conversation_history :jsonb            not null
+#  generated_name       :string
+#  prompt               :text             not null
+#  status               :string           default("pending"), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  blazer_query_id      :bigint
+#  creator_id           :bigint
 #
 # Indexes
 #
@@ -21,7 +21,6 @@
 #  index_ai_queries_on_creator_id       (creator_id)
 #  index_ai_queries_on_status           (status)
 #
-
 class AiQuery < ApplicationRecord
   belongs_to :creator, class_name: "User", optional: true
   belongs_to :blazer_query, class_name: "Blazer::Query", optional: true

--- a/app/models/ai_query.rb
+++ b/app/models/ai_query.rb
@@ -20,9 +20,9 @@ class AiQuery < ApplicationRecord
   # Append a new attempt entry to the JSONB array and persist.
   def record_attempt!(sql:, error:)
     new_attempt = {
-      "attempt" => (attempts.length + 1),
-      "sql" => sql,
-      "error" => error,
+      "attempt"      => (attempts.length + 1),
+      "sql"          => sql,
+      "error"        => error,
       "generated_at" => Time.current.iso8601
     }
     update!(attempts: attempts + [new_attempt])
@@ -75,4 +75,5 @@ class AiQuery < ApplicationRecord
       locals: { ai_query: self }
     )
   end
+
 end

--- a/app/models/ai_query.rb
+++ b/app/models/ai_query.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: ai_queries
+#
+#  id                    :bigint           not null, primary key
+#  attempts              :jsonb            not null
+#  conversation_history  :jsonb            not null
+#  generated_name        :string
+#  prompt                :text             not null
+#  status                :string           default("pending"), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  blazer_query_id       :bigint
+#  creator_id            :bigint
+#
+# Indexes
+#
+#  index_ai_queries_on_blazer_query_id  (blazer_query_id)
+#  index_ai_queries_on_creator_id       (creator_id)
+#  index_ai_queries_on_status           (status)
+#
+
 class AiQuery < ApplicationRecord
   belongs_to :creator, class_name: "User", optional: true
   belongs_to :blazer_query, class_name: "Blazer::Query", optional: true

--- a/app/models/ai_query.rb
+++ b/app/models/ai_query.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class AiQuery < ApplicationRecord
+  belongs_to :creator, class_name: "User", optional: true
+  belongs_to :blazer_query, class_name: "Blazer::Query", optional: true
+
+  enum :status, {
+    pending: "pending",
+    generating: "generating",
+    success: "success",
+    failed: "failed"
+  }
+
+  validates :prompt, presence: true
+
+  AI_PREFIX = "[AI] "
+  BLAZER_DATA_SOURCE = "main"
+  MAX_GENERATION_ATTEMPTS = 10
+
+  # Append a new attempt entry to the JSONB array and persist.
+  def record_attempt!(sql:, error:)
+    new_attempt = {
+      "attempt" => (attempts.length + 1),
+      "sql" => sql,
+      "error" => error,
+      "generated_at" => Time.current.iso8601
+    }
+    update!(attempts: attempts + [new_attempt])
+  end
+
+  # The most recent SQL that ran without error.
+  def successful_sql
+    attempts.reverse.find { |a| a["error"].nil? }&.dig("sql")
+  end
+
+  # The most recent error message, if any.
+  def latest_error
+    attempts.last&.dig("error")
+  end
+
+  # Create or update the associated Blazer::Query with the latest successful SQL.
+  # The prompt lives on the AiQuery model so no comment embedding is needed.
+  def sync_to_blazer!
+    sql = successful_sql
+    raise ArgumentError, "No successful SQL to sync" if sql.blank?
+
+    name = "#{AI_PREFIX}#{display_name}"
+    attrs = {
+      name:,
+      statement: sql,
+      description: prompt,
+      data_source: BLAZER_DATA_SOURCE,
+      creator: creator
+    }
+
+    if blazer_query
+      blazer_query.update!(attrs)
+    else
+      bq = Blazer::Query.create!(attrs)
+      update!(blazer_query: bq)
+    end
+  end
+
+  # Human-readable name derived from the AI-generated summary or the prompt.
+  def display_name
+    generated_name.presence || prompt.truncate(60)
+  end
+
+  # Broadcast the current state of this record to the show page.
+  def broadcast_generation_update
+    broadcast_replace_to(
+      [self, :generation],
+      target: "ai-query-#{id}-progress",
+      partial: "admin/ai_queries/progress",
+      locals: { ai_query: self }
+    )
+  end
+end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -114,7 +114,10 @@ module Admin
     end
 
     def validate_sql(sql)
-      ActiveRecord::Base.connection.exec_query("EXPLAIN #{sql}")
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.exec_query(sql)
+        raise ActiveRecord::Rollback
+      end
       nil
     rescue ActiveRecord::StatementInvalid => e
       e.message

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -1,78 +1,65 @@
 # frozen_string_literal: true
 
 module Admin
-  class GenerateAiQuery
-    AI_QUERY_PREFIX = "[AI] "
-    MAX_ATTEMPTS = 10
-    DATA_SOURCE = "main"
-
-    Result = Struct.new(:success, :query, :error, keyword_init: true) do
-      def success? = success
-    end
-
+  # Stateless utility for OpenAI-powered SQL generation.
+  # Orchestration (retries, state, broadcasting) lives in AiQueryGenerationJob.
+  module GenerateAiQuery
     DB_SCHEMA = <<~SCHEMA
-      PostgreSQL database schema for HCB (Hack Club Bank), a fiscal sponsorship platform for student-run nonprofits.
-      All monetary amounts are stored in cents (integers) unless noted otherwise.
+      PostgreSQL database schema for HCB (Hack Club Bank), a fiscal sponsorship platform
+      for student-run nonprofits. All monetary amounts are stored in cents (integers).
 
       TABLE: events
         id, name (org name), slug, aasm_state (approved/rejected/demo/etc),
         country (integer enum), created_at, demo_mode (bool), fee_waiver_applied (bool),
         fee_waiver_eligible (bool), financially_frozen (bool), is_public (bool),
-        parent_id (self-ref for sub-orgs), risk_level (integer), website, short_name,
-        point_of_contact_id (FK users), activated_at
+        parent_id (self-ref for sub-orgs), risk_level (integer), website, activated_at
 
       TABLE: users
         id, full_name, email, access_level (0=user 1=admin 2=superadmin 3=auditor),
         created_at, teenager (bool), verified (bool), locked_at (null if not locked),
-        joined_as_teenager (bool), discord_id, slug
+        joined_as_teenager (bool)
 
       TABLE: organizer_positions
-        id, user_id, event_id, role (100=member 200=manager), created_at, deleted_at (soft delete)
-        -- links users to events they organize
+        id, user_id, event_id, role (100=member 200=manager), created_at,
+        deleted_at (soft delete — deleted_at IS NULL means active)
 
       TABLE: canonical_transactions
-        id, amount_cents, date, memo, hcb_code, transaction_source_type, transaction_source_id, created_at
-        -- settled/finalized financial transactions
+        id, amount_cents, date, memo, hcb_code, transaction_source_type,
+        transaction_source_id, created_at -- settled/finalized transactions
 
       TABLE: canonical_event_mappings
-        id, canonical_transaction_id, event_id
-        -- joins canonical_transactions to events
+        id, canonical_transaction_id, event_id -- joins transactions to events
 
       TABLE: canonical_pending_transactions
-        id, amount_cents, date, memo, hcb_code, created_at
-        -- pending (not yet settled) transactions
+        id, amount_cents, date, memo, hcb_code, created_at -- pending transactions
 
       TABLE: canonical_pending_event_mappings
         id, canonical_pending_transaction_id, event_id
 
       TABLE: donations
-        id, amount (cents), aasm_state (pending/in_transit/deposited/refunded/etc),
-        event_id, created_at, anonymous (bool), in_person (bool), email, name,
-        fee_covered (bool), recurring_donation_id, hcb_code
+        id, amount (cents), aasm_state, event_id, created_at, anonymous (bool),
+        in_person (bool), email, name, recurring_donation_id, hcb_code
 
       TABLE: invoices
-        id, aasm_state, amount_due (cents), amount_paid (cents), amount_remaining (cents),
-        event_id, creator_id (FK users), created_at, finalized_at, due_date, item_description,
-        item_amount (cents), hcb_code, livemode (bool)
+        id, aasm_state, amount_due (cents), amount_paid (cents), event_id,
+        creator_id, created_at, finalized_at, due_date, item_description, hcb_code
 
       TABLE: disbursements
-        id, amount (cents), aasm_state (pending/reviewing/in_transit/deposited/rejected/errored),
-        event_id, source_event_id (where money came from), name, created_at, requested_by_id (FK users)
+        id, amount (cents), aasm_state, event_id, source_event_id,
+        name, created_at, requested_by_id
 
       TABLE: ach_transfers
-        id, amount (cents), aasm_state (pending/approved/rejected/etc), event_id,
-        created_at, recipient_name, same_day (bool), hcb_code
+        id, amount (cents), aasm_state, event_id, created_at, recipient_name, hcb_code
 
       TABLE: increase_checks
         id, amount_cents, aasm_state, event_id, created_at, memo, recipient_name
 
       TABLE: card_grants
-        id, amount (cents), event_id, user_id, created_at, aasm_state,
-        merchant_lock (json), category_lock (json)
+        id, amount (cents), event_id, user_id, created_at, aasm_state
 
       TABLE: stripe_cards
-        id, event_id, user_id, created_at, aasm_state (active/frozen/canceled),
-        card_type (integer: 0=physical 1=virtual)
+        id, event_id, user_id, created_at,
+        aasm_state (active/frozen/canceled), card_type (0=physical 1=virtual)
 
       TABLE: bank_fees
         id, amount_cents, event_id, created_at, aasm_state
@@ -80,93 +67,36 @@ module Admin
       TABLE: fee_revenues
         id, amount_cents, created_at, event_id
 
-      TABLE: reimbursements (reports)
-        id, aasm_state, user_id, event_id, created_at
-
-      TABLE: paypal_transfers
-        id, amount_cents, event_id, aasm_state, created_at
-
-      TABLE: wires
-        id, amount_cents, event_id, aasm_state, created_at, recipient_name
-
       TABLE: recurring_donations
         id, amount (cents), event_id, created_at, email, active (bool)
 
-      TABLE: g_suites (Google Workspaces)
-        id, event_id, aasm_state, created_at, domain
-
       NOTES:
-      - "organizations" and "events" are the same thing (historical naming)
-      - amount_cents and amount are both used; always integer cents
+      - "organizations" and "events" are the same concept (historical naming)
       - Use canonical_event_mappings to join canonical_transactions to events
-      - aasm_state values vary per table; common ones: approved, active, pending, rejected, canceled
       - organizer_positions with deleted_at IS NULL = active organizers
-      - Use DATE_TRUNC for time-based grouping, e.g. DATE_TRUNC('month', created_at)
-      - LIMIT results to reasonable numbers (50-100 rows max) unless aggregating
+      - Use DATE_TRUNC('month', col) for monthly grouping
+      - LIMIT results (50-100 rows) unless the query is purely aggregate
     SCHEMA
 
-    def initialize(prompt:, user: nil, query_name: nil)
-      @prompt = prompt
-      @user = user
-      @query_name = query_name
-    end
+    SYSTEM_PROMPT = <<~PROMPT.freeze
+      You are an expert PostgreSQL analyst for HCB (Hack Club Bank).
+      Generate a single, safe, read-only SELECT SQL query based on the user's request.
 
-    def run
-      messages = build_initial_messages
-      attempt = 0
+      #{DB_SCHEMA}
 
-      while attempt < MAX_ATTEMPTS
-        attempt += 1
-        sql = call_openai(messages)
+      RULES:
+      - Return ONLY the raw SQL — no explanation, no markdown fences
+      - SELECT only; no INSERT, UPDATE, DELETE, DROP, or DDL
+      - Always include LIMIT (max 500) unless the query is a pure aggregate
+      - Use table aliases for readability
+      - Join canonical_transactions to events via canonical_event_mappings
+      - Express cents as amount_cents / 100.0 AS amount_dollars where helpful
+      - Use descriptive column aliases ("Total Revenue" not "sum")
+    PROMPT
 
-        return Result.new(success: false, error: "AI did not return SQL") if sql.blank?
+    module_function
 
-        error = run_sql_validation(sql)
-
-        if error.nil?
-          query = save_query(sql)
-          return Result.new(success: true, query:)
-        else
-          messages << { role: "assistant", content: "```sql\n#{sql}\n```" }
-          messages << {
-            role: "user",
-            content: "That query failed with this error: #{error}\n\nPlease fix it and return only the corrected SQL."
-          }
-        end
-      end
-
-      Result.new(success: false, error: "Failed to generate a valid query after #{MAX_ATTEMPTS} attempts. Last error recorded.")
-    end
-
-    private
-
-    def build_initial_messages
-      [
-        { role: "system", content: system_prompt },
-        { role: "user", content: @prompt }
-      ]
-    end
-
-    def system_prompt
-      <<~PROMPT
-        You are an expert PostgreSQL analyst for HCB (Hack Club Bank), a fiscal sponsorship platform.
-        Generate a single, safe, read-only SELECT SQL query based on the user's request.
-
-        #{DB_SCHEMA}
-
-        RULES:
-        - Return ONLY the raw SQL query, no explanation, no markdown code fences
-        - Use only SELECT statements; no INSERT, UPDATE, DELETE, DROP, etc.
-        - Always include a LIMIT clause (max 500 rows) unless the query is an aggregate
-        - Use table aliases for readability
-        - When joining transactions to events, use canonical_event_mappings
-        - Format monetary output with amount_cents / 100.0 AS amount_dollars when helpful
-        - Use meaningful column aliases (e.g. "Total Revenue" not "sum")
-        - Ensure the query will actually run without errors
-      PROMPT
-    end
-
-    def call_openai(messages)
+    def call_openai(conversation_history)
       conn = Faraday.new(url: "https://api.openai.com") do |f|
         f.request :json
         f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :BI_DASHBOARD) }
@@ -174,30 +104,17 @@ module Admin
         f.response :json
       end
 
-      payload = { model: "gpt-4o", messages:, temperature: 0.2 }
+      payload = { model: "gpt-4o", messages: conversation_history, temperature: 0.2 }
       response = conn.post("/v1/chat/completions", payload)
-
-      content = response.body.dig("choices", 0, "message", "content").to_s.strip
-      extract_sql(content)
+      raw = response.body.dig("choices", 0, "message", "content").to_s.strip
+      extract_sql(raw)
     rescue Faraday::Error => e
-      Rails.logger.error "[Admin::GenerateAiQuery] OpenAI API error: #{e.message}"
+      Rails.logger.error "[Admin::GenerateAiQuery] OpenAI error: #{e.message}"
       nil
     end
 
-    def extract_sql(content)
-      stripped = content.strip
-      return stripped unless stripped.start_with?("```")
-
-      # Remove opening fence line (```sql or ```)
-      after_open = stripped.sub(/\A```(?:sql)?\r?\n?/i, "")
-      # Remove closing fence
-      close_idx = after_open.rindex("\n```")
-      after_open = after_open[0...close_idx] if close_idx
-      after_open.strip
-    end
-
-    def run_sql_validation(sql)
-      data_source = Blazer.data_sources[DATA_SOURCE]
+    def validate_sql(sql)
+      data_source = Blazer.data_sources[AiQuery::BLAZER_DATA_SOURCE]
       statement = Blazer::Statement.new(sql, data_source)
       result = Blazer::RunStatement.new.perform(statement, {})
       result.error
@@ -205,22 +122,7 @@ module Admin
       e.message
     end
 
-    def save_query(sql)
-      name = build_query_name
-      statement_with_comment = "/* Prompt: #{@prompt.gsub("*/", "* /")} */\n\n#{sql}"
-
-      Blazer::Query.create!(
-        name: "#{AI_QUERY_PREFIX}#{name}",
-        statement: statement_with_comment,
-        description: @prompt,
-        data_source: DATA_SOURCE,
-        creator: @user
-      )
-    end
-
-    def build_query_name
-      return @query_name if @query_name.present?
-
+    def generate_name(prompt)
       conn = Faraday.new(url: "https://api.openai.com") do |f|
         f.request :json
         f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :BI_DASHBOARD) }
@@ -231,20 +133,29 @@ module Admin
       payload = {
         model: "gpt-4o-mini",
         messages: [
-          {
-            role: "system",
-            content: "Generate a short, descriptive title (5-8 words max) for a SQL query based on this description. Return only the title, no punctuation at the end."
-          },
-          { role: "user", content: @prompt }
+          { "role" => "system",
+            "content" => "Write a short title (5-8 words) for a SQL query described below. " \
+                         "Return only the title, no punctuation at the end." },
+          { "role" => "user", "content" => prompt }
         ],
         temperature: 0.3,
         max_tokens: 20
       }
       response = conn.post("/v1/chat/completions", payload)
-
-      response.body.dig("choices", 0, "message", "content").to_s.strip.presence || @prompt.truncate(60)
+      response.body.dig("choices", 0, "message", "content").to_s.strip.presence ||
+        prompt.truncate(60)
     rescue
-      @prompt.truncate(60)
+      prompt.truncate(60)
+    end
+
+    def extract_sql(content)
+      stripped = content.strip
+      return stripped unless stripped.start_with?("```")
+
+      after_open = stripped.sub(/\A```(?:sql)?\r?\n?/i, "")
+      close_idx = after_open.rindex("\n```")
+      after_open = after_open[0...close_idx] if close_idx
+      after_open.strip
     end
   end
 end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -133,9 +133,10 @@ module Admin
       payload = {
         model: "gpt-4o-mini",
         messages: [
-          { "role" => "system",
+          { "role"    => "system",
             "content" => "Write a short title (5-8 words) for a SQL query described below. " \
-                         "Return only the title, no punctuation at the end." },
+                         "Return only the title, no punctuation at the end."
+          },
           { "role" => "user", "content" => prompt }
         ],
         temperature: 0.3,
@@ -157,5 +158,6 @@ module Admin
       after_open = after_open[0...close_idx] if close_idx
       after_open.strip
     end
+
   end
 end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -174,11 +174,8 @@ module Admin
         f.response :json
       end
 
-      response = conn.post("/v1/chat/completions", {
-        model: "gpt-4o",
-        messages:,
-        temperature: 0.2
-      })
+      payload = { model: "gpt-4o", messages:, temperature: 0.2 }
+      response = conn.post("/v1/chat/completions", payload)
 
       content = response.body.dig("choices", 0, "message", "content").to_s.strip
       extract_sql(content)
@@ -188,12 +185,15 @@ module Admin
     end
 
     def extract_sql(content)
-      # Strip markdown code fences if present
-      if content =~ /```(?:sql)?\s*(.*?)```/im
-        $1.strip
-      else
-        content.strip
-      end
+      stripped = content.strip
+      return stripped unless stripped.start_with?("```")
+
+      # Remove opening fence line (```sql or ```)
+      after_open = stripped.sub(/\A```(?:sql)?\r?\n?/i, "")
+      # Remove closing fence
+      close_idx = after_open.rindex("\n```")
+      after_open = after_open[0...close_idx] if close_idx
+      after_open.strip
     end
 
     def run_sql_validation(sql)
@@ -201,7 +201,7 @@ module Admin
       statement = Blazer::Statement.new(sql, data_source)
       result = Blazer::RunStatement.new.perform(statement, {})
       result.error
-    rescue => e
+    rescue StandardError => e
       e.message
     end
 
@@ -221,7 +221,6 @@ module Admin
     def build_query_name
       return @query_name if @query_name.present?
 
-      # Ask OpenAI for a concise title
       conn = Faraday.new(url: "https://api.openai.com") do |f|
         f.request :json
         f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :BI_DASHBOARD) }
@@ -229,7 +228,7 @@ module Admin
         f.response :json
       end
 
-      response = conn.post("/v1/chat/completions", {
+      payload = {
         model: "gpt-4o-mini",
         messages: [
           {
@@ -240,10 +239,11 @@ module Admin
         ],
         temperature: 0.3,
         max_tokens: 20
-      })
+      }
+      response = conn.post("/v1/chat/completions", payload)
 
       response.body.dig("choices", 0, "message", "content").to_s.strip.presence || @prompt.truncate(60)
-    rescue
+    rescue StandardError
       @prompt.truncate(60)
     end
   end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -201,7 +201,7 @@ module Admin
       statement = Blazer::Statement.new(sql, data_source)
       result = Blazer::RunStatement.new.perform(statement, {})
       result.error
-    rescue StandardError => e
+    rescue => e
       e.message
     end
 
@@ -243,7 +243,7 @@ module Admin
       response = conn.post("/v1/chat/completions", payload)
 
       response.body.dig("choices", 0, "message", "content").to_s.strip.presence || @prompt.truncate(60)
-    rescue StandardError
+    rescue
       @prompt.truncate(60)
     end
   end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -114,10 +114,10 @@ module Admin
     end
 
     def validate_sql(sql)
-      data_source = Blazer.data_sources[AiQuery::BLAZER_DATA_SOURCE]
-      statement = Blazer::Statement.new(sql, data_source)
-      result = Blazer::RunStatement.new.perform(statement, {})
-      result.error
+      ActiveRecord::Base.connection.exec_query("EXPLAIN #{sql}")
+      nil
+    rescue ActiveRecord::StatementInvalid => e
+      e.message
     rescue => e
       e.message
     end

--- a/app/services/admin/generate_ai_query.rb
+++ b/app/services/admin/generate_ai_query.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+module Admin
+  class GenerateAiQuery
+    AI_QUERY_PREFIX = "[AI] "
+    MAX_ATTEMPTS = 10
+    DATA_SOURCE = "main"
+
+    Result = Struct.new(:success, :query, :error, keyword_init: true) do
+      def success? = success
+    end
+
+    DB_SCHEMA = <<~SCHEMA
+      PostgreSQL database schema for HCB (Hack Club Bank), a fiscal sponsorship platform for student-run nonprofits.
+      All monetary amounts are stored in cents (integers) unless noted otherwise.
+
+      TABLE: events
+        id, name (org name), slug, aasm_state (approved/rejected/demo/etc),
+        country (integer enum), created_at, demo_mode (bool), fee_waiver_applied (bool),
+        fee_waiver_eligible (bool), financially_frozen (bool), is_public (bool),
+        parent_id (self-ref for sub-orgs), risk_level (integer), website, short_name,
+        point_of_contact_id (FK users), activated_at
+
+      TABLE: users
+        id, full_name, email, access_level (0=user 1=admin 2=superadmin 3=auditor),
+        created_at, teenager (bool), verified (bool), locked_at (null if not locked),
+        joined_as_teenager (bool), discord_id, slug
+
+      TABLE: organizer_positions
+        id, user_id, event_id, role (100=member 200=manager), created_at, deleted_at (soft delete)
+        -- links users to events they organize
+
+      TABLE: canonical_transactions
+        id, amount_cents, date, memo, hcb_code, transaction_source_type, transaction_source_id, created_at
+        -- settled/finalized financial transactions
+
+      TABLE: canonical_event_mappings
+        id, canonical_transaction_id, event_id
+        -- joins canonical_transactions to events
+
+      TABLE: canonical_pending_transactions
+        id, amount_cents, date, memo, hcb_code, created_at
+        -- pending (not yet settled) transactions
+
+      TABLE: canonical_pending_event_mappings
+        id, canonical_pending_transaction_id, event_id
+
+      TABLE: donations
+        id, amount (cents), aasm_state (pending/in_transit/deposited/refunded/etc),
+        event_id, created_at, anonymous (bool), in_person (bool), email, name,
+        fee_covered (bool), recurring_donation_id, hcb_code
+
+      TABLE: invoices
+        id, aasm_state, amount_due (cents), amount_paid (cents), amount_remaining (cents),
+        event_id, creator_id (FK users), created_at, finalized_at, due_date, item_description,
+        item_amount (cents), hcb_code, livemode (bool)
+
+      TABLE: disbursements
+        id, amount (cents), aasm_state (pending/reviewing/in_transit/deposited/rejected/errored),
+        event_id, source_event_id (where money came from), name, created_at, requested_by_id (FK users)
+
+      TABLE: ach_transfers
+        id, amount (cents), aasm_state (pending/approved/rejected/etc), event_id,
+        created_at, recipient_name, same_day (bool), hcb_code
+
+      TABLE: increase_checks
+        id, amount_cents, aasm_state, event_id, created_at, memo, recipient_name
+
+      TABLE: card_grants
+        id, amount (cents), event_id, user_id, created_at, aasm_state,
+        merchant_lock (json), category_lock (json)
+
+      TABLE: stripe_cards
+        id, event_id, user_id, created_at, aasm_state (active/frozen/canceled),
+        card_type (integer: 0=physical 1=virtual)
+
+      TABLE: bank_fees
+        id, amount_cents, event_id, created_at, aasm_state
+
+      TABLE: fee_revenues
+        id, amount_cents, created_at, event_id
+
+      TABLE: reimbursements (reports)
+        id, aasm_state, user_id, event_id, created_at
+
+      TABLE: paypal_transfers
+        id, amount_cents, event_id, aasm_state, created_at
+
+      TABLE: wires
+        id, amount_cents, event_id, aasm_state, created_at, recipient_name
+
+      TABLE: recurring_donations
+        id, amount (cents), event_id, created_at, email, active (bool)
+
+      TABLE: g_suites (Google Workspaces)
+        id, event_id, aasm_state, created_at, domain
+
+      NOTES:
+      - "organizations" and "events" are the same thing (historical naming)
+      - amount_cents and amount are both used; always integer cents
+      - Use canonical_event_mappings to join canonical_transactions to events
+      - aasm_state values vary per table; common ones: approved, active, pending, rejected, canceled
+      - organizer_positions with deleted_at IS NULL = active organizers
+      - Use DATE_TRUNC for time-based grouping, e.g. DATE_TRUNC('month', created_at)
+      - LIMIT results to reasonable numbers (50-100 rows max) unless aggregating
+    SCHEMA
+
+    def initialize(prompt:, user: nil, query_name: nil)
+      @prompt = prompt
+      @user = user
+      @query_name = query_name
+    end
+
+    def run
+      messages = build_initial_messages
+      attempt = 0
+
+      while attempt < MAX_ATTEMPTS
+        attempt += 1
+        sql = call_openai(messages)
+
+        return Result.new(success: false, error: "AI did not return SQL") if sql.blank?
+
+        error = run_sql_validation(sql)
+
+        if error.nil?
+          query = save_query(sql)
+          return Result.new(success: true, query:)
+        else
+          messages << { role: "assistant", content: "```sql\n#{sql}\n```" }
+          messages << {
+            role: "user",
+            content: "That query failed with this error: #{error}\n\nPlease fix it and return only the corrected SQL."
+          }
+        end
+      end
+
+      Result.new(success: false, error: "Failed to generate a valid query after #{MAX_ATTEMPTS} attempts. Last error recorded.")
+    end
+
+    private
+
+    def build_initial_messages
+      [
+        { role: "system", content: system_prompt },
+        { role: "user", content: @prompt }
+      ]
+    end
+
+    def system_prompt
+      <<~PROMPT
+        You are an expert PostgreSQL analyst for HCB (Hack Club Bank), a fiscal sponsorship platform.
+        Generate a single, safe, read-only SELECT SQL query based on the user's request.
+
+        #{DB_SCHEMA}
+
+        RULES:
+        - Return ONLY the raw SQL query, no explanation, no markdown code fences
+        - Use only SELECT statements; no INSERT, UPDATE, DELETE, DROP, etc.
+        - Always include a LIMIT clause (max 500 rows) unless the query is an aggregate
+        - Use table aliases for readability
+        - When joining transactions to events, use canonical_event_mappings
+        - Format monetary output with amount_cents / 100.0 AS amount_dollars when helpful
+        - Use meaningful column aliases (e.g. "Total Revenue" not "sum")
+        - Ensure the query will actually run without errors
+      PROMPT
+    end
+
+    def call_openai(messages)
+      conn = Faraday.new(url: "https://api.openai.com") do |f|
+        f.request :json
+        f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :BI_DASHBOARD) }
+        f.response :raise_error
+        f.response :json
+      end
+
+      response = conn.post("/v1/chat/completions", {
+        model: "gpt-4o",
+        messages:,
+        temperature: 0.2
+      })
+
+      content = response.body.dig("choices", 0, "message", "content").to_s.strip
+      extract_sql(content)
+    rescue Faraday::Error => e
+      Rails.logger.error "[Admin::GenerateAiQuery] OpenAI API error: #{e.message}"
+      nil
+    end
+
+    def extract_sql(content)
+      # Strip markdown code fences if present
+      if content =~ /```(?:sql)?\s*(.*?)```/im
+        $1.strip
+      else
+        content.strip
+      end
+    end
+
+    def run_sql_validation(sql)
+      data_source = Blazer.data_sources[DATA_SOURCE]
+      statement = Blazer::Statement.new(sql, data_source)
+      result = Blazer::RunStatement.new.perform(statement, {})
+      result.error
+    rescue => e
+      e.message
+    end
+
+    def save_query(sql)
+      name = build_query_name
+      statement_with_comment = "/* Prompt: #{@prompt.gsub("*/", "* /")} */\n\n#{sql}"
+
+      Blazer::Query.create!(
+        name: "#{AI_QUERY_PREFIX}#{name}",
+        statement: statement_with_comment,
+        description: @prompt,
+        data_source: DATA_SOURCE,
+        creator: @user
+      )
+    end
+
+    def build_query_name
+      return @query_name if @query_name.present?
+
+      # Ask OpenAI for a concise title
+      conn = Faraday.new(url: "https://api.openai.com") do |f|
+        f.request :json
+        f.request :authorization, "Bearer", -> { Credentials.fetch(:OPENAI, :BI_DASHBOARD) }
+        f.response :raise_error
+        f.response :json
+      end
+
+      response = conn.post("/v1/chat/completions", {
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content: "Generate a short, descriptive title (5-8 words max) for a SQL query based on this description. Return only the title, no punctuation at the end."
+          },
+          { role: "user", content: @prompt }
+        ],
+        temperature: 0.3,
+        max_tokens: 20
+      })
+
+      response.body.dig("choices", 0, "message", "content").to_s.strip.presence || @prompt.truncate(60)
+    rescue
+      @prompt.truncate(60)
+    end
+  end
+end

--- a/app/views/admin/ai_queries/_progress.html.erb
+++ b/app/views/admin/ai_queries/_progress.html.erb
@@ -1,0 +1,278 @@
+<%# locals: (ai_query:) %>
+
+<style>
+  .ai-progress-spinner {
+    display: inline-block;
+    animation: ai-spin 1.2s linear infinite;
+  }
+  @keyframes ai-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+
+  .ai-attempt-item {
+    border: 1px solid var(--hcb-border);
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 0.5rem;
+  }
+
+  .ai-attempt-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 1rem;
+    cursor: pointer;
+    user-select: none;
+    background: var(--hcb-bg-0, #f6f6f7);
+  }
+
+  .ai-attempt-header:hover { background: var(--hcb-bg-1); }
+
+  .ai-attempt-body {
+    display: none;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--hcb-border);
+  }
+
+  .ai-attempt-body.open { display: block; }
+
+  .ai-attempt-sql {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--hcb-tx-1);
+    background: var(--hcb-bg-0);
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .ai-attempt-error {
+    font-size: 0.8rem;
+    color: #b91c1c;
+    background: #fff1f2;
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .ai-blazer-wrapper {
+    border: 1px solid var(--hcb-border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+    margin-bottom: 1rem;
+  }
+
+  .ai-blazer-bar {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--hcb-bg-0, #f6f6f7);
+    border-bottom: 1px solid var(--hcb-border);
+    gap: 0.5rem;
+  }
+
+  .ai-blazer-dots { display: flex; gap: 5px; }
+  .ai-blazer-dot { width: 10px; height: 10px; border-radius: 50%; }
+
+  .ai-blazer-url {
+    flex: 1;
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--hcb-tx-3);
+    font-family: monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ai-blazer-iframe {
+    width: 100%;
+    min-height: 560px;
+    border: none;
+    display: block;
+  }
+</style>
+
+<% if ai_query.pending? || ai_query.generating? %>
+  <div class="card flex flex-col items-center justify-center gap-4 py-12 text-center"
+       style="border: 1px solid var(--hcb-border);">
+    <span class="ai-progress-spinner" style="font-size: 2rem; color: var(--hcb-accent);">
+      ✦
+    </span>
+    <div>
+      <p class="font-semibold text-lg" style="color: var(--hcb-tx-1);">
+        <%= ai_query.pending? ? "Queued for generation…" : "Generating SQL…" %>
+      </p>
+      <% if ai_query.attempts.any? %>
+        <p class="text-sm mt-1" style="color: var(--hcb-tx-2);">
+          Attempt <%= ai_query.attempts.length %> of <%= AiQuery::MAX_GENERATION_ATTEMPTS %>
+        </p>
+      <% else %>
+        <p class="text-sm mt-1" style="color: var(--hcb-tx-2);">
+          This may take up to 30 seconds.
+        </p>
+      <% end %>
+    </div>
+
+    <% if ai_query.attempts.any? %>
+      <div style="width: 100%; max-width: 480px; margin-top: 0.5rem;">
+        <% ai_query.attempts.each do |attempt| %>
+          <div class="ai-attempt-item">
+            <div class="ai-attempt-header"
+                 onclick="this.nextElementSibling.classList.toggle('open')">
+              <% if attempt["error"].present? %>
+                <span style="color: #b91c1c; font-size: 0.9em;">✕</span>
+              <% else %>
+                <span style="color: #16a34a; font-size: 0.9em;">✓</span>
+              <% end %>
+              <span class="text-sm font-medium" style="color: var(--hcb-tx-1);">
+                Attempt <%= attempt["attempt"] %>
+              </span>
+              <span class="text-xs ml-auto" style="color: var(--hcb-tx-3);">
+                <%= attempt["error"].present? ? attempt["error"].truncate(40) : "No error" %>
+              </span>
+            </div>
+            <div class="ai-attempt-body">
+              <pre class="ai-attempt-sql"><%= attempt["sql"] %></pre>
+              <% if attempt["error"].present? %>
+                <div class="ai-attempt-error"><%= attempt["error"] %></div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+<% elsif ai_query.success? && ai_query.blazer_query %>
+  <%# --- Success state --- %>
+  <% blazer_q = ai_query.blazer_query %>
+  <div class="flex items-center gap-2 mb-4">
+    <span style="color: #16a34a; font-size: 1.1rem;">✓</span>
+    <span class="font-semibold" style="color: var(--hcb-tx-1);">
+      Generated after
+      <%= pluralize ai_query.attempts.length, "attempt" %> &mdash;
+      synced to Blazer
+    </span>
+    <%= link_to "Open in Blazer →",
+                blazer.query_path(blazer_q),
+                target: "_blank",
+                rel: "noopener",
+                class: "ml-auto text-sm hover:underline shrink-0",
+                style: "color: var(--hcb-accent)" %>
+  </div>
+
+  <%# Collapsible attempt history %>
+  <% if ai_query.attempts.length > 1 %>
+    <details class="mb-4" style="border: 1px solid var(--hcb-border); border-radius: 10px;">
+      <summary class="px-4 py-2 cursor-pointer text-sm font-medium"
+               style="color: var(--hcb-tx-2);">
+        Show <%= pluralize ai_query.attempts.length, "generation attempt" %>
+      </summary>
+      <div class="p-3 pt-0">
+        <% ai_query.attempts.each do |attempt| %>
+          <div class="ai-attempt-item">
+            <div class="ai-attempt-header"
+                 onclick="this.nextElementSibling.classList.toggle('open')">
+              <% if attempt["error"].present? %>
+                <span style="color: #b91c1c; font-size: 0.9em;">✕</span>
+              <% else %>
+                <span style="color: #16a34a; font-size: 0.9em;">✓</span>
+              <% end %>
+              <span class="text-sm font-medium" style="color: var(--hcb-tx-1);">
+                Attempt <%= attempt["attempt"] %>
+              </span>
+              <span class="text-xs ml-auto" style="color: var(--hcb-tx-3);">
+                <%= attempt["error"].present? ? attempt["error"].truncate(40) : "Success" %>
+              </span>
+            </div>
+            <div class="ai-attempt-body">
+              <pre class="ai-attempt-sql"><%= attempt["sql"] %></pre>
+              <% if attempt["error"].present? %>
+                <div class="ai-attempt-error"><%= attempt["error"] %></div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+
+  <%# SQL block — collapsible %>
+  <details class="mb-4" style="border: 1px solid var(--hcb-border); border-radius: 10px;">
+    <summary class="px-4 py-2 cursor-pointer text-sm font-medium"
+             style="color: var(--hcb-tx-2);">
+      View SQL
+    </summary>
+    <pre style="padding: 1rem; font-family: 'SF Mono', 'Fira Code', monospace;
+                font-size: 0.82rem; line-height: 1.55; margin: 0; white-space: pre-wrap;
+                word-break: break-word; color: var(--hcb-tx-1);
+                border-top: 1px solid var(--hcb-border);"><%= blazer_q.statement %></pre>
+  </details>
+
+  <%# Blazer iframe — browser-chrome wrapper %>
+  <div style="font-size: 0.75rem; font-weight: 700; letter-spacing: 0.06em;
+              text-transform: uppercase; color: var(--hcb-tx-2); margin-bottom: 0.5rem;">
+    Query Results
+  </div>
+  <div class="ai-blazer-wrapper">
+    <div class="ai-blazer-bar">
+      <div class="ai-blazer-dots">
+        <div class="ai-blazer-dot" style="background: #ff5f57;"></div>
+        <div class="ai-blazer-dot" style="background: #ffbd2e;"></div>
+        <div class="ai-blazer-dot" style="background: #28c840;"></div>
+      </div>
+      <div class="ai-blazer-url">
+        /blazer/queries/<%= blazer_q.to_param %>
+      </div>
+      <%= link_to blazer.query_path(blazer_q),
+                  target: "_blank",
+                  rel: "noopener",
+                  class: "shrink-0",
+                  style: "color: var(--hcb-accent)" do %>
+        <%= inline_icon "external", size: 14 %>
+      <% end %>
+    </div>
+    <iframe src="<%= blazer.query_path(blazer_q) %>"
+            class="ai-blazer-iframe"
+            title="Blazer query: <%= ai_query.display_name %>"
+            loading="lazy">
+    </iframe>
+  </div>
+
+  <%# Edit link %>
+  <div class="mt-2">
+    <%= link_to "Edit in Blazer →",
+                blazer.edit_query_path(blazer_q),
+                target: "_blank",
+                rel: "noopener",
+                class: "text-sm hover:underline",
+                style: "color: var(--hcb-tx-2)" %>
+  </div>
+
+<% elsif ai_query.failed? %>
+  <div class="card flex flex-col items-center gap-3 py-10 text-center"
+       style="border: 1px solid #fca5a5; background: #fff1f2;">
+    <p class="font-semibold text-lg" style="color: #b91c1c;">Generation failed</p>
+    <p class="text-sm" style="color: #b91c1c; opacity: 0.8;">
+      Tried <%= pluralize ai_query.attempts.length, "time" %> without producing
+      valid SQL.
+    </p>
+    <% if ai_query.latest_error.present? %>
+      <p class="text-xs font-mono px-4"
+         style="color: #b91c1c; opacity: 0.7; max-width: 500px;">
+        Last error: <%= ai_query.latest_error %>
+      </p>
+    <% end %>
+    <div class="flex gap-2 mt-2">
+      <%= link_to new_admin_ai_query_path(prompt: ai_query.prompt),
+                  class: "btn" do %>
+        ✦ Try Again
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/ai_queries/index.html.erb
+++ b/app/views/admin/ai_queries/index.html.erb
@@ -7,23 +7,25 @@
       AI-Generated Queries
     </h1>
     <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">
-      SQL queries created by AI from natural language prompts.
-      <%= pluralize @queries.count, "query" %> saved.
+      SQL queries built from natural language prompts.
+      <%= pluralize @ai_queries.count, "query" %> total.
     </p>
   </div>
 
   <%= link_to new_admin_ai_query_path, class: "btn flex items-center gap-2" do %>
-    <span style="font-size: 1.1em;">✦</span>
-    New AI Query
+    <span>✦</span> New AI Query
   <% end %>
 </div>
 
-<% if @queries.empty? %>
-  <div class="card text-center py-16 flex flex-col items-center gap-4" style="border: 1px dashed var(--hcb-border)">
+<% if @ai_queries.empty? %>
+  <div class="card text-center py-16 flex flex-col items-center gap-4"
+       style="border: 1px dashed var(--hcb-border)">
     <div style="font-size: 3em; opacity: 0.3;">✦</div>
     <div>
       <p class="font-semibold text-lg" style="color: var(--hcb-tx-1)">No AI queries yet</p>
-      <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">Generate your first query by describing what you want to know.</p>
+      <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">
+        Generate your first query by describing what you want to know.
+      </p>
     </div>
     <%= link_to new_admin_ai_query_path, class: "btn mt-2" do %>
       Generate your first query
@@ -31,40 +33,64 @@
   </div>
 <% else %>
   <div class="grid gap-4" style="grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));">
-    <% @queries.each do |query| %>
-      <div class="card flex flex-col gap-3 hover:shadow-md transition-shadow" style="border: 1px solid var(--hcb-border);">
+    <% @ai_queries.each do |ai_query| %>
+      <div class="card flex flex-col gap-3 hover:shadow-md transition-shadow"
+           style="border: 1px solid var(--hcb-border);">
         <div class="flex items-start justify-between gap-2">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1.5 mb-1">
-              <span class="text-xs font-semibold px-1.5 py-0.5 rounded" style="background: var(--hcb-accent-bg); color: var(--hcb-accent); font-size: 0.65em; letter-spacing: 0.05em; text-transform: uppercase;">AI</span>
+              <% if ai_query.success? %>
+                <span class="text-xs font-semibold px-1.5 py-0.5 rounded"
+                      style="background: var(--hcb-accent-bg); color: var(--hcb-accent);
+                             font-size: 0.65em; letter-spacing: 0.05em; text-transform: uppercase;">
+                  AI
+                </span>
+              <% elsif ai_query.generating? || ai_query.pending? %>
+                <span class="text-xs font-semibold px-1.5 py-0.5 rounded"
+                      style="background: #fef3c7; color: #92400e;
+                             font-size: 0.65em; letter-spacing: 0.05em; text-transform: uppercase;">
+                  Generating…
+                </span>
+              <% elsif ai_query.failed? %>
+                <span class="text-xs font-semibold px-1.5 py-0.5 rounded"
+                      style="background: #fee2e2; color: #b91c1c;
+                             font-size: 0.65em; letter-spacing: 0.05em; text-transform: uppercase;">
+                  Failed
+                </span>
+              <% end %>
             </div>
-            <%= link_to admin_ai_query_path(query), class: "font-semibold hover:underline block truncate" do %>
-              <%= query.name.delete_prefix(Admin::GenerateAiQuery::AI_QUERY_PREFIX) %>
+            <%= link_to admin_ai_query_path(ai_query),
+                        class: "font-semibold hover:underline block truncate" do %>
+              <%= ai_query.display_name %>
             <% end %>
           </div>
-          <div class="flex items-center gap-2 shrink-0">
-            <%= link_to blazer.query_path(query), target: "_blank", rel: "noopener", class: "tooltipped tooltipped--w text-xs", "aria-label": "Open in Blazer" do %>
-              <%= inline_icon "external-link", size: 16 %>
+          <% if ai_query.success? && ai_query.blazer_query %>
+            <%= link_to blazer.query_path(ai_query.blazer_query),
+                        target: "_blank",
+                        rel: "noopener",
+                        class: "tooltipped tooltipped--w text-xs shrink-0",
+                        "aria-label": "Open in Blazer" do %>
+              <%= inline_icon "external", size: 16 %>
             <% end %>
-          </div>
+          <% end %>
         </div>
 
-        <% if query.description.present? %>
-          <p class="text-sm line-clamp-2" style="color: var(--hcb-tx-2)">
-            "<%= query.description %>"
-          </p>
-        <% end %>
+        <p class="text-sm line-clamp-2" style="color: var(--hcb-tx-2)">
+          "<%= ai_query.prompt %>"
+        </p>
 
-        <div class="flex items-center justify-between pt-1 border-t" style="border-color: var(--hcb-border);">
+        <div class="flex items-center justify-between pt-1 border-t"
+             style="border-color: var(--hcb-border);">
           <span class="text-xs" style="color: var(--hcb-tx-3)">
-            <%= time_ago_in_words(query.created_at) %> ago
-            <% if query.creator.present? %>
-              &middot; <%= query.creator.try(:full_name) || query.creator.try(:email) || "Unknown" %>
+            <%= time_ago_in_words(ai_query.created_at) %> ago
+            <% if ai_query.creator.present? %>
+              &middot; <%= ai_query.creator.full_name.presence || ai_query.creator.email %>
             <% end %>
           </span>
-          <%= link_to admin_ai_query_path(query), class: "text-xs font-medium hover:underline", style: "color: var(--hcb-accent)" do %>
-            View &rarr;
-          <% end %>
+          <%= link_to "View →",
+                      admin_ai_query_path(ai_query),
+                      class: "text-xs font-medium hover:underline",
+                      style: "color: var(--hcb-accent)" %>
         </div>
       </div>
     <% end %>

--- a/app/views/admin/ai_queries/index.html.erb
+++ b/app/views/admin/ai_queries/index.html.erb
@@ -1,0 +1,72 @@
+<% title "AI Queries" %>
+
+<div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+  <div>
+    <h1 class="text-2xl font-bold flex items-center gap-2">
+      <span style="font-size: 1.4em; line-height: 1;">✦</span>
+      AI-Generated Queries
+    </h1>
+    <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">
+      SQL queries created by AI from natural language prompts.
+      <%= pluralize @queries.count, "query" %> saved.
+    </p>
+  </div>
+
+  <%= link_to new_admin_ai_query_path, class: "btn flex items-center gap-2" do %>
+    <span style="font-size: 1.1em;">✦</span>
+    New AI Query
+  <% end %>
+</div>
+
+<% if @queries.empty? %>
+  <div class="card text-center py-16 flex flex-col items-center gap-4" style="border: 1px dashed var(--hcb-border)">
+    <div style="font-size: 3em; opacity: 0.3;">✦</div>
+    <div>
+      <p class="font-semibold text-lg" style="color: var(--hcb-tx-1)">No AI queries yet</p>
+      <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">Generate your first query by describing what you want to know.</p>
+    </div>
+    <%= link_to new_admin_ai_query_path, class: "btn mt-2" do %>
+      Generate your first query
+    <% end %>
+  </div>
+<% else %>
+  <div class="grid gap-4" style="grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));">
+    <% @queries.each do |query| %>
+      <div class="card flex flex-col gap-3 hover:shadow-md transition-shadow" style="border: 1px solid var(--hcb-border);">
+        <div class="flex items-start justify-between gap-2">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-1.5 mb-1">
+              <span class="text-xs font-semibold px-1.5 py-0.5 rounded" style="background: var(--hcb-accent-bg); color: var(--hcb-accent); font-size: 0.65em; letter-spacing: 0.05em; text-transform: uppercase;">AI</span>
+            </div>
+            <%= link_to admin_ai_query_path(query), class: "font-semibold hover:underline block truncate" do %>
+              <%= query.name.delete_prefix(Admin::GenerateAiQuery::AI_QUERY_PREFIX) %>
+            <% end %>
+          </div>
+          <div class="flex items-center gap-2 shrink-0">
+            <%= link_to blazer.query_path(query), target: "_blank", rel: "noopener", class: "tooltipped tooltipped--w text-xs", "aria-label": "Open in Blazer" do %>
+              <%= inline_icon "external-link", size: 16 %>
+            <% end %>
+          </div>
+        </div>
+
+        <% if query.description.present? %>
+          <p class="text-sm line-clamp-2" style="color: var(--hcb-tx-2)">
+            "<%= query.description %>"
+          </p>
+        <% end %>
+
+        <div class="flex items-center justify-between pt-1 border-t" style="border-color: var(--hcb-border);">
+          <span class="text-xs" style="color: var(--hcb-tx-3)">
+            <%= time_ago_in_words(query.created_at) %> ago
+            <% if query.creator.present? %>
+              &middot; <%= query.creator.try(:full_name) || query.creator.try(:email) || "Unknown" %>
+            <% end %>
+          </span>
+          <%= link_to admin_ai_query_path(query), class: "text-xs font-medium hover:underline", style: "color: var(--hcb-accent)" do %>
+            View &rarr;
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/ai_queries/new.html.erb
+++ b/app/views/admin/ai_queries/new.html.erb
@@ -15,11 +15,6 @@
     max-width: 680px;
   }
 
-  .ai-query-hero {
-    text-align: center;
-    margin-bottom: 2.5rem;
-  }
-
   .ai-query-sparkle {
     font-size: 2.5rem;
     margin-bottom: 0.75rem;
@@ -75,9 +70,7 @@
     box-shadow: 0 0 0 3px var(--hcb-accent-shadow, rgba(236, 55, 80, 0.12));
   }
 
-  .ai-query-textarea::placeholder {
-    color: var(--hcb-tx-3);
-  }
+  .ai-query-textarea::placeholder { color: var(--hcb-tx-3); }
 
   .ai-query-submit-btn {
     width: 100%;
@@ -97,18 +90,9 @@
     margin-top: 1rem;
   }
 
-  .ai-query-submit-btn:hover {
-    opacity: 0.88;
-  }
-
-  .ai-query-submit-btn:active {
-    transform: scale(0.98);
-  }
-
-  .ai-query-submit-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  .ai-query-submit-btn:hover { opacity: 0.88; }
+  .ai-query-submit-btn:active { transform: scale(0.98); }
+  .ai-query-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
   .ai-query-examples {
     display: flex;
@@ -135,45 +119,6 @@
     background: var(--hcb-accent-bg);
   }
 
-  .ai-generating-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0,0,0,0.4);
-    backdrop-filter: blur(4px);
-    z-index: 9999;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    gap: 1.25rem;
-  }
-
-  .ai-generating-overlay.active {
-    display: flex;
-  }
-
-  .ai-generating-card {
-    background: var(--hcb-bg-1, #fff);
-    border-radius: 16px;
-    padding: 2.5rem 3rem;
-    text-align: center;
-    box-shadow: 0 8px 40px rgba(0,0,0,0.2);
-    max-width: 360px;
-  }
-
-  .ai-generating-spinner {
-    font-size: 2.5rem;
-    animation: spin-pulse 1.4s linear infinite;
-    display: block;
-    margin: 0 auto 1rem;
-  }
-
-  @keyframes spin-pulse {
-    0% { transform: rotate(0deg) scale(1); }
-    50% { transform: rotate(180deg) scale(0.85); }
-    100% { transform: rotate(360deg) scale(1); }
-  }
-
   .ai-error-box {
     background: #fff1f2;
     border: 1px solid #fca5a5;
@@ -185,72 +130,86 @@
   }
 </style>
 
-<div id="ai-generating-overlay" class="ai-generating-overlay">
-  <div class="ai-generating-card">
-    <span class="ai-generating-spinner">✦</span>
-    <p class="font-bold text-lg" style="color: var(--hcb-tx-1)">Generating your query…</p>
-    <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">Running and validating SQL against the database. This may take up to 30 seconds.</p>
-  </div>
-</div>
-
 <div class="ai-query-prompt-container">
   <div class="ai-query-prompt-box">
-    <div class="ai-query-hero">
+    <div class="text-center mb-10">
       <span class="ai-query-sparkle">✦</span>
       <h1 class="ai-query-headline">Ask your data anything</h1>
-      <p class="ai-query-subhead">Describe what you want to know and AI will write the SQL for you.</p>
+      <p class="ai-query-subhead">
+        Describe what you want to know and AI will write the SQL for you.
+      </p>
     </div>
 
     <div class="ai-query-form-card">
       <% if flash[:error].present? %>
         <div class="ai-error-box">
-          <strong>Generation failed:</strong> <%= flash[:error] %>
+          <strong>Error:</strong> <%= flash[:error] %>
         </div>
       <% end %>
 
-      <%= form_with url: admin_ai_queries_path, method: :post, local: true, id: "ai-query-form" do |f| %>
-        <label for="prompt" class="block text-sm font-semibold mb-2" style="color: var(--hcb-tx-1)">
+      <%= form_with url: admin_ai_queries_path, method: :post, local: true,
+                    id: "ai-query-form" do |f| %>
+        <label class="block text-sm font-semibold mb-2" for="prompt"
+               style="color: var(--hcb-tx-1)">
           What would you like to know?
         </label>
 
         <%= f.text_area :prompt,
-          id: "prompt",
-          class: "ai-query-textarea",
-          placeholder: "e.g. Show me the top 10 organizations by total donation revenue in the last 90 days",
-          value: @prompt,
-          autofocus: true,
-          rows: 5 %>
+                        id: "prompt",
+                        class: "ai-query-textarea",
+                        placeholder: "e.g. Show me the top 10 organizations by " \
+                                     "total donation revenue in the last 90 days",
+                        value: @prompt,
+                        autofocus: true,
+                        rows: 5 %>
 
         <div class="ai-query-examples">
-          <span class="text-xs font-medium" style="color: var(--hcb-tx-3); line-height: 2.1;">Try:</span>
-          <span class="ai-query-example-chip" data-prompt="Monthly donation totals for the past 12 months">Monthly donation totals</span>
-          <span class="ai-query-example-chip" data-prompt="Top 20 organizations by total spending in the last 30 days">Top orgs by spending</span>
-          <span class="ai-query-example-chip" data-prompt="Number of new organizations created per month this year">New orgs per month</span>
-          <span class="ai-query-example-chip" data-prompt="Organizations with the most active organizers">Most active orgs</span>
-          <span class="ai-query-example-chip" data-prompt="Average donation amount by month for the past year">Avg donation by month</span>
+          <span class="text-xs font-medium" style="color: var(--hcb-tx-3); line-height: 2.1;">
+            Try:
+          </span>
+          <span class="ai-query-example-chip"
+                data-prompt="Monthly donation totals for the past 12 months">
+            Monthly donation totals
+          </span>
+          <span class="ai-query-example-chip"
+                data-prompt="Top 20 organizations by total spending in the last 30 days">
+            Top orgs by spending
+          </span>
+          <span class="ai-query-example-chip"
+                data-prompt="Number of new organizations created per month this year">
+            New orgs per month
+          </span>
+          <span class="ai-query-example-chip"
+                data-prompt="Organizations with the most active organizers">
+            Most active orgs
+          </span>
+          <span class="ai-query-example-chip"
+                data-prompt="Average donation amount by month for the past year">
+            Avg donation by month
+          </span>
         </div>
 
         <button type="submit" class="ai-query-submit-btn" id="ai-submit-btn">
-          <span>✦</span>
-          Generate Query
+          <span>✦</span> Generate Query
         </button>
       <% end %>
     </div>
 
     <p class="text-center text-xs mt-4" style="color: var(--hcb-tx-3)">
-      AI queries are saved to Blazer with your original prompt.
-      <%= link_to "View all AI queries →", admin_ai_queries_path, class: "hover:underline", style: "color: var(--hcb-accent)" %>
+      Generation runs in the background — you'll see live progress on the next page.
+      <%= link_to "View all AI queries →",
+                  admin_ai_queries_path,
+                  class: "hover:underline",
+                  style: "color: var(--hcb-accent)" %>
     </p>
   </div>
 </div>
 
 <script>
   const form = document.getElementById("ai-query-form");
-  const overlay = document.getElementById("ai-generating-overlay");
   const submitBtn = document.getElementById("ai-submit-btn");
   const promptEl = document.getElementById("prompt");
 
-  // Example chips
   document.querySelectorAll(".ai-query-example-chip").forEach(chip => {
     chip.addEventListener("click", () => {
       promptEl.value = chip.dataset.prompt;
@@ -258,11 +217,9 @@
     });
   });
 
-  // Show loading overlay on submit
-  form.addEventListener("submit", (e) => {
+  form.addEventListener("submit", () => {
     if (promptEl.value.trim() === "") return;
-    overlay.classList.add("active");
     submitBtn.disabled = true;
-    submitBtn.innerHTML = '<span>✦</span> Generating…';
+    submitBtn.innerHTML = "<span>✦</span> Starting…";
   });
 </script>

--- a/app/views/admin/ai_queries/new.html.erb
+++ b/app/views/admin/ai_queries/new.html.erb
@@ -1,0 +1,268 @@
+<% title "New AI Query" %>
+
+<style>
+  .ai-query-prompt-container {
+    min-height: calc(100vh - 200px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+  }
+
+  .ai-query-prompt-box {
+    width: 100%;
+    max-width: 680px;
+  }
+
+  .ai-query-hero {
+    text-align: center;
+    margin-bottom: 2.5rem;
+  }
+
+  .ai-query-sparkle {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+    display: block;
+    animation: sparkle-pulse 2.5s ease-in-out infinite;
+  }
+
+  @keyframes sparkle-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.6; transform: scale(0.92); }
+  }
+
+  .ai-query-headline {
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    margin: 0 0 0.4rem;
+    color: var(--hcb-tx-1);
+  }
+
+  .ai-query-subhead {
+    font-size: 1rem;
+    color: var(--hcb-tx-2);
+    margin: 0;
+  }
+
+  .ai-query-form-card {
+    background: var(--hcb-bg-1, #fff);
+    border: 1px solid var(--hcb-border);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.07);
+  }
+
+  .ai-query-textarea {
+    width: 100%;
+    min-height: 160px;
+    resize: vertical;
+    padding: 1rem;
+    font-size: 1rem;
+    line-height: 1.6;
+    border: 1.5px solid var(--hcb-border);
+    border-radius: 10px;
+    background: var(--hcb-bg-0, #f9f9f9);
+    color: var(--hcb-tx-1);
+    transition: border-color 0.15s, box-shadow 0.15s;
+    outline: none;
+    font-family: inherit;
+  }
+
+  .ai-query-textarea:focus {
+    border-color: var(--hcb-accent);
+    box-shadow: 0 0 0 3px var(--hcb-accent-shadow, rgba(236, 55, 80, 0.12));
+  }
+
+  .ai-query-textarea::placeholder {
+    color: var(--hcb-tx-3);
+  }
+
+  .ai-query-submit-btn {
+    width: 100%;
+    padding: 0.85rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 10px;
+    background: var(--hcb-accent);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    transition: opacity 0.15s, transform 0.1s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+
+  .ai-query-submit-btn:hover {
+    opacity: 0.88;
+  }
+
+  .ai-query-submit-btn:active {
+    transform: scale(0.98);
+  }
+
+  .ai-query-submit-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .ai-query-examples {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1.25rem;
+  }
+
+  .ai-query-example-chip {
+    font-size: 0.8rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--hcb-border);
+    background: var(--hcb-bg-0);
+    color: var(--hcb-tx-2);
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+    user-select: none;
+  }
+
+  .ai-query-example-chip:hover {
+    border-color: var(--hcb-accent);
+    color: var(--hcb-accent);
+    background: var(--hcb-accent-bg);
+  }
+
+  .ai-generating-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    backdrop-filter: blur(4px);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .ai-generating-overlay.active {
+    display: flex;
+  }
+
+  .ai-generating-card {
+    background: var(--hcb-bg-1, #fff);
+    border-radius: 16px;
+    padding: 2.5rem 3rem;
+    text-align: center;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.2);
+    max-width: 360px;
+  }
+
+  .ai-generating-spinner {
+    font-size: 2.5rem;
+    animation: spin-pulse 1.4s linear infinite;
+    display: block;
+    margin: 0 auto 1rem;
+  }
+
+  @keyframes spin-pulse {
+    0% { transform: rotate(0deg) scale(1); }
+    50% { transform: rotate(180deg) scale(0.85); }
+    100% { transform: rotate(360deg) scale(1); }
+  }
+
+  .ai-error-box {
+    background: #fff1f2;
+    border: 1px solid #fca5a5;
+    border-radius: 10px;
+    padding: 0.875rem 1rem;
+    margin-bottom: 1rem;
+    color: #b91c1c;
+    font-size: 0.9rem;
+  }
+</style>
+
+<div id="ai-generating-overlay" class="ai-generating-overlay">
+  <div class="ai-generating-card">
+    <span class="ai-generating-spinner">✦</span>
+    <p class="font-bold text-lg" style="color: var(--hcb-tx-1)">Generating your query…</p>
+    <p class="text-sm mt-1" style="color: var(--hcb-tx-2)">Running and validating SQL against the database. This may take up to 30 seconds.</p>
+  </div>
+</div>
+
+<div class="ai-query-prompt-container">
+  <div class="ai-query-prompt-box">
+    <div class="ai-query-hero">
+      <span class="ai-query-sparkle">✦</span>
+      <h1 class="ai-query-headline">Ask your data anything</h1>
+      <p class="ai-query-subhead">Describe what you want to know and AI will write the SQL for you.</p>
+    </div>
+
+    <div class="ai-query-form-card">
+      <% if flash[:error].present? %>
+        <div class="ai-error-box">
+          <strong>Generation failed:</strong> <%= flash[:error] %>
+        </div>
+      <% end %>
+
+      <%= form_with url: admin_ai_queries_path, method: :post, local: true, id: "ai-query-form" do |f| %>
+        <label for="prompt" class="block text-sm font-semibold mb-2" style="color: var(--hcb-tx-1)">
+          What would you like to know?
+        </label>
+
+        <%= f.text_area :prompt,
+          id: "prompt",
+          class: "ai-query-textarea",
+          placeholder: "e.g. Show me the top 10 organizations by total donation revenue in the last 90 days",
+          value: @prompt,
+          autofocus: true,
+          rows: 5 %>
+
+        <div class="ai-query-examples">
+          <span class="text-xs font-medium" style="color: var(--hcb-tx-3); line-height: 2.1;">Try:</span>
+          <span class="ai-query-example-chip" data-prompt="Monthly donation totals for the past 12 months">Monthly donation totals</span>
+          <span class="ai-query-example-chip" data-prompt="Top 20 organizations by total spending in the last 30 days">Top orgs by spending</span>
+          <span class="ai-query-example-chip" data-prompt="Number of new organizations created per month this year">New orgs per month</span>
+          <span class="ai-query-example-chip" data-prompt="Organizations with the most active organizers">Most active orgs</span>
+          <span class="ai-query-example-chip" data-prompt="Average donation amount by month for the past year">Avg donation by month</span>
+        </div>
+
+        <button type="submit" class="ai-query-submit-btn" id="ai-submit-btn">
+          <span>✦</span>
+          Generate Query
+        </button>
+      <% end %>
+    </div>
+
+    <p class="text-center text-xs mt-4" style="color: var(--hcb-tx-3)">
+      AI queries are saved to Blazer with your original prompt.
+      <%= link_to "View all AI queries →", admin_ai_queries_path, class: "hover:underline", style: "color: var(--hcb-accent)" %>
+    </p>
+  </div>
+</div>
+
+<script>
+  const form = document.getElementById("ai-query-form");
+  const overlay = document.getElementById("ai-generating-overlay");
+  const submitBtn = document.getElementById("ai-submit-btn");
+  const promptEl = document.getElementById("prompt");
+
+  // Example chips
+  document.querySelectorAll(".ai-query-example-chip").forEach(chip => {
+    chip.addEventListener("click", () => {
+      promptEl.value = chip.dataset.prompt;
+      promptEl.focus();
+    });
+  });
+
+  // Show loading overlay on submit
+  form.addEventListener("submit", (e) => {
+    if (promptEl.value.trim() === "") return;
+    overlay.classList.add("active");
+    submitBtn.disabled = true;
+    submitBtn.innerHTML = '<span>✦</span> Generating…';
+  });
+</script>

--- a/app/views/admin/ai_queries/show.html.erb
+++ b/app/views/admin/ai_queries/show.html.erb
@@ -1,0 +1,296 @@
+<% friendly_name = @query.name.delete_prefix(Admin::GenerateAiQuery::AI_QUERY_PREFIX) %>
+<% title friendly_name %>
+
+<style>
+  .ai-show-header {
+    margin-bottom: 1.75rem;
+  }
+
+  .ai-show-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: var(--hcb-accent-bg);
+    color: var(--hcb-accent);
+    margin-bottom: 0.6rem;
+  }
+
+  .ai-show-title {
+    font-size: 1.75rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    color: var(--hcb-tx-1);
+    margin: 0 0 0.5rem;
+    line-height: 1.2;
+  }
+
+  .ai-show-meta {
+    font-size: 0.85rem;
+    color: var(--hcb-tx-2);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .ai-show-meta-sep {
+    opacity: 0.4;
+  }
+
+  .ai-prompt-card {
+    background: var(--hcb-accent-bg, #fff5f6);
+    border: 1px solid var(--hcb-accent, rgba(236,55,80,0.3));
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .ai-prompt-icon {
+    font-size: 1.2rem;
+    line-height: 1.5;
+    flex-shrink: 0;
+    color: var(--hcb-accent);
+  }
+
+  .ai-prompt-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--hcb-accent);
+    margin-bottom: 0.2rem;
+  }
+
+  .ai-prompt-text {
+    font-size: 0.95rem;
+    color: var(--hcb-tx-1);
+    line-height: 1.5;
+  }
+
+  .ai-sql-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .ai-sql-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+  }
+
+  .ai-sql-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--hcb-tx-2);
+  }
+
+  .ai-sql-toggle {
+    font-size: 0.8rem;
+    color: var(--hcb-accent);
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: inherit;
+  }
+
+  .ai-sql-toggle:hover { text-decoration: underline; }
+
+  .ai-sql-block {
+    background: var(--hcb-bg-0, #f6f6f7);
+    border: 1px solid var(--hcb-border);
+    border-radius: 10px;
+    overflow: auto;
+    display: none;
+  }
+
+  .ai-sql-block.open {
+    display: block;
+  }
+
+  .ai-sql-block pre {
+    padding: 1rem;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--hcb-tx-1);
+    font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
+  }
+
+  .ai-blazer-frame-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .ai-blazer-frame-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--hcb-tx-2);
+    margin-bottom: 0.5rem;
+  }
+
+  .ai-blazer-frame-wrapper {
+    border: 1px solid var(--hcb-border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+  }
+
+  .ai-blazer-frame-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 1rem;
+    background: var(--hcb-bg-0, #f6f6f7);
+    border-bottom: 1px solid var(--hcb-border);
+  }
+
+  .ai-blazer-frame-dots {
+    display: flex;
+    gap: 5px;
+  }
+
+  .ai-blazer-frame-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--hcb-border);
+  }
+
+  .ai-blazer-frame-url {
+    flex: 1;
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--hcb-tx-3);
+    font-family: monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin: 0 0.75rem;
+  }
+
+  .ai-blazer-iframe {
+    width: 100%;
+    min-height: 580px;
+    border: none;
+    display: block;
+  }
+
+  .ai-show-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--hcb-border);
+  }
+</style>
+
+<%# Breadcrumb %>
+<div class="flex items-center gap-2 text-sm mb-4" style="color: var(--hcb-tx-3)">
+  <%= link_to "AI Queries", admin_ai_queries_path, class: "hover:underline", style: "color: var(--hcb-tx-2)" %>
+  <span>/</span>
+  <span style="color: var(--hcb-tx-1)"><%= friendly_name %></span>
+</div>
+
+<div class="ai-show-header">
+  <div class="ai-show-badge">
+    <span>✦</span>
+    AI Generated
+  </div>
+  <h1 class="ai-show-title"><%= friendly_name %></h1>
+  <div class="ai-show-meta">
+    <span>Created <%= @query.created_at.strftime("%B %-d, %Y at %-I:%M %p") %></span>
+    <% if @query.creator.present? %>
+      <span class="ai-show-meta-sep">&middot;</span>
+      <span>by <%= @query.creator.try(:full_name) || @query.creator.try(:email) %></span>
+    <% end %>
+    <span class="ai-show-meta-sep">&middot;</span>
+    <%= link_to "Open in Blazer →", blazer.query_path(@query), target: "_blank", rel: "noopener", class: "hover:underline", style: "color: var(--hcb-accent)" %>
+  </div>
+</div>
+
+<% if @query.description.present? %>
+  <div class="ai-prompt-card">
+    <span class="ai-prompt-icon">✦</span>
+    <div>
+      <div class="ai-prompt-label">Original Prompt</div>
+      <div class="ai-prompt-text"><%= @query.description %></div>
+    </div>
+  </div>
+<% end %>
+
+<%# SQL Block — collapsible %>
+<div class="ai-sql-section">
+  <div class="ai-sql-header">
+    <span class="ai-sql-label">SQL Statement</span>
+    <button class="ai-sql-toggle" id="sql-toggle" onclick="toggleSql()">Show SQL</button>
+  </div>
+  <div class="ai-sql-block" id="sql-block">
+    <pre><%= @query.statement %></pre>
+  </div>
+</div>
+
+<%# Blazer iframe %>
+<div class="ai-blazer-frame-section">
+  <div class="ai-blazer-frame-label">Query Results (via Blazer)</div>
+  <div class="ai-blazer-frame-wrapper">
+    <div class="ai-blazer-frame-bar">
+      <div class="ai-blazer-frame-dots">
+        <div class="ai-blazer-frame-dot" style="background: #ff5f57;"></div>
+        <div class="ai-blazer-frame-dot" style="background: #ffbd2e;"></div>
+        <div class="ai-blazer-frame-dot" style="background: #28c840;"></div>
+      </div>
+      <div class="ai-blazer-frame-url">
+        /blazer/queries/<%= @query.to_param %>
+      </div>
+      <%= link_to blazer.query_path(@query), target: "_blank", rel: "noopener", class: "text-xs hover:underline shrink-0", style: "color: var(--hcb-accent)" do %>
+        <%= inline_icon "external-link", size: 14 %>
+      <% end %>
+    </div>
+    <iframe
+      src="<%= blazer.query_path(@query) %>"
+      class="ai-blazer-iframe"
+      id="blazer-iframe"
+      title="Blazer Query: <%= friendly_name %>"
+      loading="lazy">
+    </iframe>
+  </div>
+</div>
+
+<div class="ai-show-actions">
+  <%= link_to new_admin_ai_query_path, class: "btn" do %>
+    <span>✦</span> Generate New Query
+  <% end %>
+  <%= link_to blazer.edit_query_path(@query), target: "_blank", rel: "noopener", class: "btn" do %>
+    Edit in Blazer
+  <% end %>
+  <%= button_to admin_ai_query_path(@query), method: :delete,
+    class: "btn",
+    style: "color: #b91c1c; border-color: #fca5a5; background: #fff1f2;",
+    data: { turbo_confirm: "Delete this AI query? This cannot be undone." } do %>
+    Delete
+  <% end %>
+</div>
+
+<script>
+  function toggleSql() {
+    const block = document.getElementById("sql-block");
+    const btn = document.getElementById("sql-toggle");
+    block.classList.toggle("open");
+    btn.textContent = block.classList.contains("open") ? "Hide SQL" : "Show SQL";
+  }
+</script>

--- a/app/views/admin/ai_queries/show.html.erb
+++ b/app/views/admin/ai_queries/show.html.erb
@@ -1,11 +1,6 @@
-<% friendly_name = @query.name.delete_prefix(Admin::GenerateAiQuery::AI_QUERY_PREFIX) %>
-<% title friendly_name %>
+<% title @ai_query.display_name %>
 
 <style>
-  .ai-show-header {
-    margin-bottom: 1.75rem;
-  }
-
   .ai-show-badge {
     display: inline-flex;
     align-items: center;
@@ -39,13 +34,9 @@
     flex-wrap: wrap;
   }
 
-  .ai-show-meta-sep {
-    opacity: 0.4;
-  }
-
   .ai-prompt-card {
     background: var(--hcb-accent-bg, #fff5f6);
-    border: 1px solid var(--hcb-accent, rgba(236,55,80,0.3));
+    border: 1px solid rgba(236,55,80,0.3);
     border-radius: 12px;
     padding: 1rem 1.25rem;
     margin-bottom: 1.5rem;
@@ -70,215 +61,61 @@
     margin-bottom: 0.2rem;
   }
 
-  .ai-prompt-text {
-    font-size: 0.95rem;
-    color: var(--hcb-tx-1);
-    line-height: 1.5;
-  }
-
-  .ai-sql-section {
-    margin-bottom: 1.5rem;
-  }
-
-  .ai-sql-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.5rem;
-  }
-
-  .ai-sql-label {
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--hcb-tx-2);
-  }
-
-  .ai-sql-toggle {
-    font-size: 0.8rem;
-    color: var(--hcb-accent);
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-    font-family: inherit;
-  }
-
-  .ai-sql-toggle:hover { text-decoration: underline; }
-
-  .ai-sql-block {
-    background: var(--hcb-bg-0, #f6f6f7);
-    border: 1px solid var(--hcb-border);
-    border-radius: 10px;
-    overflow: auto;
-    display: none;
-  }
-
-  .ai-sql-block.open {
-    display: block;
-  }
-
-  .ai-sql-block pre {
-    padding: 1rem;
-    font-size: 0.82rem;
-    line-height: 1.55;
-    margin: 0;
-    white-space: pre-wrap;
-    word-break: break-word;
-    color: var(--hcb-tx-1);
-    font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
-  }
-
-  .ai-blazer-frame-section {
-    margin-bottom: 1.5rem;
-  }
-
-  .ai-blazer-frame-label {
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--hcb-tx-2);
-    margin-bottom: 0.5rem;
-  }
-
-  .ai-blazer-frame-wrapper {
-    border: 1px solid var(--hcb-border);
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
-  }
-
-  .ai-blazer-frame-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.6rem 1rem;
-    background: var(--hcb-bg-0, #f6f6f7);
-    border-bottom: 1px solid var(--hcb-border);
-  }
-
-  .ai-blazer-frame-dots {
-    display: flex;
-    gap: 5px;
-  }
-
-  .ai-blazer-frame-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--hcb-border);
-  }
-
-  .ai-blazer-frame-url {
-    flex: 1;
-    text-align: center;
-    font-size: 0.75rem;
-    color: var(--hcb-tx-3);
-    font-family: monospace;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    margin: 0 0.75rem;
-  }
-
-  .ai-blazer-iframe {
-    width: 100%;
-    min-height: 580px;
-    border: none;
-    display: block;
-  }
-
   .ai-show-actions {
     display: flex;
     gap: 0.75rem;
     flex-wrap: wrap;
     padding-top: 1.5rem;
     border-top: 1px solid var(--hcb-border);
+    margin-top: 1.5rem;
   }
 </style>
 
-<%# Breadcrumb %>
 <div class="flex items-center gap-2 text-sm mb-4" style="color: var(--hcb-tx-3)">
-  <%= link_to "AI Queries", admin_ai_queries_path, class: "hover:underline", style: "color: var(--hcb-tx-2)" %>
+  <%= link_to "AI Queries",
+              admin_ai_queries_path,
+              class: "hover:underline",
+              style: "color: var(--hcb-tx-2)" %>
   <span>/</span>
-  <span style="color: var(--hcb-tx-1)"><%= friendly_name %></span>
+  <span style="color: var(--hcb-tx-1)"><%= @ai_query.display_name %></span>
 </div>
 
-<div class="ai-show-header">
-  <div class="ai-show-badge">
-    <span>✦</span>
-    AI Generated
-  </div>
-  <h1 class="ai-show-title"><%= friendly_name %></h1>
+<div class="mb-6">
+  <div class="ai-show-badge"><span>✦</span> AI Generated</div>
+  <h1 class="ai-show-title"><%= @ai_query.display_name %></h1>
   <div class="ai-show-meta">
-    <span>Created <%= @query.created_at.strftime("%B %-d, %Y at %-I:%M %p") %></span>
-    <% if @query.creator.present? %>
-      <span class="ai-show-meta-sep">&middot;</span>
-      <span>by <%= @query.creator.try(:full_name) || @query.creator.try(:email) %></span>
+    <span>Created <%= @ai_query.created_at.strftime("%B %-d, %Y") %></span>
+    <% if @ai_query.creator.present? %>
+      <span style="opacity: 0.4;">&middot;</span>
+      <span>
+        by <%= @ai_query.creator.full_name.presence || @ai_query.creator.email %>
+      </span>
     <% end %>
-    <span class="ai-show-meta-sep">&middot;</span>
-    <%= link_to "Open in Blazer →", blazer.query_path(@query), target: "_blank", rel: "noopener", class: "hover:underline", style: "color: var(--hcb-accent)" %>
   </div>
 </div>
 
-<% if @query.description.present? %>
-  <div class="ai-prompt-card">
-    <span class="ai-prompt-icon">✦</span>
-    <div>
-      <div class="ai-prompt-label">Original Prompt</div>
-      <div class="ai-prompt-text"><%= @query.description %></div>
+<div class="ai-prompt-card">
+  <span class="ai-prompt-icon">✦</span>
+  <div>
+    <div class="ai-prompt-label">Prompt</div>
+    <div style="font-size: 0.95rem; color: var(--hcb-tx-1); line-height: 1.5;">
+      <%= @ai_query.prompt %>
     </div>
-  </div>
-<% end %>
-
-<%# SQL Block — collapsible %>
-<div class="ai-sql-section">
-  <div class="ai-sql-header">
-    <span class="ai-sql-label">SQL Statement</span>
-    <button class="ai-sql-toggle" id="sql-toggle" onclick="toggleSql()">Show SQL</button>
-  </div>
-  <div class="ai-sql-block" id="sql-block">
-    <pre><%= @query.statement %></pre>
   </div>
 </div>
 
-<%# Blazer iframe %>
-<div class="ai-blazer-frame-section">
-  <div class="ai-blazer-frame-label">Query Results (via Blazer)</div>
-  <div class="ai-blazer-frame-wrapper">
-    <div class="ai-blazer-frame-bar">
-      <div class="ai-blazer-frame-dots">
-        <div class="ai-blazer-frame-dot" style="background: #ff5f57;"></div>
-        <div class="ai-blazer-frame-dot" style="background: #ffbd2e;"></div>
-        <div class="ai-blazer-frame-dot" style="background: #28c840;"></div>
-      </div>
-      <div class="ai-blazer-frame-url">
-        /blazer/queries/<%= @query.to_param %>
-      </div>
-      <%= link_to blazer.query_path(@query), target: "_blank", rel: "noopener", class: "text-xs hover:underline shrink-0", style: "color: var(--hcb-accent)" do %>
-        <%= inline_icon "external-link", size: 14 %>
-      <% end %>
-    </div>
-    <iframe
-      src="<%= blazer.query_path(@query) %>"
-      class="ai-blazer-iframe"
-      id="blazer-iframe"
-      title="Blazer Query: <%= friendly_name %>"
-      loading="lazy">
-    </iframe>
-  </div>
+<%# Turbo stream subscription — job broadcasts to [ai_query, :generation] %>
+<%= turbo_stream_from @ai_query, :generation %>
+
+<div id="ai-query-<%= @ai_query.id %>-progress">
+  <%= render "admin/ai_queries/progress", ai_query: @ai_query %>
 </div>
 
 <div class="ai-show-actions">
   <%= link_to new_admin_ai_query_path, class: "btn" do %>
-    <span>✦</span> Generate New Query
+    <span>✦</span> New Query
   <% end %>
-  <%= link_to blazer.edit_query_path(@query), target: "_blank", rel: "noopener", class: "btn" do %>
-    Edit in Blazer
-  <% end %>
-  <%= button_to admin_ai_query_path(@query),
+  <%= button_to admin_ai_query_path(@ai_query),
                 method: :delete,
                 class: "btn",
                 style: "color: #b91c1c; border-color: #fca5a5; background: #fff1f2;",
@@ -286,12 +123,3 @@
     Delete
   <% end %>
 </div>
-
-<script>
-  function toggleSql() {
-    const block = document.getElementById("sql-block");
-    const btn = document.getElementById("sql-toggle");
-    block.classList.toggle("open");
-    btn.textContent = block.classList.contains("open") ? "Hide SQL" : "Show SQL";
-  }
-</script>

--- a/app/views/admin/ai_queries/show.html.erb
+++ b/app/views/admin/ai_queries/show.html.erb
@@ -278,10 +278,11 @@
   <%= link_to blazer.edit_query_path(@query), target: "_blank", rel: "noopener", class: "btn" do %>
     Edit in Blazer
   <% end %>
-  <%= button_to admin_ai_query_path(@query), method: :delete,
-    class: "btn",
-    style: "color: #b91c1c; border-color: #fca5a5; background: #fff1f2;",
-    data: { turbo_confirm: "Delete this AI query? This cannot be undone." } do %>
+  <%= button_to admin_ai_query_path(@query),
+                method: :delete,
+                class: "btn",
+                style: "color: #b91c1c; border-color: #fca5a5; background: #fff1f2;",
+                data: { turbo_confirm: "Delete this AI query? This cannot be undone." } do %>
     Delete
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,6 +319,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: redirect("/admin/events")
+    resources :ai_queries, only: [:index, :new, :create, :show, :destroy]
     namespace :ledger_audits do
       resources :tasks, only: [:index, :show, :create] do
         post :reviewed

--- a/db/migrate/20260507120000_create_ai_queries.rb
+++ b/db/migrate/20260507120000_create_ai_queries.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateAiQueries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_queries do |t|
+      t.text :prompt, null: false
+      t.string :status, null: false, default: "pending"
+      t.jsonb :attempts, null: false, default: []
+      t.jsonb :conversation_history, null: false, default: []
+      t.string :generated_name
+      t.bigint :creator_id
+      t.bigint :blazer_query_id
+
+      t.timestamps
+    end
+
+    add_index :ai_queries, :creator_id
+    add_index :ai_queries, :blazer_query_id
+    add_index :ai_queries, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,6 +190,21 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
     t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
 
+  create_table "ai_queries", force: :cascade do |t|
+    t.text "prompt", null: false
+    t.string "status", default: "pending", null: false
+    t.jsonb "attempts", default: [], null: false
+    t.jsonb "conversation_history", default: [], null: false
+    t.string "generated_name"
+    t.bigint "creator_id"
+    t.bigint "blazer_query_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blazer_query_id"], name: "index_ai_queries_on_blazer_query_id"
+    t.index ["creator_id"], name: "index_ai_queries_on_creator_id"
+    t.index ["status"], name: "index_ai_queries_on_status"
+  end
+
   create_table "announcement_blocks", force: :cascade do |t|
     t.bigint "announcement_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_07_120000) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
## Summary

- Adds an admin-only AI query generator that creates Blazer SQL queries from natural language prompts via GPT-4o
- Introduces a proper `AiQuery` model (with `status`, JSONB `attempts`, JSONB `conversation_history`, `sync_to_blazer!`) replacing the naming-scheme approach
- Generation runs in `AiQueryGenerationJob` — controller just creates the record and redirects immediately; Turbo streams push live progress to the show page
- Each attempt (AI generation + Blazer validation) is stored in the `attempts` array; errors are fed back into the conversation so OpenAI can self-correct, up to 10 times
- `sync_to_blazer!` creates/updates a `Blazer::Query` with clean SQL (no embedded comments); prompt is stored on the `AiQuery` record

## New files

| File | Purpose |
|---|---|
| `db/migrate/20260507120000_create_ai_queries.rb` | `ai_queries` table with status, attempts (jsonb), conversation_history (jsonb), blazer_query_id |
| `app/models/ai_query.rb` | Core model: enum status, record_attempt!, sync_to_blazer!, broadcast_generation_update |
| `app/jobs/ai_query_generation_job.rb` | Orchestrates the generation loop: OpenAI → validate → retry; broadcasts Turbo updates |
| `app/services/admin/generate_ai_query.rb` | Stateless module: call_openai, validate_sql, generate_name, extract_sql |
| `app/controllers/admin/ai_queries_controller.rb` | index / new / create (enqueues job) / show / destroy |
| `app/views/admin/ai_queries/_progress.html.erb` | Turbo-replaced partial: pending spinner, live attempt list, success with Blazer iframe, failed state |
| `app/views/admin/ai_queries/new.html.erb` | Centered prompt screen with example chips |
| `app/views/admin/ai_queries/index.html.erb` | Card grid of all AiQuery records with status badges |
| `app/views/admin/ai_queries/show.html.erb` | Turbo stream subscriber; renders _progress partial live |

## Modified files

- `config/routes.rb` — `resources :ai_queries` under the `admin` namespace
- `app/models/admin/nav.rb` — "AI Queries" nav item uses `AiQuery.count`

## Credential required

`OPENAI__BI_DASHBOARD` — same pattern as other OpenAI services in the codebase (e.g. `OPENAI__RECEIPT_EXTRACTION`).

## Test plan

- [ ] Visit `/admin/ai_queries/new` as an admin — big centered prompt screen with example chips
- [ ] Submit a prompt — redirects to show page immediately with a live spinner
- [ ] Turbo stream updates show each attempt as the job runs
- [ ] On success: attempt history (collapsible), SQL (collapsible), Blazer iframe all render
- [ ] On failure after 10 attempts: red error card with "Try Again" link pre-filled with the prompt
- [ ] Index page at `/admin/ai_queries` shows card grid with AI/Generating/Failed status badges
- [ ] "AI Queries" appears in the Misc section of the admin nav with a count badge
- [ ] Delete button removes both the `AiQuery` and its associated `Blazer::Query`

https://claude.ai/code/session_018YtAV1mWWBLmPLjNPeW31j