### PR TITLE
[Maintenance Task] Add backfill legal entity payout methods

### DIFF
--- a/app/tasks/maintenance/backfill_legal_entity_payout_methods_task.rb
+++ b/app/tasks/maintenance/backfill_legal_entity_payout_methods_task.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Backfills LegalEntity::PayoutMethod records from user PayoutMethod.
+  class BackfillLegalEntityPayoutMethodsTask < MaintenanceTasks::Task
+    def collection
+      User.where.not(payout_method_id: nil)
+          .where(id: LegalEntityUser.joins(:legal_entity)
+                                    .where(legal_entities: { entity_type: :person })
+                                    .select(:user_id))
+    end
+
+    def process(user)
+      legal_entity = user.legal_entities.find_by(entity_type: :person)
+      return unless legal_entity
+
+      details_class = user.payout_method_type.sub(/\AUser::/, "LegalEntity::").safe_constantize
+      return unless LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
+
+      details = details_class.find_by(id: user.payout_method_id)
+      return unless details
+
+      LegalEntity::PayoutMethod.find_or_create_by!(legal_entity:, details:) do |payout_method|
+        payout_method.default = true
+      end
+    end
+
+  end
+end

--- a/app/tasks/maintenance/backfill_legal_entity_payout_methods_task.rb
+++ b/app/tasks/maintenance/backfill_legal_entity_payout_methods_task.rb
@@ -5,14 +5,13 @@ module Maintenance
   class BackfillLegalEntityPayoutMethodsTask < MaintenanceTasks::Task
     def collection
       User.where.not(payout_method_id: nil)
-          .where(id: LegalEntityUser.joins(:legal_entity)
-                                    .where(legal_entities: { entity_type: :person })
-                                    .select(:user_id))
     end
 
     def process(user)
       legal_entity = user.legal_entities.find_by(entity_type: :person)
-      return unless legal_entity
+      if legal_entity.nil?
+        raise ArgumentError, "LE missing for User #{user.id}"
+      end
 
       details_class = user.payout_method_type.sub(/\AUser::/, "LegalEntity::").safe_constantize
       return unless LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)


### PR DESCRIPTION
## Summary of the problem
Now that we have Legal Entity Payouts (assuming #13962 has been merged) we need to populate them with the data from User Payout Methods. 


## Describe your changes
Goes through all users who have a payout ID and are a `LegalEntityUser` then create a `LegalEntity::PayoutMethod` identical to their existing payout information. Also that payout method's default value is true.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

