### PR TITLE
Allow anyone to click up to ancestor orgs

### DIFF
--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -12,7 +12,7 @@
       <span class="muted font-medium h5 pl-2 p-1 m0">Parent <%= "organization".pluralize(parent_events.count) %></span>
       <% parent_events.each do |ancestor| %>
         <%= link_to_if organizer_signed_in?(ancestor, as: :reader), ancestor.name, ancestor do %>
-          <%= button_to ancestor.name, ancestor, method: :get, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>         
+          <%= link_to ancestor.name, ancestor, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -11,7 +11,11 @@
     <div class="menu__content menu__content--switcher h5" data-menu-target="content">
       <span class="muted font-medium h5 pl-2 p-1 m0">Parent <%= "organization".pluralize(parent_events.count) %></span>
       <% parent_events.each do |ancestor| %>
-        <%= link_to ancestor.name, ancestor, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>
+        <% if policy(ancestor).show? %>
+          <%= link_to ancestor.name, ancestor, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>
+        <% else %>
+          <span class="text-inherit">Bzzzzz a fly whizzes past you</span>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -11,9 +11,7 @@
     <div class="menu__content menu__content--switcher h5" data-menu-target="content">
       <span class="muted font-medium h5 pl-2 p-1 m0">Parent <%= "organization".pluralize(parent_events.count) %></span>
       <% parent_events.each do |ancestor| %>
-        <%= link_to_if organizer_signed_in?(ancestor, as: :reader), ancestor.name, ancestor do %>
-          <%= link_to ancestor.name, ancestor, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>
-        <% end %>
+        <%= link_to ancestor.name, ancestor, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -12,9 +12,7 @@
       <span class="muted font-medium h5 pl-2 p-1 m0">Parent <%= "organization".pluralize(parent_events.count) %></span>
       <% parent_events.each do |ancestor| %>
         <%= link_to_if organizer_signed_in?(ancestor, as: :reader), ancestor.name, ancestor do %>
-          <div class="menu__action opacity-70 pointer-events-none">
-            <%= ancestor.name %>
-          </div>
+          <%= button_to ancestor.name, ancestor, method: :get, class: "menu__action opacity-70 bg-transparent border-none cursor-pointer text-inherit hover:text-primary" %>         
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary of the problem
When viewing sub-orgs I couldn't click the parent org name to view it instead I would manually have to look for it. (You can do this if you are inside the org's team but not from outside)


## Describe your changes
I made the ancestor org div with text inside, into a button to the ancestor org

