### PR TITLE
[User] Add `subscribed_to_loops_at`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@
 #  session_validity_preference   :integer          default(259200), not null
 #  sessions_reported             :boolean          default(FALSE), not null
 #  slug                          :string
+#  subscribed_to_loops_at        :datetime
 #  teenager                      :boolean
 #  use_sms_auth                  :boolean          default(FALSE)
 #  use_two_factor_authentication :boolean          default(FALSE)

--- a/app/services/user_service/sync_with_loops.rb
+++ b/app/services/user_service/sync_with_loops.rb
@@ -27,6 +27,8 @@ module UserService
         user["HCB Has Card Grant?"] = @user.card_grants.any?
 
         user.save
+
+        @user.update(subscribed_to_loops_at: Time.now) if @user.subscribed_to_loops_at.nil?
       else
         body = {
           email: @user.email,
@@ -37,13 +39,16 @@ module UserService
           hcbLastSeenAt: format_unix(@user.last_seen_at),
           hcbLastLoginAt: format_unix(@user.last_login_at),
           hcbHasActiveOrg: @user.events.active.any?,
-          hcbHasCardGrant: @user.card_grants.any?,
-          mailingLists: {
+          hcbHasCardGrant: @user.card_grants.any?
+        }.compact_blank
+
+        if @user.subscribed_to_loops_at.nil?
+          body[:mailingLists] = {
             # https://loops.so/docs/contacts/mailing-lists#api
             Credentials.fetch(:LOOPS, :MAILING_LIST) => true
           }
-        }.compact_blank
-
+          @user.update(subscribed_to_loops_at: Time.now)
+        end
         body[:userGroup] = "HCB Adult"
         body[:subscribed] = true if @contact_details.nil?
         body[:source] = "HCB" if @contact_details.nil?

--- a/db/migrate/20260606005743_add_subscribed_to_loops_at_to_user.rb
+++ b/db/migrate/20260606005743_add_subscribed_to_loops_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToLoopsAtToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :subscribed_to_loops_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_24_221911) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_06_005743) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -2681,6 +2681,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_24_221911) do
     t.integer "session_validity_preference", default: 259200, null: false
     t.boolean "sessions_reported", default: false, null: false
     t.string "slug"
+    t.datetime "subscribed_to_loops_at"
     t.boolean "teenager"
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "use_sms_auth", default: false


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were accidentally resubscribing adults to mailing lists they had already subscribed from. Hack Club email tools does not currently support adults but when it does we can migrate them to using that system and this column will no longer be needed.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

