### PR TITLE
[v4] Wrap multiple write operations in an ActiveRecord Transaction

### DIFF
--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -37,14 +37,16 @@ module Api
         end
 
 
-        @ach_transfer.save!
-        if ach_transfer_params[:file]
-          ::ReceiptService::Create.new(
-            uploader: current_user,
-            attachments: ach_transfer_params[:file],
-            upload_method: :ach_transfer_api,
-            receiptable: @ach_transfer.local_hcb_code
-          ).run!
+        ActiveRecord::Base.transaction do
+          @ach_transfer.save!
+          if ach_transfer_params[:file]
+            ::ReceiptService::Create.new(
+              uploader: current_user,
+              attachments: ach_transfer_params[:file],
+              upload_method: :ach_transfer_api,
+              receiptable: @ach_transfer.local_hcb_code
+            ).run!
+          end
         end
 
         render :show, status: :created

--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -39,6 +39,7 @@ module Api
 
         ActiveRecord::Base.transaction do
           @ach_transfer.save!
+
           if ach_transfer_params[:file]
             ::ReceiptService::Create.new(
               uploader: current_user,

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -48,15 +48,17 @@ module Api
           }, status: :bad_request
         end
 
-        @check.save!
+        ActiveRecord::Base.transaction do
+          @check.save!
 
-        if check_params[:file]
-          ::ReceiptService::Create.new(
-            uploader: current_user,
-            attachments: check_params[:file],
-            upload_method: :check_api,
-            receiptable: @check.local_hcb_code
-          ).run!
+          if check_params[:file]
+            ::ReceiptService::Create.new(
+              uploader: current_user,
+              attachments: check_params[:file],
+              upload_method: :check_api,
+              receiptable: @check.local_hcb_code
+            ).run!
+          end
         end
 
         render :show, status: :created

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -55,7 +55,7 @@ module Api
             ::ReceiptService::Create.new(
               uploader: current_user,
               attachments: check_params[:file],
-              upload_method: :check_api,
+              upload_method: :api,
               receiptable: @check.local_hcb_code
             ).run!
           end


### PR DESCRIPTION
## Summary of the problem
Although unlikely there can be a possibility where if we save the ACH/Check object but the receipt creation fails then we end up with a scenario where we have a create transfer without its receipt. 


## Describe your changes
Using `ActiveRecord::Base.transaction` treats both operations as one atomic operation meaning if either fail it will rollback both.
