### PR TITLE
[User Admin] Turbo frame more elements independently

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
     :edit_admin, :admin_details, :admin_details_ach_transfers,
     :admin_details_check_deposits, :admin_details_disbursements, :admin_details_increase_checks,
     :admin_details_invoices, :admin_details_lob_checks, :admin_details_missing_receipts,
-    :admin_details_reimbursement_reports, :admin_details_stripe_transactions
+    :admin_details_reimbursement_reports, :admin_details_stripe_cards, :admin_details_stripe_transactions
   ]
   wrap_parameters format: :url_encoded_form
 
@@ -294,6 +294,12 @@ class UsersController < ApplicationController
     authorize @user
 
     @reimbursement_reports = @user.reimbursement_reports.includes([:event, :payout_holding])
+  end
+
+  def admin_details_stripe_cards
+    authorize @user
+
+    @stripe_cards = @user.stripe_cards
   end
 
   def admin_details_stripe_transactions

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,10 @@ class UsersController < ApplicationController
     :edit_security, :edit_notifications, :edit_integrations,
     :generate_totp, :enable_totp, :disable_totp,
     :generate_backup_codes, :activate_backup_codes, :disable_backup_codes,
-    :edit_admin, :admin_details, :admin_details_stripe_transactions
+    :edit_admin, :admin_details, :admin_details_ach_transfers,
+    :admin_details_check_deposits, :admin_details_disbursements, :admin_details_increase_checks,
+    :admin_details_invoices, :admin_details_lob_checks, :admin_details_reimbursement_reports,
+    :admin_details_stripe_transactions
   ]
   wrap_parameters format: :url_encoded_form
 
@@ -236,25 +239,71 @@ class UsersController < ApplicationController
 
   def edit_admin
     authorize @user
+
+    @permissions_overview = User::PermissionsOverview.new(user: @user)
+    @applications = @user.applications.not_archived
   end
 
   def admin_details
-    # User Information
+    authorize @user
+
     @invoices = Invoice.where(creator: @user)
     @check_deposits = CheckDeposit.where(created_by: @user)
     @increase_checks = IncreaseCheck.where(user: @user)
     @lob_checks = Check.where(creator: @user)
     @ach_transfers = AchTransfer.where(creator: @user)
-    @disbursements = Disbursement.where(requested_by: @user)
-    @permissions_overview = User::PermissionsOverview.new(user: @user)
+    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event])
+    @reimbursement_reports = @user.reimbursement_reports.includes([:event, :payout_holding])
+  end
 
+  def admin_details_ach_transfers
     authorize @user
+
+    @ach_transfers = AchTransfer.where(creator: @user)
+  end
+
+  def admin_details_check_deposits
+    authorize @user
+
+    @check_deposits = CheckDeposit.where(created_by: @user)
+  end
+
+  def admin_details_disbursements
+    authorize @user
+
+    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event])
+  end
+
+  def admin_details_increase_checks
+    authorize @user
+
+    @increase_checks = IncreaseCheck.where(user: @user)
+  end
+
+  def admin_details_invoices
+    authorize @user
+
+    @invoices = Invoice.where(creator: @user)
+  end
+
+  def admin_details_lob_checks
+    authorize @user
+
+    @lob_checks = Check.where(creator: @user)
+  end
+
+  def admin_details_reimbursement_reports
+    authorize @user
+
+    @reimbursement_reports = @user.reimbursement_reports.includes([:event, :payout_holding])
   end
 
   def admin_details_stripe_transactions
     authorize @user
 
-    @stripe_transactions = HcbCode.where(id: @user.stripe_cards.flat_map { |sc| sc.local_hcb_codes.pluck(:id) }).order(created_at: :desc)
+    @stripe_transactions = HcbCode.where(id: @user.stripe_cards.flat_map { |sc| sc.local_hcb_codes.pluck(:id) })
+                                  .order(created_at: :desc)
+                                  .includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -251,19 +251,19 @@ class UsersController < ApplicationController
   def admin_details_ach_transfers
     authorize @user
 
-    @ach_transfers = AchTransfer.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
+    @ach_transfers = @user.ach_transfers.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_check_deposits
     authorize @user
 
-    @check_deposits = CheckDeposit.where(created_by: @user).page(params[:page] || 1).per(params[:per] || 10)
+    @check_deposits = @user.check_deposits.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_disbursements
     authorize @user
 
-    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event]).page(params[:page] || 1).per(params[:per] || 10)
+    @disbursements = @user.disbursements.includes([:destination_event]).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_emburse_cards
@@ -275,19 +275,19 @@ class UsersController < ApplicationController
   def admin_details_increase_checks
     authorize @user
 
-    @increase_checks = IncreaseCheck.where(user: @user).page(params[:page] || 1).per(params[:per] || 10)
+    @increase_checks = @user.increase_checks.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_invoices
     authorize @user
 
-    @invoices = Invoice.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
+    @invoices = @user.invoices.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_lob_checks
     authorize @user
 
-    @lob_checks = Check.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
+    @lob_checks = @user.checks.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_missing_receipts

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -239,13 +239,13 @@ class UsersController < ApplicationController
 
   def edit_admin
     authorize @user
-
-    @permissions_overview = User::PermissionsOverview.new(user: @user)
-    @applications = @user.applications.not_archived
   end
 
   def admin_details
     authorize @user
+
+    @permissions_overview = User::PermissionsOverview.new(user: @user)
+    @applications = @user.applications.not_archived
   end
 
   def admin_details_ach_transfers

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -293,7 +293,7 @@ class UsersController < ApplicationController
   def admin_details_missing_receipts
     authorize @user
 
-    @hcb_codes_missing_receipts = @user.transactions_missing_receipt
+    @hcb_codes_missing_receipts = @user.transactions_missing_receipt.includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
   end
 
   def admin_details_reimbursement_reports

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,8 +29,8 @@ class UsersController < ApplicationController
     :edit_security, :edit_notifications, :edit_integrations,
     :generate_totp, :enable_totp, :disable_totp,
     :generate_backup_codes, :activate_backup_codes, :disable_backup_codes,
