### PR TITLE
[Marketing] Add funder comparison table and FAQ

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -2268,7 +2268,11 @@ $mk-term-green: #62d196;
 
   thead .mk-table__hcb {
     color: darken($red, 14%);
-    background: mix($red, $white, 6%); // opaque version of the column tint, for the sticky header
+    background: mix(
+      $red,
+      $white,
+      6%
+    ); // opaque version of the column tint, for the sticky header
     box-shadow: inset 0 3px 0 $red;
   }
 
@@ -2287,8 +2291,65 @@ $mk-term-green: #62d196;
   }
 }
 
-// Comparison table → stacked cards on small screens (avoids a cramped 4-up / scroll).
+// "Compare against" segmented control (mobile only): pick which alternative sits beside HCB.
+.mk-compare-switch {
+  display: none;
+}
+
+.mk-compare-switch__label {
+  display: block;
+  margin-bottom: 8px;
+  font-family: $mono;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: darken($muted, 18%);
+}
+
+.mk-compare-switch__track {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 4px;
+  background: rgba($black, 0.05);
+  border-radius: var(--radius-lg);
+}
+
+.mk-compare-switch__opt {
+  padding: 9px 12px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: none;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $slate;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+
+  &.is-active {
+    background: $white;
+    color: $mk-ink;
+    box-shadow: var(--shadow-border-sm);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $red;
+    outline-offset: 2px;
+  }
+}
+
+// Comparison table on small screens: the "compare against" control picks one alternative, and each
+// dimension shows HCB beside it as two equal cards, so the two values sit side by side.
 @media (max-width: 640px) {
+  // The segmented control appears only once JS can drive it (no-JS keeps the full table).
+  .mk-table-wrap.is-enhanced .mk-compare-switch {
+    display: block;
+    margin-bottom: 18px;
+  }
+
   .mk-table-wrap {
     overflow: visible;
     background: none;
@@ -2309,52 +2370,141 @@ $mk-term-green: #62d196;
     display: none;
   }
 
-  .mk-table tbody tr {
+  // Show HCB vs. the chosen alternative: hide the other one (only once JS sets data-compare).
+  .mk-table-wrap[data-compare='pf'] .mk-table tbody td[data-label='DAF'],
+  .mk-table-wrap[data-compare='daf']
+    .mk-table
+    tbody
+    td[data-label='Foundation'] {
+    display: none;
+  }
+
+  // Likewise hide the non-selected alternative's explanation in the expanded detail.
+  .mk-table-wrap[data-compare='pf']
+    .mk-compare-detail__vehicle[data-vehicle='daf'],
+  .mk-table-wrap[data-compare='daf']
+    .mk-compare-detail__vehicle[data-vehicle='pf'] {
+    display: none;
+  }
+
+  // Each dimension is a card: a full-width label header, then HCB and the alternative as two cards.
+  .mk-table tbody tr.mk-compare-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 10px;
+    align-items: stretch;
     background: $white;
     border-radius: var(--radius-xl);
     box-shadow: var(--shadow-border-sm);
-    padding: 0 18px 12px;
+    padding: 4px 14px 14px;
     margin-bottom: 14px;
   }
 
-  .mk-table tbody tr:last-child {
+  .mk-table tbody tr.mk-compare-row:last-of-type {
     margin-bottom: 0;
   }
 
+  // Dimension label spans both columns; the toggle is a full-width accordion (chevron at the edge).
   .mk-table tbody th[scope='row'] {
+    grid-column: 1 / -1;
+    padding: 14px 2px 12px;
+    border-bottom: 0; // drop the base table-cell rule so no stray line sits above the value cards
     font-size: 1rem;
     font-weight: 600;
     color: $mk-ink;
-    padding: 16px 0 12px;
-    margin-bottom: 4px;
-    border-bottom: 1px solid rgba($black, 0.08);
   }
 
+  .mk-table tbody th[scope='row'] .mk-table__toggle {
+    justify-content: space-between;
+  }
+
+  // Equal-height value cards (grid stretch): HCB is the tinted hero, the alternative is neutral.
   .mk-table tbody td {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    text-align: right;
-    padding: 7px 0;
-    border-bottom: 0;
+    align-content: flex-start; // keep the label row pinned to the top, so both cards' labels line up
+    column-gap: 8px;
+    padding: 11px 12px;
+    border: 1px solid rgba($black, 0.07);
+    border-radius: var(--radius-md);
+    background: rgba($black, 0.015);
+    color: $mk-ink;
+    font-weight: 500;
+    line-height: 1.4;
 
+    // Status chip then label share the top line; the value wraps to its own line below.
     &::before {
+      order: 1;
       content: attr(data-label);
-      color: $muted;
-      font-size: 0.9rem;
-      text-align: left;
+      font-family: $mono;
+      font-size: 0.68rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: darken($muted, 18%);
     }
   }
 
-  // Drop the column tint in card mode; keep the HCB value + label emphasis.
-  .mk-table .mk-table__hcb {
-    background: none;
+  .mk-cell__v {
+    order: 2;
+    flex: 0 0 100%;
+    margin-top: 5px;
   }
 
-  .mk-table td.mk-table__hcb::before {
+  .mk-table tbody td.mk-table__hcb {
+    background: rgba($red, 0.06);
+    border-color: rgba($red, 0.22);
     color: darken($red, 14%);
-    font-weight: 600;
+
+    &::before {
+      color: darken($red, 14%);
+    }
+  }
+
+  .mk-table tbody td.mk-table__hcb .mk-table__hcb-sub {
+    display: block;
+    margin-top: 3px;
+    color: darken($red, 14%);
+    opacity: 0.8;
+  }
+
+  // At-a-glance status chip (favorable / partial / unfavorable), inline after the vehicle label. The
+  // "no" mark is a dash, not an ✗, so the chip never reads as a close button.
+  .mk-table tbody td[data-status]::after {
+    order: 0; // chip sits before the vehicle label
+    display: grid;
+    place-items: center;
+    width: 17px;
+    height: 17px;
+    border-radius: 50%;
+    font-size: 0.62rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .mk-table tbody td[data-status='yes']::after {
+    content: '\2713'; // check
+    background: rgba($slate, 0.12);
+    color: $slate;
+  }
+
+  .mk-table tbody td[data-status='partial']::after {
+    content: '~';
+    background: rgba($yellow, 0.25);
+    color: darken($yellow, 28%);
+  }
+
+  .mk-table tbody td[data-status='no']::after {
+    content: '\2013'; // en dash (not a cross, so it doesn't read as a close button)
+    background: rgba($black, 0.06);
+    color: darken($muted, 12%);
+  }
+
+  // HCB is the recommended option: a filled red chip, cohesive with its red card, so it reads as best.
+  .mk-table tbody td.mk-table__hcb[data-status='yes']::after {
+    background: $red;
+    color: $white;
   }
 }
 
@@ -2483,9 +2633,33 @@ $mk-term-green: #62d196;
 // own rules below.)
 @media (min-width: 641px) {
   .mk-table tbody tr.mk-compare-row:has(+ .mk-table__detail:not([hidden])) > th,
-  .mk-table tbody tr.mk-compare-row:has(+ .mk-table__detail:not([hidden])) > td {
+  .mk-table
+    tbody
+    tr.mk-compare-row:has(+ .mk-table__detail:not([hidden]))
+    > td {
     border-bottom-color: transparent;
   }
+}
+
+// The expanded detail is one short, labeled explanation per vehicle (HCB / Foundation / DAF).
+.mk-compare-detail {
+  display: grid;
+  gap: 16px;
+}
+
+.mk-compare-detail__vehicle-name {
+  margin: 0 0 3px;
+  font-family: $mono;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: darken($muted, 18%);
+}
+
+.mk-compare-detail__vehicle[data-vehicle='hcb']
+  .mk-compare-detail__vehicle-name {
+  color: darken($red, 14%);
 }
 
 .mk-compare-detail__text {
@@ -2496,22 +2670,32 @@ $mk-term-green: #62d196;
   line-height: 1.6;
 }
 
-
 @media (prefers-reduced-motion: reduce) {
   .mk-table__chevron {
     transition: none;
   }
 }
 
-// Mobile (cards): the detail reads as attached to its summary card — full-width prose,
-// no label/value split, and squared-off joining corners.
+// Mobile (cards): the expanded detail is a card joined to the summary above it (shared squared
+// corners), so the full-width prose reads as that dimension opened up, not a separate card.
 @media (max-width: 640px) {
+  .mk-table tbody tr.mk-table__detail:not([hidden]) {
+    background: $white;
+    box-shadow: var(--shadow-border-sm);
+    border-radius: var(--radius-xl);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin: 0 0 14px;
+    padding: 0 14px 14px;
+  }
+
   .mk-table tbody tr.mk-table__detail td {
     display: block;
-    padding: 0 0 4px;
+    padding: 12px 0 0; // top padding so the prose clears the values it expands from
     text-align: left;
     background: none;
-    border-bottom: 0; // the desktop group-gap doesn't apply inside the stacked card
+    border: 0; // not a value card: drop the card border/radius so the prose isn't boxed
+    border-radius: 0;
 
     &::before {
       content: none;
@@ -2522,13 +2706,6 @@ $mk-term-green: #62d196;
     margin-bottom: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-  }
-
-  .mk-table tbody tr.mk-table__detail:not([hidden]) {
-    margin-top: 0;
-    padding-top: 0;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
   }
 }
 
@@ -2646,7 +2823,9 @@ $mk-term-green: #62d196;
   margin: 0 0 18px;
   padding-bottom: 13px;
   border-bottom: 1px solid rgba($black, 0.09);
-  scroll-margin-top: calc(var(--mk-nav-h) + 16px); // clear the sticky nav when jumped to
+  scroll-margin-top: calc(
+    var(--mk-nav-h) + 16px
+  ); // clear the sticky nav when jumped to
 }
 
 .mk-faq__topic-num {
@@ -2682,7 +2861,9 @@ $mk-term-green: #62d196;
   font-weight: 600;
   line-height: 1.35;
   color: $mk-ink;
-  scroll-margin-top: calc(var(--mk-nav-h) + 16px); // clear the sticky nav when a question is deep-linked
+  scroll-margin-top: calc(
+    var(--mk-nav-h) + 16px
+  ); // clear the sticky nav when a question is deep-linked
 }
 
 .mk-faq__a {
@@ -2695,11 +2876,14 @@ $mk-term-green: #62d196;
 // Meta links under an answer or a comparison detail row (Sources and Related share one treatment so
 // they read as siblings): a small mono label + subtle dotted-underline links. Shared by the FAQ page
 // and the comparison table so a citation looks the same everywhere.
+// Two columns: the mono label sits in a fixed left column and the links stack in the right one, so a
+// second citation aligns under the first instead of wrapping back under the label.
 .mk-meta {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 5px;
   align-items: baseline;
-  gap: 6px 14px;
   margin: 12px 0 0;
 }
 
@@ -2712,14 +2896,21 @@ $mk-term-green: #62d196;
 }
 
 .mk-meta__link {
+  grid-column: 2; // every link shares the right column, so they stack and align
+  justify-self: start;
   font-size: 0.85rem;
-  color: darken($muted, 18%); // AA-legible: these are citation/cross-link affordances funders click
-  text-decoration: none;
-  border-bottom: 1px dotted rgba($black, 0.4);
+  color: darken(
+    $muted,
+    18%
+  ); // AA-legible: these are citation/cross-link affordances funders click
+  // Dotted underline via text-decoration (not border-bottom) so it hugs the text uniformly, even
+  // when a long citation wraps to a second line.
+  text-decoration: underline dotted rgba($black, 0.4);
+  text-underline-offset: 3px;
 
   &:hover {
     color: $mk-ink;
-    border-bottom-color: $mk-ink;
+    text-decoration-color: $mk-ink;
   }
 }
 

--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -34,6 +34,7 @@ $mk-bg: $snow; // #f9fafc
 
 // ---------------------------------------------------------------- base / layout
 .marketing {
+  --mk-nav-h: 64px; // sticky nav height; sticky-header + scroll-margin offsets all derive from this
   background: $mk-bg;
   color: $mk-ink;
 }
@@ -83,6 +84,13 @@ $mk-bg: $snow; // #f9fafc
 
 .mk-narrow {
   max-width: 760px;
+}
+
+// The comparison section runs wider than the page's prose columns so the table's labels and
+// values wrap less. Tablet falls back to the container's own responsive width (padding-bounded),
+// and mobile renders the table as stacked cards.
+.mk-compare-wide {
+  max-width: 960px;
 }
 
 .mk-section {
@@ -2113,10 +2121,38 @@ $mk-term-green: #62d196;
 
 // ---------------------------------------------------------------- comparison
 .mk-table-wrap {
-  overflow-x: auto;
+  // `clip` clips to the border-radius (keeping the rounded corners) WITHOUT creating a scroll
+  // container, so the sticky <thead> still sticks to the viewport. `hidden`/`auto` would trap
+  // the sticky header; `visible` would let the opaque header square off (and leak through) the
+  // rounded corners. table-layout is fixed so nothing overflows horizontally; mobile is cards.
+  position: relative; // containing block for the stuck-state sentinel
+  overflow: clip;
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-border-md);
   background: $white;
+}
+
+// A zero-footprint marker at the top of the table; the controller watches it to know when the
+// sticky header has parked under the nav.
+.mk-table__sentinel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+// Once the header is stuck under the nav, give it a drop shadow so it reads as a floating bar,
+// distinct from the rows scrolling beneath it. (At rest it sits flush in the rounded card.)
+.mk-table-wrap.is-stuck thead th {
+  box-shadow: 0 6px 11px -7px rgba($black, 0.32);
+}
+
+.mk-table-wrap.is-stuck thead .mk-table__hcb {
+  box-shadow:
+    inset 0 3px 0 $red,
+    0 6px 11px -7px rgba($black, 0.32);
 }
 
 // Closing note under the comparison table: invites funders who already give through a
@@ -2142,6 +2178,37 @@ $mk-term-green: #62d196;
     color: $slate;
     line-height: 1.6;
   }
+
+  // Variant with the team avatar cluster (the FAQ page's "didn't find your answer" card).
+  &--team {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+
+    @media (max-width: 480px) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+}
+
+// Compact overlapping avatar cluster (mirrors the app's `.avatar-row`: faces overlap, separated by
+// a white ring). Decorative, so the images carry empty alt and the wrapper is aria-hidden.
+.mk-avatar-stack {
+  display: flex;
+  flex: 0 0 auto;
+
+  &__img {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 0 0 2px $white;
+
+    & + & {
+      margin-left: -10px;
+    }
+  }
 }
 
 .mk-table {
@@ -2161,6 +2228,13 @@ $mk-term-green: #62d196;
   }
 
   thead th {
+    // Sticky column headers: stay visible while scrolling a long (expanded) table. They
+    // park just below the sticky marketing nav (64px), with an opaque background so rows
+    // pass cleanly underneath.
+    position: sticky;
+    top: var(--mk-nav-h);
+    z-index: 2;
+    background: $white;
     font-size: 0.8rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;
@@ -2194,6 +2268,7 @@ $mk-term-green: #62d196;
 
   thead .mk-table__hcb {
     color: darken($red, 14%);
+    background: mix($red, $white, 6%); // opaque version of the column tint, for the sticky header
     box-shadow: inset 0 3px 0 $red;
   }
 
@@ -2202,7 +2277,7 @@ $mk-term-green: #62d196;
   @media (min-width: 641px) {
     th:first-child,
     td:first-child {
-      width: 34%;
+      width: 38%; // a bit more room for the label column so dimension names wrap less
     }
 
     thead th:not(:first-child),
@@ -2280,6 +2355,404 @@ $mk-term-green: #62d196;
   .mk-table td.mk-table__hcb::before {
     color: darken($red, 14%);
     font-weight: 600;
+  }
+}
+
+// ------------------------------------------------- comparison table interactivity
+// The comparison table's detail rows ship expanded in the HTML (so AI crawlers and
+// no-JS visitors get every fact + source); `funders-compare` adds `is-enhanced` and
+// collapses them, then toggles per row. Affordances (chevron, pointer cursor) are
+// gated on `is-enhanced` so a no-JS visitor never sees a control that does nothing.
+
+// Answer-first interceptor line above the table — also a clean, citable passage for AI.
+.mk-compare-lead {
+  margin: 0 0 22px;
+  color: $slate;
+  font-size: 1.05rem;
+  line-height: 1.6;
+
+  strong {
+    color: $mk-ink;
+  }
+}
+
+// Entity-disambiguation line directly under the comparison table, so an AI engine that extracts
+// just the table chunk still knows what HCB legally is. Matches the disclaimer so the two footnote
+// lines below the table read as one uniform block.
+.mk-compare-entity {
+  margin: 14px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: darken($muted, 18%);
+}
+
+.mk-compare-disclaimer {
+  margin: 6px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: darken($muted, 18%); // legal "not tax advice" line must clear AA
+}
+
+// Each row label becomes a full-width toggle button; plain text until JS enhances it.
+.mk-table__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  color: inherit;
+  text-align: left;
+  cursor: default;
+
+  &:focus-visible {
+    outline: 2px solid $red;
+    outline-offset: 3px;
+    border-radius: 3px;
+  }
+}
+
+.mk-table__chevron {
+  display: none; // shown only once enhanced (see .is-enhanced below)
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg); // expanded → points down
+  opacity: 0.45;
+  transition: transform 0.18s ease;
+}
+
+// Collapsed → chevron points right.
+.mk-table__toggle[aria-expanded='false'] .mk-table__chevron {
+  transform: rotate(-45deg);
+}
+
+// Secondary clause on an HCB value (e.g. "one simple fee"): its own muted line under the
+// headline value, so a separator never dangles at the end of a wrapped line.
+.mk-table__hcb-sub {
+  display: block;
+  margin-top: 3px;
+  font-weight: 400;
+  font-size: 0.82em;
+  line-height: 1.3;
+  color: $slate;
+}
+
+.is-enhanced {
+  .mk-table__toggle {
+    cursor: pointer;
+  }
+
+  // Hover affordance so the row reads as clickable.
+  .mk-table__toggle:hover {
+    color: $mk-ink;
+
+    .mk-table__chevron {
+      opacity: 0.8;
+    }
+  }
+
+  .mk-table__chevron {
+    display: inline-block;
+  }
+}
+
+// Collapsed detail rows: beat the mobile `tr { display: block }` rule further down.
+.mk-table tbody tr.mk-table__detail[hidden] {
+  display: none;
+}
+
+.mk-table__detail td {
+  // The expanded explanation, set off as a tinted sub-panel with a clear whitespace gap below, so
+  // each label-and-detail pair reads as one group, plainly separate from the next row.
+  padding: 16px 20px;
+  text-align: left;
+  background: rgba($black, 0.03);
+  border-bottom: 14px solid $white;
+}
+
+// Group an expanded row with its detail so the detail clearly belongs to the label ABOVE it: drop
+// the divider between the row and its detail. (Desktop; the stacked mobile cards join via their
+// own rules below.)
+@media (min-width: 641px) {
+  .mk-table tbody tr.mk-compare-row:has(+ .mk-table__detail:not([hidden])) > th,
+  .mk-table tbody tr.mk-compare-row:has(+ .mk-table__detail:not([hidden])) > td {
+    border-bottom-color: transparent;
+  }
+}
+
+.mk-compare-detail__text {
+  max-width: 64ch;
+  margin: 0;
+  color: $slate;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .mk-table__chevron {
+    transition: none;
+  }
+}
+
+// Mobile (cards): the detail reads as attached to its summary card — full-width prose,
+// no label/value split, and squared-off joining corners.
+@media (max-width: 640px) {
+  .mk-table tbody tr.mk-table__detail td {
+    display: block;
+    padding: 0 0 4px;
+    text-align: left;
+    background: none;
+    border-bottom: 0; // the desktop group-gap doesn't apply inside the stacked card
+
+    &::before {
+      content: none;
+    }
+  }
+
+  .mk-table tbody tr.mk-compare-row:has(+ tr.mk-table__detail:not([hidden])) {
+    margin-bottom: 0;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .mk-table tbody tr.mk-table__detail:not([hidden]) {
+    margin-top: 0;
+    padding-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+}
+
+// ---------------------------------------------------------------- funder FAQ
+// Q&A on the dedicated /for/funders/faq page and the short teaser on the main page. Plain,
+// fully-visible Q&A (no JS) so every answer is server-rendered, extractable, and scannable.
+
+// FAQ page: a wide editorial layout with a sticky, scroll-tracked table-of-contents rail.
+.mk-faq-page {
+  max-width: 1040px;
+}
+
+.mk-faq-page__head {
+  max-width: 720px;
+}
+
+.mk-faq-layout {
+  display: grid;
+  gap: clamp(32px, 5vw, 64px);
+  align-items: start;
+
+  @media (min-width: 900px) {
+    grid-template-columns: 216px minmax(0, 1fr);
+  }
+}
+
+// Sticky TOC rail (desktop only; narrow screens skim the content directly).
+.mk-faq-toc {
+  display: none;
+
+  @media (min-width: 900px) {
+    position: sticky;
+    top: calc(var(--mk-nav-h) + 24px);
+    display: block;
+    align-self: start;
+  }
+}
+
+.mk-faq-toc__label {
+  margin: 0 0 14px;
+  font-family: $mono;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: darken($muted, 18%); // clears AA contrast on snow
+}
+
+.mk-faq-toc__list {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mk-faq-toc__link {
+  display: flex;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  color: $slate;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+
+  &:hover {
+    color: $mk-ink;
+    background: rgba($black, 0.04);
+  }
+
+  &.is-active {
+    color: darken($red, 14%); // the table's already-validated AA red
+    background: rgba($red, 0.07);
+    font-weight: 600;
+  }
+}
+
+.mk-faq-toc__num {
+  flex: 0 0 auto;
+  padding-top: 1px;
+  font-family: $mono;
+  font-size: 0.72rem;
+  color: darken($muted, 18%);
+}
+
+.mk-faq-toc__link.is-active .mk-faq-toc__num {
+  color: darken($red, 14%);
+}
+
+// Smooth in-page jumps for marketing anchor links (the TOC, "talk to us", etc.).
+.marketing {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marketing {
+    scroll-behavior: auto;
+  }
+}
+
+.mk-faq {
+  display: grid;
+  gap: 40px;
+}
+
+// The topic is a mono section label (not another bold heading), so it never competes with the
+// bold questions below it. A hairline rule sets the section off.
+.mk-faq__topic {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 18px;
+  padding-bottom: 13px;
+  border-bottom: 1px solid rgba($black, 0.09);
+  scroll-margin-top: calc(var(--mk-nav-h) + 16px); // clear the sticky nav when jumped to
+}
+
+.mk-faq__topic-num {
+  flex: 0 0 auto;
+  font-family: $mono;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $red;
+}
+
+.mk-faq__topic-text {
+  font-family: $mono;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: darken($muted, 16%);
+}
+
+.mk-faq__item {
+  padding: 16px 0;
+  border-bottom: 1px solid rgba($black, 0.07);
+}
+
+.mk-faq__group .mk-faq__item:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.mk-faq__q {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.35;
+  color: $mk-ink;
+  scroll-margin-top: calc(var(--mk-nav-h) + 16px); // clear the sticky nav when a question is deep-linked
+}
+
+.mk-faq__a {
+  max-width: 68ch;
+  margin: 0;
+  color: $slate;
+  line-height: 1.65;
+}
+
+// Meta links under an answer or a comparison detail row (Sources and Related share one treatment so
+// they read as siblings): a small mono label + subtle dotted-underline links. Shared by the FAQ page
+// and the comparison table so a citation looks the same everywhere.
+.mk-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 14px;
+  margin: 12px 0 0;
+}
+
+.mk-meta__label {
+  font-family: $mono;
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: darken($muted, 18%); // clears AA contrast on snow
+}
+
+.mk-meta__link {
+  font-size: 0.85rem;
+  color: darken($muted, 18%); // AA-legible: these are citation/cross-link affordances funders click
+  text-decoration: none;
+  border-bottom: 1px dotted rgba($black, 0.4);
+
+  &:hover {
+    color: $mk-ink;
+    border-bottom-color: $mk-ink;
+  }
+}
+
+// Footer (disclaimer + "didn't find your answer" card) sits in the content column, set off from
+// the Q&A with clear space so the bottom of the page doesn't feel crowded.
+.mk-faq-content .mk-compare-disclaimer {
+  margin-top: 44px;
+}
+
+.mk-faq__more {
+  margin: 36px 0 0;
+}
+
+.mk-faq__back {
+  color: inherit;
+  text-decoration: none;
+
+  &::before {
+    content: '← ';
+  }
+}
+
+// Teaser block on the main page: a flat list (no topic groups), divider-separated.
+.mk-faq--teaser {
+  gap: 0;
+
+  .mk-faq__item:first-child {
+    padding-top: 0;
+  }
+
+  .mk-faq__item:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
   }
 }
 

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -13,7 +13,7 @@ class MarketingController < ApplicationController
 
   invisible_captcha only: [:funder_inquiry], honeypot: :subtitle
 
-  after_action :allow_indexing, only: [:funders]
+  after_action :allow_indexing, only: [:funders, :funders_faq]
 
   # Gates just the "Funders on HCB" testimonials section, so the page can ship while we
   # await sign-off on the funder quotes. Enable once the quotes are approved.
@@ -23,12 +23,28 @@ class MarketingController < ApplicationController
   # of the page once its content is approved.
   PUBLIC_GRIDS_FLAG = :funders_landing_public_grids
 
+  # Gates the redesigned comparison table and the funder FAQ (the on-page "Common questions" teaser
+  # plus the /for/funders/faq subpage). Lets the new work ship dark and switch on when approved.
+  # When off, the page falls back to the original static comparison table and the FAQ subpage 404s.
+  COMPARISON_FAQ_FLAG = :funders_landing_comparison_faq
+
   FUNDER_STATS_CACHE_KEY = "marketing/funder_stats"
 
   def funders
     @stats = funder_stats
     @show_testimonials = Flipper.enabled?(TESTIMONIALS_FLAG, current_user)
     @show_public_grids = Flipper.enabled?(PUBLIC_GRIDS_FLAG, current_user)
+    @show_comparison_faq = Flipper.enabled?(COMPARISON_FAQ_FLAG, current_user)
+    @skip_layout_og_tags = true # page provides its own funder-specific meta
+  end
+
+  # Dedicated funder FAQ subpage (the main /for/funders page links here from its short
+  # "Common questions" block). Static, indexable, same marketing layout.
+  def funders_faq
+    # Gated: the FAQ subpage isn't reachable unless the user has the flag.
+    return head :not_found unless Flipper.enabled?(COMPARISON_FAQ_FLAG, current_user)
+
+    @stats = funder_stats # the FAQ cites live platform figures ($ moved, organizations)
     @skip_layout_og_tags = true # page provides its own funder-specific meta
   end
 

--- a/app/helpers/marketing_helper.rb
+++ b/app/helpers/marketing_helper.rb
@@ -131,7 +131,10 @@ module MarketingHelper
   # IRS sources are visible to AI crawlers and no-JS visitors. Per-row keys:
   # - :label — the comparison dimension (also the expand toggle's label)
   # - :hcb / :pf / :daf — the short value for each vehicle (:hcb_sub is an optional lighter clause)
-  # - :detail — the expandable explanation; :sources is an optional list of { :text, :url } cites
+  # - :detail — a per-vehicle hash { :hcb, :pf, :daf } of short explanations. On mobile only HCB and
+  #   the chosen alternative show; desktop shows all three.
+  # - :sources — optional list of { :text, :url, :for } cites (`for` tags the vehicle a source backs).
+  #   They render together below the explanations.
   # Stats are verified against the cited IRS pages.
   def funder_comparison_rows
     irs = {
@@ -148,66 +151,119 @@ module MarketingHelper
     [
       {
         label: "Setup cost", hcb: "$0", pf: "Legal & accounting + $600 IRS fee", daf: "Low",
-        detail: "Standing up a private foundation means incorporating an entity and filing IRS Form 1023 (a $600 user fee), plus legal and accounting work. A donor-advised fund is inexpensive to open. With HCB there's no entity to form. You start under Hack Club's existing 501(c)(3).",
-        sources: [{ text: "IRS · Life cycle of a private foundation", url: irs[:life_cycle] }]
+        pf_status: "no", daf_status: "yes",
+        detail: {
+          hcb: "No entity to form and no setup cost. Your project runs on an established 501(c)(3), with the legal and compliance groundwork already in place.",
+          pf: "Incorporate an entity and file IRS Form 1023 (a $600 user fee), plus legal and accounting work.",
+          daf: "Inexpensive to open."
+        },
+        sources: [{ text: "IRS · Life cycle of a private foundation", url: irs[:life_cycle], for: "pf" }]
       },
       {
         label: "Time to first grant", hcb: "Days", pf: "Months", daf: "Days",
-        detail: "A new private foundation must file the full IRS Form 1023 (the faster 1023-EZ isn't available to private foundations) and typically waits months for a determination letter before funders and banks treat its grants as settled. HCB lets you move within days of deciding, because the 501(c)(3) already exists, every bit as fast as a donor-advised fund.",
-        sources: [{ text: "IRS · Where's my application", url: irs[:application] }]
+        pf_status: "no", daf_status: "yes",
+        detail: {
+          hcb: "Move within days of deciding. You build on an established 501(c)(3), so there's no new entity to form and no IRS waiting period.",
+          pf: "Must file the full Form 1023 (the faster 1023-EZ isn't available to private foundations) and typically waits months for a determination letter before funders and banks treat its grants as settled.",
+          daf: "Fast, like HCB. You can grant within days."
+        },
+        sources: [{ text: "IRS · Where's my application", url: irs[:application], for: "pf" }]
       },
       {
         label: "Practical minimum to be worth it", hcb: "None", pf: "~$250k to $1M+ commonly cited", daf: "Low",
-        detail: "A private foundation's fixed setup and annual costs only pencil out at scale, and are commonly cited at roughly $250k to $1M+ in assets. A donor-advised fund has little or no minimum, though its fees stack up as your balance grows. HCB has no minimum at all; fund $500 or $5M.",
-        sources: [{ text: "Foundation startup guidance", url: "https://www.cpakpa.com/learn-about-foundations/how-much-money-do-you-need-to-start-a-foundation" }]
+        pf_status: "no", daf_status: "yes",
+        detail: {
+          hcb: "No minimum at all. Fund $500 or $5M.",
+          pf: "Fixed setup and annual costs only pencil out at scale, commonly cited at roughly $250k to $1M+ in assets.",
+          daf: "Little or no minimum, though its fees stack up as your balance grows."
+        },
+        sources: [{ text: "Foundation startup guidance", url: "https://www.cpakpa.com/learn-about-foundations/how-much-money-do-you-need-to-start-a-foundation", for: "pf" }]
       },
       {
         label: "Fund projects that aren't 501(c)(3)s", hcb: "Yes", pf: "Limited (expenditure responsibility)", daf: "No (existing charities only)",
-        detail: "DAFs can only grant to existing, qualified 501(c)(3) public charities. A private foundation can support a non-charity only through expenditure responsibility, an added compliance step. HCB lets you fund a charitable project now, even a brand-new one run by a single person, and it never has to incorporate as its own nonprofit. Because your gift funds charitable work, and HCB makes sure it's used for that purpose, it stays fully tax-deductible.",
-        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf] }]
+        pf_status: "partial", daf_status: "partial",
+        detail: {
+          hcb: "Fund a charitable project now, even a brand-new one run by a single person, and it never has to incorporate. Because your gift funds charitable work and HCB makes sure it's used for that purpose, it stays fully tax-deductible.",
+          pf: "Can support a non-charity, but only through expenditure responsibility, an added compliance step.",
+          daf: "Most sponsors grant only to existing 501(c)(3) public charities. A sponsor can fund others through expenditure responsibility, but few do."
+        },
+        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf], for: "daf" }]
       },
       {
         label: "Back office (bank, cards, bookkeeping)", hcb: "Handled for funder & project", pf: "Build & staff your own", daf: "Recipient runs their own",
-        detail: "A DAF grants money to a charity that must already have its own bank account, accounting, and compliance. A private foundation can operate directly, but you build and staff that back office. HCB is the back office on both sides. The project gets a real bank account, debit cards, and bookkeeping, and you get clean reporting, with compliance handled for you."
+        pf_status: "no", daf_status: "partial",
+        detail: {
+          hcb: "HCB is the back office on both sides. The project gets a real bank account, debit cards, and bookkeeping; you get clean reporting, with compliance handled for you.",
+          pf: "Can operate directly, but you build and staff that back office yourself.",
+          daf: "The sponsor handles your account, but it grants to a charity that must already have its own bank account, accounting, and compliance."
+        }
       },
       {
         label: "Donor control over grants", hcb: "You direct grants", hcb_sub: "compliance handled", pf: "Full", daf: "Advisory only",
-        detail: "With a DAF you recommend grants; the sponsor holds legal control and approves them. A private foundation gives you full control, but you run the entity and its compliance. With HCB you direct where grants go while HCB keeps every grant compliant. As with any 501(c)(3), the charity retains ultimate discretion and control, and that's what makes your gift deductible.",
-        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf] }]
+        pf_status: "yes", daf_status: "partial",
+        detail: {
+          hcb: "You direct where grants go, and HCB keeps every grant compliant. Like any 501(c)(3) sponsor, HCB has final legal sign-off, which is what makes your gift deductible, but in practice you decide what to fund.",
+          pf: "Full control, but you run the entity and its compliance.",
+          daf: "You recommend grants; the sponsor holds legal control and approves them."
+        },
+        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf], for: "daf" }]
       },
       {
         label: "Mandatory annual payout & excise tax", hcb: "None", pf: "~5% payout + 1.39% excise", daf: "None",
-        detail: "Private foundations must pay out about 5% of their investment assets each year or owe an initial 30% excise tax on the shortfall (rising to 100% if uncorrected), and they owe a 1.39% excise tax on net investment income. DAFs and HCB carry no such requirement.",
-        sources: [{ text: "IRS · §4942 (payout)", url: irs[:payout] }, { text: "IRS · §4940 (excise)", url: irs[:excise] }]
+        pf_status: "no", daf_status: "yes",
+        detail: {
+          hcb: "No mandatory payout and no excise tax.",
+          pf: "Must pay out about 5% of investment assets each year or owe an initial 30% excise tax on the shortfall (rising to 100% if uncorrected), plus a 1.39% excise tax on net investment income.",
+          daf: "No mandatory payout or excise tax."
+        },
+        sources: [{ text: "IRS · §4942 (payout)", url: irs[:payout], for: "pf" }, { text: "IRS · §4940 (excise)", url: irs[:excise], for: "pf" }]
       },
       {
         label: "Real-time transparency", hcb: "Real-time", hcb_sub: "every dollar as it moves", pf: "Annual (Form 990-PF)", daf: "Limited (periodic statements)",
-        detail: "Foundations report publicly once a year on Form 990-PF. A DAF shows you your contributions and grants out, but not live, transaction-level visibility into how the money is used. HCB gives you a real-time dashboard down to every transaction, so you can see exactly where each dollar goes, break spending out by project and category, and turn it into the impact reports your board and stakeholders expect.",
-        sources: [{ text: "IRS · About Form 990-PF", url: irs[:form990pf] }]
+        pf_status: "no", daf_status: "partial",
+        detail: {
+          hcb: "A real-time dashboard down to every transaction. See exactly where each dollar goes, break spending out by project and category, and turn it into the impact reports your board and stakeholders expect.",
+          pf: "Reports publicly once a year on Form 990-PF.",
+          daf: "Shows your contributions and grants out, but not live, transaction-level visibility into how the money is used."
+        },
+        sources: [{ text: "IRS · About Form 990-PF", url: irs[:form990pf], for: "pf" }]
       },
       {
         label: "Ongoing admin & cost", hcb: "We handle it", hcb_sub: "one simple fee", pf: "High (990-PF, staff/advisors)", daf: "Layered fees (admin + investment + advisor)",
-        detail: "Private foundations file Form 990-PF annually and often need staff or advisors. A DAF is low-effort to maintain, but its costs stack up: an administrative (sponsor) fee, the underlying investment fees, and often a separate advisor fee, each charged on your balance, year after year. HCB handles bookkeeping, compliance, and reporting for you, for one simple fee, with no stacked or recurring charges. We'll walk you through it.",
-        sources: [{ text: "Fidelity Charitable · what a DAF costs", url: "https://www.fidelitycharitable.org/giving-account/what-it-costs.html" }]
+        pf_status: "no", daf_status: "partial",
+        detail: {
+          hcb: "HCB handles bookkeeping, compliance, and reporting for you, for one simple fee, with no stacked or recurring charges.",
+          pf: "File Form 990-PF annually and often need staff or advisors.",
+          daf: "Low-effort to maintain, but costs stack up: an administrative (sponsor) fee, the underlying investment fees, and often a separate advisor fee, each charged on your balance, year after year."
+        },
+        sources: [{ text: "Fidelity Charitable · what a DAF costs", url: "https://www.fidelitycharitable.org/giving-account/what-it-costs.html", for: "daf" }]
       },
       {
         label: "Deduction limit, cash gifts", hcb: "Up to 60% of AGI", hcb_sub: "plus a 2026 break the others don't get", pf: "30% of AGI", daf: "Up to 60% of AGI",
-        detail: "Because HCB operates as a public charity, cash gifts are generally deductible up to 60% of AGI, versus 30% for gifts to a private foundation (appreciated assets: 30% vs. 20%, and public charities like HCB let you deduct appreciated assets such as stock or crypto at fair market value). Starting in tax year 2026, federal rules add a 0.5%-of-AGI floor, cap the deduction's value at 35% for top-bracket donors, and let non-itemizers deduct up to $1,000 ($2,000 joint) in cash gifts to public charities, a break that doesn't apply to DAFs or private foundations.",
-        sources: [{ text: "IRS · Publication 526", url: irs[:pub526] }, { text: "Tax Foundation · 2026 charitable deduction changes", url: "https://taxfoundation.org/blog/charitable-deduction-big-beautiful-bill/" }]
+        pf_status: "no", daf_status: "yes",
+        detail: {
+          hcb: "As a public charity, cash gifts are generally deductible up to 60% of AGI, and you can deduct appreciated assets such as stock or crypto at fair market value. Starting in 2026, non-itemizers can also deduct up to $1,000 ($2,000 joint) in cash gifts to public charities, a break that doesn't apply to DAFs or private foundations.",
+          pf: "Cash gifts deductible up to 30% of AGI. Appreciated assets are capped at 20%, and non-publicly-traded stock is valued at cost basis.",
+          daf: "Like HCB, a public charity: cash gifts deductible up to 60% of AGI, and appreciated assets at fair market value."
+        },
+        sources: [{ text: "IRS · Publication 526", url: irs[:pub526], for: "hcb" }, { text: "Tax Foundation · 2026 charitable deduction changes", url: "https://taxfoundation.org/blog/charitable-deduction-big-beautiful-bill/", for: "hcb" }]
       },
       {
         label: "Tax-deductible · 501(c)(3)", hcb: "Yes", pf: "Yes", daf: "Yes",
-        detail: "All three give you a tax-deductible gift backed by a real 501(c)(3). The limits differ (above), but the deduction is real in every case.",
-        sources: [{ text: "IRS · Charitable contribution deductions", url: irs[:deductions] }]
+        pf_status: "yes", daf_status: "yes",
+        detail: {
+          hcb: "A tax-deductible gift backed by a real 501(c)(3). The limits differ (above), but the deduction is real.",
+          pf: "Also a real 501(c)(3); your gift is deductible, at the lower limits above.",
+          daf: "Also a real 501(c)(3); your gift is deductible at the same limits as HCB."
+        },
+        sources: [{ text: "IRS · Charitable contribution deductions", url: irs[:deductions], for: "hcb" }]
       }
     ]
   end
 
   # Q&A for the funder FAQ, grouped by topic. The full set renders on the dedicated
   # /for/funders/faq subpage; the `teaser: true` ones also surface in a short "Common questions"
