### PR TITLE
Added Editing Wise Reimbursements: Admins can now edit the payout inf…

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -72,6 +72,9 @@ module Reimbursement
         return redirect_to auth_users_path(url_queries), flash: { info: "To continue, please sign in with the email which received the invite." }
       end
       authorize @report
+      if @report.user.payout_method.is_a?(User::PayoutMethod::WiseTransfer) && @report.wise_transfer_draft.nil?
+        @report.ensure_wise_transfer_draft!
+      end
       @commentable = @report
       @comments = @commentable.comments
       @use_user_nav = @event.nil? || current_user == @user && !@event.users.include?(@user) && !auditor_signed_in?
@@ -294,6 +297,10 @@ module Reimbursement
       authorize @report
 
       clearinghouse = Event.find_by(id: EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING)
+      wise_details = @report.wise_transfer_draft
+      recipient_name = wise_details&.account_holder.presence || wise_details&.recipient_name.presence || @report.user.full_name
+      recipient_email = wise_details&.recipient_email.presence || @report.user.email
+      recipient_phone_number = wise_details&.recipient_phone_number.presence || @report.user.phone_number
       payout_holding = @report.payout_holding
       payout_holding.with_lock do
         unless payout_holding.settled?
@@ -307,16 +314,16 @@ module Reimbursement
         @report.user.payout_method.update(wise_recipient_id: params[:wise_recipient_id])
         wise_transfer = clearinghouse.wise_transfers.create!(
           payment_for: "Reimbursement for #{@report.name}.",
-          address_line1: @report.user.payout_method.address_line1,
-          address_line2: @report.user.payout_method.address_line2,
-          address_city: @report.user.payout_method.address_city,
-          address_state: @report.user.payout_method.address_state,
-          address_postal_code: @report.user.payout_method.address_postal_code,
-          recipient_country: @report.user.payout_method.recipient_country,
-          recipient_email: @report.user.email,
-          recipient_name: @report.user.full_name,
-          bank_name: @report.user.payout_method.bank_name,
-          recipient_information: @report.user.payout_method.recipient_information,
+          address_line1: wise_details&.address_line1 || @report.user.payout_method.address_line1,
+          address_line2: wise_details&.address_line2 || @report.user.payout_method.address_line2,
+          address_city: wise_details&.address_city || @report.user.payout_method.address_city,
+          address_state: wise_details&.address_state || @report.user.payout_method.address_state,
+          address_postal_code: wise_details&.address_postal_code || @report.user.payout_method.address_postal_code,
+          recipient_country: wise_details&.recipient_country || @report.user.payout_method.recipient_country,
+          recipient_email: recipient_email,
+          recipient_name: recipient_name,
+          bank_name: wise_details&.bank_name || @report.user.payout_method.bank_name,
+          recipient_information: wise_details&.recipient_information || @report.user.payout_method.recipient_information,
           currency: @report.currency,
           user: User.system_user,
           usd_amount_cents: payout_holding.amount_cents,
@@ -325,7 +332,7 @@ module Reimbursement
           wise_id: params[:wise_id],
           wise_recipient_id: params[:wise_recipient_id],
           sent_at: Time.now,
-          recipient_phone_number: @report.user.phone_number,
+          recipient_phone_number: recipient_phone_number,
         )
         wise_transfer.mark_approved!
         wise_transfer.mark_sent!
@@ -353,6 +360,22 @@ module Reimbursement
       end
 
       # Reimbursement::NightlyJob.perform_later
+
+      redirect_to @report
+    end
+
+    def update_wise_transfer_draft
+      authorize @report, :update_wise_transfer_draft?
+
+      @wise_transfer_draft = @report.wise_transfer_draft || @report.build_wise_transfer_draft(currency: @report.currency)
+      @wise_transfer_draft.assign_attributes(wise_transfer_draft_params)
+      @wise_transfer_draft.currency ||= @report.currency
+
+      if @wise_transfer_draft.save
+        flash[:success] = "Wise transfer draft updated."
+      else
+        flash[:error] = @wise_transfer_draft.errors.full_messages.to_sentence
+      end
 
       redirect_to @report
     end
@@ -455,6 +478,25 @@ module Reimbursement
       reimbursement_report_params.delete(:maximum_amount) unless @report.draft? || @report.submitted?
       reimbursement_report_params.delete(:reviewer_id) unless admin_signed_in? || OrganizerPosition.role_at_least?(current_user, @event, :manager)
       reimbursement_report_params
