### PR TITLE
[Marketing] Polish the For Funders page and make it interactive

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -163,34 +163,32 @@ $mk-bg: $snow; // #f9fafc
   }
 }
 
+// Copy fades up on load; the hero media (the fan-out diagram) runs its own
+// JS-driven intro via the funders-flow controller, with a static fallback.
 @media (prefers-reduced-motion: no-preference) {
-  .mk-hero__copy > *,
-  .mk-hero__media {
-    animation: mk-fade-up 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
-  }
-
   .mk-hero__copy > * {
+    animation: mk-fade-up 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+
     @for $i from 1 through 5 {
       &:nth-child(#{$i}) {
         animation-delay: #{0.06s * $i};
       }
     }
   }
-
-  .mk-hero__media {
-    animation-delay: 0.2s;
-  }
 }
 
 // ---------------------------------------------------------------- buttons
+// Squared, flat fills on HCB's own radius + shadow tokens — deliberately the same
+// language as the in-app button (components/_buttons.scss), not a pill with a gradient
+// fill and a colored glow (which read as generic SaaS rather than HCB).
 .marketing-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   height: 44px;
-  padding: 0 22px;
-  border-radius: 999px;
+  padding: 0 20px;
+  border-radius: var(--radius-lg);
   font-size: 1rem;
   font-weight: 600;
   text-decoration: none;
@@ -198,36 +196,37 @@ $mk-bg: $snow; // #f9fafc
   cursor: pointer;
   border: 0;
   transition:
-    transform 0.12s ease,
     box-shadow 0.12s ease,
     background-color 0.12s ease;
 
   &--sm {
     height: 38px;
-    padding: 0 16px;
+    padding: 0 14px;
     font-size: 0.9375rem;
   }
 
   &--lg {
-    height: 52px;
-    padding: 0 26px;
+    height: 50px;
+    padding: 0 24px;
     font-size: 1.0625rem;
   }
 
   &--primary {
     color: #fff;
     background-color: $red;
-    background-image: linear-gradient(to bottom, lighten($red, 6%), $red);
     box-shadow:
-      0 1px 2px rgba($red, 0.4),
-      0 8px 24px -8px rgba($red, 0.5);
+      inset 0 0 0 0.5px rgba($black, 0.2),
+      var(--shadow-sm);
 
     &:hover,
     &:focus-visible {
-      transform: translateY(-1px);
+      // Keep the text white on hover — re-stated here so it beats the app's
+      // global `a:hover` colour rule (which otherwise wins by specificity).
+      color: #fff;
+      background-color: darken($red, 6%);
       box-shadow:
-        0 2px 4px rgba($red, 0.4),
-        0 14px 30px -8px rgba($red, 0.55);
+        inset 0 0 0 0.5px rgba($black, 0.2),
+        var(--shadow-md);
     }
   }
 
@@ -238,7 +237,8 @@ $mk-bg: $snow; // #f9fafc
 
     &:hover,
     &:focus-visible {
-      transform: translateY(-1px);
+      color: $mk-ink;
+      background: darken($white, 4%);
       box-shadow: var(--shadow-border-md);
     }
   }
@@ -260,13 +260,13 @@ $mk-bg: $snow; // #f9fafc
     flex: 1 1 240px;
     min-width: 0;
     max-width: none;
-    height: 52px;
-    padding: 0 22px;
+    height: 50px;
+    padding: 0 18px;
     font-size: 1.0625rem;
     color: $mk-ink;
     background: $white;
     border: 0;
-    border-radius: var(--radius-xl);
+    border-radius: var(--radius-lg);
     box-shadow: var(--shadow-border-sm);
     transition: box-shadow 0.12s ease;
 
@@ -400,6 +400,8 @@ $mk-bg: $snow; // #f9fafc
     gap: 9px;
     height: 38px;
     padding: 0 14px 0 8px;
+    // Pill on purpose: it wraps a circular avatar, so the concentric radius reads
+    // right. (The AI tell was the gradient pill *CTA*, not avatar chips.)
     border-radius: 999px;
     font-size: 0.95rem;
     font-weight: 500;
@@ -435,28 +437,34 @@ $mk-bg: $snow; // #f9fafc
     pointer-events: none;
   }
 