-  # block on the main funders page. Answers stay consistent with the comparison table and the
-  # strategy doc (the fee stays a "simple pricing, let's talk" pointer, not a number) and avoid
-  # claims that need confirmation (custody, audit dates, exact stats, wind-down mechanics, etc.).
+  # block on the main funders page.
   def funder_faqs(stats: nil)
     [
       {
@@ -216,7 +272,7 @@ module MarketingHelper
           {
             teaser: true,
             q: "How do I accept tax-deductible donations for a project that isn't a 501(c)(3)?",
-            a: "Through fiscal sponsorship. HCB takes your charitable project under Hack Club's 501(c)(3), so donations are tax-deductible from day one, with no nonprofit of your own to form. The project gets a real bank account, debit cards, and compliance, and HCB handles the paperwork for one simple fee.",
+            a: "Through fiscal sponsorship. Your charitable project runs on an established 501(c)(3), so donations are tax-deductible from day one, with no nonprofit of your own to form. The project keeps its own name and gets a real bank account, debit cards, and compliance, while HCB handles the paperwork for one simple fee.",
             related: ["fiscal-sponsorship"]
           },
           {
@@ -276,7 +332,7 @@ module MarketingHelper
           {
             id: "is-hcb-a-daf",
             q: "Is HCB a donor-advised fund?",
-            a: "No. HCB is fiscal sponsorship: your charitable project becomes part of Hack Club's 501(c)(3) with its own account, not a donor-advised account that can only grant to other charities. That's why HCB can fund brand-new, not-yet-incorporated work that a DAF can't.",
+            a: "No. HCB is fiscal sponsorship: your charitable project operates under an established 501(c)(3) with its own account and identity, not a donor-advised account that can only grant to other charities. That's why HCB can fund brand-new, not-yet-incorporated work that a DAF can't.",
             related: ["fiscal-sponsorship"]
           },
           {
@@ -297,6 +353,10 @@ module MarketingHelper
             teaser: true,
             q: "Who decides where the money goes, me or HCB?",
             a: "You direct where grants go. HCB's role is to keep every grant compliant and handle the money movement, paperwork, and reporting. As with any 501(c)(3), the charity retains final legal discretion, which is what makes your gift deductible, but in practice you choose what to fund."
+          },
+          {
+            q: "Does my project keep its own identity and get credit for the work?",
+            a: "Yes. Your project keeps its own name and brand, and the work and the funding are credited to it, not to HCB. HCB is the financial infrastructure behind the scenes, the account, cards, and compliance, not the public face. The funds sit under an established 501(c)(3), which is what makes gifts tax-deductible, but day to day your project operates as itself, and the impact is yours to claim and report."
           },
           {
             q: "Can I run a regranting program, funding many projects at once?",
@@ -368,7 +428,7 @@ module MarketingHelper
           },
           {
             q: "What happens to unspent funds if a project winds down?",
-            a: "By IRS rules, the money stays dedicated to charitable purposes within the 501(c)(3) world. A project that's closing can direct its remaining balance to another charitable organization, either another nonprofit or another project on HCB. It never reverts to a donor."
+            a: "You stay in control of the unspent balance. If a project you funded closes with money left over, you can re-grant it to another project or charitable organization. By IRS rules the funds stay dedicated to charitable purposes and never revert to you personally, but you decide where they go next."
           },
           {
             q: "How much does HCB cost?",

--- a/app/helpers/marketing_helper.rb
+++ b/app/helpers/marketing_helper.rb
@@ -124,4 +124,316 @@ module MarketingHelper
       },
     ].reject { |org| org[:gated] && !show_public_grids }
   end
+
+  # Rows for the "How it compares" table (HCB vs. private foundation vs. donor-advised fund) on
+  # the /for/funders page. Each row renders a summary line plus a detail row that ships EXPANDED
+  # in the HTML and is collapsed by the funders-compare Stimulus controller, so the evidence and
+  # IRS sources are visible to AI crawlers and no-JS visitors. Per-row keys:
+  # - :label — the comparison dimension (also the expand toggle's label)
+  # - :hcb / :pf / :daf — the short value for each vehicle (:hcb_sub is an optional lighter clause)
+  # - :detail — the expandable explanation; :sources is an optional list of { :text, :url } cites
+  # Stats are verified against the cited IRS pages.
+  def funder_comparison_rows
+    irs = {
+      life_cycle: "https://www.irs.gov/charities-non-profits/private-foundations/life-cycle-of-a-private-foundation-applying-to-the-irs",
+      application: "https://www.irs.gov/charities-non-profits/charitable-organizations/wheres-my-application-for-tax-exempt-status",
+      daf: "https://www.irs.gov/charities-non-profits/charitable-organizations/donor-advised-funds",
+      payout: "https://www.irs.gov/charities-non-profits/private-foundations/taxes-on-failure-to-distribute-income-private-foundations",
+      excise: "https://www.irs.gov/charities-non-profits/private-foundations/tax-on-net-investment-income",
+      form990pf: "https://www.irs.gov/forms-pubs/about-form-990-pf",
+      pub526: "https://www.irs.gov/publications/p526",
+      deductions: "https://www.irs.gov/charities-non-profits/charitable-organizations/charitable-contribution-deductions"
+    }
+
+    [
+      {
+        label: "Setup cost", hcb: "$0", pf: "Legal & accounting + $600 IRS fee", daf: "Low",
+        detail: "Standing up a private foundation means incorporating an entity and filing IRS Form 1023 (a $600 user fee), plus legal and accounting work. A donor-advised fund is inexpensive to open. With HCB there's no entity to form. You start under Hack Club's existing 501(c)(3).",
+        sources: [{ text: "IRS · Life cycle of a private foundation", url: irs[:life_cycle] }]
+      },
+      {
+        label: "Time to first grant", hcb: "Days", pf: "Months", daf: "Days",
+        detail: "A new private foundation must file the full IRS Form 1023 (the faster 1023-EZ isn't available to private foundations) and typically waits months for a determination letter before funders and banks treat its grants as settled. HCB lets you move within days of deciding, because the 501(c)(3) already exists, every bit as fast as a donor-advised fund.",
+        sources: [{ text: "IRS · Where's my application", url: irs[:application] }]
+      },
+      {
+        label: "Practical minimum to be worth it", hcb: "None", pf: "~$250k to $1M+ commonly cited", daf: "Low",
+        detail: "A private foundation's fixed setup and annual costs only pencil out at scale, and are commonly cited at roughly $250k to $1M+ in assets. A donor-advised fund has little or no minimum, though its fees stack up as your balance grows. HCB has no minimum at all; fund $500 or $5M.",
+        sources: [{ text: "Foundation startup guidance", url: "https://www.cpakpa.com/learn-about-foundations/how-much-money-do-you-need-to-start-a-foundation" }]
+      },
+      {
+        label: "Fund projects that aren't 501(c)(3)s", hcb: "Yes", pf: "Limited (expenditure responsibility)", daf: "No (existing charities only)",
+        detail: "DAFs can only grant to existing, qualified 501(c)(3) public charities. A private foundation can support a non-charity only through expenditure responsibility, an added compliance step. HCB lets you fund a charitable project now, even a brand-new one run by a single person, and it never has to incorporate as its own nonprofit. Because your gift funds charitable work, and HCB makes sure it's used for that purpose, it stays fully tax-deductible.",
+        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf] }]
+      },
+      {
+        label: "Back office (bank, cards, bookkeeping)", hcb: "Handled for funder & project", pf: "Build & staff your own", daf: "Recipient runs their own",
+        detail: "A DAF grants money to a charity that must already have its own bank account, accounting, and compliance. A private foundation can operate directly, but you build and staff that back office. HCB is the back office on both sides. The project gets a real bank account, debit cards, and bookkeeping, and you get clean reporting, with compliance handled for you."
+      },
+      {
+        label: "Donor control over grants", hcb: "You direct grants", hcb_sub: "compliance handled", pf: "Full", daf: "Advisory only",
+        detail: "With a DAF you recommend grants; the sponsor holds legal control and approves them. A private foundation gives you full control, but you run the entity and its compliance. With HCB you direct where grants go while HCB keeps every grant compliant. As with any 501(c)(3), the charity retains ultimate discretion and control, and that's what makes your gift deductible.",
+        sources: [{ text: "IRS · Donor-advised funds", url: irs[:daf] }]
+      },
+      {
+        label: "Mandatory annual payout & excise tax", hcb: "None", pf: "~5% payout + 1.39% excise", daf: "None",
+        detail: "Private foundations must pay out about 5% of their investment assets each year or owe an initial 30% excise tax on the shortfall (rising to 100% if uncorrected), and they owe a 1.39% excise tax on net investment income. DAFs and HCB carry no such requirement.",
+        sources: [{ text: "IRS · §4942 (payout)", url: irs[:payout] }, { text: "IRS · §4940 (excise)", url: irs[:excise] }]
+      },
+      {
+        label: "Real-time transparency", hcb: "Real-time", hcb_sub: "every dollar as it moves", pf: "Annual (Form 990-PF)", daf: "Limited (periodic statements)",
+        detail: "Foundations report publicly once a year on Form 990-PF. A DAF shows you your contributions and grants out, but not live, transaction-level visibility into how the money is used. HCB gives you a real-time dashboard down to every transaction, so you can see exactly where each dollar goes, break spending out by project and category, and turn it into the impact reports your board and stakeholders expect.",
+        sources: [{ text: "IRS · About Form 990-PF", url: irs[:form990pf] }]
+      },
+      {
+        label: "Ongoing admin & cost", hcb: "We handle it", hcb_sub: "one simple fee", pf: "High (990-PF, staff/advisors)", daf: "Layered fees (admin + investment + advisor)",
+        detail: "Private foundations file Form 990-PF annually and often need staff or advisors. A DAF is low-effort to maintain, but its costs stack up: an administrative (sponsor) fee, the underlying investment fees, and often a separate advisor fee, each charged on your balance, year after year. HCB handles bookkeeping, compliance, and reporting for you, for one simple fee, with no stacked or recurring charges. We'll walk you through it.",
+        sources: [{ text: "Fidelity Charitable · what a DAF costs", url: "https://www.fidelitycharitable.org/giving-account/what-it-costs.html" }]
+      },
+      {
+        label: "Deduction limit, cash gifts", hcb: "Up to 60% of AGI", hcb_sub: "plus a 2026 break the others don't get", pf: "30% of AGI", daf: "Up to 60% of AGI",
+        detail: "Because HCB operates as a public charity, cash gifts are generally deductible up to 60% of AGI, versus 30% for gifts to a private foundation (appreciated assets: 30% vs. 20%, and public charities like HCB let you deduct appreciated assets such as stock or crypto at fair market value). Starting in tax year 2026, federal rules add a 0.5%-of-AGI floor, cap the deduction's value at 35% for top-bracket donors, and let non-itemizers deduct up to $1,000 ($2,000 joint) in cash gifts to public charities, a break that doesn't apply to DAFs or private foundations.",
+        sources: [{ text: "IRS · Publication 526", url: irs[:pub526] }, { text: "Tax Foundation · 2026 charitable deduction changes", url: "https://taxfoundation.org/blog/charitable-deduction-big-beautiful-bill/" }]
+      },
+      {
+        label: "Tax-deductible · 501(c)(3)", hcb: "Yes", pf: "Yes", daf: "Yes",
+        detail: "All three give you a tax-deductible gift backed by a real 501(c)(3). The limits differ (above), but the deduction is real in every case.",
+        sources: [{ text: "IRS · Charitable contribution deductions", url: irs[:deductions] }]
+      }
+    ]
+  end
+
+  # Q&A for the funder FAQ, grouped by topic. The full set renders on the dedicated
+  # /for/funders/faq subpage; the `teaser: true` ones also surface in a short "Common questions"
+  # block on the main funders page. Answers stay consistent with the comparison table and the
+  # strategy doc (the fee stays a "simple pricing, let's talk" pointer, not a number) and avoid
+  # claims that need confirmation (custody, audit dates, exact stats, wind-down mechanics, etc.).
+  def funder_faqs(stats: nil)
+    [
+      {
+        topic: "Getting started and what you can fund",
+        faqs: [
+          {
+            teaser: true,
+            q: "How do I accept tax-deductible donations for a project that isn't a 501(c)(3)?",
+            a: "Through fiscal sponsorship. HCB takes your charitable project under Hack Club's 501(c)(3), so donations are tax-deductible from day one, with no nonprofit of your own to form. The project gets a real bank account, debit cards, and compliance, and HCB handles the paperwork for one simple fee.",
+            related: ["fiscal-sponsorship"]
+          },
+          {
+            q: "What kinds of projects can I fund through HCB?",
+            a: "Charitable, mission-driven work of almost any size: open-source software, hackathons and student programs, research, mutual aid and disaster relief, robotics teams, new initiatives, and regranting programs. If it advances a charitable purpose, HCB can almost certainly support it, and we'll confirm fit on a call."
+          },
+          {
+            q: "How fast can I actually start granting?",
+            a: "In days, not quarters. Because the 501(c)(3) already exists, there's no new entity to form and no IRS waiting period. After an initial conversation, funders are typically up and granting within days."
+          },
+          {
+            q: "Can I fund a brand-new project that's run by just one person?",
+            a: "Yes. A project doesn't need a team, a track record, or its own legal entity. As long as it's doing charitable work, a single person can run it on HCB with a real bank account and cards, and your gift is tax-deductible."
+          },
+          {
+            q: "Can I give money directly to an individual?",
+            a: "Your gift funds charitable work, not a person's personal use. Unfortunately, IRS rules don't let a 501(c)(3) be a pass-through to a hand-picked individual, but it can still put money in people's hands for charitable purposes, like stipends, hardship relief, or paying someone to do the work. HCB keeps that line compliant so your gift stays deductible."
+          },
+          {
+            q: "Does a project ever have to incorporate as its own nonprofit?",
+            a: "No. Many organizations run on HCB for years and never incorporate. HCB is built to be long-term, reliable infrastructure, not a temporary step on the way to forming a 501(c)(3). Incorporate later if it makes sense for you, or never."
+          },
+          {
+            q: "Can I move a project I already run onto HCB?",
+            a: "Yes. Funders and organizations move existing initiatives onto HCB all the time. Onboarding is simple: sign a contract, invite your team, and transfer your existing funds. From there the project gets a real bank account, cards, and real-time reporting."
+          },
+          {
+            q: "Can I fund charitable work outside the US?",
+            a: "Yes. HCB supports charitable work in 40+ countries. International funding follows US law, including OFAC sanctions rules, and the practical limits of local banking, and our team helps you navigate it."
+          }
+        ]
+      },
+      {
+        topic: "How HCB compares",
+        faqs: [
+          {
+            teaser: true,
+            q: "What are the alternatives to starting a private foundation?",
+            a: "Donor-advised funds and HCB. A private foundation can cost thousands and take months to set up and only makes sense at scale. HCB lets you deploy grants in days for one simple fee, with real-time reporting, no setup cost, and the ability to fund projects that aren't yet 501(c)(3)s. HCB is a fiscal sponsor, but a rare kind that's built for funders, not just the projects it hosts.",
+            related: ["fiscal-sponsorship"]
+          },
+          {
+            teaser: true,
+            q: "How is HCB different from a donor-advised fund?",
+            a: "A donor-advised fund grants money to existing 501(c)(3) public charities and holds the rest. HCB can fund and operate brand-new charitable projects, giving each a bank account, cards, and compliance, and showing you every dollar in real time. A DAF holds money and grants it to existing charities; HCB holds and grants too, and runs the back office that makes the funded work happen.",
+            related: ["is-hcb-a-daf", "fiscal-sponsorship"]
+          },
+          {
+            q: "Donor-advised fund vs. private foundation vs. HCB: which is right for me?",
+            a: "A private foundation gives maximum control but is costly and slow. A donor-advised fund is simple but can only grant to existing charities. HCB fits funders who want to move fast, fund projects rather than just established nonprofits, and see exactly where the money goes. Many funders use HCB alongside a DAF or foundation."
+          },
+          {
+            id: "fiscal-sponsorship",
+            q: "What is fiscal sponsorship?",
+            a: "Fiscal sponsorship is when an established 501(c)(3) lets a charitable project operate under its tax-exempt status, so the project can accept tax-deductible donations and run real finances without forming its own nonprofit. HCB is a fiscal sponsor, but an unusual one: most fiscal sponsors serve only the projects they host, while HCB is also built for the funders backing them, with real-time visibility and the tools to deploy capital at scale."
+          },
+          {
+            id: "is-hcb-a-daf",
+            q: "Is HCB a donor-advised fund?",
+            a: "No. HCB is fiscal sponsorship: your charitable project becomes part of Hack Club's 501(c)(3) with its own account, not a donor-advised account that can only grant to other charities. That's why HCB can fund brand-new, not-yet-incorporated work that a DAF can't.",
+            related: ["fiscal-sponsorship"]
+          },
+          {
+            q: "Do donor-advised funds have a payout requirement?",
+            a: "No. Donor-advised funds have no federal payout requirement, unlike private foundations, which must distribute about 5% of their assets each year. HCB has no payout requirement either, but it's built to put money to work, with a real-time record of every dollar.",
+            sources: [{ text: "IRS · §4942 (payout)", url: "https://www.irs.gov/charities-non-profits/private-foundations/taxes-on-failure-to-distribute-income-private-foundations" }, { text: "IRS · Donor-advised funds", url: "https://www.irs.gov/charities-non-profits/charitable-organizations/donor-advised-funds" }]
+          },
+          {
+            q: "Can I keep my existing DAF or foundation and use HCB alongside it?",
+            a: "Yes. You don't have to choose. Many funders grant from their DAF or foundation into HCB to reach fast-moving projects and brand-new initiatives those vehicles can't fund directly, with real-time visibility into every dollar."
+          }
+        ]
+      },
+      {
+        topic: "Control and involvement",
+        faqs: [
+          {
+            teaser: true,
+            q: "Who decides where the money goes, me or HCB?",
+            a: "You direct where grants go. HCB's role is to keep every grant compliant and handle the money movement, paperwork, and reporting. As with any 501(c)(3), the charity retains final legal discretion, which is what makes your gift deductible, but in practice you choose what to fund."
+          },
+          {
+            q: "Can I run a regranting program, funding many projects at once?",
+            a: "Yes. Funders use HCB to regrant across dozens or hundreds of recipients without standing up a back office. You bring the thesis and the picks; HCB handles disbursement, compliance, and real-time reporting at scale."
+          },
+          {
+            q: "How hands-on can I be with the projects I fund?",
+            a: "As hands-on as you like. You choose the projects, initiatives, and impact you want to back. Want to be deeply involved? Great. Prefer to lean on our expertise to run it for you? We can take the wheel."
+          },
+          {
+            q: "Can HCB decline a grant I want to make?",
+            a: "Compliance comes first, and we're upfront about it. We work with you to make every grant compliant, and if IRS rules wouldn't allow one, we tell you before taking the money, not after. We won't accept funds we can't put to work, so nothing ever gets stuck."
+          },
+          {
+            q: "Can I set milestones or track impact on my grants?",
+            a: "Yes. HCB helps funders gather the impact metrics and reporting they need. Tell us what you want to measure and we'll help you track it."
+          }
+        ]
+      },
+      {
+        topic: "Tax and deductibility",
+        faqs: [
+          {
+            q: "Is my gift tax-deductible?",
+            a: "Yes. You give to HCB by Hack Club, legally The Hack Foundation, a registered 501(c)(3) public charity, so your deduction is immediate."
+          },
+          {
+            q: "Is my gift still deductible if I pick the specific project I want to support?",
+            a: "Yes. Choosing a charitable project to support doesn't affect deductibility, because HCB retains discretion and control and ensures the money is used for charitable purposes. What isn't deductible is earmarking a gift for a specific individual's personal benefit, which HCB doesn't do."
+          },
+          {
+            q: "Who is the 501(c)(3) behind HCB, and what's the EIN?",
+            a: "HCB is operated by The Hack Foundation (Hack Club), a registered 501(c)(3) nonprofit, EIN 81-2908499. When you look us up, that's who you'll find."
+          },
+          {
+            q: "What is Hack Club, and is hacking a bad thing?",
+            a: "Hack Club is the 501(c)(3) nonprofit (legally The Hack Foundation) that runs HCB. Founded in 2014, it supports a global community of more than 100,000 young people building across 1,000+ clubs worldwide, and it created HCB as the financial platform to move money for that work. Here, 'hacking' means building things, not breaking them. It's the resourceful, creative problem-solving the word originally meant in tech. The organization behind the name is a real, independently audited 501(c)(3) that serious funders and nonprofits already trust."
+          },
+          {
+            q: "What are the deduction limits, and how do they compare to a private foundation?",
+            a: "Because HCB is a public charity, cash gifts are generally deductible up to 60% of AGI, versus 30% for a private foundation. Appreciated assets like stock or crypto are deductible at fair market value, up to 30% of AGI, versus 20% for a foundation. This isn't tax advice; confirm specifics with your advisor.",
+            sources: [{ text: "IRS · Publication 526", url: "https://www.irs.gov/publications/p526" }]
+          },
+          {
+            q: "How do the 2026 tax-law (OBBBA) changes affect my deduction?",
+            a: "Starting in tax year 2026, federal rules add a 0.5%-of-AGI floor on itemized charitable deductions, cap their value at 35% for top-bracket donors, and let non-itemizers deduct up to $1,000 ($2,000 joint) in cash gifts to public charities, a break that doesn't apply to DAFs or private foundations. Talk to your tax advisor about your situation.",
+            sources: [{ text: "IRS · Publication 526", url: "https://www.irs.gov/publications/p526" }, { text: "Tax Foundation · 2026 charitable deduction changes", url: "https://taxfoundation.org/blog/charitable-deduction-big-beautiful-bill/" }]
+          },
+          {
+            q: "Will I get a receipt for my gift?",
+            a: "Yes. You receive an acknowledgment and receipt for every tax-deductible gift, so you have what you need at tax time."
+          }
+        ]
+      },
+      {
+        topic: "Money, assets, and fees",
+        faqs: [
+          {
+            q: "Can I donate stock, crypto, or other appreciated assets?",
+            a: "Yes. HCB accepts cash, stock, crypto, wire transfers, and grants from a donor-advised fund or foundation. Stock and crypto are liquidated to cash on receipt. Giving appreciated assets to a public charity like HCB can be especially efficient, since you generally deduct the full fair market value."
+          },
+          {
+            q: "Where is my money held, and is it FDIC-insured?",
+            a: "Your funds are held at HCB's banking partners, Column N.A. and The Business Bank, and are FDIC-insured through the IntraFi network. HCB runs on bank-grade infrastructure, not a patchwork of tools."
+          },
+          {
+            q: "Do I have to grant the money right away, or can I hold it?",
+            a: "There's no requirement to spend immediately; you can hold funds in HCB long-term. That said, HCB exists to put money to work and create impact, so most funders use it to deploy quickly rather than park funds."
+          },
+          {
+            q: "What happens to unspent funds if a project winds down?",
+            a: "By IRS rules, the money stays dedicated to charitable purposes within the 501(c)(3) world. A project that's closing can direct its remaining balance to another charitable organization, either another nonprofit or another project on HCB. It never reverts to a donor."
+          },
+          {
+            q: "How much does HCB cost?",
+            a: "HCB's pricing is simple: one straightforward fee, with none of the stacked administrative, investment, and advisor fees that pile up in other vehicles. We'll walk you through the specifics on a call."
+          },
+          {
+            q: "Can I get my money back if I change my mind?",
+            a: "Unfortunately, IRS rules don't allow it: like any tax-deductible charitable gift, contributions are irrevocable once they're made. It's the same for donor-advised funds and private foundations, and it's the trade-off for the tax deduction you receive."
+          }
+        ]
+      },
+      {
+        topic: "Trust, compliance, and risk",
+        faqs: [
+          {
+            teaser: true,
+            q: "Is it safe to move serious money through HCB?",
+            a: "Yes. HCB is high-tech financial infrastructure, built by engineers from the ground up rather than a patchwork of off-the-shelf tools, with bank-level security through reputable partners like Column and Stripe. The platform itself is open source, so its code is public for anyone to inspect. Every dollar sits behind a real, registered 501(c)(3), The Hack Foundation (EIN 81-2908499), is independently audited every year, and is tracked in real time. Funders moving large sums work directly with our team."
+          },
+          {
+            q: "Does HCB have an API? Can I integrate it with my own tools?",
+            a: "Yes. HCB is API-first, so you can integrate it with your own systems, automate regranting, and pull real-time spend and transaction data programmatically, straight into your dashboards or impact reports. It's far ahead of the closed, legacy systems most foundations and donor-advised funds run on."
+          },
+          {
+            q: "What compliance and due diligence does HCB run?",
+            a: "HCB handles 501(c)(3) compliance on every project and grant, and runs fraud auditing across transactions and financials. Keeping the money compliant is HCB's job, not yours."
+          },
+          {
+            q: "Is HCB audited?",
+            a: "Yes. HCB is independently audited every year, on top of the ongoing 501(c)(3) compliance and fraud monitoring built into the platform."
+          },
+          {
+            q: "Who's responsible if a funded project misuses money or fails?",
+            a: "HCB takes that risk off you. As the 501(c)(3) of record, HCB runs compliance, oversight, and fraud monitoring on every project, so a funder isn't on the hook for a project's missteps."
+          },
+          {
+            q: "How much money has HCB moved, and how many organizations run on it?",
+            a: "More than #{stats&.dig(:moved)} has moved through HCB, across #{stats&.dig(:organizations)} organizations, from small projects on a $500 budget to operations running tens of millions annually. Every dollar sits behind a registered 501(c)(3) with real-time reporting."
+          }
+        ]
+      },
+      {
+        topic: "Reporting and transparency",
+        faqs: [
+          {
+            teaser: true,
+            q: "What visibility do I get into how my money is spent?",
+            a: "A real-time dashboard down to every transaction. You can see exactly where each dollar goes, break spending out by project and category, and turn it into the impact reports your board and stakeholders expect, instead of waiting for a year-end PDF."
+          },
+          {
+            q: "Can I give privately or anonymously?",
+            a: "Yes. Transparency is optional. You can give publicly, privately, or anonymously, and choose how much of a project's activity is visible."
+          }
+        ]
+      }
+    ]
+  end
+
+  # The funder-facing team, shared by the main page's "you'll hear from one of us" CTA and the FAQ
+  # page's "didn't find your answer" card, so the roster stays in sync in both places.
+  def funder_team
+    [
+      { name: "Melanie Smith", avatar: "https://cdn.hackclub.com/019e7570-8304-7de8-abfe-cbcaf12616b7/image.png" },
+      { name: "Paul Spitler", avatar: "https://cdn.hackclub.com/019e7570-80b5-7eae-9d54-cf4bf1460953/image.png" },
+      { name: "Gary Tou", avatar: "https://cdn.hackclub.com/019e7570-7d87-707e-bb85-4d39a3fc5114/image.png" }
+    ]
+  end
 end

