### PR TITLE
[CI] Fix broken apt in workflows

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -8,7 +8,9 @@ runs:
       # ubuntu-latest ships with recent enough apt indexes to resolve
       # libpoppler-glib-dev without a fresh `apt-get update` (~30 s).
       # Re-add one here if a future runner image breaks that.
-      run: sudo apt-get install -y libpoppler-glib-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --fix-missing libpoppler-glib-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
      # ubuntu-latest ships with recent enough apt indexes to resolve
      # libpoppler-glib-dev without a fresh `apt-get update` (~30 s).
      # Re-add one here if a future runner image breaks that.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Readded the apt-get update


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

