### PR TITLE
Manually include non-v4 helpers in ApplicationHelper

### DIFF
--- a/app/helpers/ach_transfers_helper.rb
+++ b/app/helpers/ach_transfers_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module AchTransfersHelper
-end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,27 @@
 module ApplicationHelper
   include ActionView::Helpers
 
+  include DonationsHelper
+  include EmburseCardsHelper
+  include EventsHelper
+  include GSuiteAccountsHelper
+  include GSuitesHelper
+  include HcbCodeHelper
+  include InvoicesHelper
+  include LoginsHelper
+  include LogoHelper
+  include OrganizerPosition::Spending::AllowancesHelper
+  include PopoverHelper
+  include SeasonalHelper
+  include SessionsHelper
+  include StaticPagesHelper
+  include StripeAuthorizationsHelper
+  include StripeCardsHelper
+  include TagsHelper
+  include ToursHelper
+  include TurboStreamActionsHelper
+  include UsersHelper
+
   def upsert_query_params(**new_params)
     params = request.query_parameters || {}
     params.merge(new_params)

--- a/app/helpers/bank_accounts_helper.rb
+++ b/app/helpers/bank_accounts_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module BankAccountsHelper
-end

--- a/app/helpers/checks_helper.rb
+++ b/app/helpers/checks_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module ChecksHelper
-end

--- a/app/helpers/disbursements_helper.rb
+++ b/app/helpers/disbursements_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module DisbursementsHelper
-end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module DocumentsHelper
-end

--- a/app/helpers/organizer_positions_helper.rb
+++ b/app/helpers/organizer_positions_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module OrganizerPositionsHelper
-end

--- a/app/helpers/receipts_helper.rb
+++ b/app/helpers/receipts_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module ReceiptsHelper
-end

--- a/app/helpers/sponsors_helper.rb
+++ b/app/helpers/sponsors_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module SponsorsHelper
-end

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module TransactionsHelper
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -124,5 +124,7 @@ module Bank
 
     config.active_support.deprecation = :notify
 
+    config.action_controller.include_all_helpers = false
+
   end
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We recently ran into an interesting bug where a method defined in `Api::V4::ApplicationHelper` overrode a method defined in `ApplicationHelper`. Unexpectedly, Rails automatically includes _all_ helpers, even those scoped under a different module.

This is not intuitive - v4 helpers should only be available in v4.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Sets the Rails configuration value for including all helpers to false, and manually includes non-v4 helpers in ApplicationHelper. Tested both the website and v4 in development and everything works, but would appreciate an additional sanity check here. I also deleted some empty helpers (these are generated by Rails when you generate a new controller).

I also think that not every helper needs to be included in `ApplicationHelper` - it would make sense if `DonationsHelper` is only available to the views of `DonationsController`. However, this requires more discussion and can be a later PR if we decide to implement it.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

