### PR TITLE
Allow members to create suborganizations behind opt-in flag

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -95,7 +95,7 @@ class EventMailer < ApplicationMailer
     @emails = @event.organizer_contact_emails(only_managers: true)
     return if @emails.none?
 
-    mail to: @emails, subject: "#{@creator.name} created a new sub-organization under #{@event.name}"
+    mail to: @emails, subject: "[#{@event.name}] #{@creator.name} created #{@subevent.name}, a new sub-organization under #{@event.name}"
   end
 
   private

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -2,7 +2,7 @@
 
 class EventMailer < ApplicationMailer
   before_action { @event = params[:event] }
-  before_action :set_emails, except: [:monthly_donation_summary, :monthly_follower_summary]
+  before_action :set_emails, except: [:monthly_donation_summary, :monthly_follower_summary, :subevent_created]
   before_action :set_whodunnit, only: [:transparency_mode_enabled, :transparency_mode_disabled, :monthly_announcements_enabled, :monthly_announcements_disabled]
 
   def monthly_donation_summary
@@ -87,6 +87,15 @@ class EventMailer < ApplicationMailer
 
   def monthly_announcements_disabled
     mail to: @emails, subject: "#{@event.name} has disabled monthly announcements"
+  end
+
+  def subevent_created
+    @subevent = params[:subevent]
+    @creator = params[:creator]
+    @emails = @event.organizer_contact_emails(only_managers: true)
+    return if @emails.none?
+
+    mail to: @emails, subject: "#{@creator.name} created a new sub-organization under #{@event.name}"
   end
 
   private

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -200,7 +200,9 @@ class EventPolicy < ApplicationPolicy
   end
 
   def create_sub_organization?
-    admin_or_manager? && record.subevents_enabled?
+    return false unless record.subevents_enabled?
+
+    admin_or_manager? || (Flipper.enabled?(:member_subevent_creation, record) && member?)
   end
 
   def donation_overview?

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -82,7 +82,7 @@ module EventService
     def notify_parent_event_managers(event)
       # Only suborg creation notifies (parent_event present); top-level/admin org creation never does.
       return if @parent_event.nil? || @invited_by.nil?
-      # Suppress when creator is a manager/admin/ancestor-manager of the parent — only sub-manager creators trigger the email.
+      # Suppress when creator is a manager/admin/ancestor-manager of the parent — only members creators trigger the email.
       return if OrganizerPosition.role_at_least?(@invited_by, @parent_event, :manager)
 
       EventMailer.with(event: @parent_event, subevent: event, creator: @invited_by).subevent_created.deliver_later

--- a/app/services/event_service/create.rb
+++ b/app/services/event_service/create.rb
@@ -44,7 +44,7 @@ module EventService
       raise ArgumentError, "organization name is required" unless @name.present?
       raise ArgumentError, "approved must be true or false" unless @approved == true || @approved == false
 
-      ActiveRecord::Base.transaction do
+      event = ActiveRecord::Base.transaction do
         event = ::Event.create!(attrs)
         @tags
           .filter { |tag| EventTag::Tags::ALL.include?(tag) }
@@ -71,9 +71,22 @@ module EventService
 
         event
       end
+
+      notify_parent_event_managers(event)
+
+      event
     end
 
     private
