### PR TITLE
[Documents] Fix creator tooltip

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -37,7 +37,7 @@
 <section class="details mb3 pt2">
 
   <p>
-    <strong>Added by</strong> <%= user_mention @document.user %>
+    <strong>Added by</strong> <span><%= user_mention @document.user %></span>
   </p>
 
   <p>


### PR DESCRIPTION
Fixes the tooltip for the "added by" section for documents

## Before
<img width="728" height="172" alt="image" src="https://github.com/user-attachments/assets/d627ff82-9fcf-4386-854c-edc4ea38ef4b" />


## After
<img width="556" height="211" alt="image" src="https://github.com/user-attachments/assets/2f9b9131-160d-4dcc-bfa6-72b94a5ecad5" />
