### PR TITLE
Use Flipper to temporarily allow any merchant

### DIFF
--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -57,7 +57,7 @@ module StripeAuthorizationService
       def approve?
         return decline_with_reason!("event_frozen") if event.financially_frozen?
 
-        if forbidden_merchant? && !card.user&.admin?
+        if forbidden_merchant? && !card.user&.admin? && !Flipper.enabled?(:allowlist_for_blocked_merchants, card.user)
           AdminMailer
             .with(stripe_card: card, merchant_category:)
             .blocked_authorization


### PR DESCRIPTION
## Summary of the problem

Requested by Mel in instances that require manual override


## Describe your changes

Adds a check with Flipper to allow non-admins to use any merchant