### PR TITLE
[Contracts] Add more links for HCB to sign a contract

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -17,6 +17,17 @@ module EventsHelper
       }
     end
 
+    if event.financially_frozen? && (contracts = event.contracts.select { |c| c.parties.not_hcb.all?(&:signed?) }).one? && event.contracts.signed.none?
+      items << {
+        name: "Sign",
+        path: contract_party_path(contracts.first.party(:hcb)),
+        tooltip: "Sign the fiscal sponsorship contract as HCB",
+        icon: "checkmark",
+        selected: false,
+        adminTool: true,
+      }
+    end
+
     if policy(event).show?
       items << {
         name: "Home",

--- a/app/views/organizer_position_invites/_organizer_position_invite.html.erb
+++ b/app/views/organizer_position_invites/_organizer_position_invite.html.erb
@@ -33,6 +33,9 @@
                         Resend to the <%= party.role %>
                       <% end %>
                     <% end %>
+                    <% if organizer_position_invite.contract.parties.not_hcb.all?(&:signed?) %>
+                      <%= link_to "Sign as HCB", contract_party_path(organizer_position_invite.contract.party(:hcb)) %>
+                    <% end %>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Right now, the only way for HCB admins to find a link to sign a contract for an OPI is by seeing the email in Intercom or by searching in the admin contracts page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add two links - one in the context menu on the OPI, and another in the event nav (similar to the activate button).

<img width="525" height="200" alt="image" src="https://github.com/user-attachments/assets/9947e5c5-d2d3-413d-af68-625d14d6f1d3" />
<img width="346" height="206" alt="image" src="https://github.com/user-attachments/assets/687cbfd6-3f6f-4025-8cff-c402a1dc95b0" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