-    :edit_admin, :admin_details, :admin_details_ach_transfers,
-    :admin_details_check_deposits, :admin_details_disbursements, :admin_details_increase_checks,
+    :edit_admin, :admin_details, :admin_details_ach_transfers, :admin_details_check_deposits,
+    :admin_details_disbursements, :admin_details_emburse_cards, :admin_details_increase_checks,
     :admin_details_invoices, :admin_details_lob_checks, :admin_details_missing_receipts,
     :admin_details_reimbursement_reports, :admin_details_stripe_cards, :admin_details_stripe_transactions
   ]
@@ -264,6 +264,12 @@ class UsersController < ApplicationController
     authorize @user
 
     @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event])
+  end
+
+  def admin_details_emburse_cards
+    authorize @user
+
+    @emburse_cards = @user.emburse_cards
   end
 
   def admin_details_increase_checks

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,8 +31,8 @@ class UsersController < ApplicationController
     :generate_backup_codes, :activate_backup_codes, :disable_backup_codes,
     :edit_admin, :admin_details, :admin_details_ach_transfers,
     :admin_details_check_deposits, :admin_details_disbursements, :admin_details_increase_checks,
-    :admin_details_invoices, :admin_details_lob_checks, :admin_details_reimbursement_reports,
-    :admin_details_stripe_transactions
+    :admin_details_invoices, :admin_details_lob_checks, :admin_details_missing_receipts,
+    :admin_details_reimbursement_reports, :admin_details_stripe_transactions
   ]
   wrap_parameters format: :url_encoded_form
 
@@ -282,6 +282,12 @@ class UsersController < ApplicationController
     authorize @user
 
     @lob_checks = Check.where(creator: @user)
+  end
+
+  def admin_details_missing_receipts
+    authorize @user
+
+    @hcb_codes_missing_receipts = @user.transactions_missing_receipt
   end
 
   def admin_details_reimbursement_reports

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -251,61 +251,65 @@ class UsersController < ApplicationController
   def admin_details_ach_transfers
     authorize @user
 
-    @ach_transfers = AchTransfer.where(creator: @user)
+    @ach_transfers = AchTransfer.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_check_deposits
     authorize @user
 
-    @check_deposits = CheckDeposit.where(created_by: @user)
+    @check_deposits = CheckDeposit.where(created_by: @user).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_disbursements
     authorize @user
 
-    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event])
+    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event]).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_emburse_cards
     authorize @user
 
-    @emburse_cards = @user.emburse_cards
+    @emburse_cards = @user.emburse_cards.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_increase_checks
     authorize @user
 
-    @increase_checks = IncreaseCheck.where(user: @user)
+    @increase_checks = IncreaseCheck.where(user: @user).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_invoices
     authorize @user
 
-    @invoices = Invoice.where(creator: @user)
+    @invoices = Invoice.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_lob_checks
     authorize @user
 
-    @lob_checks = Check.where(creator: @user)
+    @lob_checks = Check.where(creator: @user).page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_missing_receipts
     authorize @user
 
-    @hcb_codes_missing_receipts = @user.transactions_missing_receipt.includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
+    @hcb_codes_missing_receipts = @user.transactions_missing_receipt
+                                       .includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
+                                       .page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_reimbursement_reports
     authorize @user
 
-    @reimbursement_reports = @user.reimbursement_reports.includes([:event, :payout_holding])
+    @reimbursement_reports = @user.reimbursement_reports
+                                  .includes([:event, :payout_holding])
+                                  .page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_stripe_cards
     authorize @user
 
-    @stripe_cards = @user.stripe_cards
+    @stripe_cards = @user.stripe_cards.page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def admin_details_stripe_transactions
@@ -314,6 +318,7 @@ class UsersController < ApplicationController
     @stripe_transactions = HcbCode.where(id: @user.stripe_cards.flat_map { |sc| sc.local_hcb_codes.pluck(:id) })
                                   .order(created_at: :desc)
                                   .includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
+                                  .page(params[:page] || 1).per(params[:per] || 10)
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -246,14 +246,6 @@ class UsersController < ApplicationController
 
   def admin_details
     authorize @user
-
-    @invoices = Invoice.where(creator: @user)
-    @check_deposits = CheckDeposit.where(created_by: @user)
-    @increase_checks = IncreaseCheck.where(user: @user)
-    @lob_checks = Check.where(creator: @user)
-    @ach_transfers = AchTransfer.where(creator: @user)
-    @disbursements = Disbursement.where(requested_by: @user).includes([:destination_event])
-    @reimbursement_reports = @user.reimbursement_reports.includes([:event, :payout_holding])
   end
 
   def admin_details_ach_transfers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,8 +140,6 @@ class User < ApplicationRecord
   has_many :stripe_authorizations, through: :stripe_cards
   has_many :receipts
 
-  has_many :checks, inverse_of: :creator
-
   has_many :reimbursement_reports, class_name: "Reimbursement::Report"
   has_many :reimbursement_events, -> { distinct }, through: :reimbursement_reports, source: :event
   has_many :created_reimbursement_reports, class_name: "Reimbursement::Report", foreign_key: "invited_by_id", inverse_of: :inviter
@@ -153,7 +151,14 @@ class User < ApplicationRecord
 
   has_many :card_grants
 
+  has_many :ach_transfers, inverse_of: :creator
+  has_many :checks, inverse_of: :creator
+  has_many :disbursements, inverse_of: :requested_by
+  has_many :increase_checks
   has_many :wise_transfers
+
+  has_many :check_deposits, inverse_of: :created_by
+  has_many :invoices, inverse_of: :creator
 
   has_one_attached :profile_picture
   validates :profile_picture, size: { less_than_or_equal_to: 5.megabytes }, if: -> { attachment_changes["profile_picture"].present? }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -93,6 +93,10 @@ class UserPolicy < ApplicationPolicy
     admin_details?
   end
 
+  def admin_details_missing_receipts?
+    admin_details?
+  end
+
   def admin_details_reimbursement_reports?
     admin_details?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -69,8 +69,36 @@ class UserPolicy < ApplicationPolicy
     user.auditor?
   end
 
