### PR TITLE
Preserve sessions when locking users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -374,7 +374,7 @@ class User < ApplicationRecord
     update!(locked_at: Time.now)
 
     # Invalidate all sessions
-    user_sessions.destroy_all
+    user_sessions.update_all(signed_out_at: Time.now, expiration_at: Time.now)
     # Invalidate all API tokens
     api_tokens.accessible.update_all(revoked_at: Time.current)
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
In the past, we used to have soft deletion on user sessions. However, last year we switched to a new system without soft deletion - see #8950. In that PR, we forgot to update the `lock!` method, which still destroyed sessions instead of marking them as expired and signed out.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Mark sessions has expired and signed out instead of destroying when locking a user.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

