### PR TITLE
Fix Ahoy user for ops_call_requested email

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1079,7 +1079,7 @@ class EventsController < ApplicationController
   def request_call
     authorize @event
 
-    EventMailer.with(event: @event, user: current_user).ops_call_requested.deliver_later
+    EventMailer.with(event: @event, requesting_user: current_user).ops_call_requested.deliver_later
     EventMailer.with(event: @event, user: current_user).user_call_requested.deliver_later
     @event.config.update!(hide_onboarding_message: true)
 

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -58,10 +58,10 @@ class EventMailer < ApplicationMailer
   end
 
   def ops_call_requested
-    @user = params[:user]
+    @requesting_user = params[:requesting_user]
 
     mail to: OPERATIONS_EMAIL,
-         subject: "#{@user.name} is requesting an onboarding call for #{@event.name} #{"with #{@event.point_of_contact.name}" if @event.point_of_contact.present?}"
+         subject: "#{@requesting_user.name} is requesting an onboarding call for #{@event.name} #{"with #{@event.point_of_contact.name}" if @event.point_of_contact.present?}"
   end
 
   def transparency_mode_enabled

--- a/app/views/event_mailer/ops_call_requested.html.erb
+++ b/app/views/event_mailer/ops_call_requested.html.erb
@@ -1,11 +1,11 @@
 <p>Hi there! 👋</p>
 
 <p>
-  <%= link_to @user.name.to_s, admin_user_url(@user) %> (<%= @user.email %>)
+  <%= link_to @requesting_user.name.to_s, admin_user_url(@requesting_user) %> (<%= @requesting_user.email %>)
   has requested an onboarding call for <%= link_to @event.name, @event %><%= " with #{@event.point_of_contact.name}" if @event.point_of_contact.present? %>.
 </p>
 
-<p>Email <%= mail_to @user.email %> to schedule an onboarding call!</p>
+<p>Email <%= mail_to @requesting_user.email %> to schedule an onboarding call!</p>
 
 <p>
   Thanks!


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Ahoy stores the user the email was sent to, and it infers it by looking to see if there's an @user variable defined - which in the ops email mailer, we set to the person who requested the call. This results in /admin/emails showing that the email was sent to the person who requested the call instead of ops.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Renamed @user for that email to @requesting_user, tested in dev. Also looked to see if we set @user anywhere else that we don't actually send the email to that user and didn't find any.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

