### PR TITLE
[Donations] Fix one pager screenshot

### DIFF
--- a/app/views/events/donation_overview.html.erb
+++ b/app/views/events/donation_overview.html.erb
@@ -185,8 +185,8 @@
     title: "Donations",
     support_article: "https://help.hcb.hackclub.com/en/articles/13370938-in-what-ways-can-i-edit-my-donation-page",
     screenshots: {
-      light: "https://user-cdn.hackclub-assets.com/019c3c6f-f02f-7df4-8ee9-25bbeb451e77/hcb.hackclub.com_hq_donations.png",
-      dark: "https://user-cdn.hackclub-assets.com/019c3c6f-dfd0-76b4-ac51-94f9143eb01a/hcb.hackclub.com_hq_donations%20(1).png"
+      light: "https://cdn.hackclub.com/019e7c92-1acf-7866-80cf-5946f5515639/image.png",
+      dark: "https://cdn.hackclub.com/019e7c95-f032-727c-9379-ae4cc062889b/image.png"
     },
     hints: [
       {


### PR DESCRIPTION
Fixes the broken screenshot in the donation one-pager

## Before
<img width="965" height="640" alt="image" src="https://github.com/user-attachments/assets/05a774b5-8b90-497f-b126-879322e0d5f3" />


## After
<img width="1019" height="761" alt="image" src="https://github.com/user-attachments/assets/b24d83b0-327f-47ba-b176-e9fa6e42a979" />
