### PR TITLE
[Wise] Restrict reject and failure to admins

### DIFF
--- a/app/policies/wise_transfer_policy.rb
+++ b/app/policies/wise_transfer_policy.rb
@@ -14,7 +14,7 @@ class WiseTransferPolicy < ApplicationPolicy
   end
 
   def reject?
-    user_who_can_transfer?
+    user&.admin?
   end
 
   def update?
@@ -26,7 +26,7 @@ class WiseTransferPolicy < ApplicationPolicy
   end
 
   def mark_failed?
-    user_who_can_transfer?
+    user&.admin?
   end
 
   def generate_quote?


### PR DESCRIPTION
Only allow admins to reject and mark a Wise transfer as failed.