### PR TITLE
Prevent editing wire after sending - Fixes #13725

### DIFF
--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -22,11 +22,11 @@ class WirePolicy < ApplicationPolicy
   end
 
   def edit?
-    user&.admin?
+    user&.admin? && record.pending?
   end
 
   def update?
-    user&.admin?
+    user&.admin? && record.pending?
   end
 
   private

--- a/spec/factories/wire_factory.rb
+++ b/spec/factories/wire_factory.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wire do
+    association :event
+    association :user
+    amount_cents { 50_000 }
+    currency { "USD" }
+    memo { Faker::Lorem.sentence(word_count: 3) }
+    payment_for { Faker::Lorem.sentence(word_count: 4).truncate(140) }
+    recipient_name { Faker::Name.name }
+    recipient_email { Faker::Internet.email }
+    account_number { "DE89370400440532013000" }
+    bic_code { "DEUTDEDB" }
+    address_line1 { "123 Main St" }
+    address_city { "Berlin" }
+    address_postal_code { "10115" }
+    address_state { "Berlin" }
+    recipient_country { :DE }
+    recipient_information { {} }
+
+    trait :pending do
+      aasm_state { "pending" }
+    end
+
+    trait :approved do
+      aasm_state { "approved" }
+    end
+
+    trait :deposited do
+      aasm_state { "deposited" }
+    end
+  end
+end

--- a/spec/policies/wire_policy_spec.rb
+++ b/spec/policies/wire_policy_spec.rb
@@ -49,10 +49,22 @@ RSpec.describe WirePolicy, type: :policy do
       it "allows admin to update" do
         expect(described_class.new(admin, wire).update?).to eq(true)
       end
+
+      it "does not allow non-admin to update" do
+        expect(described_class.new(non_admin, wire).update?).to eq(false)
+      end
     end
 
     context "when wire is approved" do
       let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(false)
+      end
+    end
+
+    context "when wire is deposited" do
+      let(:wire) { create(:wire, :deposited, event: event, user: admin) }
 
       it "does not allow admin to update" do
         expect(described_class.new(admin, wire).update?).to eq(false)

--- a/spec/policies/wire_policy_spec.rb
+++ b/spec/policies/wire_policy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WirePolicy, type: :policy do
+  before do
+    stub_request(:get, /api\.column\.com\/institutions\/.*/)
+      .to_return(status: 200, body: '{"country_code": "DE"}', headers: { "Content-Type" => "application/json" })
+  end
+
+  let(:admin) { create(:user, :make_admin) }
+  let(:non_admin) { create(:user) }
+  let(:event) { create(:event, :with_positive_balance) }
+
+  describe "#edit?" do
+    context "when wire is pending" do
+      let(:wire) { create(:wire, :pending, event: event, user: admin) }
+
+      it "allows admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(true)
+      end
+
+      it "does not allow non-admin to edit" do
+        expect(described_class.new(non_admin, wire).edit?).to eq(false)
+      end
+    end
+
+    context "when wire is approved" do
+      let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(false)
+      end
+    end
+
+    context "when wire is deposited" do
+      let(:wire) { create(:wire, :deposited, event: event, user: admin) }
+
+      it "does not allow admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(false)
+      end
+    end
+  end
+
+  describe "#update?" do
+    context "when wire is pending" do
+      let(:wire) { create(:wire, :pending, event: event, user: admin) }
+
+      it "allows admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(true)
+      end
+    end
+
+    context "when wire is approved" do
+      let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #13725

## What's the bug?
Admins could edit a wire transfer even after it had already been sent to Column (approved/deposited state). This could cause HCB records to become misaligned with Column records.

## What's the fix?
Added a `record.pending?` check to `WirePolicy#edit?` and `WirePolicy#update?` so wires can only be edited while still in the pending state.

## Journey
First open source contribution! Fought through:
- WebMock blocking Column API calls
- German IBAN format validation (DE89370400440532013000)
- recipient_country enum format (:DE not 276)
- Balance validation on event
- Flipper stub conflicts

## Changes
- `app/policies/wire_policy.rb` — added state check to edit? and update?
- `spec/factories/wire_factory.rb` — new wire factory for tests
- `spec/policies/wire_policy_spec.rb` — 6 tests covering all wire states