### PR TITLE
[Stripe Auth] Add custom decline message for globally banned merchants

### DIFF
--- a/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
+++ b/app/jobs/canonical_pending_transaction/send_twilio_declined_message_job.rb
@@ -31,6 +31,8 @@ class CanonicalPendingTransaction
                            "at #{@merchant} due to suspected fraud"
                          when "webhook_declined"
                            case @webhook_declined_reason
+                           when "merchant_not_allowed_globally"
+                             "because this merchant is blocked on all HCB cards"
                            when "merchant_not_allowed"
                              "because this card isn't allowed to make purchases at #{@merchant}"
                            when "cash_withdrawals_not_allowed"

--- a/app/mailers/canonical_pending_transaction_mailer.rb
+++ b/app/mailers/canonical_pending_transaction_mailer.rb
@@ -44,7 +44,7 @@ class CanonicalPendingTransactionMailer < ApplicationMailer
     @event = @cpt.event
     @user = @card.user
 
-    return if !@user.email_charge_notifications_enabled? && !Rails.env.development?
+    return unless @user.email_charge_notifications_enabled?
     return if @card.canceled? && @card.canceled_at < 1.month.ago
 
     @merchant = @cpt.raw_pending_stripe_transaction.stripe_transaction["merchant_data"]["name"]

--- a/app/mailers/canonical_pending_transaction_mailer.rb
+++ b/app/mailers/canonical_pending_transaction_mailer.rb
@@ -44,7 +44,7 @@ class CanonicalPendingTransactionMailer < ApplicationMailer
     @event = @cpt.event
     @user = @card.user
 
-    return unless @user.email_charge_notifications_enabled?
+    return if !@user.email_charge_notifications_enabled? && !Rails.env.development?
     return if @card.canceled? && @card.canceled_at < 1.month.ago
 
     @merchant = @cpt.raw_pending_stripe_transaction.stripe_transaction["merchant_data"]["name"]

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -63,7 +63,7 @@ module StripeAuthorizationService
             .blocked_authorization
             .deliver_later
 
