### PR TITLE
[Anomaly Detection] Support missing ledger items in `logical_transaction_anomalies`

### DIFF
--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -6,8 +6,8 @@ module Admin
 
     def perform
       hcb_codes = []
-      HcbCode.where(event_id: 183).where.not(ledger_item_id: nil).find_each do |hcb_code|
-        hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents
+      HcbCode.where(event_id: 183).find_each do |hcb_code|
+        hcb_codes << hcb_code.id if hcb_code.ledger_item.nil? || hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents
       end
 
       AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(id: hcb_codes)).deliver_now

--- a/app/views/admin_mailer/logical_transaction_anomalies.html.erb
+++ b/app/views/admin_mailer/logical_transaction_anomalies.html.erb
@@ -1,6 +1,10 @@
 These logical transactions have discrepancies in their amounts between the old and new transaction engine:
 
 <% @hcb_codes.find_each do |hcb_code| %>
-  <p>Old transaction engine balance (HCB Code <%= link_to hcb_code.hashid, hcb_code_url(hcb_code) %>): <%= hcb_code.smart_amount_cents %></p>
-  <p>New transaction engine balance (Ledger::Item <%= link_to hcb_code.ledger_item.hashid, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
+  <p>Old transaction engine amount (HCB Code <%= link_to hcb_code.hashid, hcb_code_url(hcb_code) %>): <%= hcb_code.smart_amount_cents %></p>
+  <% if hcb_code.ledger_item.nil? %>
+    <p>Missing Ledger::Item record</p>
+  <% else %>
+    <p>New transaction engine amount (Ledger::Item <%= link_to hcb_code.ledger_item.hashid, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
+  <% end %>
 <% end %>

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -27,7 +27,7 @@ class AdminMailerPreview < ActionMailer::Preview
   end
 
   def logical_transaction_anomalies
-    AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(event_id: 2).where.not(ledger_item_id: nil))
+    AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(event_id: 2))
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Previously, we did not include records that were missing ledger items because there was a large number due to a bug with mapping. This bug has been fixed so we should look for these errors now.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Include HCB codes that do not have an assosciated ledger item.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

