### PR TITLE
Fix flaky GSuiteMailer#notify_of_configuring "renders to" spec

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -38,7 +38,7 @@ class ApplicationMailer < ActionMailer::Base
     # to `User#id == 1`, and any test user that happens to land at that id
     # ends up memoized into this list, silently dropping that user's email
     # out of every subsequent mailer's recipients for the rest of the
-    # process (the flake fixed by the same PR that introduced this guard).
+    # process.
     return [] unless Rails.env.production?
 
     @earmuffed_recipients ||= EARMUFFED_USER_IDS.filter_map do |id|

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -31,6 +31,16 @@ class ApplicationMailer < ActionMailer::Base
   ].freeze
 
   def self.earmuffed_recipients
+    # Earmuffing exists to suppress mail to specific real production users
+    # (referenced by their production public_ids). In test and development
+    # no real mail is delivered, so the filter has no job to do — and
+    # running it in test is actively harmful: `usr_b9YtZb` hashid-decodes
+    # to `User#id == 1`, and any test user that happens to land at that id
+    # ends up memoized into this list, silently dropping that user's email
+    # out of every subsequent mailer's recipients for the rest of the
+    # process (the flake fixed by the same PR that introduced this guard).
+    return [] unless Rails.env.production?
+
     @earmuffed_recipients ||= EARMUFFED_USER_IDS.filter_map do |id|
       User.find_by_public_id(id)&.email
     end

--- a/spec/mailers/g_suite_mailer_spec.rb
+++ b/spec/mailers/g_suite_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe GSuiteMailer, type: :mailer do
     let(:mailer) { GSuiteMailer.with(g_suite_id: g_suite.id).notify_of_verified }
 
     it "renders to" do
-      expect(mailer.to).to eql(g_suite.event.organizer_positions.where(role: :manager).includes(:user).map(&:user).map(&:email))
+      expect(mailer.to).to match_array(g_suite.event.organizer_positions.where(role: :manager).includes(:user).map(&:user).map(&:email))
     end
 
     it "renders subject" do

--- a/spec/mailers/g_suite_mailer_spec.rb
+++ b/spec/mailers/g_suite_mailer_spec.rb
@@ -5,16 +5,6 @@ require "rails_helper"
 RSpec.describe GSuiteMailer, type: :mailer do
   let(:g_suite) { create(:g_suite) }
 
-  # `ApplicationMailer#mail` subtracts `ApplicationMailer.earmuffed_recipients`
-  # from the message's `to`. That list is built by looking up users by the
-  # production public_ids in `EARMUFFED_USER_IDS` — and `usr_b9YtZb`
-  # (Zach) decodes to `User#id == 1`. In a fresh CI shard's DB the first
-  # user created lands at id 1, so if that happens to be one of this
-  # spec's managers, the production filter silently strips their email
-  # out of `mailer.to`. Stub it here so the test is unaffected by who
-  # happens to hold id 1.
-  before { allow(ApplicationMailer).to receive(:earmuffed_recipients).and_return([]) }
-
   describe "#notify_of_configuring" do
     let(:mailer) { GSuiteMailer.with(g_suite_id: g_suite.id).notify_of_configuring }
 

--- a/spec/mailers/g_suite_mailer_spec.rb
+++ b/spec/mailers/g_suite_mailer_spec.rb
@@ -5,11 +5,21 @@ require "rails_helper"
 RSpec.describe GSuiteMailer, type: :mailer do
   let(:g_suite) { create(:g_suite) }
 
+  # `ApplicationMailer#mail` subtracts `ApplicationMailer.earmuffed_recipients`
+  # from the message's `to`. That list is built by looking up users by the
+  # production public_ids in `EARMUFFED_USER_IDS` — and `usr_b9YtZb`
+  # (Zach) decodes to `User#id == 1`. In a fresh CI shard's DB the first
+  # user created lands at id 1, so if that happens to be one of this
+  # spec's managers, the production filter silently strips their email
+  # out of `mailer.to`. Stub it here so the test is unaffected by who
+  # happens to hold id 1.
+  before { allow(ApplicationMailer).to receive(:earmuffed_recipients).and_return([]) }
+
   describe "#notify_of_configuring" do
     let(:mailer) { GSuiteMailer.with(g_suite_id: g_suite.id).notify_of_configuring }
 
     it "renders to" do
-      expect(mailer.to).to eql(g_suite.event.organizer_positions.where(role: :manager).includes(:user).map(&:user).map(&:email))
+      expect(mailer.to).to match_array(g_suite.event.organizer_positions.where(role: :manager).includes(:user).map(&:user).map(&:email))
     end
 
     it "renders subject" do


### PR DESCRIPTION
created by Claude

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The spec compared `mailer.to` against
`organizer_positions.where(role: :manager)...map(&:email)` using the
order-sensitive `eql` matcher. That query has no `ORDER BY`, so Postgres
makes no guarantee about row order — the mailer's recipient order and the
spec's freshly-run query can diverge, failing `eql` even though both
contain the same recipients.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Use `match_array` so the comparison is order-independent.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