+    end
+
+    def wise_transfer_draft_params
+      permitted_keys = Reimbursement::WiseTransferDraft.recipient_information_accessors + ["account_holder"]
+      params.require(:reimbursement_wise_transfer_draft).permit(
+        :wise_recipient_id,
+        :recipient_name,
+        :recipient_email,
+        :recipient_phone_number,
+        :bank_name,
+        :address_line1,
+        :address_line2,
+        :address_city,
+        :address_state,
+        :address_postal_code,
+        :recipient_country,
+        :currency,
+        *permitted_keys
+      )
     end
 
   end

--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -53,11 +53,19 @@ class WiseTransfersController < ApplicationController
   end
 
   def edit
+    unless @wise_transfer.editable?
+      redirect_to @wise_transfer, alert: "This transfer can no longer be edited." and return
+    end
+
     authorize @wise_transfer
     @event = @wise_transfer.event
   end
 
   def update
+    unless @wise_transfer.editable?
+      redirect_to @wise_transfer, alert: "This transfer can no longer be edited." and return
+    end
+
     authorize @wise_transfer
     @event = @wise_transfer.event
 

--- a/app/models/hcb_code/memo.rb
+++ b/app/models/hcb_code/memo.rb
@@ -102,7 +102,7 @@ class HcbCode
       end
 
       def reimbursement_expense_payout_memo
-        reimbursement_expense_payout.expense.memo
+        reimbursement_expense_payout&.expense&.memo || ""
       end
 
       def reimbursement_payout_transfer_memo

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -76,6 +76,7 @@ module Reimbursement
     validates :maximum_amount_cents, numericality: { greater_than: 0 }, allow_nil: true
     has_many :expenses, foreign_key: "reimbursement_report_id", inverse_of: :report, dependent: :destroy
     has_one :payout_holding, inverse_of: :report
+    has_one :wise_transfer_draft, class_name: "Reimbursement::WiseTransferDraft", inverse_of: :report, dependent: :destroy
     alias_attribute :report_name, :name
     attribute :name, :string, default: -> { "Expenses from #{Time.now.strftime("%B %e, %Y")}" }
 
@@ -123,6 +124,7 @@ module Reimbursement
           end
         end
         after do
+          ensure_wise_transfer_draft!
           if team_review_required?
             ReimbursementMailer.with(report: self).review_requested.deliver_later
             create_activity(key: "reimbursement_report.review_requested", owner: user, recipient: reviewer.presence || event, event_id: event.id)
@@ -420,6 +422,31 @@ module Reimbursement
 
         wise_transfer
       end
+    end
+
+    def ensure_wise_transfer_draft!
+      return unless user.payout_method.is_a?(User::PayoutMethod::WiseTransfer)
+      return if wise_transfer_draft.present?
+
+      account_holder = user.payout_method.try(:account_holder)
+      wise_recipient_id = user.payout_method.try(:wise_recipient_id)
+      draft = build_wise_transfer_draft(
+        currency:,
+        recipient_name: account_holder.presence || user.full_name,
+        recipient_email: user.email,
+        recipient_phone_number: user.phone_number,
+        wise_recipient_id:,
+        address_line1: user.payout_method.address_line1,
+        address_line2: user.payout_method.address_line2,
+        address_city: user.payout_method.address_city,
+        address_state: user.payout_method.address_state,
+        address_postal_code: user.payout_method.address_postal_code,
+        recipient_country: user.payout_method.recipient_country,
+        bank_name: user.payout_method.bank_name,
+        recipient_information: user.payout_method.recipient_information&.deep_dup
+      )
+      draft.account_holder = account_holder if account_holder.present?
+      draft.save!
     end
 
     private

--- a/app/models/reimbursement/wise_transfer_draft.rb
+++ b/app/models/reimbursement/wise_transfer_draft.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Reimbursement
+  class WiseTransferDraft < ApplicationRecord
+    include HasWiseRecipient
+
+    has_encrypted :recipient_information, type: :json
+    store :recipient_information, accessors: (recipient_information_accessors + ["account_holder"]).uniq
+
+    belongs_to :report, class_name: "Reimbursement::Report", foreign_key: "reimbursement_report_id", inverse_of: :wise_transfer_draft
+
+    validates :currency, presence: true
+    validates :recipient_name, presence: true
+    validates :recipient_email, presence: true
+  end
+end

