### PR TITLE
[v4] Switch transaction filter tag to take in `public_id` instead of `id`

### DIFF
--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -113,7 +113,7 @@ module Api
         return {
           event_id: @event.id,
           search: filter_params[:search].presence,
-          tag_id: filter_params[:tag_id].presence,
+          tag_id: filter_params[:tag_id].present? ? Tag.find_by_public_id(filter_params[:tag_id])&.id : nil,
           expenses: filter_params[:expenses].presence,
           revenue: filter_params[:revenue].presence,
           minimum_amount: filter_params[:minimum_amount].presence ? Money.from_amount(filter_params[:minimum_amount].to_f) : nil,


### PR DESCRIPTION
## Summary of the problem
We should be filtering by public id for tags not by their id


## Describe your changes
uses public id instead id


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

