### PR TITLE
[CardGrant] Fix duplicate "blocked merchant" callout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -388,7 +388,7 @@ module ApplicationHelper
   end
 
   def error_boundary(fallback: nil, fallback_text: nil, ignored_errors: [], &block)
-    block.call
+    capture(&block)
   rescue => e
     Rails.error.report(e) unless e.in?(ignored_errors)
 


### PR DESCRIPTION
<img width="1186" height="583" alt="image" src="https://github.com/user-attachments/assets/445a3b1f-6fdb-4689-8702-6dd4362b9ce7" />

Users in #hcb have reported this error message appearing twice. 

`error_boundary` double-rendered: the block wrote to the buffer and returned its HTML, so `<%=` appended it twice. `capture(&block)` buffers it separately and returns it once