### PR TITLE
[Contracts] Add safe nav in party reminder job

### DIFF
--- a/app/jobs/contract/party/reminder_job.rb
+++ b/app/jobs/contract/party/reminder_job.rb
@@ -7,7 +7,7 @@ class Contract
       discard_on ActiveJob::DeserializationError
 
       def perform(party)
-        return unless party.pending? && party.contract.sent?
+        return unless party.pending? && party.contract&.sent?
 
         # If they're scheduled for an onboarding call, we shouldn't remind them
         return if party.contract.contractable.is_a?(Event::Application) && ["Interview Scheduled", "Invited to Interview"].include?(party.contract.contractable.airtable_record["Status"])


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2769/samples `NoMethodError: undefined method 'sent?' for nil`

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a safe nav - it's a little weird that ActiveJob still successfully deserializes a soft-deleted record - we may want to look into seeing if we can patch this as this isn't intuitive, but that requires more investigation for another time/PR.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

