### PR TITLE
[Contracts] Link onboarding videos for signee contracts

### DIFF
--- a/app/views/contract/parties/_contract_faq.html.erb
+++ b/app/views/contract/parties/_contract_faq.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (no_questions: false) %>
 
-<%= render "application/callout", title: "Questions about the HCB agreement?", type: "info", class: "mt-0 max-h-full", footer: no_questions ? nil : :questions do %>
+<%= render "application/callout", title: "Questions about the HCB agreement?", type: "info", class: "my-0", footer: no_questions ? nil : :questions do %>
   <p>
     <span class="font-bold">Why do I need to sign this agreement?</span><br>
     This Fiscal Sponsorship Agreement sets the terms and conditions of your usage of HCB. It allows your project to use HCB's 501(c)(3) nonprofit status and defines a restricted fund for your project.

--- a/app/views/contract/parties/show.html.erb
+++ b/app/views/contract/parties/show.html.erb
@@ -41,7 +41,19 @@
         <% end %>
       </div>
     <% else %>
-      <%= render partial: "contract_faq" %>
+      <div class="flex flex-col max-h-full gap-4">
+        <% if @party.signee? %>
+          <%= render "application/callout", title: "Watch the onboarding videos", type: "warning", class: "my-0 flex-shrink-0" do %>
+            <p class="my-0">
+              If you haven't had an onboarding meeting, please watch:
+              <a href="https://www.youtube.com/watch?v=Ucz-QT2GPOk" target="_blank">HCB Onboarding (#1): Introduction</a> and
+              <a href="https://www.youtube.com/watch?v=LMh9FCm8iIE" target="_blank">HCB Onboarding (#2): Rules & Regulations</a>.
+            </p>
+          <% end %>
+        <% end %>
+
+        <%= render partial: "contract_faq" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/event/applications/agreement.html.erb
+++ b/app/views/event/applications/agreement.html.erb
@@ -12,7 +12,7 @@
       This agreement formalizes the relationship between your project and HCB<% if @application.teen_led? %>, but it is not finalized until we review and approve your application<% end %>
     </p>
 
-    <div class="h-[40vh]">
+    <div class="h-[40vh] flex">
       <%= render partial: "contract/parties/contract_faq", locals: { no_questions: true } %>
     </div>
   </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
HCB signees onboarded through OPIs (manual invites, suborgs) still need an onboarding meeting or the onboarding videos to sign the contract. Since they may have gone through an onboarding meeting or a process specific to the HQ program, we don't need to require it like we do for applications.

Closes #12726

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a callout for signees when signing the contract that links to the onboarding videos.

<img width="1282" height="901" alt="image" src="https://github.com/user-attachments/assets/77f8b7f5-64f5-48c4-9f7f-b3db9edea81c" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

