### PR TITLE
Make ancestor_users order guaranteed and remove confusing line

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -129,6 +129,10 @@ class Event < ApplicationRecord
       .where("flipper_gates.feature_key = ? AND flipper_gates.key = ?", flag, "actors")
   }
 
+  # Following the convention of Module#ancestors https://apidock.com/ruby/Module/ancestors
+  # this returns the id of self as well as all the ancestors,
+  # in order from self->parent->grandparent->...
+  # We guarantee this order using SEARCH BREADTH FIRST https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-SEARCH
   def ancestor_ids
     [id] + Event.connection.execute(<<-SQL).map { |row| row["id"] }
       WITH RECURSIVE parent_events AS (
@@ -139,8 +143,8 @@ class Event < ApplicationRecord
         SELECT e.id, e.parent_id
         FROM events e
         INNER JOIN parent_events pe ON e.id = pe.parent_id
-      )
-      SELECT id FROM parent_events WHERE id != #{id};
+      ) SEARCH BREADTH FIRST BY id SET ordercol
+      SELECT id FROM parent_events WHERE id != #{id} ORDER BY ordercol;
     SQL
   end
 
@@ -159,8 +163,14 @@ class Event < ApplicationRecord
     SQL
   end
 
+  # Following the convention of Module#ancestors https://apidock.com/ruby/Module/ancestors
+  # this returns self as well as all the ancestors
   def ancestors
-    Event.where(id: ancestor_ids)
+    # array_position preserves the order from ancestor_ids; sanitize_sql_array parameterizes the ids so it's statically safe and passes brakeman.
+    fetched_ancestor_ids = ancestor_ids
+    Event.where(id: fetched_ancestor_ids).reorder(Arel.sql(
+                                                    Event.sanitize_sql_array(["array_position(ARRAY[?]::bigint[], events.id)", fetched_ancestor_ids])
+                                                  ))
   end
 
   def descendants

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -47,7 +47,6 @@ class CommentPolicy < ApplicationPolicy
     user_list = []
 
     if record.commentable.respond_to?(:events)
-      user_list = record.commentable.events.collect(&:users).flatten
       user_list = record.commentable.events.collect(&:ancestor_users).flatten
     elsif record.commentable.is_a?(Reimbursement::Report)
       user_list = [record.commentable.user]

--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -1,4 +1,4 @@
-<% parent_events ||= @event.ancestors.reject { |e| e.id == @event.id } %>
+<% parent_events ||= @event.ancestors.reject { |e| e.id == @event.id }.reverse %>
 <% if parent_events.present? %>
   <div data-controller="menu" class="-mb-2">
     <button

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -93,6 +93,40 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#ancestor_ids" do
+    it "returns ids ordered from self to root" do
+      root = create(:event)
+      child = create(:event, parent: root)
+      grandchild = create(:event, parent: child)
+
+      expect(grandchild.ancestor_ids).to eq([grandchild.id, child.id, root.id])
+    end
+  end
+
+  describe "#ancestors" do
+    it "returns events ordered from self to root" do
+      root = create(:event)
+      child = create(:event, parent: root)
+      grandchild = create(:event, parent: child)
+
+      expect(grandchild.ancestors.to_a).to eq([grandchild, child, root])
+    end
+  end
+
+  describe "#ancestor_organizer_positions" do
+    it "returns positions on self and all ancestors" do
+      root = create(:event)
+      child = create(:event, parent: root)
+      grandchild = create(:event, parent: child)
+
+      op_root = create(:organizer_position, event: root)
+      op_child = create(:organizer_position, event: child)
+      op_grandchild = create(:organizer_position, event: grandchild)
+
+      expect(grandchild.ancestor_organizer_positions).to match_array([op_grandchild, op_child, op_root])
+    end
+  end
+
   describe "#plan" do
     it "uses the parent event's subevent plan by default" do
       parent = create(:event)


### PR DESCRIPTION
## Summary of the problem

- We were initially confused about whether ancestor methods contained self, so the first idea was to rename them to `self_and_ancestors` which is similar to some gems
  - https://github.com/amerine/acts_as_tree/blob/9895c5e91bde72f80060b9e920cc85759c99323d/lib/acts_as_tree.rb#L337-L342
  - https://github.com/stefankroes/ancestry#tree-navigation uses `path` for self+ancestors and `ancestors` is ancestors only
- Ultimately we kept it just `ancestor*` because that matches Ruby Module#ancestors.
- The previous implementation didn't guarantee order so we modified it to guarantee order from self->parent->...->root. Some UI was depending on showing root->...->parent so we call reverse there now
- in comment policy there was a place we override a variable immediately (instead of +=) which made it look buggy, just delete that line