--- a/app/models/reimbursement/wise_transfer_draft.rb
+++ b/app/models/reimbursement/wise_transfer_draft.rb
@@ -1,5 +1,36 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: reimbursement_wise_transfer_drafts
+#
+#  id                               :bigint           not null, primary key
+#  address_city                     :string
+#  address_line1                    :string
+#  address_line2                    :string
+#  address_postal_code              :string
+#  address_state                    :string
+#  bank_name                        :string
+#  created_at                       :datetime         not null
+#  currency                         :string           not null
+#  recipient_country                :integer
+#  recipient_email                  :string           not null
+#  recipient_information_ciphertext :text
+#  recipient_name                   :string           not null
+#  recipient_phone_number           :string
+#  reimbursement_report_id          :bigint           not null
+#  updated_at                       :datetime         not null
+#  wise_recipient_id                :text
+#
+# Indexes
+#
+#  idx_r_wise_transfer_drafts_on_report_id  (reimbursement_report_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (reimbursement_report_id => reimbursement_reports.id)
+#
+
 module Reimbursement
   class WiseTransferDraft < ApplicationRecord
     include HasWiseRecipient
@@ -12,5 +43,6 @@ module Reimbursement
     validates :currency, presence: true
     validates :recipient_name, presence: true
     validates :recipient_email, presence: true
+
   end
 end

--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -87,6 +87,10 @@ module Reimbursement
       admin
     end
 
+    def update_wise_transfer_draft?
+      admin
+    end
+
     def reverse?
       admin
     end

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -287,8 +287,8 @@
                     </strong>
                   </div>
 
-                  <% if report.user.payout_method.wise_recipient_id.present? %>
-                    <%= link_to "https://wise.com/send#?contact=#{report.user.payout_method.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+                  <% if report.wise_transfer_draft.wise_recipient_id.present? %>
+                    <%= link_to "https://wise.com/send#?contact=#{report.wise_transfer_draft.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>

--- a/app/views/reimbursement/reports/_edit_wise_info_modal.html.erb
+++ b/app/views/reimbursement/reports/_edit_wise_info_modal.html.erb
@@ -1,0 +1,6 @@
+<%# locals: (report:) %>
+
+<section data-behavior="modal" role="dialog" id="edit_wise_info" class="modal modal--scroll bg-snow">
+  <%= modal_header "Edit Wise Info" %>
+  <%= render partial: "reimbursement/reports/wise_transfer_draft_form", locals: { report: } %>
+</section>

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -3,11 +3,24 @@
 <% user = report.user %>
 <% payout_method = user.payout_method %>
 
-<h3 class="mt-0">Payout information</h3>
+<div class="inline-flex items-center justify-between w-full">
+  <h3 class="mt-0">Payout information</h3>
+  <% if auditor_signed_in? && !report.closed? %>
+    <%= pop_icon_to "settings",
+                    "#",
+                    data: { behavior: "modal_trigger", modal: "edit_wise_info" },
+                    icon_size: 28,
+                    class: "tooltipped tooltipped--w",
+                    style: "height: 32px; width: 32px;",
+                    'aria-label': "Edit Wise Info",
+                    disabled: !policy(@report).edit? %>
+  <% end %>
+</div>
 
 <% if payout_method.nil? %>
   <p class="muted">No payout method configured</p>
 <% else %>
+  <% wise_display = payout_method.is_a?(User::PayoutMethod::WiseTransfer) ? (report.payout_holding&.wise_transfer || report.wise_transfer_draft || payout_method) : nil %>
   <table class="table--autosize">
     <tbody>
       <tr>
@@ -16,15 +29,15 @@
       </tr>
       <tr>
         <td>Recipient:</td>
-        <td><%= user.name %></td>
+        <td><%= wise_display&.recipient_name.presence || user.name %></td>
       </tr>
       <tr>
         <td>Name on account:</td>
-        <td><%= payout_method.try(:account_holder).presence || user.full_name %></td>
+        <td><%= wise_display&.account_holder.presence || payout_method.try(:account_holder).presence || user.full_name %></td>
       </tr>
       <tr>
         <td>Email:</td>
-        <td><%= user.email %></td>
+        <td><%= wise_display&.recipient_email.presence || user.email %></td>
       </tr>
 
       <% if payout_method.is_a?(User::PayoutMethod::AchTransfer) %>
@@ -114,57 +127,66 @@
         <% end %>
 
       <% elsif payout_method.is_a?(User::PayoutMethod::WiseTransfer) %>