-          return decline_with_reason!("merchant_not_allowed")
+          return decline_with_reason!("merchant_not_allowed_globally")
         end
 
         return decline_with_reason!("merchant_not_allowed") unless merchant_allowed?

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -16,6 +16,7 @@
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <span><%= this_transaction %> was declined
       <%= {
+          merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
           merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
           cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
           user_cards_locked: "by HCB because you have too many missing receipts"
@@ -39,6 +40,7 @@
   <span>
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <%= {
+          merchant_not_allowed_globally: "Merchant not allowed",
           merchant_not_allowed: "Merchant not allowed",
           cash_withdrawals_not_allowed: "Cash withdrawals disabled",
           user_cards_locked: "Card locked due to missing receipts",
@@ -71,7 +73,9 @@
   <% end %>
 
   <p class="mb-0">
-    <% if hcb_decline_reason == :merchant_not_allowed %>
+    <% if hcb_decline_reason == :merchant_not_allowed_globally %>
+      This merchant is not allowed to prevent fraud. If you are trying to make a payment, please use a transfer method supported by HCB.
+    <% elsif hcb_decline_reason == :merchant_not_allowed %>
       If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
     <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>
       Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -74,7 +74,7 @@
 
   <p class="mb-0">
     <% if hcb_decline_reason == :merchant_not_allowed_globally %>
-      This merchant is not allowed to prevent fraud. If you are trying to make a payment, please use a transfer method supported by HCB.
+      This merchant is blocked because it is commonly associated with fraudulent transactions. If you are trying to make a payment, please use a different transfer method.
     <% elsif hcb_decline_reason == :merchant_not_allowed %>
       If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
     <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -74,7 +74,7 @@
 
   <p class="mb-0">
     <% if hcb_decline_reason == :merchant_not_allowed_globally %>
-      This merchant is blocked because it is commonly associated with fraudulent transactions. If you are trying to make a payment, please use a different transfer method.
+      This merchant is blocked because it is commonly associated with fraudulent transactions. If you are trying to make a payment, please use a <%= link_to "different transfer method", "https://help.hcb.hackclub.com/en/articles/15033356-how-do-i-transfer-money" %>.
     <% elsif hcb_decline_reason == :merchant_not_allowed %>
       If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
     <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -16,48 +16,48 @@
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <span><%= this_transaction %> was declined
       <%= {
-          merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
-          merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
-          cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
-          user_cards_locked: "by HCB because you have too many missing receipts"
-        }[hcb_decline_reason] || "due to insufficient funds" %>.</span>``
+            merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
+            merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
+            cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
+            user_cards_locked: "by HCB because you have too many missing receipts"
+          }[hcb_decline_reason] || "due to insufficient funds" %>.</span>``
     <% else %>
       <span>
       <%= ("#{this_transaction} was declined by our card issuer " + ({
-          card_inactive: !hcb_code.stripe_card.initially_activated? ? "because this card hasn't been activated yet" : "because this card is frozen",
-          card_canceled: "because this card is canceled",
-          card_expired: "because this card is expired",
-          verification_failed: "because the card verification failed",
-          suspected_fraud: "because of suspected fraud",
-          reversed_by_merchant: "because the merchant reversed the transaction",
-          cardholder_verification_required: "because cardholder verification is required",
-          insufficient_funds: "because of an integration issue",
-          insecure_authorization_method: "because the authorization method is insecure",
-          webhook_timeout: "because of a network issue",
-        }[stripe_decline_reason] || "")).strip %>.</span>
+            card_inactive: !hcb_code.stripe_card.initially_activated? ? "because this card hasn't been activated yet" : "because this card is frozen",
+            card_canceled: "because this card is canceled",
+            card_expired: "because this card is expired",
+            verification_failed: "because the card verification failed",
+            suspected_fraud: "because of suspected fraud",
+            reversed_by_merchant: "because the merchant reversed the transaction",
+            cardholder_verification_required: "because cardholder verification is required",
+            insufficient_funds: "because of an integration issue",
+            insecure_authorization_method: "because the authorization method is insecure",
+            webhook_timeout: "because of a network issue",
+          }[stripe_decline_reason] || "")).strip %>.</span>
     <% end %>
   <% else %>
   <span>
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <%= {
-          merchant_not_allowed_globally: "Merchant not allowed",
-          merchant_not_allowed: "Merchant not allowed",
-          cash_withdrawals_not_allowed: "Cash withdrawals disabled",
-          user_cards_locked: "Card locked due to missing receipts",
-        }[hcb_decline_reason] || "Insufficient funds" %>
+            merchant_not_allowed_globally: "Merchant not allowed",
+            merchant_not_allowed: "Merchant not allowed",
+            cash_withdrawals_not_allowed: "Cash withdrawals disabled",
+            user_cards_locked: "Card locked due to missing receipts",
+          }[hcb_decline_reason] || "Insufficient funds" %>
     <% else %>
       <%= {
-          card_inactive: !hcb_code.stripe_card.initially_activated? ? "Card not activated" : "Card frozen",
-          card_canceled: "Card canceled",
-          card_expired: "Card expired",
-          verification_failed: "Card verification failed",
-          suspected_fraud: "Suspected fraud",
-          reversed_by_merchant: "Reversed by merchant",
-          cardholder_verification_required: "Cardholder verification required",
-          insufficient_funds: "Integration issue",
-          insecure_authorization_method: "Insecure authorization method",
-          webhook_timeout: "Network error",
-        }[stripe_decline_reason] || "Unknown error" %>
+            card_inactive: !hcb_code.stripe_card.initially_activated? ? "Card not activated" : "Card frozen",
+            card_canceled: "Card canceled",
+            card_expired: "Card expired",
+            verification_failed: "Card verification failed",
+            suspected_fraud: "Suspected fraud",
+            reversed_by_merchant: "Reversed by merchant",
+            cardholder_verification_required: "Cardholder verification required",
+            insufficient_funds: "Integration issue",
+            insecure_authorization_method: "Insecure authorization method",
+            webhook_timeout: "Network error",
+          }[stripe_decline_reason] || "Unknown error" %>
     <% end %>
     </span>
   <% end %>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -8,159 +8,159 @@
 <% stripe_decline_reason = pt&.stripe_decline_reason %>
 
 <% this_transaction = local_assigns[:is_email] && pt.present? ?
