### PR TITLE
[Applications] Stop syncing HCB timestamp to Airtable

### DIFF
--- a/app/jobs/event/application_sync_to_airtable_job.rb
+++ b/app/jobs/event/application_sync_to_airtable_job.rb
@@ -54,7 +54,6 @@ class Event
       airrecord["Political Activity"] = @application.political_description
       airrecord["Referral Code"] = @application.referral_code
       airrecord["HCB Status"] = @application.aasm_state.humanize unless @application.draft?
-      airrecord["Synced from HCB at"] = Time.current
       airrecord["Archived?"] = @application.archived?
 
       if @application.affiliations.any?(&:is_first?)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It's making the Airtable edit history hard to read

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove the field sync

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