--- a/app/javascript/controllers/funders_compare_controller.js
+++ b/app/javascript/controllers/funders_compare_controller.js
@@ -14,12 +14,29 @@ import { Controller } from '@hotwired/stimulus'
 // the sticky header is parked under the nav, so it can show a drop shadow (a no-JS
 // table just scrolls without the stuck styling).
 export default class extends Controller {
-  static targets = ['toggle', 'detail', 'sentinel']
+  static targets = ['toggle', 'detail', 'sentinel', 'switchOpt']
 
   connect() {
     this.element.classList.add('is-enhanced')
     this.toggleTargets.forEach((_, i) => this.setExpanded(i, false))
+    // On mobile the table shows HCB vs. one alternative at a time; default to the private foundation.
+    // With no JS, no data-compare is set and the full table (all columns) renders.
+    if (this.hasSwitchOptTarget) this.setCompare('pf')
     this.watchStuck()
+  }
+
+  // Mobile "compare against" segmented control: pick which alternative sits beside HCB.
+  compareAgainst(event) {
+    this.setCompare(event.currentTarget.dataset.vehicle)
+  }
+
+  setCompare(vehicle) {
+    this.element.dataset.compare = vehicle
+    this.switchOptTargets.forEach(opt => {
+      const active = opt.dataset.vehicle === vehicle
+      opt.classList.toggle('is-active', active)
+      opt.setAttribute('aria-pressed', String(active))
+    })
   }
 
   disconnect() {

--- a/app/javascript/controllers/funders_compare_controller.js
+++ b/app/javascript/controllers/funders_compare_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Comparison table: HCB vs. private foundation vs. donor-advised fund. Each row can
+// expand to an evidence-rich explanation with sources.
+//
+// Progressive enhancement in reverse: the detail rows are rendered EXPANDED in the
+// server HTML, so AI crawlers and no-JS visitors read every fact and source (AI
+// crawlers don't run JS — what's in the raw HTML is what they can cite). This
+// controller COLLAPSES the details once JS is running, then toggles them per row.
+// Nothing is hidden at the source; it's only collapsed after enhancement.
+//
+// `is-enhanced` on the root gates the affordances (chevron + pointer cursor) so a
+// no-JS visitor never sees a control that does nothing. `is-stuck` is toggled while
+// the sticky header is parked under the nav, so it can show a drop shadow (a no-JS
+// table just scrolls without the stuck styling).
+export default class extends Controller {
+  static targets = ['toggle', 'detail', 'sentinel']
+
+  connect() {
+    this.element.classList.add('is-enhanced')
+    this.toggleTargets.forEach((_, i) => this.setExpanded(i, false))
+    this.watchStuck()
+  }
+
+  disconnect() {
+    this.stuckObserver?.disconnect()
+  }
+
+  toggle(event) {
+    const i = this.toggleTargets.indexOf(event.currentTarget)
+    if (i === -1) return
+    const expanded =
+      event.currentTarget.getAttribute('aria-expanded') === 'true'
+    this.setExpanded(i, !expanded)
+  }
+
+  setExpanded(index, expanded) {
+    const toggle = this.toggleTargets[index]
+    const detail = this.detailTargets[index]
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+    if (detail) detail.hidden = !expanded
+  }
+
+  // The sentinel sits at the top of the table; once it scrolls above the nav line the
+  // sticky header is "stuck", so we flag the root for the drop-shadow styling.
+  watchStuck() {
+    if (!this.hasSentinelTarget) return
+    this.stuckObserver = new IntersectionObserver(
+      ([entry]) =>
+        this.element.classList.toggle('is-stuck', !entry.isIntersecting),
+      { rootMargin: '-64px 0px 0px 0px', threshold: 0 }
+    )
+    this.stuckObserver.observe(this.sentinelTarget)
+  }
+}

--- a/app/javascript/controllers/funders_faq_toc_controller.js
+++ b/app/javascript/controllers/funders_faq_toc_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Funder FAQ table-of-contents: highlights the TOC link for whichever topic section is currently
+// near the top of the viewport. Pure progressive enhancement: the TOC jump links work on their own;
+// this adds the scroll-tracked active state (visually via `.is-active`, and for assistive tech via
+// `aria-current`). No-JS visitors lose nothing.
+export default class extends Controller {
+  static targets = ['link', 'section']
+
+  connect() {
+    this.visible = new Set()
+    this.observer = new IntersectionObserver(
+      entries => this.onIntersect(entries),
+      {
+        // Active band: just below the sticky nav down to the top third of the viewport.
+        rootMargin: '-80px 0px -70% 0px',
+        threshold: 0,
+      }
+    )
+    this.sectionTargets.forEach(section => this.observer.observe(section))
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
+  }
+
+  onIntersect(entries) {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) this.visible.add(entry.target)
+      else this.visible.delete(entry.target)
+    })
+    this.update()
+  }
+
+  // Highlight the topmost section currently in the active band (not just the first to fire), so fast
+  // scrolling can't leave the wrong item lit. When none is in the band we keep the last active.
+  update() {
+    let current = null
+    let bestTop = Infinity
+    this.visible.forEach(section => {
+      const top = section.getBoundingClientRect().top
+      if (top < bestTop) {
+        bestTop = top
+        current = section
+      }
+    })
+    if (current) this.setActive(current.dataset.tocId)
+  }
+
+  setActive(id) {
+    this.linkTargets.forEach(link => {
+      const active = link.dataset.tocId === id
+      link.classList.toggle('is-active', active)
+      if (active) {
+        link.setAttribute('aria-current', 'true')
+      } else {
+        link.removeAttribute('aria-current')
+      }
+    })
+  }
+}

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -384,6 +384,20 @@
       <%# Stuck-state sentinel: when it scrolls above the nav line, the controller flags the
           sticky header so it can show a drop shadow. %>
       <div class="mk-table__sentinel" data-funders-compare-target="sentinel" aria-hidden="true"></div>
