### PR TITLE
Fix broken #payment_intent spec in donations controller

### DIFF
--- a/spec/controllers/api/v4/donations_controller_spec.rb
+++ b/spec/controllers/api/v4/donations_controller_spec.rb
@@ -7,6 +7,37 @@ RSpec.describe Api::V4::DonationsController do
 
   render_views
 
+  describe "#payment_intent" do
+    before { stub_donation_payment_intent_creation }
+
+    it "returns the payment intent id and client secret for an organizer's donation" do
+      user = create(:user)
+      event = create(:event)
+      create(:organizer_position, user:, event:)
+
+      donation = create(:donation, event:, collected_by: user, in_person: true)
+      oauth_application = Doorkeeper::Application.create!(
+        name: "Trusted POS",
+        redirect_uri: "https://example.com/callback",
+        scopes: "",
+        confidential: true,
+        trusted: true
+      )
+      token = create(:api_token, user:, application_id: oauth_application.id)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+
+      post :payment_intent, params: { event_id: event.public_id, id: donation.public_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        {
+          "payment_intent_id" => donation.stripe_payment_intent_id,
+          "client_secret"     => donation.stripe_client_secret
+        }
+      )
+    end
+  end
+
   describe "#create" do
     before do
       stub_donation_payment_intent_creation


### PR DESCRIPTION
The test added in #13705 had two bugs:

1. `create(:donation, in_person: true)` triggers the `before_create :create_stripe_payment_intent` callback (recurring? is false), which calls StripeService::Customer.create and StripeService::PaymentIntent.create. WebMock is active in tests, so those unmocked HTTP calls raised WebMock::NetConnectNotAllowedError. Fix: add `before { stub_donation_payment_intent_creation }` so the Stripe calls are intercepted before the donation is created.

2. The controller renders `render json: {...}` without a `status:` keyword, defaulting to HTTP 200. The test asserted `have_http_status(:created)` (201). Fix: assert `:ok` instead.

Also removed the spurious `allow(StripeService::PaymentIntent).to receive(:create)` stub placed after `create(:donation)` — the `payment_intent` action reads `donation.stripe_payment_intent_id` from the DB and never calls that method, so the mock had no effect and the hardcoded expected values were wrong.

https://claude.ai/code/session_01ANVXcC1VdckGJ2aYcaw3Ag

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

