### PR TITLE
[Applications] Do not allow applicants to use their email as cosigner email

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -254,7 +254,7 @@ class Event
       new_cosigner_email = params[:event_application][:cosigner_email]
 
       if new_cosigner_email == @application.user.email
-        flash[:error] = "You cannot change the cosigner email to your email"
+        flash[:error] = "You cannot use your own email as your parent's email"
       else
         @application.update!(cosigner_email: params[:event_application][:cosigner_email])
 

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -251,7 +251,7 @@ class Event
     def resend_to_cosigner
       authorize @application
 
-      new_cosigner_email = params[:event_application][:cosigner_email]
+      new_cosigner_email = params[:event_application][:cosigner_email]&.strip
 
       if new_cosigner_email == @application.user.email
         flash[:error] = "You cannot use your own email as your parent's email"

--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -251,14 +251,21 @@ class Event
     def resend_to_cosigner
       authorize @application
 
-      @application.update!(cosigner_email: params[:event_application][:cosigner_email])
+      new_cosigner_email = params[:event_application][:cosigner_email]
 
-      # If the user resends to the same email, the after_save callback does not handle this
-      unless @application.cosigner_email_previously_changed?
-        @application.contract.party(:cosigner).notify
+      if new_cosigner_email == @application.user.email
+        flash[:error] = "You cannot change the cosigner email to your email"
+      else
+        @application.update!(cosigner_email: params[:event_application][:cosigner_email])
+
+        # If the user resends to the same email, the after_save callback does not handle this
+        unless @application.cosigner_email_previously_changed?
+          @application.contract.party(:cosigner).notify
+        end
+
+        flash[:success] = "Resent agreement to parent"
       end
 
-      flash[:success] = "Resent agreement to parent"
       redirect_back_or_to application_path(@application)
     end
 

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -440,7 +440,7 @@ class Event
         self[field].nil? || self[field] == ""
       end
 
-      !missing_fields && !address_country.in?(DISALLOWED_COUNTRIES)
+      !missing_fields && !address_country.in?(DISALLOWED_COUNTRIES) && !(cosigner_email.present? && cosigner_email == user.email)
     end
 
     def user_ready_to_submit?

--- a/app/views/event/applications/_summary.html.erb
+++ b/app/views/event/applications/_summary.html.erb
@@ -177,11 +177,11 @@
       <div>
         <p class="text-sm muted mb-1">Parent email</p>
         <p class="mb-0">
-        <% if application.cosigner_email.present? && application.cosigner_email == application.user.email %>
-          <span class="text-primary"><%= application.cosigner_email %></span> - <em>you cannot use your own email</em>
-        <% else %>
-          <%= application.cosigner_email.present? ? application.cosigner_email : missing %>
-        <% end %>
+          <% if application.cosigner_email.present? && application.cosigner_email == application.user.email %>
+            <span class="text-primary"><%= application.cosigner_email %></span> - <em>you cannot use your own email</em>
+          <% else %>
+            <%= application.cosigner_email.present? ? application.cosigner_email : missing %>
+          <% end %>
         </p>
       </div>
 

--- a/app/views/event/applications/_summary.html.erb
+++ b/app/views/event/applications/_summary.html.erb
@@ -176,7 +176,13 @@
     <% if application.user.is_minor? %>
       <div>
         <p class="text-sm muted mb-1">Parent email</p>
-        <p class="mb-0"><%= application.cosigner_email.present? ? application.cosigner_email : missing %></p>
+        <p class="mb-0">
+        <% if application.cosigner_email.present? && application.cosigner_email == application.user.email %>
+          <span class="text-primary"><%= application.cosigner_email %></span> - <em>you cannot use your own email</em>
+        <% else %>
+          <%= application.cosigner_email.present? ? application.cosigner_email : missing %>
+        <% end %>
+        </p>
       </div>
 
       <% admin_tool "p-2" do %>

--- a/app/views/event/applications/personal_info.html.erb
+++ b/app/views/event/applications/personal_info.html.erb
@@ -130,7 +130,7 @@
         Parent email <span class="text-primary">*</span>
       <% end %>
       <p class="h5 muted mt0 mb1">We'll need a parent or legal guardian to sign the fiscal sponsorship agreement. They're giving you permission to create an organization on HCB but will not have access or control.</p>
-      <%= form.email_field :cosigner_email, class: "w-full !max-w-full", required: true, placeholder: "orpheus@hackclub.com", "x-bind:required": "minor" %>
+      <%= form.email_field :cosigner_email, class: "w-full !max-w-full", required: true, placeholder: "orpheus@hackclub.com", "x-bind:required": "minor", "x-on:input": "$el.value == '#{@application.user.email}' ? $el.setCustomValidity('You cannot use your own email') : $el.setCustomValidity('')" %>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
People have submitted applications using their own email as the cosigner email. We shouldn't allow this.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a check in the ready to submit method and resend to cosigner route to make sure that the emails are different, and add a frontend validation.

I did not add this as a validation on the model since there are several existing applications in various stages that would fail the validation, and cause issues whenever any of these applications are updated.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

