### PR TITLE
[Applications] Always sync applications that already have an airtable record

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -8,6 +8,8 @@ class Event
       @application = application
       airrecord = @application.airtable_record
 
+      # If there's already an Airtable record, we want to make sure it stays up to date
+      # This can happen when an application is submitted and then archived, which marks it as a draft again
       return if @application.draft? && airrecord.nil?
 
       # If Airtable record already exists, update it and move on! (no concerns for race conditions)

--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -6,10 +6,11 @@ class Event
 
     def perform(application)
       @application = application
-      return if @application.draft?
+      airrecord = @application.airtable_record
+
+      return if @application.draft? && airrecord.nil?
 
       # If Airtable record already exists, update it and move on! (no concerns for race conditions)
-      airrecord = @application.airtable_record
       return update_airtable(airrecord) if airrecord.present?
 
       # Airtable record doesn't exist, let's create it! Lock Application to prevent duplicate new Airtable records


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Applications that were submitted and then archived were not getting synced to Airtable, leaving the airtable record showing an unarchived application still in review.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a check to make sure we don't prevent updating any applications that already have an airtable record.

When merged, we should go ahead and re-run the airtable sync job for archived applications.
```ruby
Event::Application.archived.each(&:schedule_airtable_sync)
```

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

