### PR TITLE
Fix wire reimbursement minimum

### DIFF
--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -339,11 +339,7 @@ module Reimbursement
       maximum_amount_cents && amount_cents > maximum_amount_cents && currency == "USD"
     end
 
-    def minimum_wire_amount_cents
-      return event.minimum_wire_amount_cents unless card_grant.present?
-
-      500_00
-    end
+    delegate :minimum_wire_amount_cents, to: :event
 
     def below_minimum_amount?
       user.payout_method.is_a?(User::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -22,11 +22,11 @@ class WirePolicy < ApplicationPolicy
   end
 
   def edit?
-    user&.admin?
+    user&.admin? && record.pending?
   end
 
   def update?
-    user&.admin?
+    user&.admin? && record.pending?
   end
 
   private

--- a/spec/factories/wire_factory.rb
+++ b/spec/factories/wire_factory.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wire do
+    association :event
+    association :user
+    amount_cents { 50_000 }
+    currency { "USD" }
+    memo { Faker::Lorem.sentence(word_count: 3) }
+    payment_for { Faker::Lorem.sentence(word_count: 4).truncate(140) }
+    recipient_name { Faker::Name.name }
+    recipient_email { Faker::Internet.email }
+    account_number { "DE89370400440532013000" }
+    bic_code { "DEUTDEDB" }
+    address_line1 { "123 Main St" }
+    address_city { "Berlin" }
+    address_postal_code { "10115" }
+    address_state { "Berlin" }
+    recipient_country { :DE }
+    recipient_information { {} }
+
+    trait :pending do
+      aasm_state { "pending" }
+    end
+
+    trait :approved do
+      aasm_state { "approved" }
+    end
+
+    trait :deposited do
+      aasm_state { "deposited" }
+    end
+  end
+end

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe Reimbursement::Report, type: :model do
         event = create(:event)
         Flipper.enable(:exempt_from_wire_minimum, event)
         report = create(:reimbursement_report, event: event)
-        allow(report).to receive(:card_grant).and_return(double("CardGrant"))
+        allow(report).to receive(:card_grant).and_return(instance_double(CardGrant))
         expect(report.minimum_wire_amount_cents).to eq(100)
       end
 
       it "returns $500 when event is not exempt" do
         event = create(:event)
         report = create(:reimbursement_report, event: event)
-        allow(report).to receive(:card_grant).and_return(double("CardGrant"))
+        allow(report).to receive(:card_grant).and_return(instance_double(CardGrant))
         expect(report.minimum_wire_amount_cents).to eq(500_00)
       end
     end

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reimbursement::Report, type: :model do
+  describe "#minimum_wire_amount_cents" do
+    context "without a card grant" do
+      it "returns the event minimum" do
+        event = create(:event)
+        report = create(:reimbursement_report, event: event)
+        expect(report.minimum_wire_amount_cents).to eq(event.minimum_wire_amount_cents)
+      end
+
+      it "returns 100 when event is exempt from wire minimum" do
+        event = create(:event)
+        Flipper.enable(:exempt_from_wire_minimum, event)
+        report = create(:reimbursement_report, event: event)
+        expect(report.minimum_wire_amount_cents).to eq(100)
+      end
+    end
+
+    context "with a card grant" do
+      it "still respects the event wire minimum exemption" do
+        event = create(:event)
+        Flipper.enable(:exempt_from_wire_minimum, event)
+        report = create(:reimbursement_report, event: event)
+        allow(report).to receive(:card_grant).and_return(double("CardGrant"))
+        expect(report.minimum_wire_amount_cents).to eq(100)
+      end
+
+      it "returns $500 when event is not exempt" do
+        event = create(:event)
+        report = create(:reimbursement_report, event: event)
+        allow(report).to receive(:card_grant).and_return(double("CardGrant"))
+        expect(report.minimum_wire_amount_cents).to eq(500_00)
+      end
+    end
+  end
+end

--- a/spec/policies/wire_policy_spec.rb
+++ b/spec/policies/wire_policy_spec.rb
@@ -49,10 +49,22 @@ RSpec.describe WirePolicy, type: :policy do
       it "allows admin to update" do
         expect(described_class.new(admin, wire).update?).to eq(true)
       end
+
+      it "does not allow non-admin to update" do
+        expect(described_class.new(non_admin, wire).update?).to eq(false)
+      end
     end
 
     context "when wire is approved" do
       let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(false)
+      end
+    end
+
+    context "when wire is deposited" do
+      let(:wire) { create(:wire, :deposited, event: event, user: admin) }
 
       it "does not allow admin to update" do
         expect(described_class.new(admin, wire).update?).to eq(false)

--- a/spec/policies/wire_policy_spec.rb
+++ b/spec/policies/wire_policy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WirePolicy, type: :policy do
+  before do
+    stub_request(:get, /api\.column\.com\/institutions\/.*/)
+      .to_return(status: 200, body: '{"country_code": "DE"}', headers: { "Content-Type" => "application/json" })
+  end
+
+  let(:admin) { create(:user, :make_admin) }
+  let(:non_admin) { create(:user) }
+  let(:event) { create(:event, :with_positive_balance) }
+
+  describe "#edit?" do
+    context "when wire is pending" do
+      let(:wire) { create(:wire, :pending, event: event, user: admin) }
+
+      it "allows admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(true)
+      end
+
+      it "does not allow non-admin to edit" do
+        expect(described_class.new(non_admin, wire).edit?).to eq(false)
+      end
+    end
+
+    context "when wire is approved" do
+      let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(false)
+      end
+    end
+
+    context "when wire is deposited" do
+      let(:wire) { create(:wire, :deposited, event: event, user: admin) }
+
+      it "does not allow admin to edit" do
+        expect(described_class.new(admin, wire).edit?).to eq(false)
+      end
+    end
+  end
+
+  describe "#update?" do
+    context "when wire is pending" do
+      let(:wire) { create(:wire, :pending, event: event, user: admin) }
+
+      it "allows admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(true)
+      end
+    end
+
+    context "when wire is approved" do
+      let(:wire) { create(:wire, :approved, event: event, user: admin) }
+
+      it "does not allow admin to update" do
+        expect(described_class.new(admin, wire).update?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #13796

## What's the bug?
When a reimbursement report had a card grant, `minimum_wire_amount_cents` 
hardcoded $500 regardless of whether the event had the wire minimum 
disabled (via Flipper flag or plan exemption). This blocked legitimate 
wire reimbursements under $500 even when the minimum was explicitly 
disabled for that event.

## What's the fix?
Removed the card grant special case — `minimum_wire_amount_cents` now 
always delegates to `event.minimum_wire_amount_cents`, which already 
correctly handles all exemption logic.

## Journey
- card_grant factory internally calls Flipper.enabled?(:frozen) 
- user.stripe_cards undefined on nil user
- Switched to instance_double per Copilot review
- Extra commits issue from branch management

## Changes
- `app/models/reimbursement/report.rb` — removed hardcoded $500 fallback
- `spec/models/reimbursement/report_spec.rb` — 4 tests covering exemption behaviour with and without card grant