-    "A #{humanized_money_with_symbol pt.amount.abs} charge to your card ending in #{hcb_code.stripe_card.last4} at '#{pt.raw_pending_stripe_transaction.stripe_transaction["merchant_data"]["name"]}'"
+  "A #{humanized_money_with_symbol pt.amount.abs} charge to your card ending in #{hcb_code.stripe_card.last4} at '#{pt.raw_pending_stripe_transaction.stripe_transaction["merchant_data"]["name"]}'"
    : "This transaction" %>
 
 <span class="inline-flex">
-    <% if local_assigns[:include_troubleshooting] %>
-        <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
-            <span><%= this_transaction %> was declined
-            <%= {
-                  merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
-                  cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
-                  user_cards_locked: "by HCB because you have too many missing receipts"
-                }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
-        <% else %>
-            <span>
-            <%= ("#{this_transaction} was declined by our card issuer " + ({
-                  card_inactive: !hcb_code.stripe_card.initially_activated? ? "because this card hasn't been activated yet" : "because this card is frozen",
-                  card_canceled: "because this card is canceled",
-                  card_expired: "because this card is expired",
-                  verification_failed: "because the card verification failed",
-                  suspected_fraud: "because of suspected fraud",
-                  reversed_by_merchant: "because the merchant reversed the transaction",
-                  cardholder_verification_required: "because cardholder verification is required",
-                  insufficient_funds: "because of an integration issue",
-                  insecure_authorization_method: "because the authorization method is insecure",
-                  webhook_timeout: "because of a network issue",
-                }[stripe_decline_reason] || "")).strip %>.</span>
-        <% end %>
+  <% if local_assigns[:include_troubleshooting] %>
+    <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
+      <span><%= this_transaction %> was declined
+      <%= {
+          merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
+          cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
+          user_cards_locked: "by HCB because you have too many missing receipts"
+        }[hcb_decline_reason] || "due to insufficient funds" %>.</span>``
     <% else %>
-    <span>
-        <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
-            <%= {
-                  merchant_not_allowed: "Merchant not allowed",
-                  cash_withdrawals_not_allowed: "Cash withdrawals disabled",
-                  user_cards_locked: "Card locked due to missing receipts",
-                }[hcb_decline_reason] || "Insufficient funds" %>
-        <% else %>
-            <%= {
-                  card_inactive: !hcb_code.stripe_card.initially_activated? ? "Card not activated" : "Card frozen",
-                  card_canceled: "Card canceled",
-                  card_expired: "Card expired",
-                  verification_failed: "Card verification failed",
-                  suspected_fraud: "Suspected fraud",
-                  reversed_by_merchant: "Reversed by merchant",
-                  cardholder_verification_required: "Cardholder verification required",
-                  insufficient_funds: "Integration issue",
-                  insecure_authorization_method: "Insecure authorization method",
-                  webhook_timeout: "Network error",
-                }[stripe_decline_reason] || "Unknown error" %>
-        <% end %>
-        </span>
+      <span>
+      <%= ("#{this_transaction} was declined by our card issuer " + ({
+          card_inactive: !hcb_code.stripe_card.initially_activated? ? "because this card hasn't been activated yet" : "because this card is frozen",
+          card_canceled: "because this card is canceled",
+          card_expired: "because this card is expired",
+          verification_failed: "because the card verification failed",
+          suspected_fraud: "because of suspected fraud",
+          reversed_by_merchant: "because the merchant reversed the transaction",
+          cardholder_verification_required: "because cardholder verification is required",
+          insufficient_funds: "because of an integration issue",
+          insecure_authorization_method: "because the authorization method is insecure",
+          webhook_timeout: "because of a network issue",
+        }[stripe_decline_reason] || "")).strip %>.</span>
     <% end %>