+  def admin_details_ach_transfers?
+    admin_details?
+  end
+
+  def admin_details_check_deposits?
+    admin_details?
+  end
+
+  def admin_details_disbursements?
+    admin_details?
+  end
+
+  def admin_details_increase_checks?
+    admin_details?
+  end
+
+  def admin_details_invoices?
+    admin_details?
+  end
+
+  def admin_details_lob_checks?
+    admin_details?
+  end
+
+  def admin_details_reimbursement_reports?
+    admin_details?
+  end
+
   def admin_details_stripe_transactions?
-    user.auditor?
+    admin_details?
   end
 
   def update?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -81,6 +81,10 @@ class UserPolicy < ApplicationPolicy
     admin_details?
   end
 
+  def admin_details_emburse_cards?
+    admin_details?
+  end
+
   def admin_details_increase_checks?
     admin_details?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -101,6 +101,10 @@ class UserPolicy < ApplicationPolicy
     admin_details?
   end
 
+  def admin_details_stripe_cards?
+    admin_details?
+  end
+
   def admin_details_stripe_transactions?
     admin_details?
   end

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -108,204 +108,45 @@
       <% end %>
     <% end %>
 
-    <% if @invoices.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Invoices</h3>
-        <table>
-          <tr>
-            <th>ID</th>
-            <th>Amount</th>
-            <th>Status</th>
-            <th></th>
-          </tr>
-          <% @invoices.each do |invoice| %>
-            <tr>
-              <td><%= invoice.id %></td>
-              <td><%= render_money invoice.total %></td>
-              <td><%= invoice.state_text %></td>
-              <td><%= link_to "View", hcb_code_path(invoice.hcb_code), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_invoices, src: admin_details_invoices_user_path(@user), loading: :lazy do %>
+        <p>Loading user's invoices</p>
       <% end %>
     <% end %>
 
-    <% if @user.reimbursement_reports.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Reimbursement reports</h3>
-        <table>
-          <thead>
-          <tr>
-            <th>Status</th>
-            <th>Report</th>
-            <th>Event</th>
-            <th>Amount</th>
-            <th>Created</th>
-          </tr>
-          </thead>
-          <tbody>
-            <% @user.reimbursement_reports.order(created_at: :desc).each do |report| %>
-              <tr>
-                <td>
-                   <%= report.status_text %>
-                </td>
-                <td style="max-width: 250px; overflow: hidden; text-overflow: ellipsis;">
-                  <%= link_to report.name, report, data: { turbo_frame: "_top" } %>
-                </td>
-                <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">
-                   <%= report.event&.name || "No event" %>
-                </td>
-                <td>
-                   <%= render_money report.amount_cents %>
-                </td>
-                <td>
-                   <%= format_date report.created_at %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_reimbursement_reports, src: admin_details_reimbursement_reports_user_path(@user), loading: :lazy do %>
+        <p>Loading user's reimbursement reports</p>
       <% end %>
     <% end %>
 
-    <% if @checks_deposits.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Deposited checks</h3>
-        <table>
-          <tr>
-            <th>Status</th>
-            <th>Rejection reason</th>
-            <th>Amount</th>
-            <th>Date</th>
-          </tr>
-          <% @checks_deposits.each do |check| %>
-            <tr>
-              <td><%= check.increase_status %></td>
-              <td><%= check.rejection_reason %></td>
-              <td><%= render_money check.amount_cents %></td>
-              <td><%= check.created_at %></td>
-            </tr>
-          <% end %>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_check_deposits, src: admin_details_check_deposits_user_path(@user), loading: :lazy do %>
+        <p>Loading user's check deposits</p>
       <% end %>
     <% end %>
 
-    <% if @increase_checks.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Increase checks</h3>
-        <table>
-          <tr>
-            <th>Payment for</th>
-            <th>Memo</th>
-            <th>Amount</th>
-            <th>Status</th>
-            <th>Approved at</th>
-            <th></th>
-          </tr>
-          <% @increase_checks.each do |check| %>
-            <tr>
-              <td><%= check.payment_for %></td>
-              <td><%= check.memo %></td>
-              <td><%= render_money check.amount %></td>
-              <td><%= check.aasm_state %></td>
-              <td><%= check.approved_at %></td>
-              <td><%= link_to "View", hcb_code_path(check.hcb_code), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_increase_checks, src: admin_details_increase_checks_user_path(@user), loading: :lazy do %>
+        <p>Loading user's increase checks</p>
       <% end %>
     <% end %>
 
-    <% if @lob_checks.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Lob checks</h3>
-        <table>
-          <tr>
-            <th>Payment for</th>
-            <th>Memo</th>
-            <th>Amount</th>
-            <th>Status</th>
-            <th>Approved at</th>
-            <th></th>
-          </tr>
-          <% @lob_checks.each do |check| %>
-            <tr>
-              <td><%= check.payment_for %></td>
-              <td><%= check.memo %></td>
-              <td><%= render_money check.amount %></td>
-              <td><%= check.aasm_state %></td>
-              <td><%= check.approved_at %></td>
-              <td><%= link_to "View", hcb_code_path(check.hcb_code), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_lob_checks, src: admin_details_lob_checks_user_path(@user), loading: :lazy do %>
+        <p>Loading user's lob checks</p>
       <% end %>
     <% end %>
 
-    <% if @ach_transfers.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">ACH transfers</h3>
-        <table>
-          <tr>
-            <th>Recipient name</th>
-            <th>Amount</th>
-            <th>Payment for</th>
-            <th>Scheduled on</th>
-            <th></th>
-          </tr>
-          <% @ach_transfers.each do |ach| %>
-            <tr>
-              <td><%= ach.recipient_name %></td>
-              <td><%= render_money ach.amount %></td>
-              <td><%= ach.payment_for %></td>
-              <td><%= ach.scheduled_on %></td>
-              <td><%= link_to "View", hcb_code_path(ach.hcb_code), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_ach_transfers, src: admin_details_ach_transfers_user_path(@user), loading: :lazy do %>
+        <p>Loading user's ACH transfers</p>
       <% end %>
     <% end %>
 
