### PR TITLE
Fix remove scoped tag button in suborg form

### DIFF
--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -49,8 +49,7 @@
               <span x-text="scoped_tag.name"></span>
               <button
                 type="button" class="p0 line-height-0 bg-transparent border-none cursor-pointer link-reset"
-                x-on:click="scoped_tags = scoped_tags.filter(t => t.id !== scoped_tag.id)"
-              >
+                x-on:click="scoped_tags = scoped_tags.filter(t => t.id !== scoped_tag.id)">
                 <%= inline_icon "view-close", size: 16 %>
               </button>
             </span>

--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -47,8 +47,12 @@
       <template x-for="scoped_tag in scoped_tags" :key="scoped_tag.id">
             <span class="badge m0 w-fit">
               <span x-text="scoped_tag.name"></span>
-              <button class="p0 line-height-0 bg-transparent border-none cursor-pointer link-reset"
-                <%= inline_icon "view-close", size: 16 %>>
+              <button
+                type="button" class="p0 line-height-0 bg-transparent border-none cursor-pointer link-reset"
+                x-on:click="scoped_tags = scoped_tags.filter(t => t.id !== scoped_tag.id)"
+              >
+                <%= inline_icon "view-close", size: 16 %>
+              </button>
             </span>
       </template>
     </div>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
[`db892c4` (#11932)](https://github.com/hackclub/hcb/pull/11932/changes/db892c45fe4a0cd59fbea344ec277f8ae2c82bd9) broke the HTML for removing a scoped tag in the suborg creation form - unfortunately ERB lint doesn't play nice with Alpine's `@` syntax.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Fix the HTML and add the event handler back, using the ERB-lint friendly `x-on` syntax

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