+      <%# Mobile-only control: compare HCB against one alternative at a time, so the two values sit
+          side by side on a narrow screen. Shown only once JS enhances the table; with no JS the full
+          table (all three columns) renders and stays readable. %>
+      <div class="mk-compare-switch">
+        <span class="mk-compare-switch__label">Compare against</span>
+        <div class="mk-compare-switch__track" role="group" aria-label="Compare HCB against">
+          <button type="button" class="mk-compare-switch__opt" data-vehicle="pf"
+                  data-action="funders-compare#compareAgainst"
+                  data-funders-compare-target="switchOpt">Private foundation</button>
+          <button type="button" class="mk-compare-switch__opt" data-vehicle="daf"
+                  data-action="funders-compare#compareAgainst"
+                  data-funders-compare-target="switchOpt">Donor-advised fund</button>
+        </div>
+      </div>
       <table class="mk-table">
         <thead>
           <tr>
@@ -405,13 +419,24 @@
                   <span class="mk-table__chevron" aria-hidden="true"></span>
                 </button>
               </th>
-              <td class="mk-table__hcb" data-label="HCB"><strong><%= row[:hcb] %></strong><% if row[:hcb_sub] %><span class="mk-table__hcb-sub"><%= row[:hcb_sub] %></span><% end %></td>
-              <td data-label="Private foundation"><%= row[:pf] %></td>
-              <td data-label="Donor-advised fund"><%= row[:daf] %></td>
+              <%# data-label is the compact vehicle name shown only in the mobile card layout; the
+                  full column names live in <thead> for desktop and screen readers. %>
+              <td class="mk-table__hcb" data-label="HCB" data-status="yes"><span class="mk-cell__v"><strong><%= row[:hcb] %></strong><% if row[:hcb_sub] %><span class="mk-table__hcb-sub"><%= row[:hcb_sub] %></span><% end %></span></td>
+              <td data-label="Foundation" data-status="<%= row[:pf_status] %>"><span class="mk-cell__v"><%= row[:pf] %></span></td>
+              <td data-label="DAF" data-status="<%= row[:daf_status] %>"><span class="mk-cell__v"><%= row[:daf] %></span></td>
             </tr>
             <tr class="mk-table__detail" id="cmp-detail-<%= i %>" data-funders-compare-target="detail">
               <td colspan="4">