-    <% if @disbursements.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Disbursements</h3>
-        <table>
-          <tr>
-            <th>Name</th>
-            <th>Amount</th>
-            <th>Status</th>
-          </tr>
-          <% @disbursements.each do |disbursement| %>
-            <tr>
-              <td><%= link_to disbursement.name, hcb_code_path(disbursement.hcb_code), data: { turbo_frame: "_top" } %></td>
-              <td><%= render_money disbursement.amount %></td>
-              <td><%= disbursement.state_text %></td>
-            </tr>
-          <% end %>
-        </table>
-      <% end %>
-    <% end %>
-
-    <% if @permissions_overview.event_graph.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Permissions</h3>
-
-        <ul>
-          <% @permissions_overview.event_graph.each do |node| %>
-            <%= render(partial: "event_permissions", locals: { node: }) %>
-          <% end %>
-        </ul>
-      <% end %>
-    <% end %>
-
-    <% if @user.applications.not_archived.any? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Applications</h3>
-        <ul>
-          <% @user.applications.not_archived.each do |application| %>
-            <li><%= link_to "#{application.name} (#{application.aasm_state.humanize})", submission_application_path(application), data: { turbo_frame: "_top" } %></li>
-          <% end %>
-        </ul>
+    <% admin_tool "p-3" do %>
+      <%= turbo_frame_tag :admin_details_disbursements, src: admin_details_disbursements_user_path(@user), loading: :lazy do %>
+        <p>Loading user's disbursements</p>
       <% end %>
     <% end %>
   </div>

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -1,13 +1,8 @@
 <%= turbo_frame_tag :admin_details do %>
   <div class="flex flex-col gap-4">
-    <% if @user.transactions_missing_receipt.any? %>
+    <%= turbo_frame_tag :admin_details_missing_receipts, src: admin_details_missing_receipts_user_path(@user), loading: :lazy do %>
       <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Missing receipts</h3>
-        <table>
-          <% @user.transactions_missing_receipt.each do |tx| %>
-            <%= render "canonical_transactions/canonical_transaction", ct: tx %>
-          <% end %>
-        </table>
+        <p>Loading user's missing receipts</p>
       <% end %>
     <% end %>
 

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -162,14 +162,16 @@
       <% end %>
     <% end %>
 
-    <% if @applications.any? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Applications</h3>
+    <% admin_tool "p-3" do %>
+      <h3 class="mb2 mt1">Applications</h3>
+      <% if @applications.any? %>
         <ul>
           <% @applications.each do |application| %>
             <li><%= link_to "#{application.name} (#{application.aasm_state.humanize})", submission_application_path(application), data: { turbo_frame: "_top" } %></li>
           <% end %>
         </ul>
+      <% else %>
+        <%= blankslate "No applications" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -46,34 +46,9 @@
       <% end %>
     <% end %>
 
-    <% if @user.emburse_cards.present? %>
+    <%= turbo_frame_tag :admin_details_emburse_cards, src: admin_details_emburse_cards_user_path(@user), loading: :lazy do %>
       <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Emburse cards</h3>
-        <table>
-          <tr>
-            <th>Last 4</th>
-            <th>Status</th>
-            <th>Expires on</th>
-            <th></th>
-          </tr>
-          <% @user.emburse_cards.each do |card| %>
-            <td><%= card.last_four %></td>
-            <td class="inline-flex">
-              <% if card.status_text == "active" %>
-                Active
-              <% elsif card.status_text == "suspended" %>
-                <%= inline_icon "freeze", size: 25 %> Suspended
-              <% elsif card.status_text == "unactivated" %>
-                <%= inline_icon "forbidden", size: 25 %> Unactivated
-              <% elsif card.status_text == "terminated" %>
-                <%= inline_icon "forbidden", size: 25 %> Terminated
-              <% end %>
-            </td>
-            <td><% Date.parse("#{card.expiration_month}/#{card.expiration_year}").strftime("%m/%y") %></td>
-              <td><%= link_to "View", emburse_card_path(card), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+        <p>Loading user's emburse cards</p>
       <% end %>
     <% end %>
 

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -34,37 +34,9 @@
       <% end %>
     <% end %>
 
-    <% if @user.stripe_cards.present? %>
+    <%= turbo_frame_tag :admin_details_stripe_cards, src: admin_details_stripe_cards_user_path(@user), loading: :lazy do %>
       <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Stripe cards</h3>
-        <table>
-          <tr>
-            <th>Last 4</th>
-            <th>Card type</th>
-            <th>Status</th>
-            <th>Expires on</th>
-            <th></th>
-          </tr>
-          <% @user.stripe_cards.each do |card| %>
-            <tr>
-              <td><%= card.last4 %></td>
-              <td><%= card.card_type %></td>
-              <td class="inline-flex items-center w-100">
-                <% if card.status_text  == "Active" %>
-                  Active
-                <% elsif card.status_text == "Frozen" %>
-                  <%= inline_icon "freeze", size: 25 %> Frozen
-                <% elsif card.status_text == "Canceled" %>
-                  <%= inline_icon "forbidden", size: 25 %> Canceled
-                <% elsif card.status_text == "Inactive" %>
-                  Inactive
-                <% end %>
-              </td>
-              <td class="<%= "primary bold" if card.expired? %>"><%= Date.parse("#{card.stripe_exp_month}/#{card.stripe_exp_year}").strftime("%m/%y") %></td>
-              <td><%= link_to "View", stripe_card_path(card), data: { turbo_frame: "_top" } %></td>
-            </tr>
-          <% end %>
-        </table>
+        <p>Loading user's stripe cards</p>
       <% end %>
     <% end %>
 

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -11,14 +11,16 @@
       <% end %>
     <% end %>
 
-    <% if @user.events.present? %>
-      <% admin_tool "p-3" do %>
-        <h3 class="mb2 mt1">Organizations</h3>
+    <% admin_tool "p-3" do %>
+      <h3 class="mb2 mt1">Organizations</h3>
+      <% if @user.events.present? %>
         <ul>
           <% @user.events.each do |event| %>
             <li><%= link_to "#{event.name} (#{render_money(event.balance_v2_cents)})", event_path(event), data: { turbo_frame: "_top" } %></li>
           <% end %>
         </ul>
