### PR TITLE
Use correct OOO callout partial on application review page

### DIFF
--- a/app/views/event/applications/review.html.erb
+++ b/app/views/event/applications/review.html.erb
@@ -17,7 +17,7 @@
 
 <div class="flex flex-col items-center flex-grow">
   <div class="md:max-w-[600px] w-full mt-7 space-y-8 pb-5">
-    <%= render "event/applications/review_delay_callout" %>
+    <%= render "application/ooo_callout", resource: "application", financial: false, business_days: @application.response_business_days %>
     <%= render "event/applications/summary", application: @application, allow_edits: true %>
   </div>
 </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
#13812 removed the review_delay_callout partial being used for applications, but only replaced it with the new callout on the show page, not the review page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use the correct OOO callout on the application review page.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

