### PR TITLE
[Contracts] Fix invite page for manual contracts

### DIFF
--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -29,7 +29,7 @@
 
   <div class="flex justify-center items-center flex-wrap mt-3 gap-2">
     <%= link_to "Reject", organizer_position_invite_reject_path(@invite), method: :post, class: "btn bg-error" %>
-    <% if @invite.contract && !@invite.contract.party(:signee)&.signed? %>
+    <% if @invite.contract && !@invite.contract.signed? && !@invite.contract.party(:signee)&.signed? %>
       <% if @invite.contract.party(:signee).present? %>
         <%= link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent" %>
       <% else %>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -32,7 +32,7 @@
     <% if @invite.contract && !@invite.contract.signed? && !@invite.contract.party(:signee)&.signed? %>
       <% if @invite.contract.party(:signee).present? %>
         <%= link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent" %>
-      <% else %>
+      <% elsif @invite.contract.sent_with_docuseal? %>
         <%= link_to "View pending contract", @invite.contract.signee_docuseal_url, class: "btn bg-accent" %>
       <% end %>
     <% else %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2286 - Old manual contracts might not have any parties - in this case, we currently default to showing the plain docuseal URL, assuming it's sent with docuseal.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check if the contract as a whole is signed first, and only link to docuseal if the contract is actually sent with docuseal.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