+      <% else %>
+        <%= blankslate "No organizations" %>
       <% end %>
     <% end %>
 

--- a/app/views/users/admin_details.html.erb
+++ b/app/views/users/admin_details.html.erb
@@ -149,5 +149,28 @@
         <p>Loading user's disbursements</p>
       <% end %>
     <% end %>
+
+    <% if @permissions_overview.event_graph.present? %>
+      <% admin_tool "p-3" do %>
+        <h3 class="mb2 mt1">Permissions</h3>
+
+        <ul>
+          <% @permissions_overview.event_graph.each do |node| %>
+            <%= render(partial: "event_permissions", locals: { node: }) %>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+
+    <% if @applications.any? %>
+      <% admin_tool "p-3" do %>
+        <h3 class="mb2 mt1">Applications</h3>
+        <ul>
+          <% @applications.each do |application| %>
+            <li><%= link_to "#{application.name} (#{application.aasm_state.humanize})", submission_application_path(application), data: { turbo_frame: "_top" } %></li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/users/admin_details_ach_transfers.html.erb
+++ b/app/views/users/admin_details_ach_transfers.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_frame_tag :admin_details_ach_transfers do %>
+  <h3 class="mb2 mt1">ACH transfers</h3>
+  <% if @ach_transfers.present? %>
+    <table>
+      <tr>
+        <th>Recipient name</th>
+        <th>Amount</th>
+        <th>Payment for</th>
+        <th>Scheduled on</th>
+        <th></th>
+      </tr>
+      <% @ach_transfers.each do |ach| %>
+        <tr>
+          <td><%= ach.recipient_name %></td>
+          <td><%= render_money ach.amount %></td>
+          <td><%= ach.payment_for %></td>
+          <td><%= ach.scheduled_on %></td>
+          <td><%= link_to "View", hcb_code_path(ach.hcb_code), data: { turbo_frame: "_top" } %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No ACH transfers" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_ach_transfers.html.erb
+++ b/app/views/users/admin_details_ach_transfers.html.erb
@@ -19,6 +19,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @ach_transfers %>
   <% else %>
     <%= blankslate "No ACH transfers" %>
   <% end %>

--- a/app/views/users/admin_details_check_deposits.html.erb
+++ b/app/views/users/admin_details_check_deposits.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag :admin_details_check_deposits do %>
+  <h3 class="mb2 mt1">Deposited checks</h3>
+  <% if @checks_deposits.present? %>
+    <table>
+      <tr>
+        <th>Status</th>
+        <th>Rejection reason</th>
+        <th>Amount</th>
+        <th>Date</th>
+      </tr>
+      <% @checks_deposits.each do |check| %>
+        <tr>
+          <td><%= check.increase_status %></td>
+          <td><%= check.rejection_reason %></td>
+          <td><%= render_money check.amount_cents %></td>
+          <td><%= check.created_at %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No check deposits" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_check_deposits.html.erb
+++ b/app/views/users/admin_details_check_deposits.html.erb
@@ -17,6 +17,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @check_deposits %>
   <% else %>
     <%= blankslate "No check deposits" %>
   <% end %>

--- a/app/views/users/admin_details_check_deposits.html.erb
+++ b/app/views/users/admin_details_check_deposits.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :admin_details_check_deposits do %>
   <h3 class="mb2 mt1">Deposited checks</h3>
-  <% if @checks_deposits.present? %>
+  <% if @check_deposits.present? %>
     <table>
       <tr>
         <th>Status</th>
@@ -8,7 +8,7 @@
         <th>Amount</th>
         <th>Date</th>
       </tr>
-      <% @checks_deposits.each do |check| %>
+      <% @check_deposits.each do |check| %>
         <tr>
           <td><%= check.increase_status %></td>
           <td><%= check.rejection_reason %></td>

--- a/app/views/users/admin_details_disbursements.html.erb
+++ b/app/views/users/admin_details_disbursements.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag :admin_details_disbursements do %>
+  <h3 class="mb2 mt1">Disbursements</h3>
+  <% if @disbursements.present? %>
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Amount</th>
+        <th>Status</th>
+      </tr>
+      <% @disbursements.each do |disbursement| %>
+        <tr>
+          <td><%= link_to disbursement.name, hcb_code_path(disbursement.hcb_code), data: { turbo_frame: "_top" } %></td>
+          <td><%= render_money disbursement.amount %></td>
+          <td><%= disbursement.state_text %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No disbursements" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_disbursements.html.erb
+++ b/app/views/users/admin_details_disbursements.html.erb
@@ -15,6 +15,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @disbursements %>
   <% else %>
     <%= blankslate "No disbursements" %>
   <% end %>

--- a/app/views/users/admin_details_emburse_cards.html.erb
+++ b/app/views/users/admin_details_emburse_cards.html.erb
@@ -27,6 +27,7 @@
           </tr>
         <% end %>
       </table>
+      <%= paginate @emburse_cards %>
     <% else %>
       <%= blankslate "No emburse cards" %>
     <% end %>

--- a/app/views/users/admin_details_emburse_cards.html.erb
+++ b/app/views/users/admin_details_emburse_cards.html.erb
@@ -10,19 +10,20 @@
           <th></th>
         </tr>
         <% @emburse_cards.each do |card| %>
-          <td><%= card.last_four %></td>
-          <td class="inline-flex">
-            <% if card.status_text == "active" %>
-              Active
-            <% elsif card.status_text == "suspended" %>
-              <%= inline_icon "freeze", size: 25 %> Suspended
-            <% elsif card.status_text == "unactivated" %>
-              <%= inline_icon "forbidden", size: 25 %> Unactivated
-            <% elsif card.status_text == "terminated" %>
-              <%= inline_icon "forbidden", size: 25 %> Terminated
-            <% end %>
-          </td>
-          <td><% Date.parse("#{card.expiration_month}/#{card.expiration_year}").strftime("%m/%y") %></td>
+          <tr>
+            <td><%= card.last_four %></td>
+            <td class="inline-flex">
+              <% if card.status_text == "active" %>
+                Active
+              <% elsif card.status_text == "suspended" %>
+                <%= inline_icon "freeze", size: 25 %> Suspended
+              <% elsif card.status_text == "unactivated" %>
+                <%= inline_icon "forbidden", size: 25 %> Unactivated
+              <% elsif card.status_text == "terminated" %>
+                <%= inline_icon "forbidden", size: 25 %> Terminated
+              <% end %>
+            </td>
+            <td><%= Date.parse("#{card.expiration_month}/#{card.expiration_year}").strftime("%m/%y") %></td>
             <td><%= link_to "View", emburse_card_path(card), data: { turbo_frame: "_top" } %></td>
           </tr>
         <% end %>

