### PR TITLE
[Stripe] Block all `non_fi_stored_value_card_purchase_load` authorizations

### DIFF
--- a/app/services/stripe_authorization_service.rb
+++ b/app/services/stripe_authorization_service.rb
@@ -12,7 +12,8 @@ module StripeAuthorizationService
         "government_owned_lotteries_non_us_region",
         "government_owned_lotteries_us_region_only",
         "wires_money_orders",
-        "non_fi_money_orders"
+        "non_fi_money_orders",
+        "non_fi_stored_value_card_purchase_load"
       ]
     ).freeze
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
These are commonly used for fraud.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

