### PR TITLE
Fix legal name sent in organiser invoice notifications

### DIFF
--- a/app/views/invoice_mailer/notify_organizers_sent.html.erb
+++ b/app/views/invoice_mailer/notify_organizers_sent.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  <%= @invoice.creator.preferred_name %> on <%= @invoice.sponsor.event.name %> just sent a
+  <%= @invoice.creator.name %> on <%= @invoice.sponsor.event.name %> just sent a
   <strong><%= render_money @invoice.item_amount %></strong>
   <%= link_to hcb_code_url(@invoice.local_hcb_code.hashid) do %>invoice to <%= @invoice.sponsor.name %><% end %>
   for <em><%= @invoice.item_description %></em>.

--- a/app/views/invoice_mailer/notify_organizers_sent.html.erb
+++ b/app/views/invoice_mailer/notify_organizers_sent.html.erb
@@ -3,7 +3,7 @@
 </p>
 
 <p>
-  <%= @invoice.creator.full_name %> on <%= @invoice.sponsor.event.name %> just sent a
+  <%= @invoice.creator.preferred_name %> on <%= @invoice.sponsor.event.name %> just sent a
   <strong><%= render_money @invoice.item_amount %></strong>
   <%= link_to hcb_code_url(@invoice.local_hcb_code.hashid) do %>invoice to <%= @invoice.sponsor.name %><% end %>
   for <em><%= @invoice.item_description %></em>.


### PR DESCRIPTION
Currently the legal name is used in emails sent to other event managers about issued invoices. This PR changes it to preferred name which makes it consistent to the subject and removes sensitive information.