+  <% else %>
+  <span>
+    <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
+      <%= {
+          merchant_not_allowed: "Merchant not allowed",
+          cash_withdrawals_not_allowed: "Cash withdrawals disabled",
+          user_cards_locked: "Card locked due to missing receipts",
+        }[hcb_decline_reason] || "Insufficient funds" %>
+    <% else %>
+      <%= {
+          card_inactive: !hcb_code.stripe_card.initially_activated? ? "Card not activated" : "Card frozen",
+          card_canceled: "Card canceled",
+          card_expired: "Card expired",
+          verification_failed: "Card verification failed",
+          suspected_fraud: "Suspected fraud",
+          reversed_by_merchant: "Reversed by merchant",
+          cardholder_verification_required: "Cardholder verification required",
+          insufficient_funds: "Integration issue",
+          insecure_authorization_method: "Insecure authorization method",
+          webhook_timeout: "Network error",
+        }[stripe_decline_reason] || "Unknown error" %>
+    <% end %>
+    </span>
+  <% end %>
 
-    <% if local_assigns[:include_external] && !local_assigns[:include_troubleshooting] %>
-        <%= inline_icon "external", size: 24, class: "muted", 'aria-label': "Icon indicating click for more" %>
-    <% end %>
+  <% if local_assigns[:include_external] && !local_assigns[:include_troubleshooting] %>
+    <%= inline_icon "external", size: 24, class: "muted", 'aria-label': "Icon indicating click for more" %>
+  <% end %>
 </span>
 
 <% if local_assigns[:include_troubleshooting] %>
-    <% unless hcb_decline_reason == :inadequate_balance %>
-        <h3>Troubleshooting</h3>
-    <% end %>
+  <% unless hcb_decline_reason == :inadequate_balance %>
+    <h3>Troubleshooting</h3>
+  <% end %>
 
