### PR TITLE
[Contracts] Handle no signed in user when showing voided page

### DIFF
--- a/app/controllers/contract/parties_controller.rb
+++ b/app/controllers/contract/parties_controller.rb
@@ -21,7 +21,7 @@ class Contract
         redirect_to completed_contract_party_path(@party)
         return
       elsif @contract.voided?
-        @contracts = current_user.contracts.sent.select { |contract| contract.party(:signee).present? }
+        @contracts = signed_in? ? current_user.contracts.sent.select { |contract| contract.party(:signee).present? } : []
         render "contract/parties/voided"
         return
       elsif @contract.pending?

--- a/app/views/contract/parties/voided.html.erb
+++ b/app/views/contract/parties/voided.html.erb
@@ -10,10 +10,10 @@
   <% end %>
 </p>
 
-<% unless @contracts.empty? %>
+<% if @contracts.any? %>
   <div class="flex flex-col mt-2 gap-4">
     <%= render partial: "contracts/contract", collection: @contracts, as: :contract %>
   </div>
-<% else %>
+<% elsif signed_in? %>
   <%= link_to "Return to homepage", root_path, class: "btn mt-2" %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
If a cosigner views a voided contract, they may not be signed in, but the current code didn't handle that.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Handle there being no signed in user when showing the voided page.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