+
+    def notify_parent_event_managers(event)
+      # Only suborg creation notifies (parent_event present); top-level/admin org creation never does.
+      return if @parent_event.nil? || @invited_by.nil?
+      # Suppress when creator is a manager/admin/ancestor-manager of the parent — only sub-manager creators trigger the email.
+      return if OrganizerPosition.role_at_least?(@invited_by, @parent_event, :manager)
+
+      EventMailer.with(event: @parent_event, subevent: event, creator: @invited_by).subevent_created.deliver_later
+    end
 
     def attrs
       {

--- a/app/views/event_mailer/subevent_created.html.erb
+++ b/app/views/event_mailer/subevent_created.html.erb
@@ -1,0 +1,16 @@
+<p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
+
+<p>
+  <%= @creator.name %> (<%= @creator.email %>) has created a new sub-organization,
+  <%= link_to @subevent.name, event_url(@subevent) %>, under <%= @event.name %>.
+</p>
+
+<p>
+  You're receiving this because you're a manager of <%= @event.name %>. You can view all
+  sub-organizations <%= link_to "here", event_sub_organizations_url(@event) %>.
+</p>
+
+<p>
+  From,<br>
+  The HCB Team
+</p>

--- a/app/views/event_mailer/subevent_created.html.erb
+++ b/app/views/event_mailer/subevent_created.html.erb
@@ -1,13 +1,15 @@
 <p><%= @emails.length > 1 ? "Hi all," : "Hi there," %></p>
 
 <p>
-  <%= @creator.name %> (<%= @creator.email %>) has created a new sub-organization,
-  <%= link_to @subevent.name, event_url(@subevent) %>, under <%= @event.name %>.
+  <%= @creator.name %> (<%= @creator.email %>) just created
+  <%= link_to @subevent.name, event_url(@subevent) %>, a new sub-organization
+  under <%= @event.name %>. You're receiving this because you're a manager of
+  <%= @event.name %>.
 </p>
 
 <p>
-  You're receiving this because you're a manager of <%= @event.name %>. You can view all
-  sub-organizations <%= link_to "here", event_sub_organizations_url(@event) %>.
+  You can open <%= link_to @subevent.name, event_url(@subevent) %> to review it,
+  or see all of <%= link_to "#{@event.name}'s sub-organizations", event_sub_organizations_url(@event) %>.
 </p>
 
 <p>

--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -4,8 +4,8 @@
   <div class="card border b--info mt2 mb2 container--sm mx-auto">
     <p class="mt0 mb0">
       Sub-organizations are subsidiaries of your organization. All members
-      of <%= event.name %> can access and view sub-organizations, but only
-      managers can create and edit them.
+      of <%= event.name %> can access and view sub-organizations<% unless Flipper.enabled?(:member_subevent_creation, event) %>, but only
+      managers can create and edit them<% end %>.
     </p>
   </div>
 

--- a/spec/mailers/event_mailer_subevent_created_spec.rb
+++ b/spec/mailers/event_mailer_subevent_created_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe EventMailer, type: :mailer do
       expect(mailer.to).not_to include(member.email)
     end
 
-    it "renders a subject naming the creator and parent" do
-      expect(mailer.subject).to eq("#{creator.name} created a new sub-organization under #{parent_event.name}")
+    it "renders a subject naming the parent, creator, and sub-organization" do
+      expect(mailer.subject).to eq("[#{parent_event.name}] #{creator.name} created #{subevent.name}, a new sub-organization under #{parent_event.name}")
     end
 
     it "links to the new sub-organization in the body" do

--- a/spec/mailers/event_mailer_subevent_created_spec.rb
+++ b/spec/mailers/event_mailer_subevent_created_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventMailer, type: :mailer do
+  describe "#subevent_created" do
+    let(:parent_event) { create(:event) }
+    let(:subevent) { create(:event, parent: parent_event, name: "New Budget") }
+    let(:creator) { create(:user, full_name: "Member McMemberface") }
+
+    let(:manager) { create(:user) }
+    let(:member) { create(:user) }
+
+    before do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+      create(:organizer_position, user: manager, event: parent_event, role: :manager)
+      create(:organizer_position, user: member, event: parent_event, role: :member)
+    end
+
+    let(:mailer) { EventMailer.with(event: parent_event, subevent:, creator:).subevent_created }
+
+    it "is sent only to managers of the parent event" do
+      expect(mailer.to).to include(manager.email)
+      expect(mailer.to).not_to include(member.email)
+    end
+
+    it "renders a subject naming the creator and parent" do
+      expect(mailer.subject).to eq("#{creator.name} created a new sub-organization under #{parent_event.name}")
+    end
+
+    it "links to the new sub-organization in the body" do
+      expect(mailer.body.encoded).to include(subevent.name)
+      expect(mailer.body.encoded).to include(creator.name)
+    end
+  end
+end

--- a/spec/mailers/previews/event_mailer_preview.rb
+++ b/spec/mailers/previews/event_mailer_preview.rb
@@ -43,4 +43,9 @@ class EventMailerPreview < ActionMailer::Preview
     EventMailer.with(event: Event.first, whodunnit: Event.first.users.first).monthly_announcements_disabled
   end
 
+  def subevent_created
+    subevent = Event.where.not(parent_id: nil).last
+    EventMailer.with(event: subevent.parent, subevent:, creator: subevent.users.first).subevent_created
+  end
+
 end

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventPolicy, type: :policy do
+  describe "#create_sub_organization?" do
+    let(:event) { create(:event) }
+    let(:user) { create(:user) }
+
+    subject { described_class.new(user, event).create_sub_organization? }
+
+    before do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+    end
+
+    context "when sub-organizations are not enabled on the event" do
+      before { create(:organizer_position, user:, event:, role: :manager) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when sub-organizations are enabled" do
+      before { event.config.update!(subevent_plan: Event::Plan::Standard.name) }
+
+      context "as a manager" do
+        before { create(:organizer_position, user:, event:, role: :manager) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "as a member" do
+        before { create(:organizer_position, user:, event:, role: :member) }
+
+        it "is denied by default" do
+          is_expected.to eq(false)
+        end
+
+        it "is allowed when the member_subevent_creation flag is enabled for the event" do
+          Flipper.enable(:member_subevent_creation, event)
+
+          is_expected.to eq(true)
+        end
+      end
+
+      context "as a reader" do
+        before do
+          create(:organizer_position, user:, event:, role: :reader)
+          Flipper.enable(:member_subevent_creation, event)
+        end
+
+        it "is denied even when the flag is enabled" do
+          is_expected.to eq(false)
+        end
+      end
+
+      context "as an admin without a position" do
+        let(:user) { create(:user, :make_admin) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "as a manager of an ancestor org creating on a subevent" do
+        let(:subevent) { create(:event, parent: event) }
+
+        subject { described_class.new(user, subevent).create_sub_organization? }
+
+        before do
+          create(:organizer_position, user:, event:, role: :manager)
+          subevent.config.update!(subevent_plan: Event::Plan::Standard.name)
+        end
+
+        it "is allowed without the flag" do
+          is_expected.to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/event_service/create_spec.rb
+++ b/spec/services/event_service/create_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventService::Create do
+  describe "#run" do
+    let(:parent_event) { create(:event) }
+    let(:creator) { create(:user) }
+    let!(:parent_manager) { create(:organizer_position, event: parent_event, role: :manager) }
+
+    before do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+
+      # Avoid hitting the contract/DocuSeal flow triggered by signee invites.
+      invite_model = instance_double(OrganizerPositionInvite, send_contract: true)
+      invite_service = instance_double(OrganizerPositionInviteService::Create, run!: true, model: invite_model)
+      allow(OrganizerPositionInviteService::Create).to receive(:new).and_return(invite_service)
+    end
+
+    def build_service(invited_by:)
+      described_class.new(
+        name: "New Budget",
+        emails: ["organizer@example.com"],
+        point_of_contact_id: User.system_user.id,
+        invited_by:,
+        parent_event:,
+        plan: Event::Plan::Standard
+      )
+    end
+
+    context "when created by a member of the parent" do
+      before { create(:organizer_position, user: creator, event: parent_event, role: :member) }
+
+      it "notifies the parent's managers" do
+        expect { build_service(invited_by: creator).run }
+          .to have_enqueued_mail(EventMailer, :subevent_created).once
+      end
+    end
+
+    context "when created by a manager of the parent" do
+      before { create(:organizer_position, user: creator, event: parent_event, role: :manager) }
+
+      it "does not notify the parent's managers" do
+        expect { build_service(invited_by: creator).run }
+          .not_to have_enqueued_mail(EventMailer, :subevent_created)
+      end
+    end
+
+    context "when created by an admin without a position" do
+      let(:creator) { create(:user, :make_admin) }
+
+      it "does not notify the parent's managers" do
+        expect { build_service(invited_by: creator).run }
+          .not_to have_enqueued_mail(EventMailer, :subevent_created)
+      end
+    end
+  end
+end

--- a/spec/services/event_service/create_spec.rb
+++ b/spec/services/event_service/create_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventService::Create do
     let!(:parent_manager) { create(:organizer_position, event: parent_event, role: :manager) }
 
     before do
-      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+      allow(User).to receive(:system_user).and_return(create(:user, :make_admin, email: User::SYSTEM_USER_EMAIL))
 
       # Avoid hitting the contract/DocuSeal flow triggered by signee invites.
       invite_model = instance_double(OrganizerPositionInvite, send_contract: true)


### PR DESCRIPTION
Members (not just managers) can now create suborganizations when the
per-event `member_subevent_creation` Flipper flag is enabled, in addition
to the existing `subevent_plan` gate. Managers and admins are unaffected.

When a suborg is created by someone below manager in the parent org, all
parent managers are notified via a new EventMailer#subevent_created email.
No initial transfer and no approval step are introduced.

https://claude.ai/code/session_011LiPDMebKbFHV3nVJ2juPP