### PR TITLE
[Sidekiq] Stop `ActiveStorage::TransformJob` retries

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -2,6 +2,18 @@
 
 Rails.application.config.to_prepare do
   ActiveStorage::PreviewImageJob.discard_on ActiveStorage::PreviewError
+  ActiveStorage::TransformJob.discard_on MiniMagick::Error do |job, error|
+    blob, transformations = job.arguments
+
+    Rails.error.report(
+      error,
+      handled: true,
+      context: {
+        active_storage_blob_id: blob&.id,
+        transformations:
+      }
+    )
+  end
 end
 
 Rails.application.configure do

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
       handled: true,
       context: {
         active_storage_blob_id: blob&.id,
-        transformations:
+        transformations: transformations
       }
     )
   end


### PR DESCRIPTION

<img width="776" height="186" alt="image" src="https://github.com/user-attachments/assets/596a0d45-0a06-4abb-ae4f-4244a4e69da7" />

This job has been retrying for a while: 

```
MiniMagick::Error: `convert /tmp/XXXXXXX.jpg[0] -auto-orient -resize 1024x1024 /tmp/XXXXXX.jpg` failed with status: 1 and error: co...
```