### PR TITLE
[Suborganizations] Fix search bar gap

### DIFF
--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -30,7 +30,7 @@
   </div>
 </div>
 
-<div class="flex items-center gap-6 sm:gap-4 flex-col-reverse sm:flex-row mb-2">
+<div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
     <%= render "events/filters/search", form: %>
   <% end %>


### PR DESCRIPTION
Noticed this inconsistent gap when working on mermaid graphs:
<img width="235" height="137" alt="image" src="https://github.com/user-attachments/assets/17334009-cca7-464d-8b6f-3aa242a0be2e" />


Fix:
<img width="89" height="52" alt="image" src="https://github.com/user-attachments/assets/f10838b8-3607-4cc0-9659-e392826f5f21" />