-        <tr>
-          <td>Currency:</td>
-          <td><%= payout_method.currency %></td>
-        </tr>
-        <% if payout_method.bank_name.present? %>
+        <% wise_transfer = report.payout_holding&.wise_transfer || report.wise_transfer_draft || payout_method %>
+
+        <% if wise_transfer.nil? %>
           <tr>
-            <td>Bank name:</td>
-            <td><%= payout_method.bank_name %></td>
+            <td colspan="2" class="muted">Wise transfer details not available</td>
           </tr>
-        <% end %>
-        <tr>
-          <td>Address (Line 1):</td>
-          <td><%= payout_method.address_line1 %></td>
-        </tr>
-        <% if payout_method.address_line2.present? %>
+        <% else %>
           <tr>
-            <td>Address (Line 2):</td>
-            <td><%= payout_method.address_line2 %></td>
+            <td>Currency:</td>
+            <td><%= wise_transfer.currency %></td>
           </tr>
-        <% end %>
-        <tr>
-          <td>City:</td>
-          <td><%= payout_method.address_city %></td>
-        </tr>
-        <tr>
-          <td>State:</td>
-          <td><%= payout_method.address_state %></td>
-        </tr>
-        <tr>
-          <td>Postal code:</td>
-          <td><%= payout_method.address_postal_code %></td>
-        </tr>
-        <tr>
-          <td>Recipient country:</td>
-          <td><%= payout_method.recipient_country %></td>
-        </tr>
-        <% WiseTransfer.recipient_information_accessors&.each do |key| %>
-          <% next if key == "account_holder" %>
-          <% if payout_method.recipient_information[key].presence != nil %>
+          <% if wise_transfer.bank_name.present? %>
             <tr>
-              <td><%= key.humanize %>:</td>
-              <td><%= payout_method.recipient_information[key] %></td>
+              <td>Bank name:</td>
+              <td><%= wise_transfer.bank_name %></td>
             </tr>
-          <% elsif payout_method.read_attribute(key.to_sym).present? %>
+          <% end %>
+          <tr>
+            <td>Address (Line 1):</td>
+            <td><%= wise_transfer.address_line1 %></td>
+          </tr>
+          <% if wise_transfer.address_line2.present? %>
             <tr>
-              <td><%= key.humanize %>:</td>
-              <td><%= payout_method.read_attribute(key.to_sym) %></td>
+              <td>Address (Line 2):</td>
+              <td><%= wise_transfer.address_line2 %></td>
             </tr>
+          <% end %>
+          <tr>
+            <td>City:</td>
+            <td><%= wise_transfer.address_city %></td>
+          </tr>
+          <tr>
+            <td>State:</td>
+            <td><%= wise_transfer.address_state %></td>
+          </tr>
+          <tr>
+            <td>Postal code:</td>
+            <td><%= wise_transfer.address_postal_code %></td>
+          </tr>
+          <tr>
+            <td>Recipient country:</td>
+            <td><%= wise_transfer.recipient_country %></td>
+          </tr>
+          <% WiseTransfer.recipient_information_accessors&.each do |key| %>
+            <% next if key == "account_holder" %>
+            <% if wise_transfer.recipient_information[key].presence != nil %>
+              <tr>
+                <td><%= key.humanize %>:</td>
+                <td><%= wise_transfer.recipient_information[key] %></td>
+              </tr>
+            <% elsif wise_transfer.read_attribute(key.to_sym).present? %>
+              <tr>
+                <td><%= key.humanize %>:</td>
+                <td><%= wise_transfer.read_attribute(key.to_sym) %></td>
+              </tr>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
     </tbody>
   </table>
 <% end %>
+

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -5,7 +5,7 @@
 
 <div class="inline-flex items-center justify-between w-full">
   <h3 class="mt-0">Payout information</h3>
-  <% if auditor_signed_in? && !report.closed? %>
+  <% if auditor_signed_in? && !report.closed? && payout_method.is_a?(User::PayoutMethod::WiseTransfer) %>
     <%= pop_icon_to "settings",
                     "#",
                     data: { behavior: "modal_trigger", modal: "edit_wise_info" },

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -189,4 +189,3 @@
     </tbody>
   </table>
 <% end %>
-

--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -1,5 +1,7 @@
 <%# locals: (report:) %>
 
+<% wise_details = report.wise_transfer_draft || report.user.payout_method %>
+
 <table class="w-full table-fixed my-6">
   <tbody>
     <tr>
