### PR TITLE
feat(users): add locked reason functionality for user management

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -342,7 +342,7 @@ class UsersController < ApplicationController
       end
 
       locked = params[:user][:locked] == "1"
-      if @user.locked? != locked && (!params[:user][:locked_reason].empty? || @user.locked?)
+      if @user.locked? != locked
         if @user == current_user
           flash[:error] = "As much as you might desire to, you cannot lock yourself out."
           return redirect_to admin_user_path(@user)
@@ -352,16 +352,15 @@ class UsersController < ApplicationController
         elsif locked && @user.superadmin?
           flash[:error] = "To lock this user, demote them to a regular admin first."
           return redirect_to admin_user_path(@user)
+        elsif locked && params[:user][:locked_reason].blank?
+          flash[:error] = "To lock this user, provide a reason"
+          return redirect_to admin_user_path(@user)
         elsif locked
           Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Locked #{@user.preferred_name} : For - #{params[:user][:locked_reason]}")
           @user.lock!
         else
-          Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Unlocked #{@user.preferred_name} : At - #{Time.now}")
           @user.unlock!
         end
-      else
-        flash[:error] = "To lock this user, provide a reason"
-        return redirect_to admin_user_path(@user)
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -342,7 +342,7 @@ class UsersController < ApplicationController
       end
 
       locked = params[:user][:locked] == "1"
-      if @user.locked? != locked
+      if @user.locked? != locked && (!params[:user][:locked_reason].empty? || @user.locked?)
         if @user == current_user
           flash[:error] = "As much as you might desire to, you cannot lock yourself out."
           return redirect_to admin_user_path(@user)
@@ -353,10 +353,15 @@ class UsersController < ApplicationController
           flash[:error] = "To lock this user, demote them to a regular admin first."
           return redirect_to admin_user_path(@user)
         elsif locked
+          Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Locked #{@user.preferred_name} : For - #{params[:user][:locked_reason]}")
           @user.lock!
         else
+          Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Unlocked #{@user.preferred_name} : At - #{Time.now}")
           @user.unlock!
         end
+      else
+        flash[:error] = "To lock this user, provide a reason"
+        return redirect_to admin_user_path(@user)
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -359,6 +359,7 @@ class UsersController < ApplicationController
           Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Locked #{@user.preferred_name} : For - #{params[:user][:locked_reason]}")
           @user.lock!
         else
+          Comment.create(admin_only: true, commentable: @user, user_id: current_user.id, content: "Unlocked #{@user.preferred_name} : At - #{Time.now}")
           @user.unlock!
         end
       end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,7 @@ import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers'
 import { installErrorHandler } from '@appsignal/stimulus'
 import { appsignal } from '../appsignal'
 import HwComboboxController from '@josefarias/hotwire_combobox'
+import LockedReasonController from './locked_reason_controller'
 
 const application = Application.start()
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,7 +6,6 @@ import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers'
 import { installErrorHandler } from '@appsignal/stimulus'
 import { appsignal } from '../appsignal'
 import HwComboboxController from '@josefarias/hotwire_combobox'
-import LockedReasonController from './locked_reason_controller'
 
 const application = Application.start()
 

--- a/app/javascript/controllers/locked_reason_controller.js
+++ b/app/javascript/controllers/locked_reason_controller.js
@@ -1,0 +1,20 @@
+import $ from 'jquery'
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['reason', 'checkbox']
+  static values = { originallyLocked: Boolean }
+
+  connect() {
+    this.toggle()
+    $(this.reasonTarget).hide()
+  }
+
+  toggle() {
+    if (this.checkboxTarget.checked && !this.originallyLockedValue) {
+      $(this.reasonTarget).show()
+    } else {
+      $(this.reasonTarget).hide()
+    }
+  }
+}

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -51,8 +51,8 @@
             </div>
 
             <div class="field field--text-field" data-locked-reason-target="reason">
-              <%= form.label :locked_reason, "Reason for Locking User"%>
-              <%= form.text_field :locked_reason%>
+              <%= form.label :locked_reason, "Reason for Locking User" %>
+              <%= form.text_field :locked_reason %>
             </div>
           </div>
 

--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -44,9 +44,16 @@
             <%= link_to "Impersonate", impersonate_user_path(@user.id), data: { turbo_confirm: "Are you sure?", turbo_method: :post } unless current_session&.impersonated? %>
           </p>
 
