### PR TITLE
[SEO] Add sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Disallow: /
 
 User-agent: *
 Allow: /
+
+Sitemap: https://hcb.hackclub.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Discovery feed for crawlers. The app defaults to `X-Robots-Tag: none`
+  (see ApplicationController), so this only lists the handful of public pages
+  that explicitly opt back into indexing. Served as a static file so it
+  bypasses the app's auth redirect. Keep in sync when adding indexable pages.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hcb.hackclub.com/for/funders</loc>
+  </url>
+  <url>
+    <loc>https://hcb.hackclub.com/branding</loc>
+  </url>
+  <url>
+    <loc>https://hcb.hackclub.com/security</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary of the problem

The new For Funders page hasn't been picked up by Google. That's because it's not linked anywhere


## Describe your changes

Add a site map