### PR TITLE
[Admin] Fix excluding reimbursement option in transfer searches

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -497,7 +497,7 @@ class AdminController < Admin::BaseController
 
     @count = relation.count
     @ach_transfers = relation.page(@page).per(@per).order(
-      Arel.sql("aasm_state = 'pending' DESC"),
+      Arel.sql("ach_transfers.aasm_state = 'pending' DESC"),
       "created_at desc"
     )
 
@@ -729,7 +729,7 @@ class AdminController < Admin::BaseController
     relation = relation.where.missing(:reimbursement_payout_holding) if @exclude_reimbursements
 
     @checks = relation.page(@page).per(@per).order(
-      Arel.sql("aasm_state = 'pending' DESC"),
+      Arel.sql("increase_checks.aasm_state = 'pending' DESC"),
       "created_at desc"
     )
 
@@ -796,7 +796,7 @@ class AdminController < Admin::BaseController
     end
 
     @wires = @wires.page(@page).per(@per).order(
-      Arel.sql("aasm_state = 'pending' DESC"),
+      Arel.sql("wires.aasm_state = 'pending' DESC"),
       "created_at desc"
     )
 
@@ -837,8 +837,8 @@ class AdminController < Admin::BaseController
     end
 
     @wise_transfers = @wise_transfers.page(@page).per(@per).order(
-      Arel.sql("aasm_state = 'pending' DESC"),
-      Arel.sql("aasm_state = 'approved' DESC"),
+      Arel.sql("wise_transfers.aasm_state = 'pending' DESC"),
+      Arel.sql("wise_transfers.aasm_state = 'approved' DESC"),
       "created_at desc"
     )
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/1030/samples/timestamp/2026-06-09T14:52:45Z

#13826 added a checkbox to exclude reimbursements in transfer admin pages, but introduced a SQL join that made ordering by `aasm_state` ambiguous.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Specify the table name to make ordering by `aasm_state` unambiguous.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

