### PR TITLE
Redux - Add Disbursement#events and refactor comment_policy

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -258,6 +258,10 @@ class Disbursement < ApplicationRecord
     Comment.where(commentable: [self, outgoing_disbursement.local_hcb_code, incoming_disbursement.local_hcb_code])
   end
 
+  def events
+    [source_event, destination_event]
+  end
+
   def canonical_transactions
     @canonical_transactions ||= CanonicalTransaction.where(hcb_code: [outgoing_hcb_code, incoming_hcb_code])
   end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -56,9 +56,6 @@ class CommentPolicy < ApplicationPolicy
         user_list += record.commentable.event&.users || [] # event&.users can be nil (event-less reports)
         user_list += record.commentable.event&.ancestor_users || []
       end
-    elsif record.commentable.is_a?(Disbursement)
-      # TODO: possibly replace this by adding #events to Disbursement?
-      user_list = record.commentable.source_event.users + record.commentable.destination_event.users
     elsif record.commentable.is_a?(Event)
       user_list = []
     else

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -43,17 +43,27 @@ RSpec.describe CommentPolicy, type: :policy do
     end
 
     context "when commentable is a Disbursement" do
-      it "includes users from both source and destination events" do
+      it "includes users from both source and destination events, plus their ancestors" do
+        source_parent = create(:event)
+        source_ancestor_user = create(:user)
+        create(:organizer_position, event: source_parent, user: source_ancestor_user)
+        source_event = create(:event, parent: source_parent)
         source_user = create(:user)
+        create(:organizer_position, event: source_event, user: source_user)
+
+        destination_parent = create(:event)
+        destination_ancestor_user = create(:user)
+        create(:organizer_position, event: destination_parent, user: destination_ancestor_user)
+        destination_event = create(:event, parent: destination_parent)
         destination_user = create(:user)
-        disbursement = create(:disbursement)
-        create(:organizer_position, event: disbursement.source_event, user: source_user)
-        create(:organizer_position, event: disbursement.destination_event, user: destination_user)
+        create(:organizer_position, event: destination_event, user: destination_user)
+
+        disbursement = create(:disbursement, source_event: source_event, event: destination_event)
 
         comment = create(:comment, commentable: disbursement)
         policy = described_class.new(source_user, comment)
 
-        expect(policy.send(:users)).to include(source_user, destination_user)
+        expect(policy.send(:users)).to include(source_user, destination_user, source_ancestor_user, destination_ancestor_user)
       end
     end
 


### PR DESCRIPTION
## Summary of the problem

Recreating https://github.com/hackclub/hcb/pull/13698 since it got merged into a stacked branch and not main

Follow up to https://github.com/hackclub/hcb/pull/13248#discussion_r2997165705

This also fixes an inadvertent bug where members of ancestor events could not view disbursement comments