### PR TITLE
Make comment order_by created_at default in concern

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -3,7 +3,7 @@
 module Commentable
   extend ActiveSupport::Concern
   included do
-    has_many :comments, as: :commentable
+    has_many :comments, -> { order(:created_at) }, as: :commentable, inverse_of: :commentable
   end
 
   def comment_recipients_for(comment)
@@ -29,7 +29,7 @@ module Commentable
 
   def all_comments
     if shared_commentable
-      Comment.where(commentable: self).or(Comment.where(commentable: shared_commentable))
+      Comment.where(commentable: self).or(Comment.where(commentable: shared_commentable)).order(:created_at)
     else
       comments
     end

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -2,6 +2,6 @@
   <% if policy_scope(comments).empty? && defined?(show_blankslate) %>
     <%= blankslate "No comments yet." %>
   <% else %>
-    <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file.order(created_at: :asc), as: :comment, locals: { viewing_commentable: local_assigns[:viewing_commentable] } %>
+    <%= render partial: "comments/item", collection: policy_scope(comments).includes(:user, :versions).with_attached_file, as: :comment, locals: { viewing_commentable: local_assigns[:viewing_commentable] } %>
   <% end %>
 </section>


### PR DESCRIPTION
## Summary of the problem

This seems like it shouldn't belong in the partial nor would we want the default order from postgres (which is often by id but is actually undefined)