-                <p class="mk-compare-detail__text"><%= row[:detail] %></p>
+                <%# One short explanation per vehicle. On mobile the non-selected alternative is
+                    hidden (see the data-compare CSS), so you only read about the two you're comparing. %>
+                <div class="mk-compare-detail">
+                  <% [["hcb", "HCB"], ["pf", "Foundation"], ["daf", "DAF"]].each do |vehicle, name| %>
+                    <div class="mk-compare-detail__vehicle" data-vehicle="<%= vehicle %>">
+                      <p class="mk-compare-detail__vehicle-name"><%= name %></p>
+                      <p class="mk-compare-detail__text"><%= row[:detail][vehicle.to_sym] %></p>
+                    </div>
+                  <% end %>
+                </div>
                 <% if row[:sources].present? %>
                   <p class="mk-meta">
                     <span class="mk-meta__label">Sources</span>

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -35,16 +35,9 @@
           "legalName": "The Hack Foundation",
           "url": "https://hcb.hackclub.com",
           "logo": "https://hcb.hackclub.com/brand/hcb-icon-icon-original.png",
-          "sameAs": ["https://github.com/hackclub/hcb", "https://hackclub.com"]
-        },
-        {
-          "@type": "FAQPage",
-          "mainEntity": [
-            { "@type": "Question", "name": "How fast can I make a grant?", "acceptedAnswer": { "@type": "Answer", "text": "In days, not quarters. There's no new legal entity and no IRS waiting period." } },
-            { "@type": "Question", "name": "Is my giving tax-deductible?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. You give to HCB by Hack Club, a 501(c)(3) nonprofit, so your deduction is immediate." } },
-            { "@type": "Question", "name": "Do I need to set up a foundation?", "acceptedAnswer": { "@type": "Answer", "text": "No. You get the legitimacy of a foundation without becoming one. You direct the grants, and HCB handles compliance, paperwork, and money movement." } },
-            { "@type": "Question", "name": "Can I give privately?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Transparency is optional, so you can give publicly, privately, or anonymously." } }
-          ]
+          "taxID": "81-2908499",
+          "identifier": { "@type": "PropertyValue", "propertyID": "EIN", "value": "81-2908499" },
+          "sameAs": ["https://github.com/hackclub/hcb", "https://hackclub.com", "https://en.wikipedia.org/wiki/Hack_Club", "https://projects.propublica.org/nonprofits/organizations/812908499"]
         }
       ]
     }