--- a/app/views/users/admin_details_emburse_cards.html.erb
+++ b/app/views/users/admin_details_emburse_cards.html.erb
@@ -1,0 +1,34 @@
+<%= turbo_frame_tag :admin_details_emburse_cards do %>
+  <% admin_tool "p-3" do %>
+    <h3 class="mb2 mt1">Emburse cards</h3>
+    <% if @emburse_cards.present? %>
+      <table>
+        <tr>
+          <th>Last 4</th>
+          <th>Status</th>
+          <th>Expires on</th>
+          <th></th>
+        </tr>
+        <% @emburse_cards.each do |card| %>
+          <td><%= card.last_four %></td>
+          <td class="inline-flex">
+            <% if card.status_text == "active" %>
+              Active
+            <% elsif card.status_text == "suspended" %>
+              <%= inline_icon "freeze", size: 25 %> Suspended
+            <% elsif card.status_text == "unactivated" %>
+              <%= inline_icon "forbidden", size: 25 %> Unactivated
+            <% elsif card.status_text == "terminated" %>
+              <%= inline_icon "forbidden", size: 25 %> Terminated
+            <% end %>
+          </td>
+          <td><% Date.parse("#{card.expiration_month}/#{card.expiration_year}").strftime("%m/%y") %></td>
+            <td><%= link_to "View", emburse_card_path(card), data: { turbo_frame: "_top" } %></td>
+          </tr>
+        <% end %>
+      </table>
+    <% else %>
+      <%= blankslate "No emburse cards" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_increase_checks.html.erb
+++ b/app/views/users/admin_details_increase_checks.html.erb
@@ -21,6 +21,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @increase_checks %>
   <% else %>
     <%= blankslate "No increase checks" %>
   <% end %>

--- a/app/views/users/admin_details_increase_checks.html.erb
+++ b/app/views/users/admin_details_increase_checks.html.erb
@@ -12,7 +12,7 @@
       </tr>
       <% @increase_checks.each do |check| %>
         <tr>
-          <td><%= check.payment_for %></td>
+          <td style="max-width: 250px; overflow: hidden; text-overflow: ellipsis;"><%= check.payment_for %></td>
           <td><%= check.memo %></td>
           <td><%= render_money check.amount %></td>
           <td><%= check.aasm_state %></td>

--- a/app/views/users/admin_details_increase_checks.html.erb
+++ b/app/views/users/admin_details_increase_checks.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :admin_details_increase_checks do %>
+  <h3 class="mb2 mt1">Increase checks</h3>
+  <% if @increase_checks.present? %>
+    <table>
+      <tr>
+        <th>Payment for</th>
+        <th>Memo</th>
+        <th>Amount</th>
+        <th>Status</th>
+        <th>Approved at</th>
+        <th></th>
+      </tr>
+      <% @increase_checks.each do |check| %>
+        <tr>
+          <td><%= check.payment_for %></td>
+          <td><%= check.memo %></td>
+          <td><%= render_money check.amount %></td>
+          <td><%= check.aasm_state %></td>
+          <td><%= check.approved_at %></td>
+          <td><%= link_to "View", hcb_code_path(check.hcb_code), data: { turbo_frame: "_top" } %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No increase checks" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_invoices.html.erb
+++ b/app/views/users/admin_details_invoices.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag :admin_details_invoices do %>
+  <h3 class="mb2 mt1">Invoices</h3>
+  <% if @invoices.present? %>
+    <table>
+      <tr>
+        <th>ID</th>
+        <th>Amount</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+      <% @invoices.each do |invoice| %>
+        <tr>
+          <td><%= invoice.id %></td>
+          <td><%= render_money invoice.total %></td>
+          <td><%= invoice.state_text %></td>
+          <td><%= link_to "View", hcb_code_path(invoice.hcb_code), data: { turbo_frame: "_top" } %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No invoices" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_invoices.html.erb
+++ b/app/views/users/admin_details_invoices.html.erb
@@ -17,6 +17,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @invoices %>
   <% else %>
     <%= blankslate "No invoices" %>
   <% end %>

--- a/app/views/users/admin_details_lob_checks.html.erb
+++ b/app/views/users/admin_details_lob_checks.html.erb
@@ -21,6 +21,7 @@
         </tr>
       <% end %>
     </table>
+    <%= paginate @lob_checks %>
   <% else %>
     <%= blankslate "No lob checks" %>
   <% end %>

--- a/app/views/users/admin_details_lob_checks.html.erb
+++ b/app/views/users/admin_details_lob_checks.html.erb
@@ -12,7 +12,7 @@
       </tr>
       <% @lob_checks.each do |check| %>
         <tr>
-          <td><%= check.payment_for %></td>
+          <td style="max-width: 250px; overflow: hidden; text-overflow: ellipsis;"><%= check.payment_for %></td>
           <td><%= check.memo %></td>
           <td><%= render_money check.amount %></td>
           <td><%= check.aasm_state %></td>

