### PR TITLE
[v4] Use donation model create_stripe_payment_intent instead

### DIFF
--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       before_action :set_api_event, only: [:create]
       before_action :set_donation, only: [:payment_intent]
-      before_action :require_trusted_oauth_app!, only: [:payment_intent]
+      before_action :require_trusted_oauth_app!, only: [:create, :payment_intent]
 
       def create
         amount = params[:amount_cents]

--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -38,7 +38,7 @@ module Api
       def payment_intent
         authorize @donation
 
-        render json: { payment_intent_id: @donation.stripe_payment_intent_id, client_secret: @donation.stripe_client_secret }, status: :created
+        render json: { payment_intent_id: @donation.stripe_payment_intent_id, client_secret: @donation.stripe_client_secret }
       end
 
       private

--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -38,9 +38,6 @@ module Api
       def payment_intent
         authorize @donation
 
-        @donation.create_stripe_payment_intent
-        @donation.save!
-
         render json: { payment_intent_id: @donation.stripe_payment_intent_id, client_secret: @donation.stripe_client_secret }, status: :created
       end
 

--- a/app/controllers/api/v4/donations_controller.rb
+++ b/app/controllers/api/v4/donations_controller.rb
@@ -38,22 +38,10 @@ module Api
       def payment_intent
         authorize @donation
 
-        amount = @donation.amount
-        if @donation.fee_covered
-          amount /= (1 - @donation.event.revenue_fee).ceil
-        end
+        @donation.create_stripe_payment_intent
+        @donation.save!
 
-        payment_intent = StripeService::PaymentIntent.create({
-                                                               amount:,
-                                                               currency: "usd",
-                                                               payment_method_types: ["card_present"],
-                                                               capture_method: "automatic",
-                                                               statement_descriptor: "HCB",
-                                                               statement_descriptor_suffix: StripeService::StatementDescriptor.format(@donation.event.short_name, as: :suffix),
-                                                               metadata: { donation: true, donation_id: @donation.id, event_id: @donation.event.id },
-                                                             })
-
-        render json: { payment_intent_id: payment_intent.id, client_secret: payment_intent.client_secret }, status: :created
+        render json: { payment_intent_id: @donation.stripe_payment_intent_id, client_secret: @donation.stripe_client_secret }, status: :created
       end
 
       private

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -388,7 +388,7 @@ class Donation < ApplicationRecord
   end
 
   def create_payment_intent_attrs(customer)
-    {
+    attrs = {
       amount:,
       customer: customer.id,
       currency: "usd",
@@ -396,6 +396,13 @@ class Donation < ApplicationRecord
       statement_descriptor_suffix: StripeService::StatementDescriptor.format(event.short_name, as: :suffix),
       metadata: { 'donation': true, 'event_id': event.id }
     }
+
+    if in_person?
+      attrs[:payment_method_types] = ["card_present"]
+      attrs[:capture_method] = "automatic"
+    end
+
+    attrs
   end
 
   def create_stripe_payment_intent

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -347,6 +347,15 @@ class Donation < ApplicationRecord
     gravatar_url(email, name, email&.sum || rand(1000), size) unless anonymous?
   end
 
+  def create_stripe_payment_intent
+    customer = StripeService::Customer.create(email:, name:)
+    payment_intent = StripeService::PaymentIntent.create(create_payment_intent_attrs(customer))
+
+    self.stripe_payment_intent_id = payment_intent.id
+
+    self.set_fields_from_stripe_payment_intent(payment_intent)
+  end
+
   private
 
   def raw_pending_donation_transaction
@@ -394,17 +403,8 @@ class Donation < ApplicationRecord
       currency: "usd",
       statement_descriptor: "HCB",
       statement_descriptor_suffix: StripeService::StatementDescriptor.format(event.short_name, as: :suffix),
-      metadata: { 'donation': true, 'event_id': event.id }
+      metadata: { 'donation': true, 'donation_id': id, 'event_id': event.id }
     }
-  end
-
-  def create_stripe_payment_intent
-    customer = StripeService::Customer.create(email:, name:)
-    payment_intent = StripeService::PaymentIntent.create(create_payment_intent_attrs(customer))
-
-    self.stripe_payment_intent_id = payment_intent.id
-
-    self.set_fields_from_stripe_payment_intent(payment_intent)
   end
 
   def assign_unique_hash

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -86,7 +86,7 @@ class Donation < ApplicationRecord
 
   before_save :trim_utm_referrer_fields
 
-  before_create :create_stripe_payment_intent, unless: -> { recurring? || in_person? }
+  before_create :create_stripe_payment_intent, unless: -> { recurring? }
   before_create :assign_unique_hash, unless: -> { recurring? }
 
   after_commit :send_notification
@@ -347,15 +347,6 @@ class Donation < ApplicationRecord
     gravatar_url(email, name, email&.sum || rand(1000), size) unless anonymous?
   end
 
-  def create_stripe_payment_intent
-    customer = StripeService::Customer.create(email:, name:)
-    payment_intent = StripeService::PaymentIntent.create(create_payment_intent_attrs(customer))
-
-    self.stripe_payment_intent_id = payment_intent.id
-
-    self.set_fields_from_stripe_payment_intent(payment_intent)
-  end
-
   private
 
   def raw_pending_donation_transaction
@@ -403,8 +394,17 @@ class Donation < ApplicationRecord
       currency: "usd",
       statement_descriptor: "HCB",
       statement_descriptor_suffix: StripeService::StatementDescriptor.format(event.short_name, as: :suffix),
-      metadata: { 'donation': true, 'donation_id': id, 'event_id': event.id }
+      metadata: { 'donation': true, 'event_id': event.id }
     }
+  end
+
+  def create_stripe_payment_intent
+    customer = StripeService::Customer.create(email:, name:)
+    payment_intent = StripeService::PaymentIntent.create(create_payment_intent_attrs(customer))
+
+    self.stripe_payment_intent_id = payment_intent.id
+
+    self.set_fields_from_stripe_payment_intent(payment_intent)
   end
 
   def assign_unique_hash

--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Api::V4::DonationsController do
       event = create(:event)
       create(:organizer_position, user:, event:)
 
-      token = create(:api_token, user:)
+      trusted_app = Doorkeeper::Application.create!(name: "Trusted App", redirect_uri: "", trusted: true)
+      token = create(:api_token, user:, application: trusted_app)
       request.headers["Authorization"] = "Bearer #{token.token}"
 
       message = "Thanks for the great work — keep it up!"

--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V4::DonationsController do
       event = create(:event)
       create(:organizer_position, user:, event:)
 
-      trusted_app = Doorkeeper::Application.create!(name: "Trusted App", redirect_uri: "", trusted: true)
+      trusted_app = Doorkeeper::Application.create!(name: "Trusted App", redirect_uri: "https://hcb.hackclub.com", trusted: true)
       token = create(:api_token, user:, application: trusted_app)
       request.headers["Authorization"] = "Bearer #{token.token}"
 

--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -3,9 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Api::V4::DonationsController do
+  include DonationSupport
+
   render_views
 
   describe "#create" do
+    before do
+      stub_donation_payment_intent_creation
+      allow(StripeService::PaymentIntent).to receive(:retrieve).and_return(Stripe::PaymentIntent.construct_from(id: "pi_stub", payment_method: nil))
+    end
+
     it "creates a donation" do
       user  = create(:user)
       event = create(:event)


### PR DESCRIPTION
## Summary of the problem
The problem is that when we create a payment intent using our current implementation we don't attach the payment intent ID to the donation object.


## Describe your changes
Uses model's create_stripe_payment_intent function instead


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