@@ -376,11 +369,75 @@
 
 <%# ============================ COMPARISON ============================ %>
 <section class="mk-section">
-  <div class="mk-container mk-narrow">
+  <div class="mk-container <%= @show_comparison_faq ? "mk-compare-wide" : "mk-narrow" %>">
     <div class="mk-section__head">
       <p class="mk-eyebrow">How it compares</p>
       <h2 class="mk-section__title">The agility of a fund. The legitimacy of a foundation.</h2>
     </div>
+    <% if @show_comparison_faq %>
+    <%# Comparison rows come from MarketingHelper#funder_comparison_rows. Each row's detail ships
+        EXPANDED in the server HTML (so AI crawlers and no-JS visitors read every fact + source);
+        the funders-compare controller collapses them once JS runs and toggles per row. %>
+    <p class="mk-compare-lead">Fund a charitable project tax-deductibly from day one,
+      <strong>even if it isn't its own 501(c)(3)</strong>, without standing up a foundation.</p>
+    <div class="mk-table-wrap" data-controller="funders-compare">
+      <%# Stuck-state sentinel: when it scrolls above the nav line, the controller flags the
+          sticky header so it can show a drop shadow. %>
+      <div class="mk-table__sentinel" data-funders-compare-target="sentinel" aria-hidden="true"></div>
+      <table class="mk-table">
+        <thead>
+          <tr>
+            <th scope="col"><span class="mk-vh">Capability</span></th>
+            <th scope="col" class="mk-table__hcb">HCB</th>
+            <th scope="col">Private foundation</th>
+            <th scope="col">Donor-advised fund</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% funder_comparison_rows.each_with_index do |row, i| %>
+            <tr class="mk-compare-row">
+              <th scope="row">
+                <button type="button" class="mk-table__toggle" aria-expanded="true"
+                        aria-controls="cmp-detail-<%= i %>"
+                        data-funders-compare-target="toggle"
+                        data-action="funders-compare#toggle">
+                  <span class="mk-table__toggle-label"><%= row[:label] %></span>
+                  <span class="mk-table__chevron" aria-hidden="true"></span>
+                </button>
+              </th>
+              <td class="mk-table__hcb" data-label="HCB"><strong><%= row[:hcb] %></strong><% if row[:hcb_sub] %><span class="mk-table__hcb-sub"><%= row[:hcb_sub] %></span><% end %></td>
+              <td data-label="Private foundation"><%= row[:pf] %></td>
+              <td data-label="Donor-advised fund"><%= row[:daf] %></td>
+            </tr>
+            <tr class="mk-table__detail" id="cmp-detail-<%= i %>" data-funders-compare-target="detail">
+              <td colspan="4">
+                <p class="mk-compare-detail__text"><%= row[:detail] %></p>
+                <% if row[:sources].present? %>
+                  <p class="mk-meta">
+                    <span class="mk-meta__label">Sources</span>
+                    <% row[:sources].each do |source| %>
+                      <a class="mk-meta__link" href="<%= source[:url] %>" target="_blank" rel="noopener"><%= source[:text] %><span class="mk-vh"> (opens in a new tab)</span></a>
+                    <% end %>
+                  </p>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <p class="mk-compare-entity">HCB by Hack Club, a registered 501(c)(3) (The Hack Foundation,
+      EIN 81-2908499).</p>
+    <p class="mk-compare-disclaimer">This comparison is general information, not tax or legal advice;
+      confirm specifics with your own advisor.</p>
+    <div class="mk-compare-note">
+      <p class="mk-compare-note__lead">Already give through a donor-advised fund or foundation?</p>
+      <p class="mk-compare-note__body">You don't have to choose. Route your existing vehicle's grants
+        into HCB to reach the fast-moving projects and brand-new initiatives it can't fund on its own,
+        with real-time visibility into every dollar. It's where your giving goes to work.</p>
+    </div>
+    <% else %>
+    <%# Original static comparison table (shown when the funders_landing_comparison_faq flag is off). %>
     <div class="mk-table-wrap">
       <table class="mk-table">
         <thead>