-    <p class="mb-0">
-        <% if hcb_decline_reason == :merchant_not_allowed %>
-            If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
-        <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>
-            Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.
-        <% elsif hcb_decline_reason == :user_cards_locked %>
-            You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>. If you have 10 or more missing receipts, your cards will be locked until you submit them.
-        <% elsif stripe_decline_reason == :authorization_controls %>
-            This transaction exceeded daily limits set by our card issuer. Please try again later, or use a different card for this transaction.
-        <% elsif stripe_decline_reason == :webhook_timeout %>
-            HCB experienced a network issue while processing this transaction. Please try again.
-        <% elsif stripe_decline_reason == :card_inactive %>
-            <% if hcb_code.stripe_card.initially_activated? %>
-                You can defrost your card at any time <%= link_to "here", stripe_card_url(hcb_code.stripe_card) %>.
-            <% else %>
-                Activate your new card <%= link_to "here", stripe_card_url(hcb_code.stripe_card) %> before using it.
-            <% end %>
-        <% elsif stripe_decline_reason == :card_canceled %>
-            <% if card.replacement %>
-                Try using its <%= link_to "replacement card", stripe_card_url(card.replacement) %> ending in <%= card.replacement.last4 %>.
-            <% else %>
-                Try using another card.
-            <% end %>
-        <% elsif stripe_decline_reason == :card_expired %>
-            Try again using a different card.
-        <% elsif stripe_decline_reason.in? %i[cardholder_verification_required insufficient_funds] %>
-            This could be a persistent issue affecting many of your transactions. Please contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
-        <% elsif stripe_decline_reason == :insecure_authorization_method %>
-            <% auth_method = pt&.raw_pending_stripe_transaction&.stripe_transaction&.[]("authorization_method") %>
-            <% if auth_method == "swipe" %>
-                Your card was swiped, which can be considered insecure in some cases. Try again using chip or contactless, if possible.
-            <% elsif auth_method == "keyed_in" %>
-                Your card was keyed in by the merchant, which can be considered insecure in some cases. Try again using chip or contactless, if possible.
-            <% else %>
-                The card issuer deemed this transaction insecure. Try again using chip, if possible.
-            <% end %>
-        <% elsif stripe_decline_reason.in? %i[verification_failed suspected_fraud] %>
-            <% verification_data = pt&.raw_pending_stripe_transaction&.stripe_transaction&.[]("verification_data") %>
-            <% card_details = capture do %>
-                <% if defined?(current_user) && hcb_code.stripe_card.user == current_user %>
-                    <%= link_to "your card details", stripe_card_path(hcb_code.stripe_card) %>
-                <% else %>
-                    the card details
-                <% end %>
-            <% end %>
-
-            <% if verification_data["cvc_check"] == "mismatch" %>
-                <span>
-                    <% unless local_assigns[:is_email] %>
-                        <span class="align-top"><%= stripe_verification_check_badge("cvc", verification_data) %></span>
-                    <% end %>
-                    <b class="font-bold">CVC</b> did not match <%= card_details %>
-                </span>
-            <% elsif verification_data["address_postal_code_check"] == "mismatch" %>
-                <span>
-                    <% unless local_assigns[:is_email] %>
-                        <span class="align-top"><%= stripe_verification_check_badge("address_postal_code", verification_data) %></span>
-                    <% end %>
-                    <b class="font-bold">Zip code</b> did not match <%= card_details %>
-                </span>
-            <% elsif verification_data["address_line1_check"] == "mismatch" %>
-                <span>
-                    <% unless local_assigns[:is_email] %>
-                        <span class="align-top"><%= stripe_verification_check_badge("address_line1", verification_data) %></span>
-                    <% end %>
-                    <b class="font-bold">Address</b> did not match <%= card_details %>
-                </span>
-            <% elsif verification_data["expiry_check"] == "mismatch" %>
-                <span>
-                    <% unless local_assigns[:is_email] %>
-                        <span class="align-top"><%= stripe_verification_check_badge("expiry", verification_data) %></span>
-                    <% end %>
-                    <b class="font-bold">Expiration date</b> did not match <%= card_details %>
-                </span>
-            <% end %>
-
-            <br>
-
-            <span class="mt-2 block">If this transaction was intentional, double check the card details and try again. If you don't recognize this transaction, <%= link_to "freeze your card", stripe_card_url(hcb_code.stripe_card), method: :post %>.</span>
-        <% elsif hcb_decline_reason != :inadequate_balance %>
-            Try again, or contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
-
-            <% if stripe_decline_reason %>
-
-                <code class="mt-3 block">stripe:<%= stripe_decline_reason %></code>
-            <% end %>
-
-            <% if hcb_decline_reason %>
-                <code class="mt-3 block">hcb:<%= hcb_decline_reason %></code>
-            <% end %>
+  <p class="mb-0">
+    <% if hcb_decline_reason == :merchant_not_allowed %>
+      If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
+    <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>
+      Cash withdrawals are disabled for most HCB cards. If you need to make a purchase with cash, try using personal funds and submitting a reimbursement report.
+    <% elsif hcb_decline_reason == :user_cards_locked %>
+      You can manage your receipts on HCB <%= link_to "receipts page", my_inbox_url %>. If you have 10 or more missing receipts, your cards will be locked until you submit them.
+    <% elsif stripe_decline_reason == :authorization_controls %>
+      This transaction exceeded daily limits set by our card issuer. Please try again later, or use a different card for this transaction.
+    <% elsif stripe_decline_reason == :webhook_timeout %>
+      HCB experienced a network issue while processing this transaction. Please try again.
+    <% elsif stripe_decline_reason == :card_inactive %>
+      <% if hcb_code.stripe_card.initially_activated? %>
+        You can defrost your card at any time <%= link_to "here", stripe_card_url(hcb_code.stripe_card) %>.
+      <% else %>
+        Activate your new card <%= link_to "here", stripe_card_url(hcb_code.stripe_card) %> before using it.
+      <% end %>
+    <% elsif stripe_decline_reason == :card_canceled %>
+      <% if card.replacement %>
+        Try using its <%= link_to "replacement card", stripe_card_url(card.replacement) %> ending in <%= card.replacement.last4 %>.
+      <% else %>
+        Try using another card.
+      <% end %>
+    <% elsif stripe_decline_reason == :card_expired %>
+      Try again using a different card.
+    <% elsif stripe_decline_reason.in? %i[cardholder_verification_required insufficient_funds] %>
+      This could be a persistent issue affecting many of your transactions. Please contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
+    <% elsif stripe_decline_reason == :insecure_authorization_method %>
+      <% auth_method = pt&.raw_pending_stripe_transaction&.stripe_transaction&.[]("authorization_method") %>
+      <% if auth_method == "swipe" %>
+        Your card was swiped, which can be considered insecure in some cases. Try again using chip or contactless, if possible.
+      <% elsif auth_method == "keyed_in" %>
+        Your card was keyed in by the merchant, which can be considered insecure in some cases. Try again using chip or contactless, if possible.
+      <% else %>
+        The card issuer deemed this transaction insecure. Try again using chip, if possible.
+      <% end %>
+    <% elsif stripe_decline_reason.in? %i[verification_failed suspected_fraud] %>
+      <% verification_data = pt&.raw_pending_stripe_transaction&.stripe_transaction&.[]("verification_data") %>
+      <% card_details = capture do %>
+        <% if defined?(current_user) && hcb_code.stripe_card.user == current_user %>
+          <%= link_to "your card details", stripe_card_path(hcb_code.stripe_card) %>
+        <% else %>
+          the card details
         <% end %>
