### PR TITLE
[Marketing] Add Public Grids to the For Funders page

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -580,6 +580,26 @@ $mk-bg: $snow; // #f9fafc
   }
 }
 
+// Mirror the layout (media left, copy right) so stacked product/case sections alternate
+// instead of repeating the same zig. Desktop only — on mobile both columns collapse to one
+// and copy stays first (source order).
+.mk-product--reverse {
+  @media (min-width: 920px) {
+    .mk-product__copy {
+      order: 2;
+    }
+
+    .mk-product__media {
+      order: 1;
+    }
+
+    // Keep the copy in the wider column even though it now sits on the right.
+    &.mk-product--metric .mk-product__grid {
+      grid-template-columns: 0.9fr 1.1fr;
+    }
+  }
+}
+
 .mk-product__copy {
   min-width: 0;
 }
@@ -1132,13 +1152,11 @@ $mk-bg: $snow; // #f9fafc
   text-align: center;
 }
 
-// Reboot recipient card: .mk-case plus a brand mark above the quote and a "Backed by" footer.
-.mk-case--reboot {
-  .mk-case__brand {
-    height: 22px;
-    width: auto;
-    align-self: flex-start; // shrink-wrap the wordmark instead of stretching it across the card
-  }
+// Recipient card brand mark: a wordmark above the quote (used by the Reboot and Public Grids cards).
+.mk-case__brand {
+  height: 22px;
+  width: auto;
+  align-self: flex-start; // shrink-wrap the wordmark instead of stretching it across the card
 }
 
 .mk-case__backers {

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -19,11 +19,16 @@ class MarketingController < ApplicationController
   # await sign-off on the funder quotes. Enable once the quotes are approved.
   TESTIMONIALS_FLAG = :funders_landing_testimonials
 
+  # Gates the Public Grids recipient story, so it can switch on independently of the rest
+  # of the page once its content is approved.
+  PUBLIC_GRIDS_FLAG = :funders_landing_public_grids
+
   FUNDER_STATS_CACHE_KEY = "marketing/funder_stats"
 
   def funders
     @stats = funder_stats
     @show_testimonials = Flipper.enabled?(TESTIMONIALS_FLAG, current_user)
+    @show_public_grids = Flipper.enabled?(PUBLIC_GRIDS_FLAG, current_user)
     @skip_layout_og_tags = true # page provides its own funder-specific meta
   end
 

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -401,7 +401,7 @@
       </div>
 
       <div class="mk-product__media">
-        <figure class="mk-case mk-case--reboot">
+        <figure class="mk-case">
           <%= image_tag "https://cdn.hackclub.com/019ed937-fe26-77a0-8d7e-d6b9cf428eb9/image.png",
                 class: "mk-case__brand", alt: "Reboot", loading: "lazy", decoding: "async" %>
           <blockquote>“HCB’s platform has made it possible to scale Reboot’s team and operations in
@@ -430,6 +430,57 @@
     </div>
   </div>
 </section>
+
+<%# ============================ RECIPIENT STORY: PUBLIC GRIDS ============================ %>
+<%# Another recipient-side story, like Reboot. Public Grids is an early-stage nonprofit, so we lead
+    with the platform-quality angle and keep the mission description light. Mirrored (media-left)
+    so it doesn't read as a repeat of the Reboot section directly above it. Gated behind
+    :funders_landing_public_grids so it can switch on once the content is approved. %>
+<% if @show_public_grids %>
+  <section class="mk-section mk-product mk-product--metric mk-product--reverse">
+    <div class="mk-container">
+      <div class="mk-product__grid">
+        <div class="mk-product__copy">
+          <p class="mk-eyebrow">On HCB &middot; Public Grids</p>
+          <h2 class="mk-section__title">
+            Early-stage teams run on HCB so their hours go to the work, not the back office.
+          </h2>
+          <p class="mk-lead">
+            <a href="https://www.publicgrids.org" target="_blank" rel="noopener">Public Grids</a> is a
+            national nonprofit. Like many young organizations on HCB, they needed serious financial
+            infrastructure from day one, without standing up a finance team to run it.
+          </p>
+          <ul class="mk-ticks">
+            <li>A tech-first, in-house platform, not a patchwork of vendors</li>
+            <li>More of every hour spent on the mission, not paperwork</li>
+            <li>Built to scale as they grow</li>
+          </ul>
+        </div>
+
+        <div class="mk-product__media">
+          <figure class="mk-case">
+            <%= image_tag "https://cdn.hackclub.com/019edd06-7875-7022-af3a-64517fac3020/image.png",
+                  class: "mk-case__brand", alt: "Public Grids", loading: "lazy", decoding: "async" %>
+            <blockquote>“No one comes close to the quality of Hack Club’s services at a price a startup
+              like ours can afford. The in-house, flexible, tech-first platform lets us spend our team’s
+              finite hours on our work, not on paperwork. But most of all, the team is incomparable in
+              their integrity and transparency, which is why we keep choosing to grow with Hack Club as
+              we scale.”</blockquote>
+            <figcaption>
+              <%= image_tag "https://cdn.hackclub.com/019edd08-6185-7556-a382-67f43d652c04/image.png",
+                    class: "mk-case__avatar", alt: "Isaac Sevier", width: 84, height: 84,
+                    loading: "lazy", decoding: "async" %>
+              <span class="mk-case__meta">
+                <span class="mk-case__name">Isaac Sevier</span>
+                <span class="mk-case__detail">Founder &amp; Executive Director of Public Grids</span>
+              </span>
+            </figcaption>
+          </figure>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>
 
 <%# ============================ IMPACT (where it lands) ============================ %>
 <%# Three real funded projects (Ghostty, Miami Hack Week, MALAN) — approved logos/photos


### PR DESCRIPTION
Add a Public Grids recipient story to /for/funders, mirroring the Reboot section. Lead with the platform-quality angle and keep the mission description light. Gate behind :funders_landing_public_grids so it can switch on once the content is approved.

<img width="1139" height="511" alt="image" src="https://github.com/user-attachments/assets/29cafdd9-00de-4c8f-8bec-9d39ac4b93a3" />