@@ -437,6 +494,7 @@
         use HCB as the fast, transparent layer it grants into, reaching the projects and
         brand-new initiatives a DAF isn't built to fund.</p>
     </div>
+    <% end %>
   </div>
 </section>
 
@@ -777,6 +835,30 @@
   </div>
 </section>
 
+<%# ===================== COMMON QUESTIONS (FAQ teaser) ===================== %>
+<%# The top funder questions; the full set lives on the dedicated /for/funders/faq subpage. %>
+<% if @show_comparison_faq %>
+<section class="mk-section mk-section--alt">
+  <div class="mk-container mk-narrow">
+    <div class="mk-section__head">
+      <p class="mk-eyebrow">Common questions</p>
+      <h2 class="mk-section__title">Funders ask, we answer.</h2>
+    </div>
+    <div class="mk-faq mk-faq--teaser">
+      <% funder_faqs(stats: @stats).flat_map { |group| group[:faqs] }.select { |faq| faq[:teaser] }.each do |faq| %>
+        <div class="mk-faq__item">
+          <h3 class="mk-faq__q"><%= faq[:q] %></h3>
+          <p class="mk-faq__a"><%= faq[:a] %></p>
+        </div>
+      <% end %>
+    </div>
+    <p class="mk-faq__more">
+      <a class="marketing-btn marketing-btn--ghost" href="<%= funders_faq_path %>">See all funder questions</a>
+    </p>
+  </div>
+</section>
+<% end %>
+
 <%# ============================ FINAL CTA ============================ %>
 <section class="mk-section mk-cta" id="talk-to-us">
   <div class="mk-container mk-narrow mk-cta__inner">
@@ -813,18 +895,12 @@
         <div class="mk-team">
           <p class="mk-team__label">You'll hear from one of us</p>
           <ul class="mk-team__list">
-            <li>
-              <img class="mk-team__avatar" src="https://cdn.hackclub.com/019e7570-8304-7de8-abfe-cbcaf12616b7/image.png" alt="" width="72" height="72" loading="lazy" decoding="async">
-              Melanie Smith
-            </li>
-            <li>
-              <img class="mk-team__avatar" src="https://cdn.hackclub.com/019e7570-80b5-7eae-9d54-cf4bf1460953/image.png" alt="" width="72" height="72" loading="lazy" decoding="async">
-              Paul Spitler
-            </li>
-            <li>
-              <img class="mk-team__avatar" src="https://cdn.hackclub.com/019e7570-7d87-707e-bb85-4d39a3fc5114/image.png" alt="" width="72" height="72" loading="lazy" decoding="async">
-              Gary Tou
-            </li>
+            <% funder_team.each do |member| %>
+              <li>
+                <img class="mk-team__avatar" src="<%= member[:avatar] %>" alt="" width="72" height="72" loading="lazy" decoding="async">
+                <%= member[:name] %>
+              </li>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/app/views/marketing/funders_faq.html.erb
+++ b/app/views/marketing/funders_faq.html.erb
@@ -1,0 +1,145 @@
+<% content_for :title, "Funder FAQ: funding through HCB" %>
+
+<% content_for :head do %>
+  <% description = "For funders and donors: answers to common questions about funding through HCB by Hack Club, including funding projects that aren't 501(c)(3)s, how it compares to a private foundation or donor-advised fund, tax-deductibility, control, fees, and transparency." %>
+  <% share_image = "#{request.base_url}/brand/hcb-icon-icon-original.png" %>
+  <meta name="description" content="<%= description %>">
+  <link rel="canonical" href="<%= funders_faq_url %>">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="HCB">
+  <meta property="og:url" content="<%= funders_faq_url %>">
+  <meta property="og:title" content="HCB for funders: frequently asked questions">
+  <meta property="og:description" content="<%= description %>">
+  <meta property="og:image" content="<%= share_image %>">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="HCB for funders: frequently asked questions">
+  <meta name="twitter:description" content="<%= description %>">
+  <meta name="twitter:image" content="<%= share_image %>">
+
+  <%# FAQPage structured data, generated from the same source as the visible Q&A below so the two
+      always match. AI engines extract these Q&A pairs near-verbatim. %>
+  <script type="application/ld+json"> <%# erb_lint:disable AllowedScriptType %>
+    <%= raw({
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "Organization",
+              "name": "HCB",
+              "legalName": "The Hack Foundation",
+              "url": "https://hcb.hackclub.com",
+              "logo": "https://hcb.hackclub.com/brand/hcb-icon-icon-original.png",
+              "taxID": "81-2908499",
+              "identifier": { "@type": "PropertyValue", "propertyID": "EIN", "value": "81-2908499" },
+              "sameAs": ["https://github.com/hackclub/hcb", "https://hackclub.com", "https://en.wikipedia.org/wiki/Hack_Club", "https://projects.propublica.org/nonprofits/organizations/812908499"]
+            },
+            {
+              "@type": "FAQPage",
+              "audience": { "@type": "Audience", "audienceType": "Funders, donors, and grantmakers" },
+              "mainEntity": funder_faqs(stats: @stats).flat_map { |group| group[:faqs] }.map { |faq|
+                { "@type": "Question", "name": faq[:q], "acceptedAnswer": { "@type": "Answer", "text": faq[:a] } }
+              }
+            },
+            {
+              "@type": "BreadcrumbList",
+              "itemListElement": [
+                { "@type": "ListItem", "position": 1, "name": "For funders", "item": funders_url },
+                { "@type": "ListItem", "position": 2, "name": "Funder FAQ", "item": funders_faq_url }
+              ]
+            }
+          ]
+        }.to_json) %>
+  </script>
+<% end %>
+
+<section class="mk-section">
+  <div class="mk-container mk-faq-page">
+    <div class="mk-section__head mk-faq-page__head">
+      <p class="mk-eyebrow"><a href="<%= funders_path %>" class="mk-faq__back">For funders</a></p>
+      <h1 class="mk-section__title">Funder questions, answered</h1>
+      <p class="mk-lead">Everything funders ask before moving money through HCB, from what you can
+        fund and how it compares to a foundation or donor-advised fund, to tax-deductibility,
+        control, fees, and transparency. These answers are written for funders and donors; if you
+        run a project on HCB, some answers will be different for you. Still have a question?
+        <a href="<%= funders_path(anchor: "talk-to-us") %>">Talk to our team</a>.</p>
+    </div>
+
+    <% faqs = funder_faqs(stats: @stats).select { |group| group[:faqs].present? } %>
+    <%# Stable-id lookup so "related" links reference an id (not the question's wording), which keeps
+        them from breaking when an answer is reworded. %>
+    <% faq_by_id = faqs.flat_map { |group| group[:faqs] }.select { |entry| entry[:id] }.index_by { |entry| entry[:id] } %>
+    <div class="mk-faq-layout" data-controller="funders-faq-toc">
+      <%# Sticky table of contents (desktop). The jump links work without JS; the controller adds
+          the scroll-tracked active state. %>
+      <nav class="mk-faq-toc" aria-label="On this page">
+        <p class="mk-faq-toc__label">On this page</p>
+        <ol class="mk-faq-toc__list">
+          <% faqs.each_with_index do |group, i| %>
+            <li>
+              <a class="mk-faq-toc__link" href="#<%= group[:topic].parameterize %>"
+                 data-funders-faq-toc-target="link" data-toc-id="<%= group[:topic].parameterize %>">
+                <span class="mk-faq-toc__num"><%= format("%02d", i + 1) %></span>
+                <span class="mk-faq-toc__text"><%= group[:topic] %></span>
+              </a>
+            </li>
+          <% end %>
+        </ol>
+      </nav>
+
+      <div class="mk-faq-content">
+        <div class="mk-faq">
+          <% faqs.each_with_index do |group, i| %>
+            <section class="mk-faq__group" id="<%= group[:topic].parameterize %>"
+                     data-funders-faq-toc-target="section" data-toc-id="<%= group[:topic].parameterize %>">
+              <h2 class="mk-faq__topic">
+                <span class="mk-faq__topic-num"><%= format("%02d", i + 1) %></span>
+                <span class="mk-faq__topic-text"><%= group[:topic] %></span>
+              </h2>
+              <% group[:faqs].each do |faq| %>
+                <div class="mk-faq__item">
+                  <h3 class="mk-faq__q" id="<%= faq[:id] || faq[:q].parameterize %>"><%= faq[:q] %></h3>
+                  <p class="mk-faq__a"><%= faq[:a] %></p>
+                  <% if faq[:sources].present? %>
+                    <p class="mk-meta">
+                      <span class="mk-meta__label">Sources</span>
+                      <% faq[:sources].each do |source| %>
+                        <a class="mk-meta__link" href="<%= source[:url] %>" target="_blank" rel="noopener"><%= source[:text] %><span class="mk-vh"> (opens in a new tab)</span></a>
+                      <% end %>
+                    </p>
+                  <% end %>
+                  <% if faq[:related].present? %>
+                    <p class="mk-meta">
+                      <span class="mk-meta__label">Related</span>
+                      <% faq[:related].each do |rel_id| %>
+                        <% rel = faq_by_id[rel_id] %>
+                        <% if rel %>
+                          <a class="mk-meta__link" href="#<%= rel[:id] %>"><%= rel[:q] %></a>
+                        <% end %>
+                      <% end %>
+                    </p>
+                  <% end %>
+                </div>
+              <% end %>
+            </section>
+          <% end %>
+        </div>
+
+        <p class="mk-compare-disclaimer">This page is general information, not tax or legal advice;
+          confirm specifics with your own advisor.</p>
+
+        <div class="mk-compare-note mk-compare-note--team">
+          <div class="mk-avatar-stack" aria-hidden="true">
+            <% funder_team.each do |member| %>
+              <img class="mk-avatar-stack__img" src="<%= member[:avatar] %>" alt="" width="36" height="36" loading="lazy" decoding="async">
+            <% end %>
+          </div>
+          <div>
+            <p class="mk-compare-note__lead">Didn't find your answer?</p>
+            <p class="mk-compare-note__body">Tell us what you're trying to fund and a real person will
+              walk you through it. <a href="<%= funders_path(anchor: "talk-to-us") %>">Talk to our team</a>.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -644,6 +644,7 @@ Rails.application.routes.draw do
   # Marketing landing pages. Public, server-rendered, largely static. Built so future
   # audience pages slot in under the same /for/* prefix and reuse the marketing layout.
   get "for/funders", to: "marketing#funders", as: :funders