-    </p>
+      <% end %>
+
+      <% if verification_data["cvc_check"] == "mismatch" %>
+        <span>
+          <% unless local_assigns[:is_email] %>
+            <span class="align-top"><%= stripe_verification_check_badge("cvc", verification_data) %></span>
+          <% end %>
+          <b class="font-bold">CVC</b> did not match <%= card_details %>
+        </span>
+      <% elsif verification_data["address_postal_code_check"] == "mismatch" %>
+        <span>
+          <% unless local_assigns[:is_email] %>
+            <span class="align-top"><%= stripe_verification_check_badge("address_postal_code", verification_data) %></span>
+          <% end %>
+          <b class="font-bold">Zip code</b> did not match <%= card_details %>
+        </span>
+      <% elsif verification_data["address_line1_check"] == "mismatch" %>
+        <span>
+          <% unless local_assigns[:is_email] %>
+            <span class="align-top"><%= stripe_verification_check_badge("address_line1", verification_data) %></span>
+          <% end %>
+          <b class="font-bold">Address</b> did not match <%= card_details %>
+        </span>
+      <% elsif verification_data["expiry_check"] == "mismatch" %>
+        <span>
+          <% unless local_assigns[:is_email] %>
+            <span class="align-top"><%= stripe_verification_check_badge("expiry", verification_data) %></span>
+          <% end %>
+          <b class="font-bold">Expiration date</b> did not match <%= card_details %>
+        </span>
+      <% end %>
+
+      <br>
+
+      <span class="mt-2 block">If this transaction was intentional, double check the card details and try again. If you don't recognize this transaction, <%= link_to "freeze your card", stripe_card_url(hcb_code.stripe_card), method: :post %>.</span>
+    <% elsif hcb_decline_reason != :inadequate_balance %>
+      Try again, or contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
+
+      <% if stripe_decline_reason %>
+
+        <code class="mt-3 block">stripe:<%= stripe_decline_reason %></code>
+      <% end %>
+
+      <% if hcb_decline_reason %>
+        <code class="mt-3 block">hcb:<%= hcb_decline_reason %></code>
+      <% end %>
+    <% end %>
+  </p>
 
 <% end %>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -16,11 +16,11 @@
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <span><%= this_transaction %> was declined
       <%= {
-          merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
-          merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
-          cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
-          user_cards_locked: "by HCB because you have too many missing receipts"
-        }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
+            merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
+            merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
+            cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
+            user_cards_locked: "by HCB because you have too many missing receipts"
+          }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
     <% else %>
       <span>
       <%= ("#{this_transaction} was declined by our card issuer " + ({

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -16,11 +16,11 @@
     <% if hcb_decline_reason.present? || stripe_decline_reason == "webhook_declined" %>
       <span><%= this_transaction %> was declined
       <%= {
-            merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
-            merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
-            cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
-            user_cards_locked: "by HCB because you have too many missing receipts"
-          }[hcb_decline_reason] || "due to insufficient funds" %>.</span>``
+          merchant_not_allowed_globally: "by HCB because this merchant is not allowed",
+          merchant_not_allowed: "by #{hcb_code.event.name} because this merchant is not allowed",
+          cash_withdrawals_not_allowed: "by HCB because cash withdrawals were not enabled on this card",
+          user_cards_locked: "by HCB because you have too many missing receipts"
+        }[hcb_decline_reason] || "due to insufficient funds" %>.</span>
     <% else %>
       <span>
       <%= ("#{this_transaction} was declined by our card issuer " + ({

--- a/spec/mailers/previews/canonical_pending_transaction_mailer_preview.rb
+++ b/spec/mailers/previews/canonical_pending_transaction_mailer_preview.rb
@@ -3,7 +3,7 @@
 class CanonicalPendingTransactionMailerPreview < ActionMailer::Preview
   def notify_approved
     # @cpt = CanonicalPendingTransaction.stripe.last
-    @cpt = CanonicalPendingTransaction.stripe.where("amount_cents < ?", -1_000_00).last
+    @cpt = CanonicalPendingTransaction.stripe.last
 
     CanonicalPendingTransactionMailer.with(
       canonical_pending_transaction_id: @cpt.id,
@@ -12,7 +12,7 @@ class CanonicalPendingTransactionMailerPreview < ActionMailer::Preview
 
   def notify_declined
     # @cpt = CanonicalPendingTransaction.stripe.last
-    @cpt = CanonicalPendingTransaction.stripe.where("amount_cents < ?", -1_000_00).last
+    @cpt = CanonicalPendingTransaction.stripe.last
 
     CanonicalPendingTransactionMailer.with(
       canonical_pending_transaction_id: @cpt.id,
@@ -21,7 +21,7 @@ class CanonicalPendingTransactionMailerPreview < ActionMailer::Preview
 
   def notify_settled
     # @cpt = CanonicalPendingTransaction.stripe.last
-    @cpt = CanonicalPendingTransaction.stripe.where("amount_cents < ?", -1_000_00).first
+    @cpt = CanonicalPendingTransaction.stripe.first
     @ct = @cpt.local_hcb_code.ct
 
     CanonicalPendingTransactionMailer.with(

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
         expect(service.run).to be(false)
       end
 
-      expect(service.declined_reason).to eq("merchant_not_allowed")
+      expect(service.declined_reason).to eq("merchant_not_allowed_globally")
 
       ops_email =
         sent_emails
@@ -71,7 +71,7 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
         expect(service.run).to be(false)
       end
 
-      expect(service.declined_reason).to eq("merchant_not_allowed")
+      expect(service.declined_reason).to eq("merchant_not_allowed_globally")
 
       ops_email =
         sent_emails


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It's confusing when people receive an email telling them to reach out to the organization when it was blocked by HCB.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds a custom decline reason and message for when a merchant is blocked by HCB globally and not by the specific organization.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

