### PR TITLE
[v4][Receipt] Use api as upload method for all v4 receipts

### DIFF
--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -42,7 +42,7 @@ module Api
           ::ReceiptService::Create.new(
             uploader: current_user,
             attachments: ach_transfer_params[:file],
-            upload_method: :ach_transfer_api,
+            upload_method: :api,
             receiptable: @ach_transfer.local_hcb_code
           ).run!
         end

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -54,7 +54,7 @@ module Api
           ::ReceiptService::Create.new(
             uploader: current_user,
             attachments: check_params[:file],
-            upload_method: :check_api,
+            upload_method: :api,
             receiptable: @check.local_hcb_code
           ).run!
         end


### PR DESCRIPTION
## Summary of the problem
@polypixeldev pointed out that we use different upload method values throughout the v4 API. However for consistency we should just keep it as `:api` which is the only one named in :

https://github.com/hackclub/hcb/blob/c622c4ab74fc856237c3e730bbee09819ee08960/app/models/receipt.rb#L105-L129


## Describe your changes
changed others to `:api`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

