### PR TITLE
Prevent old nuke scripts from running in production

### DIFF
--- a/app/services/event_mapping_engine/nuke.rb
+++ b/app/services/event_mapping_engine/nuke.rb
@@ -3,6 +3,8 @@
 module EventMappingEngine
   class Nuke
     def run
+      return unless Rails.env.development?
+
       Fee.delete_all
       CanonicalEventMapping.delete_all
     end

--- a/app/services/pending_event_mapping_engine/nuke.rb
+++ b/app/services/pending_event_mapping_engine/nuke.rb
@@ -3,6 +3,8 @@
 module PendingEventMappingEngine
   class Nuke
     def run
+      return unless Rails.env.development?
+
       CanonicalPendingEventMapping.delete_all
     end
 

--- a/app/services/pending_transaction_engine/nuke.rb
+++ b/app/services/pending_transaction_engine/nuke.rb
@@ -3,6 +3,8 @@
 module PendingTransactionEngine
   class Nuke
     def run
+      return unless Rails.env.development?
+
       CanonicalPendingEventMapping.delete_all
       CanonicalPendingTransaction.delete_all
       RawPendingStripeTransaction.delete_all

--- a/app/services/transaction_engine/nuke.rb
+++ b/app/services/transaction_engine/nuke.rb
@@ -3,6 +3,8 @@
 module TransactionEngine
   class Nuke
     def run
+      return unless Rails.env.development?
+
       Fee.delete_all
       CanonicalEventMapping.delete_all
 


### PR DESCRIPTION
## Summary of the problem

Nothing stops these very dangerous scripts from running in production.


## Describe your changes

This PR prevents these scripts from running outside of development.