-  &__mesh {
-    position: absolute;
-    inset: -20% -10% 0;
-    background:
-      radial-gradient(42% 52% at 14% 6%, rgba($red, 0.12), transparent 70%),
-      radial-gradient(38% 46% at 86% 0%, rgba($blue, 0.1), transparent 70%),
-      radial-gradient(44% 44% at 72% 64%, rgba($cyan, 0.09), transparent 70%);
-  }
-
-  &__grid {
+  // A single, quiet warm light anchored behind the headline — one hue, low
+  // opacity. Deliberately not the multi-color radial "mesh" blob that reads as AI.
+  &__glow {
     position: absolute;
     inset: 0;
-    background-image:
-      linear-gradient(to right, rgba($black, 0.045) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba($black, 0.045) 1px, transparent 1px);
-    background-size: 64px 64px;
+    background: radial-gradient(
+      52% 60% at 8% -8%,
+      rgba($red, 0.07),
+      transparent 68%
+    );
+  }
+
+  // Faint vertical rules echoing HCB's columns mark (pillars / a bar chart),
+  // confined to the right where the diagram sits and softly masked at the edges.
+  &__ledger {
+    position: absolute;
+    inset: 0 0 0 48%;
+    background-image: repeating-linear-gradient(
+      to right,
+      rgba($black, 0.04) 0 1px,
+      transparent 1px 92px
+    );
     -webkit-mask-image: radial-gradient(
-      circle at 50% 0%,
+      120% 90% at 78% 30%,
       #000,
       transparent 72%
     );
-    mask-image: radial-gradient(circle at 50% 0%, #000, transparent 72%);
+    mask-image: radial-gradient(120% 90% at 78% 30%, #000, transparent 72%);
   }
 
   &__inner {
@@ -525,7 +533,226 @@ $mk-bg: $snow; // #f9fafc
   }
 }
 
-// ---------------------------------------------------------------- app window mockup
+// ---------------------------------------------------------------- hero fan-out
+// "Capital → grants": a funder source node wired to several recipient orgs, with
+// pulses traveling the wires (animated by funders_flow_controller). Renders as a
+// sensible static state with no JS / reduced motion.
+.mk-flow {
+  position: relative;
+  width: 100%;
+  // Keep the diagram compact on wide screens so the wires don't sprawl.
+  max-width: 560px;
+  margin: 0 auto;
+  min-height: clamp(330px, 33vw, 430px);
+}
+
+.mk-flow__wires {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.mk-flow__rail {
+  stroke: rgba($black, 0.16);
+  stroke-width: 1.5;
+}
+
+.mk-flow__pulse {
+  fill: $red;
+  filter: drop-shadow(0 0 5px rgba($red, 0.55));
+}
+
+.mk-flow__source {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: clamp(118px, 27%, 154px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 16px;
+  background: $white;
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-border-md);
+}
+
+.mk-flow__mark {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.mk-flow__source-name {
+  font-weight: 700;
+  color: $mk-ink;
+  font-size: 1.05rem;
+}
+
+.mk-flow__source-sub {
+  margin-top: 3px;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  color: $muted;
+}
+
+.mk-flow__feed {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 2;
+  width: clamp(210px, 60%, 300px);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+}
+
+.mk-flow__grant {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 10px 13px;
+  background: $white;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-border-sm);
+
+  // "Received" ring. Its strength is driven by --recv, which the flow controller
+  // tweens 1 -> 0 on the same timeline as the ball, so the flash lands exactly
+  // when the ball does. Defaults to 0 (no flash) with no JS / reduced motion.
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1.5px rgba($red, 0.6);
+    opacity: var(--recv, 0);
+    pointer-events: none;
+  }
+}
+
+.mk-flow__avatar {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: rgba($black, 0.05);
+  color: $slate;
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.mk-flow__org {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.mk-flow__name {
+  font-weight: 600;
+  color: $mk-ink;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mk-flow__meta {
+  font-size: 0.78rem;
+  color: $muted;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mk-flow__amt {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  line-height: 1.3;
+}
+
+.mk-flow__sum {
+  font-weight: 700;
+  color: $mk-ink;
+  font-size: 0.95rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.mk-flow__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  color: $green-dark;
+
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: $green;
+  }
+}
+
+// Narrow screens can't fit the source + rows side by side, so stack them and
+// drop the wires (the controller detects the hidden SVG and skips the animation).
+@media (max-width: 640px) {
+  .mk-flow {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .mk-flow__wires {
+    display: none;
+  }
+
+  .mk-flow__source {
+    position: static;
+    transform: none;
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .mk-flow__mark {
+    margin-bottom: 0;
+  }
+
+  .mk-flow__source-sub {
+    margin-top: 0;
+  }
+
+  .mk-flow__feed {
+    position: static;
+    width: auto;
+    gap: 10px;
+  }
+}
+
+// --------------------------------------------------------- app screenshot frame
+// Frameless: the product screenshot already carries the full HCB app chrome, so
+// we just round + lift it. (No invented title bar — it duplicated the shot's own
+// heading/logo and a "LIVE" badge would be false on a static image.)
 .mk-window {
   margin: 0;
   border-radius: var(--radius-xl);
@@ -535,27 +762,21 @@ $mk-bg: $snow; // #f9fafc
     var(--shadow-border-lg),
     0 40px 80px -28px rgba($black, 0.25);
 
-  &__bar {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    height: 38px;
-    padding: 0 16px;
-    background: $snow-dark;
-    box-shadow: inset 0 -1px 0 rgba($black, 0.06);
-
-    i {
-      width: 11px;
-      height: 11px;
-      border-radius: 999px;
-      background: $smoke-dark;
-    }
-  }
-
   &__shot {
     display: block;
     width: 100%;
     height: auto;
+  }
+}
+
+// Soft pulsing dot used by the "Real-time data" value prop in the explorer.
+@keyframes mk-live-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba($green, 0.5);
+  }
+  70%,
+  100% {
+    box-shadow: 0 0 0 6px rgba($green, 0);
   }
 }
 
@@ -897,52 +1118,231 @@ $mk-bg: $snow; // #f9fafc
   }
 }
 
-// ---------------------------------------------------------------- pillars
-.mk-pillars {
+// ------------------------------------------------------- value-prop explorer
+// Tabs (left) drive a detail panel (right). On no-JS the controller never adds
+// `.is-enhanced`, so every panel stays visible and the tabs read as a plain list.
+.mk-explore {
   display: grid;
-  gap: 20px;
+  gap: 16px;
   grid-template-columns: 1fr;
 
-  @media (min-width: 620px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  @media (min-width: 980px) {
-    grid-template-columns: repeat(4, 1fr);
+  @media (min-width: 880px) {
+    grid-template-columns: 0.9fr 1.1fr;
+    gap: 24px;
+    align-items: stretch;
   }
 }
 
-.mk-pillar {
-  padding: 28px 24px;
+.mk-explore__tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mk-explore__tab {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  text-align: left;
+  padding: 16px 18px;
+  background: $white;
+  border: 0;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-border-sm);
+  cursor: pointer;
+  color: $mk-ink;
+  transition:
+    box-shadow 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.15s ease;
+
+  &-icon {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: var(--radius-lg);
+    color: $red;
+    background: rgba($red, 0.08);
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
+
+    svg {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
+  &-text {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+    min-width: 0;
+  }
+
+  &-title {
+    font-weight: 600;
+    font-size: 1.05rem;
+  }
+
+  &-sub {
+    font-size: 0.85rem;
+    color: $muted;
+  }
+
+  // Chevron that signals each row is selectable (CSS-drawn ">").
+  &-caret {
+    flex: none;
+    width: 8px;
+    height: 8px;
+    border: solid $smoke-dark;
+    border-width: 2px 2px 0 0;
+    transform: rotate(45deg);
+    transition:
+      border-color 0.15s ease,
+      transform 0.15s ease;
+  }
+
+  &:hover {
+    box-shadow: var(--shadow-border-md);
+
+    .mk-explore__tab-caret {
+      border-color: $slate;
+      transform: rotate(45deg) translate(1px, -1px);
+    }
+  }
+
+  // Active tab (set by the controller): red mark + accent ring + red caret.
+  &.is-active {
+    box-shadow:
+      var(--shadow-border-md),
+      inset 0 0 0 1.5px rgba($red, 0.5);
+
+    .mk-explore__tab-icon {
+      color: #fff;
+      background: $red;
+    }
+
+    .mk-explore__tab-caret {
+      border-color: $red;
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid $red;
+    outline-offset: 2px;
+  }
+}
+
+.mk-explore__stage {
+  position: relative;
+}
+
+.mk-explore__panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: clamp(24px, 3vw, 36px);
   background: $white;
   border-radius: var(--radius-2xl);
   box-shadow: var(--shadow-border-md);
 
-  &__icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    border-radius: var(--radius-lg);
-    color: $red;
-    background: rgba($red, 0.08);
-    margin-bottom: 18px;
-
-    svg {
-      width: 24px;
-      height: 24px;
-    }
-  }
-
   h3 {
-    font-size: 1.2rem;
-    margin-bottom: 8px;
+    font-size: clamp(1.3rem, 2.2vw, 1.6rem);
+    margin-bottom: 14px;
+    text-wrap: balance;
   }
 
   p {
     color: $slate;
-    line-height: 1.55;
-    font-size: 0.975rem;
+    line-height: 1.6;
+    font-size: 1.05rem;
+  }
+
+  // When enhanced, the active panel fades in as it swaps.
+  .is-enhanced &.is-active {
+    @media (prefers-reduced-motion: no-preference) {
+      animation: mk-fade-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+  }
+}
+
+// Stacked-card fallback spacing when JS hasn't enhanced the explorer.
+.mk-explore:not(.is-enhanced) .mk-explore__panel + .mk-explore__panel {
+  margin-top: 12px;
+}
+
+.mk-explore__proof {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: auto;
+  padding-top: 24px;
+
+  &--badge {
+    align-items: center;
+  }
+}
+
+.mk-explore__stat {
+  font-size: clamp(2.4rem, 5vw, 3.2rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: $red;
+
+  &--range {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    letter-spacing: -0.02em;
+    white-space: nowrap;
+  }
+}
+
+.mk-explore__stat-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: $mk-ink;
+  line-height: 1.35;
+
+  span {
+    display: block;
+    margin-top: 3px;
+    font-weight: 400;
+    font-size: 0.85rem;
+    color: $muted;
+  }
+}
+
+.mk-explore__badge-mark {
+  display: block;
+  flex: none;
+  border-radius: 11px;
+}
+
+.mk-explore__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: $green-dark;
+
+  i {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: $green;
+
+    @media (prefers-reduced-motion: no-preference) {
+      animation: mk-live-pulse 2s ease-out infinite;
+    }
   }
 }
 

--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -680,37 +680,6 @@ $mk-bg: $snow; // #f9fafc
   text-overflow: ellipsis;
 }
 
-.mk-flow__amt {
-  flex: none;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  line-height: 1.3;
-}
-
-.mk-flow__sum {
-  font-weight: 700;
-  color: $mk-ink;
-  font-size: 0.95rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.mk-flow__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 0.72rem;
-  color: $green-dark;
-
-  &::before {
-    content: '';
-    width: 6px;
-    height: 6px;
-    border-radius: 999px;
-    background: $green;
-  }
-}
-
 // Narrow screens can't fit the source + rows side by side, so stack them and
 // drop the wires (the controller detects the hidden SVG and skips the animation).
 @media (max-width: 640px) {
@@ -1126,7 +1095,9 @@ $mk-bg: $snow; // #f9fafc
   gap: 16px;
   grid-template-columns: 1fr;
 
-  @media (min-width: 880px) {
+  // Go side-by-side from tablet up (matches the stats/uses breakpoint) so iPad-width
+  // viewers get the panel beside the tabs rather than scrolled off below them.
+  @media (min-width: 720px) {
     grid-template-columns: 0.9fr 1.1fr;
     gap: 24px;
     align-items: stretch;
@@ -1192,7 +1163,7 @@ $mk-bg: $snow; // #f9fafc
 
   &-sub {
     font-size: 0.85rem;
-    color: $muted;
+    color: darken($muted, 18%); // clears AA contrast on white at this size
   }
 
   // Chevron that signals each row is selectable (CSS-drawn ">").
@@ -1241,6 +1212,13 @@ $mk-bg: $snow; // #f9fafc
 
 .mk-explore__stage {
   position: relative;
+
+  // When enhanced, stack every panel into a single grid cell so the stage always
+  // reserves the height of the *tallest* panel. Switching props (by hand or via
+  // auto-rotate) then never changes the stage height, so there's no layout jump.
+  .is-enhanced & {
+    display: grid;
+  }
 }
 
 .mk-explore__panel {
@@ -1264,8 +1242,18 @@ $mk-bg: $snow; // #f9fafc
     font-size: 1.05rem;
   }
 
-  // When enhanced, the active panel fades in as it swaps.
+  // Enhanced: every panel shares the one grid cell on the stage, so they overlap and
+  // the stage stays as tall as the tallest. Inactive panels keep their layout box (so
+  // that height holds steady) but are hidden from view and assistive tech.
+  .is-enhanced & {
+    grid-area: 1 / 1;
+    visibility: hidden;
+  }
+
   .is-enhanced &.is-active {
+    visibility: visible;
+
+    // The active panel fades in as it swaps.
     @media (prefers-reduced-motion: no-preference) {
       animation: mk-fade-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
     }
@@ -1419,6 +1407,31 @@ $mk-bg: $snow; // #f9fafc
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-border-md);
   background: $white;
+}
+
+// Closing note under the comparison table: invites funders who already give through a
+// DAF or foundation to use HCB alongside it (not instead of it). A left-aligned callout
+// card with a bold hook so it reads as an aside, not another paragraph of body copy.
+.mk-compare-note {
+  margin: 28px 0 0;
+  padding: 20px 24px;
+  text-align: left;
+  background: $white;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-border-sm);
+
+  &__lead {
+    margin: 0 0 4px;
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: $mk-ink;
+  }
+
+  &__body {
+    margin: 0;
+    color: $slate;
+    line-height: 1.6;
+  }
 }
 
 .mk-table {
@@ -1840,6 +1853,14 @@ $mk-bg: $snow; // #f9fafc
   &__title {
     font-size: clamp(1.8rem, 4vw, 2.8rem);
     margin-bottom: 16px;
+    text-wrap: balance;
+  }
+
+  // Centered lead: cap the width and balance the lines so it forms a tidy block
+  // instead of two long lines over one short one.
+  .mk-lead {
+    max-width: 48ch;
+    margin-inline: auto;
     text-wrap: balance;
   }
 

--- a/app/javascript/controllers/funders_explorer_controller.js
+++ b/app/javascript/controllers/funders_explorer_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Interactive "why funders choose HCB" explorer: a vertical list of value props
+// on the left, a detail panel on the right that swaps as you select a prop
+// (hover on a fine pointer, click/tap anywhere). Implements the WAI-ARIA tabs
+// pattern with roving tabindex + arrow-key navigation. With no JS the markup
+// shows every panel stacked, so nothing is hidden.
+//
+// On desktop it also slowly auto-advances through the props to demonstrate that
+// the panel is interactive. That self-demo pauses while the pointer is over the
+// component (so reading isn't interrupted) and stops for good the moment the
+// user selects anything themselves.
+const ADVANCE_MS = 4200
+const MAX_CYCLES = 2
+
+export default class extends Controller {
+  static targets = ['tab', 'panel']
+
+  connect() {
+    this.element.classList.add('is-enhanced')
+    this.hover = window.matchMedia('(hover: hover) and (pointer: fine)').matches
+    // Auto-rotate only where the panel sits beside the tabs (desktop) and the
+    // user hasn't asked to reduce motion; on mobile the panel can be off-screen.
+    this.canAuto =
+      window.matchMedia('(min-width: 880px)').matches &&
+      !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    this.cycles = 0
+    this.select(0)
+
+    if (this.canAuto) {
+      this.observer = new IntersectionObserver(
+        ([entry]) =>
+          entry.isIntersecting ? this.startAuto() : this.clearTimer(),
+        { threshold: 0.5 }
+      )
+      this.observer.observe(this.element)
+    }
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
+    this.clearTimer()
+  }
+
+  // Wired from each tab (click / mouseenter / focus).
+  choose(event) {
+    const i = Number(event.currentTarget.dataset.index)
+    if (event.type === 'mouseenter' && !this.hover) return
+    this.stopAuto() // a deliberate selection means they know it's interactive
+    this.select(i)
+    // On tap (mobile), the panel sits below the tabs — bring it into view so
+    // the swapped content isn't off-screen. `nearest` is a no-op on desktop
+    // where the panel is already visible beside the tabs.
+    if (event.type === 'click' && !this.hover) {
+      this.panelTargets[i].scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      })
+    }
+  }
+
+  select(index) {
+    this.active = index
+    this.tabTargets.forEach((tab, i) => {
+      const on = i === index
+      tab.setAttribute('aria-selected', on ? 'true' : 'false')
+      tab.tabIndex = on ? 0 : -1
+      tab.classList.toggle('is-active', on)
+    })
+    this.panelTargets.forEach((panel, i) => {
+      panel.classList.toggle('is-active', i === index)
+      panel.hidden = i !== index
+    })
+  }
+
+  // Arrow-key navigation across the tablist.
+  keydown(event) {
+    const last = this.tabTargets.length - 1
+    let next = null
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight')
+      next = this.active >= last ? 0 : this.active + 1
+    else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft')
+      next = this.active <= 0 ? last : this.active - 1
+    else if (event.key === 'Home') next = 0
+    else if (event.key === 'End') next = last
+    if (next === null) return
+    event.preventDefault()
+    this.stopAuto()
+    this.select(next)
+    this.tabTargets[next].focus()
+  }
+
+  // --- auto-rotation -------------------------------------------------------
+
+  startAuto() {
+    if (this.timer || this.stopped) return
+    this.timer = setInterval(() => {
+      if (this.paused) return // pointer is over the component; hold position
+      const next = (this.active + 1) % this.tabTargets.length
+      this.select(next)
+      if (next === 0 && ++this.cycles >= MAX_CYCLES) this.stopAuto()
+    }, ADVANCE_MS)
+  }
+
+  clearTimer() {
+    clearInterval(this.timer)
+    this.timer = null
+  }
+
+  // Pointer over the component (wired on the root) pauses the rotation.
+  hoverIn() {
+    this.paused = true
+  }
+
+  hoverOut() {
+    this.paused = false
+  }
+
+  // Permanent: the user has taken control.
+  stopAuto() {
+    this.stopped = true
+    this.clearTimer()
+  }
+}

--- a/app/javascript/controllers/funders_explorer_controller.js
+++ b/app/javascript/controllers/funders_explorer_controller.js
@@ -19,10 +19,11 @@ export default class extends Controller {
   connect() {
     this.element.classList.add('is-enhanced')
     this.hover = window.matchMedia('(hover: hover) and (pointer: fine)').matches
-    // Auto-rotate only where the panel sits beside the tabs (desktop) and the
-    // user hasn't asked to reduce motion; on mobile the panel can be off-screen.
+    // Auto-rotate only where the panel sits beside the tabs (tablet up, matching the
+    // two-column breakpoint) and the user hasn't asked to reduce motion; on a stacked
+    // single column the panel can be scrolled off-screen.
     this.canAuto =
-      window.matchMedia('(min-width: 880px)').matches &&
+      window.matchMedia('(min-width: 720px)').matches &&
       !window.matchMedia('(prefers-reduced-motion: reduce)').matches
     this.cycles = 0
     this.select(0)
@@ -67,9 +68,11 @@ export default class extends Controller {
       tab.tabIndex = on ? 0 : -1
       tab.classList.toggle('is-active', on)
     })
+    // Only toggle the class; the stylesheet shows the active panel and hides the rest
+    // (via visibility, not display) so every panel keeps its box and the stacked stage
+    // stays as tall as the tallest — no height jump as panels swap.
     this.panelTargets.forEach((panel, i) => {
       panel.classList.toggle('is-active', i === index)
-      panel.hidden = i !== index
     })
   }
 

--- a/app/javascript/controllers/funders_flow_controller.js
+++ b/app/javascript/controllers/funders_flow_controller.js
@@ -1,0 +1,220 @@
+import { Controller } from '@hotwired/stimulus'
+import { gsap } from 'gsap'
+
+// Animates the "capital -> grants" fan-out in the funders hero: a single funder
+// source node wired to several recipient organizations, with pulses of capital
+// traveling along each wire and each grant row lighting up as its pulse lands.
+//
+// The wires are drawn in JS (measured from the live DOM) so the layout stays
+// responsive. Everything degrades to a sensible static state: with no JS the
+// markup already renders the source + rows, and with prefers-reduced-motion we
+// draw the wires once and skip the looping motion.
+export default class extends Controller {
+  static targets = ['svg', 'source', 'grant']
+
+  connect() {
+    this.reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    this.wires = []
+    this.pulses = []
+
+    this.buildWires()
+
+    this.resizeObserver = new ResizeObserver(() => this.onResize())
+    this.resizeObserver.observe(this.element)
+
+    this.layout()
+  }
+
+  // On narrow screens CSS hides the wires and stacks the source over the rows,
+  // so we skip the fan-out animation and just show the static list.
+  isStacked() {
+    return getComputedStyle(this.svgTarget).display === 'none'
+  }
+
+  layout() {
+    if (this.isStacked()) {
+      this.intro?.kill()
+      this.loop?.kill()
+      gsap.set([this.sourceTarget, ...this.grantTargets], {
+        clearProps: 'opacity,transform',
+      })
+      return
+    }
+
+    this.drawWires()
+
+    if (this.reduce || this.animated) {
+      // Static (reduced motion) or already played: just show the drawn wires.
+      this.wires.forEach(rail => gsap.set(rail, { strokeDashoffset: 0 }))
+      return
+    }
+
+    this.animated = true
+    // Defer one frame so first layout is settled before measuring/animating.
+    requestAnimationFrame(() => this.animate())
+  }
+
+  disconnect() {
+    this.resizeObserver?.disconnect()
+    this.intro?.kill()
+    this.loop?.kill()
+    clearTimeout(this.resizeTimer)
+  }
+
+  // Create one rail + one pulse <circle> per grant row, once.
+  buildWires() {
+    const svgNS = 'http://www.w3.org/2000/svg'
+    this.grantTargets.forEach(() => {
+      const rail = document.createElementNS(svgNS, 'path')
+      rail.setAttribute('class', 'mk-flow__rail')
+      rail.setAttribute('fill', 'none')
+
+      const pulse = document.createElementNS(svgNS, 'circle')
+      pulse.setAttribute('class', 'mk-flow__pulse')
+      pulse.setAttribute('r', '4')
+      pulse.style.opacity = '0'
+
+      this.svgTarget.appendChild(rail)
+      this.svgTarget.appendChild(pulse)
+      this.wires.push(rail)
+      this.pulses.push(pulse)
+    })
+  }
+
+  // Measure source + rows and route a smooth horizontal S-curve to each row.
+  drawWires() {
+    const box = this.element.getBoundingClientRect()
+    const w = Math.round(box.width)
+    const h = Math.round(box.height)
+    this.svgTarget.setAttribute('width', w)
+    this.svgTarget.setAttribute('height', h)
+    this.svgTarget.setAttribute('viewBox', `0 0 ${w} ${h}`)
+
+    const src = this.sourceTarget.getBoundingClientRect()
+    const sx = src.right - box.left
+    const sy = src.top + src.height / 2 - box.top
+
+    this.lengths = []
+    this.grantTargets.forEach((row, i) => {
+      const r = row.getBoundingClientRect()
+      const ex = r.left - box.left
+      const ey = r.top + r.height / 2 - box.top
+      const dx = ex - sx
+      const d = `M ${sx} ${sy} C ${sx + dx * 0.55} ${sy}, ${ex - dx * 0.55} ${ey}, ${ex} ${ey}`
+      this.wires[i].setAttribute('d', d)
+      this.lengths[i] = this.wires[i].getTotalLength()
+    })
+  }
+
+  animate() {
+    // The intro is deferred a frame, so the controller may have disconnected
+    // (e.g. a Turbo navigation) before this runs — bail if the targets are gone.
+    if (!this.hasSourceTarget || !this.hasSvgTarget) return
+
+    // Intro: source in, rails draw toward the rows, grant rows stagger in.
+    this.intro = gsap.timeline()
+
+    this.wires.forEach((rail, i) => {
+      const len = this.lengths[i]
+      gsap.set(rail, { strokeDasharray: len, strokeDashoffset: len })
+    })
+
+    this.intro
+      .from(this.sourceTarget, {
+        opacity: 0,
+        x: -16,
+        duration: 0.5,
+        ease: 'power2.out',
+      })
+      .to(
+        this.wires,
+        {
+          strokeDashoffset: 0,
+          duration: 0.7,
+          ease: 'power2.inOut',
+          stagger: 0.08,
+        },
+        '-=0.2'
+      )
+      .from(
+        this.grantTargets,
+        {
+          opacity: 0,
+          x: 16,
+          duration: 0.5,
+          ease: 'power2.out',
+          stagger: 0.1,
+        },
+        '-=0.6'
+      )
+      .add(() => this.startLoop())
+  }
+
+  // Looping payment pulses: capital streams down each wire top-to-bottom, then
+  // each row "receives" as its pulse lands. The ball and the row's ring flash
+  // ride the SAME timeline, so they can never drift apart.
+  startLoop() {
+    // Launches are spaced so a ball lands before the next one leaves — the
+    // rhythm reads as deliberate "land → flash" beats rather than a busy stream.
+    const STAGGER = 1.0
+    const SPEED = 360 // px/s — fixed so every pulse moves at the same visual pace
+
+    this.loop = gsap.timeline({ repeat: -1, repeatDelay: 1.2 })
+
+    this.grantTargets.forEach((row, i) => {
+      const rail = this.wires[i]
+      const pulse = this.pulses[i]
+      const len = this.lengths[i]
+      const travel = gsap.utils.clamp(0.62, 1.0, len / SPEED)
+      const proxy = { p: 0 }
+      const seg = gsap.timeline()
+
+      seg
+        // Launch: fade in at the source instead of popping into existence.
+        .set(pulse, { opacity: 0, attr: { r: 4 } }, 0)
+        .to(pulse, { opacity: 1, duration: 0.16, ease: 'sine.out' }, 0)
+        .to(
+          proxy,
+          {
+            p: 1,
+            duration: travel,
+            ease: 'power1.inOut',
+            onUpdate: () => {
+              const pt = rail.getPointAtLength(proxy.p * len)
+              pulse.setAttribute('cx', pt.x)
+              pulse.setAttribute('cy', pt.y)
+            },
+          },
+          0
+        )
+        // Arrival: the ball dissolves exactly as it reaches the row...
+        .to(
+          pulse,
+          { opacity: 0, attr: { r: 7 }, duration: 0.2, ease: 'power2.out' },
+          travel - 0.18
+        )
+        // ...and the row's ring flashes in the same instant (same clock as the
+        // ball via the --recv variable, so the two stay locked together).
+        // immediateRender:false keeps the ring dark until its moment — otherwise
+        // every ring would snap on at the start of each loop (a harsh reset).
+        .fromTo(
+          row,
+          { '--recv': 1 },
+          {
+            '--recv': 0,
+            duration: 0.6,
+            ease: 'power2.out',
+            immediateRender: false,
+          },
+          travel - 0.04
+        )
+
+      this.loop.add(seg, i * STAGGER)
+    })
+  }
+
+  onResize() {
+    clearTimeout(this.resizeTimer)
+    this.resizeTimer = setTimeout(() => this.layout(), 150)
+  }
+}

--- a/app/views/marketing/_nav.html.erb
+++ b/app/views/marketing/_nav.html.erb
@@ -10,7 +10,6 @@
     <nav class="marketing-nav__links" aria-label="Primary">
       <a href="https://hackclub.com/fiscal-sponsorship">Fiscal sponsorship</a>
       <a href="<%= funders_path %>" aria-current="page">For funders</a>
-      <a href="https://help.hcb.hackclub.com">Docs</a>
     </nav>
 
     <div class="marketing-nav__actions">

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -54,8 +54,8 @@
 <%# ============================ HERO ============================ %>
 <section class="mk-hero">
   <div class="mk-hero__bg" aria-hidden="true">
-    <div class="mk-hero__mesh"></div>
-    <div class="mk-hero__grid"></div>
+    <div class="mk-hero__glow"></div>
+    <div class="mk-hero__ledger"></div>
   </div>
   <div class="mk-container mk-hero__inner">
     <div class="mk-hero__copy">
@@ -79,12 +79,68 @@
     </div>
 
     <div class="mk-hero__media">
-      <figure class="mk-window">
-        <span class="mk-window__bar" aria-hidden="true"><i></i><i></i><i></i></span>
-        <%= image_tag "https://cdn.hackclub.com/019e85f1-0dcf-7369-a690-dbb9ddadadf6/image.png",
-              class: "mk-window__shot", width: 2620, height: 1638, fetchpriority: "high",
-              alt: "The HCB dashboard, with balances and recent activity at a glance" %>
-      </figure>
+      <%# Animated "capital → grants" fan-out: one funder, many recipients. The prose
+          above states the same idea, so the diagram is decorative for assistive tech. %>
+      <%# Recipients are generic, illustrative entities (not real orgs), with made-up
+          amounts and dates. They convey the one-to-many concept without implying real
+          transactions; the actual featured organizations live in their own sections below. %>
+      <div class="mk-flow" data-controller="funders-flow"
+           role="img" aria-label="A funder directing capital as tax-deductible grants to organizations of their choosing on HCB.">
+        <svg class="mk-flow__wires" data-funders-flow-target="svg" aria-hidden="true" preserveAspectRatio="none"></svg>
+
+        <div class="mk-flow__source" data-funders-flow-target="source">
+          <%= image_tag "/brand/hcb-icon-icon-original.svg", class: "mk-flow__mark", alt: "", width: 36, height: 36 %>
+          <span class="mk-flow__source-name">Your capital</span>
+          <span class="mk-flow__source-sub">You pick who gets funded</span>
+        </div>
+
+        <ul class="mk-flow__feed">
+          <li class="mk-flow__grant" data-funders-flow-target="grant">
+            <span class="mk-flow__avatar"><%= inline_icon "terminal", size: 20 %></span>
+            <span class="mk-flow__org">
+              <span class="mk-flow__name">Open-source</span>
+              <span class="mk-flow__meta">Builder-led</span>
+            </span>
+            <span class="mk-flow__amt">
+              <span class="mk-flow__sum">$40,000</span>
+              <span class="mk-flow__status">Sent · 2d</span>
+            </span>
+          </li>
+          <li class="mk-flow__grant" data-funders-flow-target="grant">
+            <span class="mk-flow__avatar"><%= inline_icon "cpu", size: 20 %></span>
+            <span class="mk-flow__org">
+              <span class="mk-flow__name">AI research lab</span>
+              <span class="mk-flow__meta">Independent</span>
+            </span>
+            <span class="mk-flow__amt">
+              <span class="mk-flow__sum">$120,000</span>
+              <span class="mk-flow__status">Sent · 5d</span>
+            </span>
+          </li>
+          <li class="mk-flow__grant" data-funders-flow-target="grant">
+            <span class="mk-flow__avatar"><%= inline_icon "people-2", size: 20 %></span>
+            <span class="mk-flow__org">
+              <span class="mk-flow__name">Mutual aid</span>
+              <span class="mk-flow__meta">Volunteer-run</span>
+            </span>
+            <span class="mk-flow__amt">
+              <span class="mk-flow__sum">$25,000</span>
+              <span class="mk-flow__status">Sent · 1w</span>
+            </span>
+          </li>
+          <li class="mk-flow__grant" data-funders-flow-target="grant">
+            <span class="mk-flow__avatar"><%= inline_icon "idea", size: 20 %></span>
+            <span class="mk-flow__org">
+              <span class="mk-flow__name">New initiative</span>
+              <span class="mk-flow__meta">Brand new</span>
+            </span>
+            <span class="mk-flow__amt">
+              <span class="mk-flow__sum">$9,500</span>
+              <span class="mk-flow__status">Sent · 2w</span>
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 
@@ -131,31 +187,103 @@
       <p class="mk-eyebrow">Why funders choose HCB</p>
       <h2 class="mk-section__title">Built for conviction, speed, and transparency.</h2>
     </div>
-    <div class="mk-pillars">
-      <article class="mk-pillar">
-        <span class="mk-pillar__icon"><%= inline_icon "bolt", size: 24 %></span>
-        <h3>Days, not quarters</h3>
-        <p>Fund a grant or launch an initiative the same week you decide to. No new legal
-          entity, no IRS waiting period, no committee cycle.</p>
-      </article>
-      <article class="mk-pillar">
-        <span class="mk-pillar__icon"><%= inline_icon "badge-check", size: 24 %></span>
-        <h3>Tax-deductible 501(c)(3)</h3>
-        <p>Every grant is compliant and accountable. You get the legitimacy of a
-          foundation without having to become one.</p>
-      </article>
-      <article class="mk-pillar">
-        <span class="mk-pillar__icon"><%= inline_icon "analytics", size: 24 %></span>
-        <h3>Real-time financial data</h3>
-        <p>Dashboards on every dollar (balances, spend, and activity), not a year-end
-          PDF.</p>
-      </article>
-      <article class="mk-pillar">
-        <span class="mk-pillar__icon"><%= inline_icon "apps", size: 24 %></span>
-        <h3>Any scale</h3>
-        <p>Seed a single idea or run a portfolio of thousands. The workflow is the
-          same.</p>
-      </article>
+    <%# Interactive explorer (funders_explorer_controller): pick a value prop to
+        expand it. Falls back to all panels shown when JS is unavailable. %>
+    <div class="mk-explore" data-controller="funders-explorer"
+         data-action="keydown->funders-explorer#keydown mouseenter->funders-explorer#hoverIn mouseleave->funders-explorer#hoverOut">
+      <div class="mk-explore__tabs" role="tablist" aria-label="Why funders choose HCB" aria-orientation="vertical">
+        <button type="button" class="mk-explore__tab" role="tab" id="mk-exp-tab-0"
+                aria-controls="mk-exp-panel-0" aria-selected="true" data-index="0"
+                data-funders-explorer-target="tab"
+                data-action="click->funders-explorer#choose mouseenter->funders-explorer#choose focus->funders-explorer#choose">
+          <span class="mk-explore__tab-icon"><%= inline_icon "bolt", size: 22 %></span>
+          <span class="mk-explore__tab-text">
+            <span class="mk-explore__tab-title">Days, not quarters</span>
+            <span class="mk-explore__tab-sub">Move the week you decide</span>
+          </span>
+          <span class="mk-explore__tab-caret" aria-hidden="true"></span>
+        </button>
+        <button type="button" class="mk-explore__tab" role="tab" id="mk-exp-tab-1"
+                aria-controls="mk-exp-panel-1" aria-selected="false" tabindex="-1" data-index="1"
+                data-funders-explorer-target="tab"
+                data-action="click->funders-explorer#choose mouseenter->funders-explorer#choose focus->funders-explorer#choose">
+          <span class="mk-explore__tab-icon"><%= inline_icon "badge-check", size: 22 %></span>
+          <span class="mk-explore__tab-text">
+            <span class="mk-explore__tab-title">A real 501(c)(3)</span>
+            <span class="mk-explore__tab-sub">Foundation legitimacy, no foundation</span>
+          </span>
+          <span class="mk-explore__tab-caret" aria-hidden="true"></span>
+        </button>
+        <button type="button" class="mk-explore__tab" role="tab" id="mk-exp-tab-2"
+                aria-controls="mk-exp-panel-2" aria-selected="false" tabindex="-1" data-index="2"
+                data-funders-explorer-target="tab"
+                data-action="click->funders-explorer#choose mouseenter->funders-explorer#choose focus->funders-explorer#choose">
+          <span class="mk-explore__tab-icon"><%= inline_icon "analytics", size: 22 %></span>
+          <span class="mk-explore__tab-text">
+            <span class="mk-explore__tab-title">Real-time data</span>
+            <span class="mk-explore__tab-sub">Every dollar, as it moves</span>
+          </span>
+          <span class="mk-explore__tab-caret" aria-hidden="true"></span>
+        </button>
+        <button type="button" class="mk-explore__tab" role="tab" id="mk-exp-tab-3"
+                aria-controls="mk-exp-panel-3" aria-selected="false" tabindex="-1" data-index="3"
+                data-funders-explorer-target="tab"
+                data-action="click->funders-explorer#choose mouseenter->funders-explorer#choose focus->funders-explorer#choose">
+          <span class="mk-explore__tab-icon"><%= inline_icon "apps", size: 22 %></span>
+          <span class="mk-explore__tab-text">
+            <span class="mk-explore__tab-title">Any scale</span>
+            <span class="mk-explore__tab-sub">One project or thousands</span>
+          </span>
+          <span class="mk-explore__tab-caret" aria-hidden="true"></span>
+        </button>
+      </div>
+
+      <div class="mk-explore__stage">
+        <div class="mk-explore__panel" role="tabpanel" id="mk-exp-panel-0"
+             aria-labelledby="mk-exp-tab-0" data-funders-explorer-target="panel">
+          <h3>Fund the same week you decide.</h3>
+          <p>No new legal entity, no IRS waiting period, no committee cycle. When conviction
+            strikes, the grant goes out that week, not whenever the next board meeting allows.</p>
+          <div class="mk-explore__proof">
+            <span class="mk-explore__stat">Days</span>
+            <span class="mk-explore__stat-label">to your first grant<br><span>versus months to stand up a private foundation</span></span>
+          </div>
+        </div>
+
+        <div class="mk-explore__panel" role="tabpanel" id="mk-exp-panel-1"
+             aria-labelledby="mk-exp-tab-1" data-funders-explorer-target="panel">
+          <h3>The legitimacy of a foundation, without becoming one.</h3>
+          <p>Every grant is compliant and accountable. You give to a registered 501(c)(3),
+            so your deduction is immediate and the compliance, recipient checks, and
+            paperwork are ours to handle, not yours.</p>
+          <div class="mk-explore__proof mk-explore__proof--badge">
+            <%= image_tag "/brand/hcb-icon-icon-original.svg", class: "mk-explore__badge-mark", alt: "", width: 40, height: 40 %>
+            <span class="mk-explore__stat-label">HCB by Hack Club<br><span>501(c)(3) nonprofit · EIN 81-2908499</span></span>
+          </div>
+        </div>
+
+        <div class="mk-explore__panel" role="tabpanel" id="mk-exp-panel-2"
+             aria-labelledby="mk-exp-tab-2" data-funders-explorer-target="panel">
+          <h3>See every dollar the moment it moves.</h3>
+          <p>Balances, grants, card swipes, and transfers stream into dashboards in real
+            time. Not a year-end PDF, but a live ledger you and your team can open any time.</p>
+          <div class="mk-explore__proof">
+            <span class="mk-explore__live"><i></i>Live</span>
+            <span class="mk-explore__stat-label">across your whole portfolio<br><span>drill into any organization, export anytime</span></span>
+          </div>
+        </div>
+
+        <div class="mk-explore__panel" role="tabpanel" id="mk-exp-panel-3"
+             aria-labelledby="mk-exp-tab-3" data-funders-explorer-target="panel">
+          <h3>Seed one idea or run a portfolio of thousands.</h3>
+          <p>The workflow is the same whether you're backing a single builder or regranting
+            across hundreds of organizations. There's no back office to staff as you grow.</p>
+          <div class="mk-explore__proof">
+            <span class="mk-explore__stat mk-explore__stat--range">$10K&nbsp;→&nbsp;$10M+</span>
+            <span class="mk-explore__stat-label">on one platform<br><span>the same software, at every size</span></span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -216,7 +344,6 @@
       </div>
       <div class="mk-product__media">
         <figure class="mk-window">
-          <span class="mk-window__bar" aria-hidden="true"><i></i><i></i><i></i></span>
           <%= image_tag "https://cdn.hackclub.com/019e85ef-c890-772a-bf24-8252b544a015/image.png",
                 class: "mk-window__shot", width: 2624, height: 1640, loading: "lazy",
                 decoding: "async", alt: "A real-time HCB transaction feed" %>
@@ -233,9 +360,9 @@
       <p class="mk-eyebrow mk-eyebrow--light">What you can fund</p>
       <h2 class="mk-section__title">Your giving isn't limited to established 501(c)(3)s.</h2>
       <p class="mk-lead">
-        The next wave of charitable work — fast-moving projects, new labs, builder-led
-        teams — often doesn't fit the 501(c)(3) timeline or structure. With HCB, you can
-        fund it now, tax-deductibly, without waiting for it to incorporate.
+        The next wave of charitable work doesn't always fit the 501(c)(3) timeline or
+        structure. Fast-moving projects, new labs, and builder-led teams often can't wait
+        for incorporation. With HCB, you can fund them now, tax-deductibly, without waiting.
       </p>
     </div>
     <div class="mk-uses">
@@ -566,7 +693,7 @@
             his approval. %>
         <figure class="mk-case">
           <blockquote>“With HCB, we could start accepting tax-deductible donations and operate
-            under a charitable structure on a much faster timeline. They do amazing work — I
+            under a charitable structure on a much faster timeline. They do amazing work. I
             would’ve supported them regardless.”</blockquote>
           <figcaption>
             <%= image_tag "https://cdn.hackclub.com/019e8635-0733-77b6-9442-bfe6a1b7b3a8/image.png",

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -81,11 +81,11 @@
     <div class="mk-hero__media">
       <%# Animated "capital → grants" fan-out: one funder, many recipients. The prose
           above states the same idea, so the diagram is decorative for assistive tech. %>
-      <%# Recipients are generic, illustrative entities (not real orgs), with made-up
-          amounts and dates. They convey the one-to-many concept without implying real
-          transactions; the actual featured organizations live in their own sections below. %>
+      <%# The recipients are illustrative *categories* of fundable work, not real orgs or
+          transactions: no amounts or dates, so nothing reads as a live ledger. The actual
+          featured organizations and funders live in their own sections below. %>
       <div class="mk-flow" data-controller="funders-flow"
-           role="img" aria-label="A funder directing capital as tax-deductible grants to organizations of their choosing on HCB.">
+           role="img" aria-label="A funder directing capital as tax-deductible grants to many kinds of organizations of their choosing on HCB.">
         <svg class="mk-flow__wires" data-funders-flow-target="svg" aria-hidden="true" preserveAspectRatio="none"></svg>
 
         <div class="mk-flow__source" data-funders-flow-target="source">
@@ -98,45 +98,29 @@
           <li class="mk-flow__grant" data-funders-flow-target="grant">
             <span class="mk-flow__avatar"><%= inline_icon "terminal", size: 20 %></span>
             <span class="mk-flow__org">
-              <span class="mk-flow__name">Open-source</span>
+              <span class="mk-flow__name">Open-source projects</span>
               <span class="mk-flow__meta">Builder-led</span>
-            </span>
-            <span class="mk-flow__amt">
-              <span class="mk-flow__sum">$40,000</span>
-              <span class="mk-flow__status">Sent · 2d</span>
             </span>
           </li>
           <li class="mk-flow__grant" data-funders-flow-target="grant">
             <span class="mk-flow__avatar"><%= inline_icon "cpu", size: 20 %></span>
             <span class="mk-flow__org">
-              <span class="mk-flow__name">AI research lab</span>
+              <span class="mk-flow__name">AI research labs</span>
               <span class="mk-flow__meta">Independent</span>
-            </span>
-            <span class="mk-flow__amt">
-              <span class="mk-flow__sum">$120,000</span>
-              <span class="mk-flow__status">Sent · 5d</span>
             </span>
           </li>
           <li class="mk-flow__grant" data-funders-flow-target="grant">
             <span class="mk-flow__avatar"><%= inline_icon "people-2", size: 20 %></span>
             <span class="mk-flow__org">
-              <span class="mk-flow__name">Mutual aid</span>
+              <span class="mk-flow__name">Mutual aid groups</span>
               <span class="mk-flow__meta">Volunteer-run</span>
-            </span>
-            <span class="mk-flow__amt">
-              <span class="mk-flow__sum">$25,000</span>
-              <span class="mk-flow__status">Sent · 1w</span>
             </span>
           </li>
           <li class="mk-flow__grant" data-funders-flow-target="grant">
             <span class="mk-flow__avatar"><%= inline_icon "idea", size: 20 %></span>
             <span class="mk-flow__org">
-              <span class="mk-flow__name">New initiative</span>
+              <span class="mk-flow__name">New initiatives</span>
               <span class="mk-flow__meta">Brand new</span>
-            </span>
-            <span class="mk-flow__amt">
-              <span class="mk-flow__sum">$9,500</span>
-              <span class="mk-flow__status">Sent · 2w</span>
             </span>
           </li>
         </ul>
@@ -170,12 +154,11 @@
       A new generation of funders is giving differently.
     </h2>
     <p class="mk-lead">
-      Philanthropy is changing. Funders want to put capital to work now, back ambitious,
-      fast-moving projects, and see the work happen in the open. Private foundations and
-      donor-advised funds serve traditional giving well, but they weren't built for that
-      pace, and their overhead can slow the people doing the real work.
-      <strong>We built HCB to counter that</strong>, so you can move fast, adapt as
-      circumstances change, and fund the projects you truly believe in.
+      Philanthropy is changing. Technologists, founders, and institutions want to put capital
+      to work now: back fast-moving projects, fund them at any scale, and see the work happen
+      in the open. Private foundations and donor-advised funds serve traditional giving well,
+      but weren't built for that pace. <strong>We built HCB to counter that</strong>, so you
+      can move fast, adapt, and fund the projects you believe in.
     </p>
   </div>
 </section>
@@ -447,6 +430,12 @@
           </tr>
         </tbody>
       </table>
+    </div>
+    <div class="mk-compare-note">
+      <p class="mk-compare-note__lead">Already give through a donor-advised fund or foundation?</p>
+      <p class="mk-compare-note__body">You don't have to choose. Keep your existing vehicle and
+        use HCB as the fast, transparent layer it grants into, reaching the projects and
+        brand-new initiatives a DAF isn't built to fund.</p>
     </div>
   </div>
 </section>
@@ -745,7 +734,9 @@
       </div>
     <% else %>
       <h2 class="mk-cta__title">Put your capital to work.</h2>
-      <p class="mk-lead">Tell us a bit about what you want to fund. We'll take it from there.</p>
+      <p class="mk-lead">HCB pairs modern financial software with a hands-on team. You get a
+        partner who helps map your giving and runs the operations behind it, not just a login.
+        Tell us what you want to fund.</p>
       <% if flash[:error].present? %>
         <div class="mk-notice mk-notice--error" role="alert">
           <span class="mk-notice__icon"><%= inline_icon "important-fill", size: 24 %></span>


### PR DESCRIPTION
Refine the page's UI and add motion/interactivity, anchored in HCB's own design system:

- New animated hero: a "capital -> grants" fan-out where a funder source node is wired to several recipients, with capital pulses traveling each wire and each row flashing as it lands. Built with GSAP in a Stimulus controller, with static + stacked-mobile + reduced-motion fallbacks.
- Turn the static value props into an interactive explorer: pick a prop to expand its detail panel. It slowly auto-rotates to reveal it's interactive, then stops once you take over (pauses on hover, respects reduced motion).
- Refine the buttons to HCB's squared, flat style with proper hover states (and keep the label readable on hover).
- Present the product screenshot frameless instead of in a faux browser window.
- Tidy the nav (drop the duplicate Docs link, already in the footer) and the copy (remove em dashes).
