### PR TITLE
[Marketing] CC the outreach team on funder inquiries

### DIFF
--- a/app/mailers/funder_inquiry_mailer.rb
+++ b/app/mailers/funder_inquiry_mailer.rb
@@ -4,14 +4,27 @@
 # It's a warm confirmation addressed to the funder, with the HCB operations team CC'd
 # so a real person can follow up on the same thread.
 class FunderInquiryMailer < ApplicationMailer
+  # Team members CC'd on funder inquiries so they can follow up directly.
+  # Referenced by public_id so the list survives email changes; any id that
+  # no longer resolves to a user is silently skipped.
+  CC_USER_IDS = [
+    "usr_wVtRav", # Melanie
+    "usr_notLKl", # Paul
+    "usr_8YEt6d", # Gary
+  ].freeze
+
   def inquiry
     @name = params[:name].presence
     @email = params[:email]
     @message = params[:message].presence
 
+    team_cc = CC_USER_IDS.filter_map do |id|
+      User.find_by_public_id(id)&.email_address_with_name(full_name: true)
+    end
+
     mail(
       to: @email,
-      cc: ApplicationMailer::OPERATIONS_EMAIL,
+      cc: [ApplicationMailer::OPERATIONS_EMAIL, *team_cc],
       subject: "Thanks for reaching out to HCB"
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -432,8 +432,9 @@ class User < ApplicationRecord
     self.payout_method = payout_method_type.constantize.new(params)
   end
 
-  def email_address_with_name
-    ActionMailer::Base.email_address_with_name(email, name)
+  def email_address_with_name(full_name: false)
+    display_name = full_name ? (self.full_name.presence || name) : name
+    ActionMailer::Base.email_address_with_name(email, display_name)
   end
 
   def hack_clubber?


### PR DESCRIPTION
CC Melanie, Paul, and Gary on the funder inquiry confirmation email so they can follow up on the same thread. Recipients are referenced by public_id and formatted with their full name via a new full_name option on User#email_address_with_name.
