### PR TITLE
[Marketing] Remove old flippers

### DIFF
--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -11,29 +11,19 @@ class MarketingController < ApplicationController
   skip_before_action :redirect_to_onboarding
   skip_after_action :verify_authorized # not Pundit-managed
 
-  # Gated behind a Flipper flag during rollout: anyone without it 404s. Flip the flag on
-  # per-user (or boolean-enable it globally to make the page public at launch).
-  before_action :require_funders_access
   invisible_captcha only: [:funder_inquiry], honeypot: :subtitle
 
   after_action :allow_indexing, only: [:funders]
 
-  FUNDERS_FLAG = :funders_landing_page
-
   # Gates just the "Funders on HCB" testimonials section, so the page can ship while we
   # await sign-off on the funder quotes. Enable once the quotes are approved.
   TESTIMONIALS_FLAG = :funders_landing_testimonials
-
-  # Gates the Argosy Foundation case study independently, so it can be held back until it's
-  # cleared to show.
-  ARGOSY_FLAG = :funders_landing_argosy
 
   FUNDER_STATS_CACHE_KEY = "marketing/funder_stats"
 
   def funders
     @stats = funder_stats
     @show_testimonials = Flipper.enabled?(TESTIMONIALS_FLAG, current_user)
-    @show_argosy = Flipper.enabled?(ARGOSY_FLAG, current_user)
     @skip_layout_og_tags = true # page provides its own funder-specific meta
   end
 
@@ -61,10 +51,6 @@ class MarketingController < ApplicationController
   end
 
   private
-
-  def require_funders_access
-    not_found unless Flipper.enabled?(FUNDERS_FLAG, current_user)
-  end
 
   # Headline figures for the funders page, computed live and cached so the page never
   # runs heavy aggregates inline.

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -325,9 +325,7 @@
 </section>
 
 <%# ============================ CASE STUDY: ARGOSY ============================ %>
-<%# Argosy Foundation / FIRST Robotics case study, gated behind :funders_landing_argosy so
-    it can be held back until it's cleared to show. %>
-<% if @show_argosy %>
+<%# Argosy Foundation / FIRST Robotics case study. %>
 <section class="mk-section mk-product mk-product--metric">
   <div class="mk-container">
     <div class="mk-product__grid">
@@ -379,7 +377,6 @@
     </div>
   </div>
 </section>
-<% end %>
 
 <%# ============================ IMPACT (where it lands) ============================ %>
 <%# Three real funded projects (Ghostty, Miami Hack Week, MALAN) — approved logos/photos

--- a/spec/requests/marketing_spec.rb
+++ b/spec/requests/marketing_spec.rb
@@ -10,17 +10,11 @@ require "rails_helper"
 #   light-mode only — the funder audience doesn't need dark mode, so it's deferred.
 # - Unlike the rest of the app (which sends a noindex X-Robots-Tag), this page is
 #   *deliberately* indexable — it's public marketing meant to be found in search.
-# - During rollout the whole page sits behind :funders_landing_page. Visitors without the
-#   flag get a 404 (not a 403/redirect) so the unreleased page is indistinguishable from one
-#   that doesn't exist.
 # - "HCB by Hack Club": Hack Club (legally The Hack Foundation) is the 501(c)(3); HCB is the
 #   platform it operates. The page never claims HCB itself is the charity.
 RSpec.describe "Funders landing page", type: :request do
-  # Most examples assume the rollout flag is on; the gating examples flip it off explicitly.
-  before { Flipper.enable(MarketingController::FUNDERS_FLAG) }
-
   describe "GET /for/funders" do
-    it "renders for signed-out visitors when the flag is enabled" do
+    it "renders for signed-out visitors" do
       get funders_path
 
       expect(response).to have_http_status(:ok)
@@ -68,23 +62,12 @@ RSpec.describe "Funders landing page", type: :request do
       expect(response.body).to include("Dashboard")
       expect(response.body).not_to include(">Log in<")
     end
-
-    # Before launch the page must be invisible to the public — a 404 (not a redirect or 403)
-    # so its existence isn't leaked.
-    it "404s when the funders flag is disabled" do
-      Flipper.disable(MarketingController::FUNDERS_FLAG)
-
-      get funders_path
-
-      expect(response).to have_http_status(:not_found)
-      expect(response.body).not_to include("Deploy your capital as grants")
-    end
   end
 
-  # The "Funders on HCB" testimonials block has its OWN flag, separate from the page flag.
-  # The Mitchell Hashimoto quote is adapted from public material and still pending sign-off —
-  # so the page can ship publicly while this section stays hidden until the quote is approved,
-  # then it's flipped on without a deploy. (The Argosy story lives in its own ungated section.)
+  # The "Funders on HCB" testimonials block is gated behind its own flag. The Mitchell
+  # Hashimoto quote is adapted from public material and still pending sign-off — so the page
+  # stays public while this section is hidden until the quote is approved, then it's flipped
+  # on without a deploy. (The Argosy story now ships ungated in its own section.)
   describe "Funders on HCB testimonials section" do
     it "is hidden by default so the page can launch before the quotes are approved" do
       get funders_path
@@ -112,17 +95,8 @@ RSpec.describe "Funders landing page", type: :request do
     end
   end
 
-  # The Argosy Foundation case study is gated separately so it can be held back until cleared.
   describe "Argosy case study" do
-    it "is hidden by default" do
-      get funders_path
-
-      expect(response.body).not_to include("Case study")
-    end
-
-    it "appears once :funders_landing_argosy is enabled" do
-      Flipper.enable(MarketingController::ARGOSY_FLAG)
-
+    it "shows the Argosy Foundation case study" do
       get funders_path
 
       expect(response.body).to include("Case study")
@@ -166,14 +140,6 @@ RSpec.describe "Funders landing page", type: :request do
       expect do
         post funder_inquiry_path, params: { email: "bot@example.com", subtitle: "i am a bot" }
       end.not_to have_enqueued_mail(FunderInquiryMailer, :inquiry)
-    end
-
-    it "404s when the funders flag is disabled" do
-      Flipper.disable(MarketingController::FUNDERS_FLAG)
-
-      post funder_inquiry_path, params: { email: "funder@example.com" }
-
-      expect(response).to have_http_status(:not_found)
     end
   end
 end


### PR DESCRIPTION
## Summary of the problem

Many sections of the marketing site have shipped (flippers fully enabled).


## Describe your changes

We can now remove those flippers