@@ -24,53 +26,53 @@
     <tr>
       <td>Name on account:</td>
       <td>
-        <%= report.user.payout_method.account_holder %>
+        <%= wise_details.try(:account_holder).presence || wise_details.try(:recipient_name).presence || report.user.full_name %>
       </td>
     </tr>
     <tr>
       <td>Bank name:</td>
       <td>
-        <%= report.user.payout_method.bank_name %>
+        <%= wise_details.bank_name %>
       </td>
     </tr>
     <tr>
       <td>Email:</td>
-      <td><%= report.user.email %></td>
+      <td><%= wise_details.try(:recipient_email).presence || report.user.email %></td>
     </tr>
     <tr>
       <td>Address (Line 1):</td>
-      <td><%= report.user.payout_method.address_line1 %></td>
+      <td><%= wise_details.address_line1 %></td>
     </tr>
     <tr>
       <td>Address (Line 2):</td>
-      <td><%= report.user.payout_method.address_line2 %></td>
+      <td><%= wise_details.address_line2 %></td>
     </tr>
     <tr>
       <td>City:</td>
-      <td><%= report.user.payout_method.address_city %></td>
+      <td><%= wise_details.address_city %></td>
     </tr>
     <tr>
       <td>State:</td>
-      <td><%= report.user.payout_method.address_state %></td>
+      <td><%= wise_details.address_state %></td>
     </tr>
     <tr>
       <td>Postal code:</td>
-      <td><%= report.user.payout_method.address_postal_code %></td>
+      <td><%= wise_details.address_postal_code %></td>
     </tr>
     <tr>
       <td>Recipient country:</td>
-      <td><%= report.user.payout_method.recipient_country %></td>
+      <td><%= wise_details.recipient_country %></td>
     </tr>
     <% WiseTransfer.recipient_information_accessors.each do |key| %>
-      <% if report.user.payout_method.recipient_information[key].presence != nil %>
+      <% if wise_details.recipient_information[key].presence != nil %>
         <tr>
           <td><%= key.humanize %></td>
-          <td><%= report.user.payout_method.recipient_information[key] %></td>
+          <td><%= wise_details.recipient_information[key] %></td>
         </tr>
-      <% elsif report.user.payout_method.read_attribute(key.to_sym).present? %>
+      <% elsif wise_details.read_attribute(key.to_sym).present? %>
         <tr>
           <td><%= key.humanize %></td>
-          <td><%= report.user.payout_method.read_attribute(key.to_sym) %></td>
+          <td><%= wise_details.read_attribute(key.to_sym) %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/reimbursement/reports/_wise_transfer_draft_form.html.erb
+++ b/app/views/reimbursement/reports/_wise_transfer_draft_form.html.erb
@@ -1,0 +1,46 @@
+<%# locals: (report:) %>
+
+<% wise_transfer_draft = report.wise_transfer_draft || report.build_wise_transfer_draft(currency: report.currency) %>
+
+<div class="mt-4">
+  <%= form_with model: wise_transfer_draft, url: reimbursement_report_update_wise_transfer_draft_path(report), method: :post, local: true do |form| %>
+    <div class="field">
+      <%= form.label :recipient_name, "Recipient name" %>
+      <%= form.text_field :recipient_name, required: true %>
+    </div>
+
+    <div class="field">
+      <%= form.label :recipient_email, "Recipient email" %>
+      <%= form.email_field :recipient_email, required: true %>
+    </div>
+
+    <div class="field">
+      <%= form.label :recipient_phone_number, "Recipient phone number" %>
+      <%= form.telephone_field :recipient_phone_number %>
+    </div>
+
+    <div class="field">
+      <%= form.label :account_holder, "Account holder" %>
+      <%= form.text_field :account_holder %>
+    </div>
+
+    <div class="field">
+      <%= form.label :bank_name, "Bank name" %>
+      <%= form.text_field :bank_name %>
+    </div>
+
+    <div class="field">
+      <%= form.label :currency, "Currency" %>
+      <%= form.select :currency, WiseTransfer::AVAILABLE_CURRENCIES, { selected: wise_transfer_draft.currency || report.currency, disabled: true }, { "@change" => "currency = $event.target.value;" } %>
+    </div>
+
+    <div x-data="{ currency: '<%= wise_transfer_draft.currency || report.currency %>', account_type: '<%= wise_transfer_draft.account_type %>' }">
+      <%= render partial: "transfers/recipient_details", locals: { form:, disabled: false, required: true } %>
+      <%= render partial: "wise_transfers/currency_specific_details", locals: { form:, disabled: false, model: Reimbursement::WiseTransferDraft } %>
+    </div>
+
+    <div class="actions inline-block mt1">
+      <%= form.submit "Update draft" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -75,6 +75,8 @@
   <%= render "reimbursement/reports/edit_form" %>
 </section>
 