-          <div class="field field--checkbox">
-            <%= form.label :locked, "Lock user from signing into HCB" %>
-            <%= form.check_box :locked, checked: @user.locked?, disabled: !admin_signed_in? %>
+          <div data-controller="locked-reason" data-locked-reason-originally-locked-value="<%= @user.locked? %>">
+            <div class="field field--checkbox">
+              <%= form.label :locked, "Lock user from signing into HCB" %>
+              <%= form.check_box :locked, { checked: @user.locked?, disabled: !admin_signed_in?, data: { locked_reason_target: "checkbox", action: "change->locked-reason#toggle" } } %>
+            </div>
+
+            <div class="field field--text-field" data-locked-reason-target="reason">
+              <%= form.label :locked_reason, "Reason for Locking User"%>
+              <%= form.text_field :locked_reason%>
+            </div>
           </div>
 
           <div class="field field--checkbox">

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -160,6 +160,88 @@ RSpec.describe UsersController do
       expect(flash.to_h).to eq("error" => "#{reason} Please choose another method.")
       expect(user.reload.payout_method_type).to eq(nil)
     end
+
+    context "when locking a user" do
+      let(:admin_user) { create(:user, :make_admin) }
+      let(:target_user) { create(:user, full_name: "Jane Doe", preferred_name: "Jane") }
+
+      before { create_session(admin_user, verified: true) }
+
+      it "creates a comment with the lock reason" do
+        patch(
+          :update,
+          params: {
+            id: target_user.id,
+            user: { locked: "1", locked_reason: "Spam account" }
+          }
+        )
+
+        expect(target_user.reload.locked?).to eq(true)
+
+        comment = Comment.last
+        expect(comment.commentable).to eq(target_user)
+        expect(comment.admin_only).to eq(true)
+        expect(comment.user_id).to eq(admin_user.id)
+        expect(comment.content).to eq("Locked Jane : For - Spam account")
+      end
+
+      it "does not create a comment when unlocking" do
+        target_user.lock!
+
+        expect {
+          patch(
+            :update,
+            params: {
+              id: target_user.id,
+              user: { locked: "0", locked_reason: "" }
+            }
+          )
+        }.not_to change(Comment, :count)
+
+        expect(target_user.reload.locked?).to eq(false)
+      end
+
+      it "requires a lock reason" do
+        patch(
+          :update,
+          params: {
+            id: target_user.id,
+            user: { locked: "1", locked_reason: "" }
+          }
+        )
+
+        expect(flash[:error]).to eq("To lock this user, provide a reason")
+        expect(target_user.reload.locked?).to eq(false)
+      end
+
+      it "prevents admins from locking themselves" do
+        patch(
+          :update,
+          params: {
+            id: admin_user.id,
+            user: { locked: "1", locked_reason: "Testing" }
+          }
+        )
+
+        expect(flash[:error]).to eq("As much as you might desire to, you cannot lock yourself out.")
+        expect(admin_user.reload.locked?).to eq(false)
+      end
+
+      it "prevents regular admins from locking other admins" do
+        other_admin = create(:user, :make_admin, full_name: "Other Admin")
+
+        patch(
+          :update,
+          params: {
+            id: other_admin.id,
+            user: { locked: "1", locked_reason: "Testing" }
+          }
+        )
+
+        expect(flash[:error]).to eq("Only superadmins can lock or unlock admins.")
+        expect(other_admin.reload.locked?).to eq(false)
+      end
+    end
   end
 
   describe "settings access for unverified users" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -185,20 +185,23 @@ RSpec.describe UsersController do
         expect(comment.content).to eq("Locked Jane : For - Spam account")
       end
 
-      it "does not create a comment when unlocking" do
+      it "creates an unlock comment when unlocking" do
         target_user.lock!
 
-        expect {
-          patch(
-            :update,
-            params: {
-              id: target_user.id,
-              user: { locked: "0", locked_reason: "" }
-            }
-          )
-        }.not_to change(Comment, :count)
+        patch(
+          :update,
+          params: {
+            id: target_user.id,
+            user: { locked: "0", locked_reason: "" }
+          }
+        )
 
         expect(target_user.reload.locked?).to eq(false)
+
+        comment = Comment.last
+        expect(comment.commentable).to eq(target_user)
+        expect(comment.admin_only).to eq(true)
+        expect(comment.content).to include("Unlocked")
       end
 
       it "requires a lock reason" do


### PR DESCRIPTION
## Summary of the problem
https://github.com/hackclub/hcb/issues/12931



## Describe your changes
- add locked_reason field and validation when locking users
- create Comment with lock reason when user is locked
- implement LockedReasonController to show/hide reason field based on lock checkbox
- update view to show locked reason input when locking user
- add controller specs for lock/unlock behavior with reason validation
- prevent locking without providing a reason
- maintain existing self-lock and admin-lock prevention logic



Demo:
https://github.com/user-attachments/assets/1e42ff6d-af1d-45d8-8bcd-11a2f060be5b


