### PR TITLE
Fix card styling on event homepage

### DIFF
--- a/app/views/events/home/_balance.html.erb
+++ b/app/views/events/home/_balance.html.erb
@@ -1,4 +1,4 @@
-<div class="card p-0 flex-1 flex flex-col" style="pointer-events: none;" data-controller="balance-graph" data-balance-graph-available-value="<%= @event.balance_available_v2_cents %>" data-balance-graph-slug-value="<%= @event.slug %>">
+<div class="card card--breakdown p-0 flex-1 flex flex-col" style="pointer-events: none;" data-controller="balance-graph" data-balance-graph-available-value="<%= @event.balance_available_v2_cents %>" data-balance-graph-slug-value="<%= @event.slug %>">
   <h3 data-balance-graph-target="label" class="m-0 p-4 pb-0 mb-2" style="margin-bottom: -4px">Account balance</h3>
   <div
     class="flex flex-grow flex-col"

--- a/app/views/events/home/_heatmap.html.erb
+++ b/app/views/events/home/_heatmap.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "transaction_heatmap" do %>
   <% if @past_year_transactions_count > 0 %>
-    <div class="card  p-4 flex-1 flex flex-col overflow-visible">
+    <div class="card card--breakdown p-4 flex-1 flex flex-col overflow-visible">
       <h4 class="text-muted uppercase text-sm font-bold mt-0 mb-3" style="font-size: 16px">
         <%= @past_year_transactions_count %> <%= "transaction".pluralize(@past_year_transactions_count) %> in the past
         year

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -97,7 +97,7 @@
   <%= render "events/public_message" %>
 
   <%= turbo_frame_tag "balance_transactions", src: event_balance_transactions_path(@event), class: "flex-1 homepage-row empty:hidden flex gap-4 mb-4", loading: "lazy", target: "_top" do %>
-    <div class="card p-0 text-center flex-1 flex flex-col items-center justify-center min-h-[422px]">
+    <div class="card card--breakdown p-0 text-center flex-1 flex flex-col items-center justify-center min-h-[422px]">
       <%= render partial: "application/loading_container" %>
     </div>
     <div class="card card--breakdown p-0 text-center flex-1 flex flex-col items-center justify-center min-h-[422px]" style="flex: 1">
@@ -115,7 +115,7 @@
       <div class="card card--breakdown p-0 text-center flex-1 flex flex-col items-center justify-center" style="flex: 1">
         <%= render partial: "application/loading_container" %>
       </div>
-      <div class="card p-0 text-center flex-1 flex flex-col items-center justify-center">
+      <div class="card card--breakdown p-0 text-center flex-1 flex flex-col items-center justify-center">
         <%= render partial: "application/loading_container" %>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some cards on the homepage have been missing the `card--breakdown` class which sets a slightly different border color and shadow than the default. 😭

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add `card--breakdown` class to the homepage cards that didn't have it. ✨

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