+<%= render partial: "reimbursement/reports/edit_wise_info_modal", locals: { report: @report } %>
+
 <section data-behavior="modal" role="dialog" id="request_changes" class="modal modal--scroll bg-snow">
   <%= modal_header "Return report" %>
   <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -576,6 +576,7 @@ Rails.application.routes.draw do
       post "convert_to_wise_transfer"
       post "admin_approve"
       post "admin_send_wise_transfer"
+      post "update_wise_transfer_draft"
       post "reverse"
       post "approve_all_expenses"
       post "request_changes"

--- a/db/migrate/20260519000000_create_reimbursement_wise_transfer_drafts.rb
+++ b/db/migrate/20260519000000_create_reimbursement_wise_transfer_drafts.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateReimbursementWiseTransferDrafts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reimbursement_wise_transfer_drafts do |t|
+      t.references :reimbursement_report, null: false, foreign_key: true, index: { unique: true, name: "idx_r_wise_transfer_drafts_on_report_id" }
+      t.string :currency, null: false
+      t.string :recipient_name, null: false
+      t.string :recipient_email, null: false
+      t.string :recipient_phone_number
+      t.string :bank_name
+      t.string :address_line1
+      t.string :address_line2
+      t.string :address_city
+      t.string :address_state
+      t.string :address_postal_code
+      t.integer :recipient_country
+      t.text :recipient_information_ciphertext
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260519000100_add_wise_recipient_id_to_reimbursement_wise_transfer_drafts.rb
+++ b/db/migrate/20260519000100_add_wise_recipient_id_to_reimbursement_wise_transfer_drafts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWiseRecipientIdToReimbursementWiseTransferDrafts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :reimbursement_wise_transfer_drafts, :wise_recipient_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_19_000100) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2250,6 +2250,26 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
     t.index ["user_id"], name: "index_reimbursement_reports_on_user_id"
   end
 
+  create_table "reimbursement_wise_transfer_drafts", force: :cascade do |t|
+    t.string "address_city"
+    t.string "address_line1"
+    t.string "address_line2"
+    t.string "address_postal_code"
+    t.string "address_state"
+    t.string "bank_name"
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.integer "recipient_country"
+    t.string "recipient_email", null: false
+    t.text "recipient_information_ciphertext"
+    t.string "recipient_name", null: false
+    t.string "recipient_phone_number"
+    t.bigint "reimbursement_report_id", null: false
+    t.datetime "updated_at", null: false
+    t.text "wise_recipient_id"
+    t.index ["reimbursement_report_id"], name: "idx_r_wise_transfer_drafts_on_report_id", unique: true
+  end
+
   create_table "sponsors", force: :cascade do |t|
     t.text "address_city"
     t.text "address_country", default: "US"
@@ -2959,6 +2979,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_044254) do
   add_foreign_key "reimbursement_reports", "events"
   add_foreign_key "reimbursement_reports", "users"
   add_foreign_key "reimbursement_reports", "users", column: "invited_by_id"
+  add_foreign_key "reimbursement_wise_transfer_drafts", "reimbursement_reports"
   add_foreign_key "sponsors", "events"
   add_foreign_key "stripe_authorizations", "stripe_cards"
   add_foreign_key "stripe_card_personalization_designs", "events"


### PR DESCRIPTION
## Summary of the problem
Ops were unable to edit payout info on a Wise Transfer


## Describe your changes
I added a wise_transfer_draft which is created with reimbursement and is prefilled with user data. The draft can be edited without editing user payout info, and when processing/approving the draft info is carried forward for fufillment.


### Demo video - Note i got a bit lost in the UI, but it shows the changes
https://github.com/user-attachments/assets/8f665758-de7c-447c-b712-62f94b8bd791

### Image to show that the button to open the wise transfer menu isn't showing for other payout methods
<img width="995" height="905" alt="Screenshot 2026-05-19 at 17 03 30" src="https://github.com/user-attachments/assets/a1b7296e-5a19-4323-8d69-7918273595bd" />
