### PR TITLE
Add ledger item amount callback to canonical pending mappings

### DIFF
--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -20,4 +20,8 @@
 class CanonicalPendingDeclinedMapping < ApplicationRecord
   belongs_to :canonical_pending_transaction
 
+  after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
+    ledger_item.map!
+    ledger_item.write_amount_cents!
+  end
 end

--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -21,8 +21,8 @@ class CanonicalPendingDeclinedMapping < ApplicationRecord
   belongs_to :canonical_pending_transaction
 
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
-    ledger_item.map!
-    ledger_item.write_amount_cents!
+    canonical_pending_transaction.ledger_item.map!
+    canonical_pending_transaction.ledger_item.write_amount_cents!
   end
 
 end

--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -24,4 +24,5 @@ class CanonicalPendingDeclinedMapping < ApplicationRecord
     ledger_item.map!
     ledger_item.write_amount_cents!
   end
+
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -45,4 +45,5 @@ class CanonicalPendingSettledMapping < ApplicationRecord
     ledger_item.write_amount_cents!
   end
 
+
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -44,5 +44,4 @@ class CanonicalPendingSettledMapping < ApplicationRecord
     ledger_item.map!
     ledger_item.write_amount_cents!
   end
-
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -40,4 +40,9 @@ class CanonicalPendingSettledMapping < ApplicationRecord
     canonical_transaction.update(ledger_item: canonical_pending_transaction.ledger_item)
   end
 
+  after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
+    ledger_item.map!
+    ledger_item.write_amount_cents!
+  end
+
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -44,4 +44,5 @@ class CanonicalPendingSettledMapping < ApplicationRecord
     ledger_item.map!
     ledger_item.write_amount_cents!
   end
+
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -45,5 +45,4 @@ class CanonicalPendingSettledMapping < ApplicationRecord
     ledger_item.write_amount_cents!
   end
 
-
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -41,8 +41,8 @@ class CanonicalPendingSettledMapping < ApplicationRecord
   end
 
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
-    ledger_item.map!
-    ledger_item.write_amount_cents!
+    canonical_pending_transaction.ledger_item.map!
+    canonical_pending_transaction.ledger_item.write_amount_cents!
   end
 
 end


### PR DESCRIPTION
## Summary of the problem

Ledger items aren't re-computing the amount when a canonical pending declined mapping is created


## Describe your changes

This PR adds an after_commit hook to both canonical pending declined and canonical pending settled mappings.