+  get "for/funders/faq", to: "marketing#funders_faq", as: :funders_faq
   post "for/funders/inquiry", to: "marketing#funder_inquiry", as: :funder_inquiry
 
   resources :emburse_card_requests, path: "emburse_card_requests", except: [:new, :create] do

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,6 +10,9 @@
     <loc>https://hcb.hackclub.com/for/funders</loc>
   </url>
   <url>
+    <loc>https://hcb.hackclub.com/for/funders/faq</loc>
+  </url>
+  <url>
     <loc>https://hcb.hackclub.com/branding</loc>
   </url>
   <url>

--- a/spec/helpers/marketing_helper_spec.rb
+++ b/spec/helpers/marketing_helper_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MarketingHelper, type: :helper do
+  describe "#funder_faqs" do
+    # Guards the "related" cross-links: they reference stable ids (not question wording), so this
+    # catches a typo'd or stale id before it silently drops a link on the page.
+    it "has unique ids, and every 'related' reference points to an existing FAQ id" do
+      entries = helper.funder_faqs(stats: nil).flat_map { |group| group[:faqs] }
+      ids = entries.filter_map { |entry| entry[:id] }
+      related = entries.flat_map { |entry| entry[:related] || [] }
+
+      expect(ids).to eq(ids.uniq), "FAQ ids must be unique"
+      expect(related - ids).to be_empty, "every related id must match an existing FAQ id"
+    end
+  end
+end

--- a/spec/helpers/marketing_helper_spec.rb
+++ b/spec/helpers/marketing_helper_spec.rb
@@ -3,6 +3,41 @@
 require "rails_helper"
 
 RSpec.describe MarketingHelper, type: :helper do
+  describe "#funder_comparison_rows" do
+    # The comparison data drives a structured UI: status badges keyed on a fixed set, a per-vehicle
+    # `detail` hash, and vehicle-tagged sources. A missing key or a typo'd status fails silently in
+    # the view (a bad status renders no badge; a missing detail key renders a blank snippet), so
+    # guard the shape here.
+    it "every row is well-formed: values, valid statuses, complete detail, and tagged sources" do
+      vehicle_keys = %i[hcb pf daf]
+
+      helper.funder_comparison_rows.each do |row|
+        label = row[:label]
+        expect(label).to be_present, "a comparison row is missing :label"
+
+        vehicle_keys.each do |vehicle|
+          expect(row[vehicle]).to be_present, "#{label}: missing :#{vehicle} value"
+        end
+
+        [row[:pf_status], row[:daf_status]].each do |status|
+          expect(%w[yes partial no]).to include(status), "#{label}: bad status #{status.inspect}"
+        end
+
+        detail = row[:detail]
+        expect(detail).to be_a(Hash), "#{label}: :detail must be a per-vehicle hash"
+        vehicle_keys.each do |vehicle|
+          expect(detail[vehicle]).to be_present, "#{label}: :detail is missing the :#{vehicle} snippet"
+        end
+
+        (row[:sources] || []).each do |source|
+          expect(source[:text]).to be_present, "#{label}: a source is missing :text"
+          expect(source[:url]).to be_present, "#{label}: a source is missing :url"
+          expect(%w[hcb pf daf]).to include(source[:for]), "#{label}: source :for must be hcb/pf/daf, got #{source[:for].inspect}"
+        end
+      end
+    end
+  end
+
   describe "#funder_faqs" do
     # Guards the "related" cross-links: they reference stable ids (not question wording), so this
     # catches a typo'd or stale id before it silently drops a link on the page.
@@ -13,6 +48,18 @@ RSpec.describe MarketingHelper, type: :helper do
 
       expect(ids).to eq(ids.uniq), "FAQ ids must be unique"
       expect(related - ids).to be_empty, "every related id must match an existing FAQ id"
+    end
+
+    it "every group has a topic, and every question has a question and an answer" do
+      helper.funder_faqs(stats: nil).each do |group|
+        expect(group[:topic]).to be_present, "a FAQ group is missing :topic"
+        expect(group[:faqs]).to be_present, "FAQ group #{group[:topic].inspect} has no questions"
+
+        group[:faqs].each do |faq|
+          expect(faq[:q]).to be_present, "a question in #{group[:topic].inspect} is missing :q"
+          expect(faq[:a]).to be_present, "question #{faq[:q].inspect} is missing :a"
+        end
+      end
     end
   end
 end

--- a/spec/requests/marketing_spec.rb
+++ b/spec/requests/marketing_spec.rb
@@ -104,6 +104,42 @@ RSpec.describe "Funders landing page", type: :request do
     end
   end
 
+  # The HCB vs. private-foundation vs. DAF comparison table. Its detail rows ship EXPANDED
+  # in the server HTML and are collapsed by the funders-compare Stimulus controller, so the
+  # evidence-rich copy and IRS sources are present for AI crawlers and no-JS visitors (this
+  # page is deliberately indexable). AI crawlers don't run JS, so any content that only
+  # appeared after client-side rendering would be invisible to them.
+  describe "comparison table" do
+    before { Flipper.enable(MarketingController::COMPARISON_FAQ_FLAG) }
+
+    it "renders the funder-facing comparison rows" do
+      get funders_path
+
+      expect(response.body).to include("Practical minimum to be worth it")
+      expect(response.body).to include("Back office")
+      expect(response.body).to include("Mandatory annual payout")
+      expect(response.body).to include("Layered fees")
+    end
+
+    # The AI-SEO premise: the detail copy and cited sources must be in the raw HTML, and
+    # expanded by default — the controller collapses them only once JS is running.
+    it "server-renders the expandable detail copy and IRS sources, expanded by default" do
+      get funders_path
+
+      expect(response.body).to include("expenditure responsibility")
+      expect(response.body).to include("1.39% excise tax on net investment income")
+      expect(response.body).to include("irs.gov")
+      expect(response.body).to include('aria-expanded="true"')
+    end
+
+    # Answer-first interceptor line that doubles as a citable passage for AI engines.
+    it "shows the answer-first interceptor caption" do
+      get funders_path
+
+      expect(response.body).to include("Fund a charitable project tax-deductibly from day one")
+    end
+  end
+
   describe "POST /for/funders/inquiry" do
     # A lead is precious: we email the funder a confirmation AND CC the ops team, so an
     # inquiry can't be silently lost even if one delivery path fails.
@@ -140,6 +176,76 @@ RSpec.describe "Funders landing page", type: :request do
       expect do
         post funder_inquiry_path, params: { email: "bot@example.com", subtitle: "i am a bot" }
       end.not_to have_enqueued_mail(FunderInquiryMailer, :inquiry)
+    end
+  end
+
+  # The short "Common questions" teaser on the main page links to the dedicated FAQ subpage.
+  describe "FAQ teaser on the funders page" do
+    before { Flipper.enable(MarketingController::COMPARISON_FAQ_FLAG) }
+
+    it "shows the common-questions teaser and a link to the full FAQ" do
+      get funders_path
+
+      expect(response.body).to include("Common questions")
+      expect(response.body).to include("How is HCB different from a donor-advised fund?")
+      expect(response.body).to include(funders_faq_path)
+    end
+  end
+
+  # The dedicated funder FAQ subpage: fully server-rendered, grouped Q&A with FAQPage structured
+  # data, and deliberately indexable like the main funders page.
+  describe "GET /for/funders/faq" do
+    before { Flipper.enable(MarketingController::COMPARISON_FAQ_FLAG) }
+
+    it "renders grouped questions and answers, server-side" do
+      get funders_faq_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Funder questions, answered")
+      expect(response.body).to include("How do I accept tax-deductible donations for a project that isn't a 501(c)(3)?")
+      expect(response.body).to include("Through fiscal sponsorship.")
+      expect(response.body).to include("Tax and deductibility") # a topic heading
+    end
+
+    it "emits FAQPage structured data covering the questions" do
+      get funders_faq_path
+
+      expect(response.body).to include('"@type":"FAQPage"')
+      expect(response.body).to include("Do donor-advised funds have a payout requirement?")
+    end
+
+    it "is indexable (does not set a noindex X-Robots-Tag)" do
+      get funders_faq_path
+
+      expect(response.headers["X-Robots-Tag"]).to be_blank
+    end
+
+    it "cross-links related questions to their stable id anchor" do
+      get funders_faq_path
+
+      expect(response.body).to include('class="mk-meta__link"')
+      expect(response.body).to include('href="#fiscal-sponsorship"')
+      expect(response.body).to include('id="fiscal-sponsorship"') # the link target exists
+    end
+  end
+
+  # The funders_landing_comparison_faq flag gates all of the above: with it off, the page falls
+  # back to the original static comparison table, the FAQ teaser is hidden, and the subpage 404s.
+  describe "with the funders_landing_comparison_faq flag off" do
+    before { Flipper.disable(MarketingController::COMPARISON_FAQ_FLAG) }
+
+    it "falls back to the original static comparison table and hides the FAQ teaser" do
+      get funders_path
+
+      expect(response.body).to include("Fund brand-new initiatives") # original row label
+      expect(response.body).not_to include("Practical minimum to be worth it") # new table only
+      expect(response.body).not_to include("Common questions") # FAQ teaser hidden
+    end
+
+    it "404s the FAQ subpage" do
+      get funders_faq_path
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 end


### PR DESCRIPTION
Funders likely have questions. So let's answer them.

Add an interactive HCB vs. private foundation vs. donor-advised fund comparison table and a funder FAQ (a "Common questions" teaser on /for/funders plus a dedicated /for/funders/faq subpage), gated behind the funders_landing_comparison_faq flag so they ship dark until the content is approved.

<img width="974" height="959" alt="image" src="https://github.com/user-attachments/assets/bf4210fa-3885-4898-be30-c1be2138f697" />
<img width="397" height="849" alt="image" src="https://github.com/user-attachments/assets/b8d72b77-d5c9-4017-8e35-89ea12d3f15e" />


<img width="1098" height="840" alt="image" src="https://github.com/user-attachments/assets/b6c4dabf-6295-4f02-81a1-916870878edd" />

