### PR TITLE
[Contracts] Add contract voided page

### DIFF
--- a/app/controllers/contract/parties_controller.rb
+++ b/app/controllers/contract/parties_controller.rb
@@ -21,8 +21,8 @@ class Contract
         redirect_to completed_contract_party_path(@party)
         return
       elsif @contract.voided?
-        flash[:error] = "This contract has been voided."
-        redirect_to @contract.redirect_path
+        @contracts = current_user.contracts.sent.select { |contract| contract.party(:signee).present? }
+        render "contract/parties/voided"
         return
       elsif @contract.pending?
         flash[:error] = "This contract has not been sent yet. Try again later."

--- a/app/views/contract/parties/voided.html.erb
+++ b/app/views/contract/parties/voided.html.erb
@@ -17,5 +17,3 @@
 <% else %>
   <%= link_to "Return to homepage", root_path, class: "btn mt-2" %>
 <% end %>
-
-

--- a/app/views/contract/parties/voided.html.erb
+++ b/app/views/contract/parties/voided.html.erb
@@ -6,7 +6,7 @@
   You no longer need to sign this agreement.
 
   <% unless @contracts.empty? %>
-    However, you have <%= @contracts.size %> other <%= "agreement".pluralize(@contracts.size) %> to sign:
+    However, you have <%= pluralize(@contracts.size, "other agreements") %> to sign:
   <% end %>
 </p>
 

--- a/app/views/contract/parties/voided.html.erb
+++ b/app/views/contract/parties/voided.html.erb
@@ -1,0 +1,21 @@
+<% title "Voided agreement" %>
+
+<h1>This agreement has been voided</h1>
+
+<p>
+  You no longer need to sign this agreement.
+
+  <% unless @contracts.empty? %>
+    However, you have <%= @contracts.size %> other <%= "agreement".pluralize(@contracts.size) %> to sign:
+  <% end %>
+</p>
+
+<% unless @contracts.empty? %>
+  <div class="flex flex-col mt-2 gap-4">
+    <%= render partial: "contracts/contract", collection: @contracts, as: :contract %>
+  </div>
+<% else %>
+  <%= link_to "Return to homepage", root_path, class: "btn mt-2" %>
+<% end %>
+
+

--- a/app/views/contracts/_contract.html.erb
+++ b/app/views/contracts/_contract.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (contract:) %>
+
+<%= link_to contract_party_path(contract.party(:signee)), target: "_blank", class: "card card--item flex gap-4 items-baseline" do %>
+  <%= status_badge "info" %>
+  <strong class="dark:text-white text-black">Fiscal sponsorship agreement for <%= contract.event_name %></strong>
+  <small class="muted flex-grow" style="margin-left: 3.5px">
+    sent <%= time_ago_in_words contract.created_at %> ago
+  </small>
+<% end %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -194,19 +194,9 @@
     <% if valid_contracts.any? %>
       <h2 class="w-full text-left mt-4 pb-0 border-none">Pending forms</h2>
       <p class="text-left my0 w-100 muted">Forms are sent to your HCB email, currently set to <%= mail_to current_user.email %>.</p>
-      <ul class="grid grid--narrow grid-cols-1 text-left w-full mt-2">
-        <% valid_contracts.each do |contract| %>
-          <%= link_to contract_party_path(contract.party(:signee)), target: "_blank" do %>
-            <li class="card card--item flex" style="gap: 4.5px; align-items: baseline">
-              <%= status_badge "info" %>
-              <strong>Fiscal sponsorship agreement for <%= contract.event_name %></strong>
-              <small class="muted flex-grow" style="margin-left: 3.5px">
-                sent <%= time_ago_in_words contract.created_at %> ago
-              </small>
-            </li>
-          <% end %>
-        <% end %>
-      </ul>
+      <div class="grid grid--narrow grid-cols-1 text-left w-full mt-2">
+        <%= render partial: "contracts/contract", collection: valid_contracts, as: :contract %>
+      </div>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The "you are not authorized to perform this action" error is a little confusing when you visit a voided contract signing page.

Closes #13506

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Renders a different voided page when visiting the signing page for a voided contract, which includes other contracts that need to be signed, if any.

Refactors the contract row into a partial so we can show it on homepage and the new voided page

<img width="1004" height="228" alt="image" src="https://github.com/user-attachments/assets/0771828d-0d80-41a9-bb2a-8d70371dcba6" />

<img width="1014" height="393" alt="image" src="https://github.com/user-attachments/assets/1e1b8715-53ec-4698-b7ef-436a45becc0a" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

