### PR TITLE
[Marketing] Add Reboot to the For Funders page

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -1132,6 +1132,44 @@ $mk-bg: $snow; // #f9fafc
   text-align: center;
 }
 
+// Reboot recipient card: .mk-case plus a brand mark above the quote and a "Backed by" footer.
+.mk-case--reboot {
+  .mk-case__brand {
+    height: 22px;
+    width: auto;
+    align-self: flex-start; // shrink-wrap the wordmark instead of stretching it across the card
+  }
+}
+
+.mk-case__backers {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px 22px; // row gap (label to logos) / column gap (between logos)
+  padding-top: 22px;
+  border-top: 1px solid rgba($black, 0.08);
+}
+
+.mk-case__backers-label {
+  flex-basis: 100%; // sit on its own line so the two logos get the card's full width
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $muted;
+}
+
+.mk-case__backer {
+  height: 18px;
+  width: auto;
+
+  // Omidyar's lockup packs an icon plus text into a taller image, so its wordmark reads small at
+  // Ford's height; bump it up to optically match. Also recolor its native grey to black.
+  &--omidyar {
+    height: 24px;
+    filter: brightness(0);
+  }
+}
+
 // ---------------------------------------------------------------- trust
 .mk-trust {
   text-align: center;

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -378,6 +378,59 @@
   </div>
 </section>
 
+<%# ============================ RECIPIENT STORY: REBOOT ============================ %>
+<%# Recipient-side counterpart to the Argosy case study. The Ford Foundation and Omidyar Network are
+    credited as Reboot's backers, not as HCB users. Keep it that way. %>
+<section class="mk-section mk-product mk-product--metric">
+  <div class="mk-container">
+    <div class="mk-product__grid">
+      <div class="mk-product__copy">
+        <p class="mk-eyebrow">On HCB &middot; Reboot</p>
+        <h2 class="mk-section__title">
+          The organizations serious funders back already run on HCB.
+        </h2>
+        <p class="mk-lead">
+          <a href="https://joinreboot.org" target="_blank" rel="noopener">Reboot</a> is a nonprofit
+          publication and community on technology and society.
+        </p>
+        <ul class="mk-ticks">
+          <li>Since 2020: a newsletter and five print issues of its magazine, <em>Kernel</em></li>
+          <li>More than $400,000 raised on HCB</li>
+          <li>Run by volunteers, with no back office to staff</li>
+        </ul>
+      </div>
+
+      <div class="mk-product__media">
+        <figure class="mk-case mk-case--reboot">
+          <%= image_tag "https://cdn.hackclub.com/019ed937-fe26-77a0-8d7e-d6b9cf428eb9/image.png",
+                class: "mk-case__brand", alt: "Reboot", loading: "lazy", decoding: "async" %>
+          <blockquote>“HCB’s platform has made it possible to scale Reboot’s team and operations in
+            a way that would be otherwise impossible. The platform is extremely transparent and easy
+            to use; and the team is incredibly kind and responsive.”</blockquote>
+          <figcaption>
+            <%= image_tag "https://cdn.hackclub.com/019ed937-f871-772f-9b5f-1d54f33ae264/image.png",
+                  class: "mk-case__avatar", alt: "Jasmine Sun", width: 84, height: 84,
+                  loading: "lazy", decoding: "async" %>
+            <span class="mk-case__meta">
+              <span class="mk-case__name">Jasmine Sun</span>
+              <span class="mk-case__detail">Co-founder of Reboot</span>
+            </span>
+          </figcaption>
+          <%# Reboot's backers. Not linked, since they're not HCB partners. %>
+          <div class="mk-case__backers">
+            <span class="mk-case__backers-label">Backed by</span>
+            <%= image_tag "https://cdn.hackclub.com/019ed938-00a8-714d-bd51-3a7145ef976e/image.png",
+                  class: "mk-case__backer", alt: "Ford Foundation", loading: "lazy", decoding: "async" %>
+            <%= image_tag "https://cdn.hackclub.com/019ed938-0314-7502-9dca-4a7f342c53d7/image.png",
+                  class: "mk-case__backer mk-case__backer--omidyar", alt: "Omidyar Network",
+                  loading: "lazy", decoding: "async" %>
+          </div>
+        </figure>
+      </div>
+    </div>
+  </div>
+</section>
+
 <%# ============================ IMPACT (where it lands) ============================ %>
 <%# Three real funded projects (Ghostty, Miami Hack Week, MALAN) — approved logos/photos
     on our CDN, each linking out to the project. Captions final/approved. %>


### PR DESCRIPTION
## Summary of the problem

We want to feature Reboot.


## Describe your changes

Recipient-side counterpart to the Argosy case study: a quote from Reboot co-founder Jasmine Sun, with the Ford Foundation and Omidyar Network credited as Reboot's backers (not as HCB users). Mirrors the Argosy layout with a quote card and a "Backed by" logo footer.

<img width="1148" height="473" alt="image" src="https://github.com/user-attachments/assets/509a7e1c-ace1-401a-80d5-bc067040f288" />
