### PR TITLE
[Anomaly Mailer] Use hashids and correct HCB code amount

### DIFF
--- a/app/views/admin_mailer/logical_transaction_anomalies.html.erb
+++ b/app/views/admin_mailer/logical_transaction_anomalies.html.erb
@@ -1,6 +1,6 @@
 These logical transactions have discrepancies in their amounts between the old and new transaction engine:
 
 <% @hcb_codes.find_each do |hcb_code| %>
-  <p>Old transaction engine balance (HCB Code <%= link_to hcb_code.id, hcb_code_url(hcb_code) %>): <%= hcb_code.amount_cents %></p>
-  <p>New transaction engine balance (Ledger::Item <%= link_to hcb_code.ledger_item.id, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
+  <p>Old transaction engine balance (HCB Code <%= link_to hcb_code.hashid, hcb_code_url(hcb_code) %>): <%= hcb_code.smart_amount_cents %></p>
+  <p>New transaction engine balance (Ledger::Item <%= link_to hcb_code.ledger_item.hashid, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Hash IDs are better and `smart_amount_cents` returns a more accurate amount of the HCB code.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Switch to these


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

