### PR TITLE
Fix attachment download links in comments

### DIFF
--- a/app/views/comments/_item.html.erb
+++ b/app/views/comments/_item.html.erb
@@ -46,11 +46,7 @@
       </div>
       <% if comment.has_attached_file? %>
         <div class="border-top card__banner">
-        <% if organizer_signed_in? %>
           <%= link_to "📎 attachment", url_for(comment.file), target: "_blank" %>
-        <% else %>
-          <%= link_to "📎 sign in to download attachment", root_path, target: "_blank" %>
-        <% end %>
         </div>
       <% end %>
         <%# if comment.edited? %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Closes #13731

On the receipt upload page, attachments uploaded in the comments section cannot be opened directly. The link shows `📎 sign in to download attachment`, and clicking it redirects to `https://hcb.hackclub.com/ `instead of opening the attachment.

This affects users who are not members of the organization that owns the comment — including the comment's own author, who cannot reopen the attachment they just uploaded.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

The attachment link was gated by `organizer_signed_in?`, but the surrounding partial is already wrapped in `<% if policy(comment).show? %>`, which guarantees the current user is authorized to view the comment. The inner check was therefore both redundant and incorrect: `organizer_signed_in?` returns false for legitimate non-organizer viewers such as card grant recipients, blocking access they should have.