--- a/app/views/users/admin_details_lob_checks.html.erb
+++ b/app/views/users/admin_details_lob_checks.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag :admin_details_lob_checks do %>
+  <h3 class="mb2 mt1">Lob checks</h3>
+  <% if @lob_checks.present? %>
+    <table>
+      <tr>
+        <th>Payment for</th>
+        <th>Memo</th>
+        <th>Amount</th>
+        <th>Status</th>
+        <th>Approved at</th>
+        <th></th>
+      </tr>
+      <% @lob_checks.each do |check| %>
+        <tr>
+          <td><%= check.payment_for %></td>
+          <td><%= check.memo %></td>
+          <td><%= render_money check.amount %></td>
+          <td><%= check.aasm_state %></td>
+          <td><%= check.approved_at %></td>
+          <td><%= link_to "View", hcb_code_path(check.hcb_code), data: { turbo_frame: "_top" } %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <%= blankslate "No lob checks" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_missing_receipts.html.erb
+++ b/app/views/users/admin_details_missing_receipts.html.erb
@@ -1,0 +1,14 @@
+<%= turbo_frame_tag :admin_details_missing_receipts do %>
+  <% admin_tool "p-3" do %>
+    <h3 class="mb2 mt1">Missing receipts</h3>
+    <% if @hcb_codes_missing_receipts.any? %>
+      <table>
+        <% @hcb_codes_missing_receipts.each do |tx| %>
+          <%= render "canonical_transactions/canonical_transaction", ct: tx %>
+        <% end %>
+      </table>
+    <% else %>
+      <%= blankslate "No missing receipts" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_missing_receipts.html.erb
+++ b/app/views/users/admin_details_missing_receipts.html.erb
@@ -7,6 +7,7 @@
           <%= render "canonical_transactions/canonical_transaction", ct: tx %>
         <% end %>
       </table>
+      <%= paginate @hcb_codes_missing_receipts %>
     <% else %>
       <%= blankslate "No missing receipts" %>
     <% end %>

--- a/app/views/users/admin_details_reimbursement_reports.html.erb
+++ b/app/views/users/admin_details_reimbursement_reports.html.erb
@@ -33,6 +33,7 @@
         <% end %>
       </tbody>
     </table>
+    <%= paginate @reimbursement_reports %>
   <% else %>
     <%= blankslate "No reimbursement reports" %>
   <% end %>

--- a/app/views/users/admin_details_reimbursement_reports.html.erb
+++ b/app/views/users/admin_details_reimbursement_reports.html.erb
@@ -1,0 +1,39 @@
+<%= turbo_frame_tag :admin_details_reimbursement_reports do %>
+  <h3 class="mb2 mt1">Reimbursement reports</h3>
+  <% if @reimbursement_reports.present? %>
+    <table>
+      <thead>
+      <tr>
+        <th>Status</th>
+        <th>Report</th>
+        <th>Event</th>
+        <th>Amount</th>
+        <th>Created</th>
+      </tr>
+      </thead>
+      <tbody>
+        <% @reimbursement_reports.order(created_at: :desc).each do |report| %>
+          <tr>
+            <td>
+               <%= report.status_text %>
+            </td>
+            <td style="max-width: 250px; overflow: hidden; text-overflow: ellipsis;">
+              <%= link_to report.name, report, data: { turbo_frame: "_top" } %>
+            </td>
+            <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">
+               <%= report.event&.name || "No event" %>
+            </td>
+            <td>
+               <%= render_money report.amount_cents %>
+            </td>
+            <td>
+               <%= format_date report.created_at %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+      <%= blankslate "No reimbursement reports" %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_reimbursement_reports.html.erb
+++ b/app/views/users/admin_details_reimbursement_reports.html.erb
@@ -15,25 +15,25 @@
         <% @reimbursement_reports.order(created_at: :desc).each do |report| %>
           <tr>
             <td>
-               <%= report.status_text %>
+              <%= report.status_text %>
             </td>
             <td style="max-width: 250px; overflow: hidden; text-overflow: ellipsis;">
               <%= link_to report.name, report, data: { turbo_frame: "_top" } %>
             </td>
             <td style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">
-               <%= report.event&.name || "No event" %>
+              <%= report.event&.name || "No event" %>
             </td>
             <td>
-               <%= render_money report.amount_cents %>
+              <%= render_money report.amount_cents %>
             </td>
             <td>
-               <%= format_date report.created_at %>
+              <%= format_date report.created_at %>
             </td>
           </tr>
         <% end %>
       </tbody>
     </table>
   <% else %>
-      <%= blankslate "No reimbursement reports" %>
+    <%= blankslate "No reimbursement reports" %>
   <% end %>
 <% end %>

--- a/app/views/users/admin_details_stripe_cards.html.erb
+++ b/app/views/users/admin_details_stripe_cards.html.erb
@@ -30,6 +30,7 @@
           </tr>
         <% end %>
       </table>
+      <%= paginate @stripe_cards %>
     <% else %>
       <%= blankslate "No stripe cards" %>
     <% end %>

--- a/app/views/users/admin_details_stripe_cards.html.erb
+++ b/app/views/users/admin_details_stripe_cards.html.erb
@@ -1,0 +1,37 @@
+<%= turbo_frame_tag :admin_details_stripe_cards do %>
+  <% admin_tool "p-3" do %>
+    <h3 class="mb2 mt1">Stripe cards</h3>
+    <% if @stripe_cards.present? %>
+      <table>
+        <tr>
+          <th>Last 4</th>
+          <th>Card type</th>
+          <th>Status</th>
+          <th>Expires on</th>
+          <th></th>
+        </tr>
+        <% @stripe_cards.each do |card| %>
+          <tr>
+            <td><%= card.last4 %></td>
+            <td><%= card.card_type %></td>
+            <td class="inline-flex items-center w-100">
+              <% if card.status_text  == "Active" %>
+                Active
+              <% elsif card.status_text == "Frozen" %>
+                <%= inline_icon "freeze", size: 25 %> Frozen
+              <% elsif card.status_text == "Canceled" %>
+                <%= inline_icon "forbidden", size: 25 %> Canceled
+              <% elsif card.status_text == "Inactive" %>
+                Inactive
+              <% end %>
+            </td>
+            <td class="<%= "primary bold" if card.expired? %>"><%= Date.parse("#{card.stripe_exp_month}/#{card.stripe_exp_year}").strftime("%m/%y") %></td>
+            <td><%= link_to "View", stripe_card_path(card), data: { turbo_frame: "_top" } %></td>
+          </tr>
+        <% end %>
+      </table>
+    <% else %>
+      <%= blankslate "No stripe cards" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/admin_details_stripe_transactions.html.erb
+++ b/app/views/users/admin_details_stripe_transactions.html.erb
@@ -1,12 +1,14 @@
 <%= turbo_frame_tag :admin_details_stripe_transactions do %>
