### PR TITLE
[RackAttack] Support multiple office IPs in rate-limit safelist

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -18,8 +18,8 @@ class Rack::Attack
     bad_ips&.include?(req.ip)
   end
 
-  # Safelist Hack Club Office
-  if office_ip = Credentials.fetch(:OFFICE_IP)
+  # Safelist Hack Club Office(s)
+  Credentials.fetch(:OFFICE_IP)&.split(",")&.map(&:strip)&.each do |office_ip|
     safelist_ip(office_ip)
   end
   safelist_ip("10.0.0.0/16")


### PR DESCRIPTION
OFFICE_IP now accepts a comma-separated list of IPs, each safelisted individually, so additional offices can bypass rate limiting.
