### PR TITLE
[v4][Card Grant] only update exp date if passed

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -92,9 +92,10 @@ module Api
       def update
         authorize @card_grant
 
-        expiration_at = params["expiration_at"]&.to_date
+        attrs = params.permit(:merchant_lock, :category_lock, :keyword_lock, :purpose, :one_time_use, :instructions)
+        attrs[:expiration_at] = params["expiration_at"]&.to_date if params["expiration_at"].present?
 
-        @card_grant.update!(params.permit(:merchant_lock, :category_lock, :keyword_lock, :purpose, :one_time_use, :instructions).merge(expiration_at:))
+        @card_grant.update!(attrs)
 
         render :show
       end


### PR DESCRIPTION
## Summary of the problem
When you PATCH with with no `expiration_at` in the body, `expiration_at` evaluates to nil, and `.merge(expiration_at:
  nil)` tries to write NULL to the column. But card_grants.expiration_at is NOT NULL 


## Describe your changes
makes sure to only pass when needed


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

