### PR TITLE
Fix bug with parent event titles

### DIFF
--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -1,4 +1,4 @@
-<% parent_events ||= @event.ancestors[0...-1].reject { |e| e.id == @event.id } %>
+<% parent_events ||= @event.ancestors.reject { |e| e.id == @event.id } %>
 <% if parent_events.present? %>
   <div data-controller="menu" class="-mb-2">
     <button


### PR DESCRIPTION
This seemed like a potential bug where we are cutting off an ancestor from the array

in local dev console
```
PaperTrail.request(enabled: false) do
  gp = Event.create!(name: "GP", slug: "demo-gp-#{SecureRandom.hex(3)}", country: "US")
  p  = Event.create!(name: "P",  slug: "demo-p-#{SecureRandom.hex(3)}",  country: "US", parent: gp)
  c  = Event.create!(name: "C",  slug: "demo-c-#{SecureRandom.hex(3)}",  country: "US", parent: p)

  ordered = c.self_and_ancestors.sort_by { |e| e.id == c.id ? 0 : 1 }
  puts "ordered: #{ordered.map(&:name).inspect}"
  puts "buggy:   #{ordered[0...-1].reject { |e| e.id == c.id }.map(&:name).inspect}"
  puts "fixed:   #{ordered.reject       { |e| e.id == c.id }.map(&:name).inspect}"
end
```
ordered: ["C", "GP", "P"]
buggy:   ["GP"]
fixed:   ["GP", "P"]
