### PR TITLE
[Dev env] Bind dev services to localhost instead of 0.0.0.0

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: rm -f tmp/pids/server.pid; RAILS_LOG_TO_STDOUT=1 bin/rails server -b "0.0.0.0"
+web: rm -f tmp/pids/server.pid; RAILS_LOG_TO_STDOUT=1 bin/rails server -b "${WEB_BIND:-127.0.0.1}"
 js: NODE_ENV=development yarn build --watch
 stripe: stripe listen --events charge.dispute.funds_withdrawn,invoice.paid,issuing_authorization.created,issuing_authorization.request,issuing_authorization.updated,issuing_card.updated,issuing_transaction.created,payment_intent.succeeded,customer.subscription.updated,customer.subscription.deleted,setup_intent.succeeded,source.transaction.created,charge.refunded,payout.updated,payout.canceled,payout.failed,payout.paid --forward-to http://localhost:3000/stripe/webhook
 css: NODE_ENV=development yarn build:css --watch --verbose

--- a/docker-compose.dbonly.yml
+++ b/docker-compose.dbonly.yml
@@ -8,13 +8,13 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
   redis:
     image: redis
     volumes:
       - redis-data:/data
     ports:
-      - 6379:6379
+      - 127.0.0.1:6379:6379
 
 volumes:
   pg-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,11 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis:6379
+      # Inside the container Rails must listen on all interfaces so Docker can
+      # forward the published port; the host mapping below controls exposure.
+      WEB_BIND: 0.0.0.0
     ports:
-      - 3000:3000
+      - 127.0.0.1:3000:3000
 
 volumes:
   pg-data:


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Local dev published Postgres and Redis on `0.0.0.0` (the `dbonly` compose file) and ran Puma with `-b 0.0.0.0`, so on a shared or public network any device on the LAN could reach them. Postgres uses `trust` auth, so the database was passwordless-reachable from the network.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

- Bind the published ports to `127.0.0.1` in `docker-compose.dbonly.yml` so the DB and Redis are only reachable from the host.
- Make Puma's bind address configurable via `WEB_BIND` (defaulting to `127.0.0.1`) in `Procfile.dev`.
- The main `docker-compose.yml` web container sets `WEB_BIND=0.0.0.0`, since it must listen on all interfaces for Docker to forward the port, and its host mapping is pinned to `127.0.0.1:3000`.

No effect on local workflows; access from other devices now requires an explicit tunnel.
