### PR TITLE
Add tasks for backfilling and scrubbing session metadata

### DIFF
--- a/app/tasks/maintenance/backfill_session_device_info_task.rb
+++ b/app/tasks/maintenance/backfill_session_device_info_task.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillSessionDeviceInfoTask < MaintenanceTasks::Task
+    def collection
+      User::Session.where(device_info: nil)
+    end
+
+    def process(session)
+      version_with_device_info = session.versions.where_object_changes_to(device_info: nil).last
+
+      return if version_with_device_info.nil?
+
+      session.update!(device_info: version_with_device_info.object["device_info"])
+    end
+
+  end
+end

--- a/app/tasks/maintenance/scrub_papertrail_session_data_task.rb
+++ b/app/tasks/maintenance/scrub_papertrail_session_data_task.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class ScrubPapertrailSessionDataTask < MaintenanceTasks::Task
+    COLUMNS = ["ip", "latitude", "longitude"].freeze
+
+    def collection
+      PaperTrail::Version.where(item_type: "User::Session")
+    end
+
+    def process(version)
+      changes = {}
+
+      if version.object.present?
+        object = version.object
+
+        COLUMNS.each do |column|
+          if object.key?(column)
+            object.delete(column)
+            changes[:object] = object
+          end
+        end
+      end
+
+      if version.object_changes.present?
+        object_changes = version.object_changes
+
+        COLUMNS.each do |column|
+          if object_changes.key?(column)
+            object_changes.delete(column)
+            changes[:object_changes] = object_changes
+          end
+        end
+      end
+
+      version.update!(changes) if changes.any?
+    end
+
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13786 changed our job that deletes the PII in old user sessions to not delete device info but also delete IP along with latitude and longitude. We need to clean up the existing data for this.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add maintenance tasks for:
- Backfilling the device_info column from PaperTrail now that we are no longer clearing it
- Clearing IP, latitude, and longitude data from PaperTrail, now that it is being skipped in new records.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

