### PR TITLE
[Marketing] Fix funder logo overflow on Reboot card

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -1961,7 +1961,9 @@ $mk-term-green: #62d196;
 .mk-portfolio__funded {
   display: flex;
   align-items: center;
-  gap: 12px;
+  flex-wrap: wrap; // wrap onto multiple lines on a narrow card instead of overflowing
+  gap: 8px 12px;
+  min-width: 0;
 }
 
 .mk-portfolio__funded-label {
@@ -1969,11 +1971,17 @@ $mk-term-green: #62d196;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: $muted;
+
+  // Give the label its own line on phone widths so both logos sit together beneath it.
+  @media (max-width: 600px) {
+    flex-basis: 100%;
+  }
 }
 
 .mk-portfolio__funder {
   height: 18px;
   width: auto;
+  max-width: 100%; // never let a wide logo bleed past the card edge
   // Greyscale + slight transparency downweights the backer logos so a recipient card never
   // reads as a funder testimonial — and so they don't compete with the full-colour logos in
   // the "In good company" funder marquee directly below.


### PR DESCRIPTION
## Problem

On the `/for/funders` page, the Reboot card's "Backed by" credit row overflowed on phone-width screens: the row was a non-wrapping flex, so the label plus the Ford Foundation and Omidyar Network logos exceeded the card width and the Omidyar lockup bled past the right edge.

## Fix

In `_marketing.scss`:
- `.mk-portfolio__funded` now wraps (`flex-wrap: wrap`) with `min-width: 0` so the credit row can shrink within the footer instead of overflowing.
- `.mk-portfolio__funder` gets `max-width: 100%` as a hard backstop so no single wide logo can bleed past the card edge.
- On phone widths (`max-width: 600px`), the "Backed by" label takes its own line so both logos sit together beneath it, rather than one logo wrapping out on its own.

Inline layout on wider screens is unchanged.
