### PR TITLE
[Applications] Redirect users to status page if archived

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -4,6 +4,7 @@ class Event
   class ApplicationsController < ApplicationController
     before_action :set_application, except: [:apply, :new, :create, :index]
     before_action :prevent_access_after_submission, only: [:project_info, :personal_info, :review]
+    before_action :prevent_access_if_archived, only: [:project_info, :personal_info, :review, :videos, :agreement]
     after_action :record_pageview
     skip_before_action :signed_in_user, only: [:new, :apply, :create]
     skip_after_action :verify_authorized, only: :create
@@ -283,6 +284,12 @@ class Event
 
     def prevent_access_after_submission
       unless @application.draft? || current_user.auditor?
+        redirect_to application_path(@application)
+      end
+    end
+
+    def prevent_access_if_archived
+      if @application.archived? && !current_user.auditor?
         redirect_to application_path(@application)
       end
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Users might visit an old link after archiving their application, which can be confusing and cause errors such as https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/2887

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a before action similar to `prevent_access_after_submission` that checks if the application is archived, and redirects them to the status page where they'll have to unarchive their application before continuing.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

