### PR TITLE
Add tooltips to organization settings nav links

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -226,55 +226,63 @@ module EventsHelper
         {
           name: "Organization",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "details") },
+          tooltip: "Edit organization details and visibility",
           symbol: :settings_details,
           available_proc: ->(event) { true },
         },
         {
           name: "Donations",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "donations") },
+          tooltip: "Edit donation page, goals, and tiers",
           symbol: :settings_donations,
           available_proc: ->(event) { event.approved? && event.plan.donations_enabled? }
         },
         {
           name: "Reimbursements",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "reimbursements") },
+          tooltip: "Edit reimbursement page and review requirements",
           symbol: :settings_reimbursements,
           available_proc: ->(event) { event.approved? && event.plan.reimbursements_enabled? }
         },
         {
           name: "Card grants",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "card_grants") },
+          tooltip: "Edit card grant default settings, restrictions, and support",
           symbol: :settings_card_grants,
           available_proc: ->(event) { event.approved? && event.plan.card_grants_enabled? },
-          tooltip: "Manage card grants"
         },
         {
           name: "Tags",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "tags") },
+          tooltip: "Manage transaction tags",
           symbol: :settings_tags,
           available_proc: ->(event) { true }
         },
         {
           name: "Affiliations",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "affiliations") },
+          tooltip: "Update organization affiliations",
           symbol: :settings_affiliations,
           available_proc: ->(event) { true }
         },
         {
           name: "Integrations",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "integrations") },
+          tooltip: "Setup and manage integrations with HCB",
           symbol: :settings_integrations,
           available_proc: ->(event) { true }
         },
         {
           name: "Feature previews",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "features") },
+          tooltip: "Get access to new HCB features",
           symbol: :settings_features,
           available_proc: ->(event) { true }
         },
         {
           name: "Audit log",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "audit_log") },
+          tooltip: "View all organization activity",
           symbol: :settings_audit_log,
           available_proc: ->(event) { true }
         },

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -275,7 +275,7 @@ module EventsHelper
         {
           name: "Feature previews",
           path_proc: ->(event_id) { edit_event_path(event_id, tab: "features") },
-          tooltip: "Get access to new HCB features",
+          tooltip: "Enable new HCB features",
           symbol: :settings_features,
           available_proc: ->(event) { true }
         },


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, only the card grant nav link has a tooltip. All links should have a tooltip to explain what the page is without having to go to it, and to display on the org placeholder page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add tooltips to all links except for admin (doesn't really need one).

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

