### PR TITLE
[Applications] Update airtable status on activation and reissue

### DIFF
--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -291,6 +291,8 @@ class Event
       fs_contract.send!(reissue_signee_message:, reissue_cosigner_message:)
       fs_contract.party(:cosigner)&.notify unless reissue_of.present?
 
+      set_airtable_status("Documents sent") if reissue_of.present?
+
       fs_contract
     end
 
@@ -362,9 +364,7 @@ class Event
         end
       end
 
-      airrecord = airtable_record
-      airrecord["Status"] = "Onboarded"
-      airrecord.save
+      set_airtable_status("Onboarded")
 
       schedule_airtable_sync
 
@@ -455,6 +455,15 @@ class Event
       end
 
       !missing_fields
+    end
+
+    def set_airtable_status(status)
+      airrecord = airtable_record
+
+      if airrecord.present?
+        airrecord["Status"] = status
+        airrecord.save
+      end
     end
 
   end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -464,6 +464,8 @@ class Event
         airrecord["Status"] = status
         airrecord.save
       end
+    rescue => e
+      Rails.error.report(e)
     end
 
   end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -362,6 +362,10 @@ class Event
         end
       end
 
+      airrecord = airtable_record
+      airrecord["Status"] = "Onboarded"
+      airrecord.save
+
       schedule_airtable_sync
 
       Event::ApplicationMailer.with(application: self).activated.deliver_later


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We initially decided to not update the normal ops Status field in Airtable - however, this has been requested and would be helpful. These are one-time updates, and the status can still be changed by ops later and it will not revert back.

Closes #13718

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a `set_airtable_status` method to Event::Application and use it on activation and contract reissue.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