-  <% if @stripe_transactions.any? %>
-    <% admin_tool "p-3" do %>
-      <h3 class="mb2 mt1">Stripe transactions</h3>
+  <% admin_tool "p-3" do %>
+    <h3 class="mb2 mt1">Stripe transactions</h3>
+    <% if @stripe_transactions.any? %>
       <table>
         <% @stripe_transactions.each do |tx| %>
           <%= render "canonical_transactions/canonical_transaction", ct: tx %>
         <% end %>
       </table>
+    <% else %>
+      <%= blankslate "No stripe transactions" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/admin_details_stripe_transactions.html.erb
+++ b/app/views/users/admin_details_stripe_transactions.html.erb
@@ -7,6 +7,7 @@
           <%= render "canonical_transactions/canonical_transaction", ct: tx %>
         <% end %>
       </table>
+      <%= paginate @stripe_transactions %>
     <% else %>
       <%= blankslate "No stripe transactions" %>
     <% end %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -84,6 +84,7 @@
   <% end %>
 
   <% admin_tool "p-3" do %>
+    <h3 class="mb2 mt1">Comments</h3>
     <%= render "comments/list", comments: @user.comments, show_blankslate: true %>
     <%= render "comments/form", commentable: @user, admin_only: true %>
   <% end %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -83,6 +83,29 @@
     <% end %>
   <% end %>
 
+  <% if @permissions_overview.event_graph.present? %>
+    <% admin_tool "p-3" do %>
+      <h3 class="mb2 mt1">Permissions</h3>
+
+      <ul>
+        <% @permissions_overview.event_graph.each do |node| %>
+          <%= render(partial: "event_permissions", locals: { node: }) %>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <% if @applications.any? %>
+    <% admin_tool "p-3" do %>
+      <h3 class="mb2 mt1">Applications</h3>
+      <ul>
+        <% @applications.each do |application| %>
+          <li><%= link_to "#{application.name} (#{application.aasm_state.humanize})", submission_application_path(application), data: { turbo_frame: "_top" } %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
   <% admin_tool "p-3" do %>
     <%= render "comments/list", comments: @user.comments, show_blankslate: true %>
     <%= render "comments/form", commentable: @user, admin_only: true %>

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -83,29 +83,6 @@
     <% end %>
   <% end %>
 
-  <% if @permissions_overview.event_graph.present? %>
-    <% admin_tool "p-3" do %>
-      <h3 class="mb2 mt1">Permissions</h3>
-
-      <ul>
-        <% @permissions_overview.event_graph.each do |node| %>
-          <%= render(partial: "event_permissions", locals: { node: }) %>
-        <% end %>
-      </ul>
-    <% end %>
-  <% end %>
-
-  <% if @applications.any? %>
-    <% admin_tool "p-3" do %>
-      <h3 class="mb2 mt1">Applications</h3>
-      <ul>
-        <% @applications.each do |application| %>
-          <li><%= link_to "#{application.name} (#{application.aasm_state.humanize})", submission_application_path(application), data: { turbo_frame: "_top" } %></li>
-        <% end %>
-      </ul>
-    <% end %>
-  <% end %>
-
   <% admin_tool "p-3" do %>
     <%= render "comments/list", comments: @user.comments, show_blankslate: true %>
     <%= render "comments/form", commentable: @user, admin_only: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
       get "admin_details_ach_transfers", to: "users#admin_details_ach_transfers"
       get "admin_details_check_deposits", to: "users#admin_details_check_deposits"
       get "admin_details_disbursements", to: "users#admin_details_disbursements"
+      get "admin_details_emburse_cards", to: "users#admin_details_emburse_cards"
       get "admin_details_increase_checks", to: "users#admin_details_increase_checks"
       get "admin_details_invoices", to: "users#admin_details_invoices"
       get "admin_details_lob_checks", to: "users#admin_details_lob_checks"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Rails.application.routes.draw do
       get "admin_details_increase_checks", to: "users#admin_details_increase_checks"
       get "admin_details_invoices", to: "users#admin_details_invoices"
       get "admin_details_lob_checks", to: "users#admin_details_lob_checks"
+      get "admin_details_missing_receipts", to: "users#admin_details_missing_receipts"
       get "admin_details_reimbursement_reports", to: "users#admin_details_reimbursement_reports"
       get "admin_details_stripe_transactions", to: "users#admin_details_stripe_transactions"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Rails.application.routes.draw do
       get "admin_details_lob_checks", to: "users#admin_details_lob_checks"
       get "admin_details_missing_receipts", to: "users#admin_details_missing_receipts"
       get "admin_details_reimbursement_reports", to: "users#admin_details_reimbursement_reports"
+      get "admin_details_stripe_cards", to: "users#admin_details_stripe_cards"
       get "admin_details_stripe_transactions", to: "users#admin_details_stripe_transactions"
 
       delete "logout_all", to: "users#logout_all"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,13 @@ Rails.application.routes.draw do
       get "integrations", to: "users#edit_integrations"
       get "admin", to: "users#edit_admin"
       get "admin_details", to: "users#admin_details"
+      get "admin_details_ach_transfers", to: "users#admin_details_ach_transfers"
+      get "admin_details_check_deposits", to: "users#admin_details_check_deposits"
+      get "admin_details_disbursements", to: "users#admin_details_disbursements"
+      get "admin_details_increase_checks", to: "users#admin_details_increase_checks"
+      get "admin_details_invoices", to: "users#admin_details_invoices"
+      get "admin_details_lob_checks", to: "users#admin_details_lob_checks"
+      get "admin_details_reimbursement_reports", to: "users#admin_details_reimbursement_reports"
       get "admin_details_stripe_transactions", to: "users#admin_details_stripe_transactions"
 
       delete "logout_all", to: "users#logout_all"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
closes #13784


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Separated most records into their own turbo-framed page and added pagination to them. Some records which we can reasonably expect users to have few of are still directly in the admin_details turbo frame and not paginated for simplicity.

Adds `includes` statements to some record 

Also adds missing Rails model relation to make referencing records by `User` easier.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

