### PR TITLE
[Marketing] Mobile: make For Funders FSO spotlight a swipeable strip

### DIFF
--- a/app/assets/stylesheets/components/_marketing.scss
+++ b/app/assets/stylesheets/components/_marketing.scss
@@ -1432,7 +1432,7 @@ $mk-bg: $snow; // #f9fafc
   }
 }
 
-// Mobile-only "tap a row" cue; on desktop the rail + stage are side by side so it's redundant.
+// Mobile-only "swipe / tap" cue; on desktop the rail + stage are side by side so it's redundant.
 .mk-portfolio__hint {
   margin: 4px 2px 0;
   font-size: 0.85rem;
@@ -1440,6 +1440,63 @@ $mk-bg: $snow; // #f9fafc
 
   @media (min-width: 880px) {
     display: none;
+  }
+}
+
+// Mobile-only position dots beneath the swipe strip: one per real org, so the count itself signals
+// how many orgs there are; the active dot (set by the controller) mirrors the selected org. Hidden
+// on desktop, where the full vertical rail makes a position indicator redundant.
+.mk-portfolio__dots {
+  display: none;
+  justify-content: center;
+  gap: 7px;
+  margin: 12px 0 2px;
+
+  @media (max-width: 879.98px) {
+    display: flex;
+  }
+}
+
+.mk-portfolio__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba($black, 0.16);
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+
+  &.is-active {
+    background: $red;
+    transform: scale(1.4);
+  }
+}
+
+// Mobile-only closing CTA — the open-door wildcard lifted out of the swipe strip. Desktop keeps the
+// in-stage wildcard tab/panel; on mobile it's a standalone card set apart by its own eyebrow so it
+// reads as "and beyond this list", not more detail about the selected org above it.
+.mk-portfolio__open-cta {
+  display: none;
+
+  @media (max-width: 879.98px) {
+    display: block;
+    margin-top: 16px;
+    padding: clamp(20px, 5vw, 26px);
+    border-radius: var(--radius-2xl);
+    background: $snow;
+    box-shadow: inset 0 0 0 1.5px rgba($black, 0.1);
+
+    .mk-portfolio__name {
+      margin-top: 6px;
+    }
+
+    .mk-portfolio__what {
+      margin-bottom: 18px;
+    }
+
+    .marketing-btn {
+      width: 100%; // full-width tap target to close out the section
+    }
   }
 }
 
@@ -1483,6 +1540,122 @@ $mk-bg: $snow; // #f9fafc
   @media (min-width: 880px) {
     display: flex;
     visibility: hidden;
+  }
+}
+
+// ---- mobile (<880px): FSO spotlight as a horizontal swipeable strip ----
+// The vertical rail of orgs pushed the detail card a full screen below the nav, so picking an org
+// and reading its story were never visible together. Below 880px the rail becomes a horizontal,
+// swipeable strip (the next card peeks → "there's more") with position dots beneath it, the active
+// org's card renders directly under it, and the open-door wildcard is lifted out of the strip into
+// a standalone closing CTA (.mk-portfolio__open-cta). Desktop (>=880px) is untouched.
+@media (max-width: 879.98px) {
+  .mk-portfolio__rail {
+    flex-direction: row;
+    gap: 10px;
+    overflow-x: auto;
+    // No scroll-snap: snapping every chip made the strip feel jumpy and refused to rest a card
+    // mid-scroll. Free momentum scroll instead; the dots + peeking neighbour carry the position cue.
+    padding-block: 6px; // room so the cards' shadows aren't clipped by the scroll container
+    margin-inline: -4px; // bleed into the gutter so the first card lines up with the heading
+    padding-inline: 4px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none; // the peeking card + dots are the scroll cue; a bar would clutter it
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    // Edge fades are class-driven (the controller sets these from scroll position) so a fade only
+    // shows where there's actually more to scroll: both edges mid-scroll, and neither on a short
+    // strip that doesn't overflow. At a boundary the relevant override below drops that edge.
+    &.is-overflowing {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 22px,
+        #000 calc(100% - 28px),
+        transparent 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 22px,
+        #000 calc(100% - 28px),
+        transparent 100%
+      );
+    }
+
+    // At the start there's nothing to the left — keep that edge crisp, fade only the right.
+    &.is-overflowing.is-at-start {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        #000 0,
+        #000 calc(100% - 28px),
+        transparent 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        #000 0,
+        #000 calc(100% - 28px),
+        transparent 100%
+      );
+    }
+
+    // At the end there's nothing to the right — fade only the left, so the last card stays solid.
+    &.is-overflowing.is-at-end {
+      -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 22px,
+        #000 100%
+      );
+      mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 22px,
+        #000 100%
+      );
+    }
+  }
+
+  .mk-portfolio__item {
+    // Fixed-ish width so the next org card always peeks at the right edge as a scroll affordance.
+    flex: 0 0 auto;
+    width: min(76%, 320px);
+  }
+
+  // The chevron points right, which on a horizontal strip reads as "swipe" and fights the scroll
+  // axis; the chips are obviously tappable, so drop it here.
+  .mk-portfolio__item-caret {
+    display: none;
+  }
+
+  // Fixed-width chips can't wrap a long name (e.g. "Mutual Aid LA Network") to two lines without
+  // throwing off the strip's baseline, so clamp the name and sub to one line each.
+  .mk-portfolio__item-name,
+  .mk-portfolio__item-sub {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Shorter banner on a phone so the org's story sits higher and shares the screen with the strip
+  // (the desktop hero-height banner is overkill here). The terminal art keeps a touch more room.
+  .mk-portfolio__media {
+    min-height: 132px;
+  }
+
+  .mk-portfolio__media--terminal {
+    min-height: 160px;
+  }
+
+  // The wildcard is desktop-only as a tab: on mobile its tab AND panel are hidden, and it's
+  // re-rendered as a standalone, non-tab CTA below the content (see .mk-portfolio__open-cta). This
+  // keeps the strip a clean roster of real orgs and avoids an orphan tabpanel in the a11y tree.
+  .mk-portfolio__item--open,
+  .mk-portfolio__panel--open {
+    display: none;
   }
 }
 

--- a/app/javascript/controllers/funders_portfolio_controller.js
+++ b/app/javascript/controllers/funders_portfolio_controller.js
@@ -1,42 +1,51 @@
 import { Controller } from '@hotwired/stimulus'
 import { gsap } from 'gsap'
 
-// Interactive "organizations on HCB" portfolio explorer: a vertical rail of real
-// recipient organizations on the left, a detail "stage" on the right that swaps
-// as you select one (hover on a fine pointer, click/tap anywhere). The last rail
-// item is a "wildcard" that reframes the list as a sample — your giving isn't
-// limited to these orgs, or even to orgs already on HCB.
+// Interactive "organizations on HCB" portfolio explorer: a rail of real recipient organizations
+// and a detail "stage" that swaps as you select one (hover on a fine pointer, click/tap anywhere).
+// The last rail item is a "wildcard" that reframes the list as a sample — your giving isn't limited
+// to these orgs, or even to orgs already on HCB.
 //
-// Implements the WAI-ARIA tabs pattern with roving tabindex + arrow-key
-// navigation, mirroring funders_explorer_controller so the two selectable rails
-// on the page behave identically. With no JS the markup shows every panel
-// stacked, so nothing is hidden.
+// Desktop: the rail is a vertical list beside the stage. Below 880px it becomes a horizontal,
+// swipeable strip above the active org's card, with position dots beneath it and edge fades driven
+// from scroll position; the wildcard is lifted out of the strip into a static CTA (see the view).
 //
-// On desktop it slowly auto-advances through the *real* orgs (never the wildcard
-// CTA) to demonstrate that the stage is interactive. That self-demo pauses while
-// the pointer is over the component and stops for good once the user selects
-// anything themselves.
+// Implements the WAI-ARIA tabs pattern with roving tabindex + arrow-key navigation. With no JS the
+// markup shows every panel stacked, so nothing is hidden.
+//
+// On desktop it slowly auto-advances through the *real* orgs (never the wildcard CTA) to show the
+// stage is interactive. That self-demo pauses while the pointer is over the component and stops for
+// good once the user selects anything themselves.
 const ADVANCE_MS = 4500
 const MAX_CYCLES = 1
 
 export default class extends Controller {
-  static targets = ['tab', 'panel', 'count']
+  static targets = ['rail', 'tab', 'panel', 'count', 'dot']
 
   connect() {
     this.element.classList.add('is-enhanced')
     this.enhanced = true
     this.hover = window.matchMedia('(hover: hover) and (pointer: fine)').matches
     this.reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    // Auto-rotate only where the stage sits beside the rail (desktop) and the
-    // user hasn't asked to reduce motion; on mobile the stage can be off-screen.
-    this.canAuto =
-      window.matchMedia('(min-width: 880px)').matches && !this.reduce
+    // The 880px breakpoint splits the two layouts: vertical rail beside the stage (desktop) vs the
+    // horizontal swipe strip (mobile). Watched live so orientation/auto-rotate track orientation
+    // changes (rotating a phone, resizing a window).
+    this.desktopMq = window.matchMedia('(min-width: 880px)')
     this.cycles = 0
     // Rail items the auto-demo cycles through: the real orgs, never the wildcard.
     this.rotatable = this.tabTargets.filter(
       tab => tab.dataset.wildcard !== 'true'
     ).length
+
+    this.applyOrientation()
+    this.onBreakpoint = () => {
+      this.applyOrientation()
+      this.updateStrip()
+    }
+    this.desktopMq.addEventListener('change', this.onBreakpoint)
+
     this.select(0, false)
+    this.updateStrip() // seed the strip's edge-fade state from the initial scroll position
 
     this.observer = new IntersectionObserver(
       ([entry]) => {
@@ -51,11 +60,29 @@ export default class extends Controller {
 
   disconnect() {
     this.observer?.disconnect()
+    this.desktopMq?.removeEventListener('change', this.onBreakpoint)
     this.clearTimer()
     // Kill any in-flight tweens so their onUpdate can't write to a detached element
     // after the controller goes away (e.g. a Turbo navigation mid-animation).
     this.countTween?.kill()
     gsap.killTweensOf(this.panelTargets)
+  }
+
+  // Auto-rotate only where the stage sits beside the rail (desktop) and the user hasn't asked to
+  // reduce motion; on mobile the stage can be off-screen. A getter so it tracks live resizes.
+  get canAuto() {
+    return this.desktopMq.matches && !this.reduce
+  }
+
+  // The rail is the tablist: a vertical list on desktop, a horizontal strip on mobile. Keep the
+  // declared orientation honest so AT announces the right arrow-key axis (the handler accepts both).
+  applyOrientation() {
+    if (this.hasRailTarget) {
+      this.railTarget.setAttribute(
+        'aria-orientation',
+        this.desktopMq.matches ? 'vertical' : 'horizontal'
+      )
+    }
   }
 
   // Wired from each rail item (click / mouseenter / focus).
@@ -64,14 +91,19 @@ export default class extends Controller {
     if (event.type === 'mouseenter' && !this.hover) return
     this.stopAuto() // a deliberate selection means they know it's interactive
     this.select(i, true)
-    // On tap (mobile), the stage sits below the rail — bring the swapped panel to the top
-    // of the viewport so the change is always visible feedback (`nearest` under-scrolls when
-    // a short panel is already partly in view). `scroll-margin-top` clears the header.
+    // On tap (mobile) the rail is a horizontal strip sitting just above the stage, so the swapped
+    // card already renders in place beneath it (the gsap crossfade is the visible feedback). Only
+    // scroll if the card is entirely off-screen — never yank it to the top, which would push the
+    // strip the user is swiping out of view.
     if (event.type === 'click' && !this.hover) {
-      this.panelTargets[i].scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      })
+      const rect = this.panelTargets[i].getBoundingClientRect()
+      const offscreen = rect.top >= window.innerHeight || rect.bottom <= 0
+      if (offscreen) {
+        this.panelTargets[i].scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        })
+      }
     }
   }
 
@@ -89,6 +121,11 @@ export default class extends Controller {
     this.panelTargets.forEach((panel, i) => {
       panel.classList.toggle('is-active', i === index)
     })
+    // Mobile position dots mirror the selected org; their count also signals how many orgs there
+    // are (hidden on desktop). The wildcard has no dot, so selecting it clears them.
+    this.dotTargets.forEach((dot, i) =>
+      dot.classList.toggle('is-active', i === index)
+    )
     // Crossfade the incoming panel in. CSS handles the no-JS / reduced-motion
     // cases (all panels shown, or shown without motion); this is the enhancement.
     if (animate && !this.reduce) {
@@ -98,23 +135,66 @@ export default class extends Controller {
         { opacity: 1, y: 0, duration: 0.4, ease: 'power2.out' }
       )
     }
+    // Keep the selected chip within the horizontal strip on mobile. Guarded by `animate` so it
+    // never runs on the initial connect select, and by `!this.hover` so it's mobile-only.
+    if (animate && !this.hover) this.revealTab(index)
   }
 
-  // Arrow-key navigation across the rail.
+  // Bring a chip fully into the strip by nudging ONLY the rail's own scrollLeft — never
+  // scrollIntoView, which would scroll every ancestor (including the document) and jump the page.
+  revealTab(index) {
+    const tab = this.tabTargets[index]
+    if (!this.hasRailTarget || !tab) return
+    const rail = this.railTarget.getBoundingClientRect()
+    const chip = tab.getBoundingClientRect()
+    const pad = 14 // leave a sliver of the neighbour visible so the strip still reads as scrollable
+    if (chip.left < rail.left + pad) {
+      this.railTarget.scrollLeft -= rail.left + pad - chip.left
+    } else if (chip.right > rail.right - pad) {
+      this.railTarget.scrollLeft += chip.right - (rail.right - pad)
+    }
+  }
+
+  // Arrow-key navigation across the rail. Walks only the *visible* tabs so the wildcard tab —
+  // display:none on mobile, where it's replaced by a static CTA — is never a dead stop.
   keydown(event) {
-    const last = this.tabTargets.length - 1
+    const tabs = this.tabTargets.filter(tab => tab.offsetParent !== null)
+    if (!tabs.length) return
+    const last = tabs.length - 1
+    const cur = Math.max(0, tabs.indexOf(this.tabTargets[this.active]))
     let next = null
     if (event.key === 'ArrowDown' || event.key === 'ArrowRight')
-      next = this.active >= last ? 0 : this.active + 1
+      next = cur >= last ? 0 : cur + 1
     else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft')
-      next = this.active <= 0 ? last : this.active - 1
+      next = cur <= 0 ? last : cur - 1
     else if (event.key === 'Home') next = 0
     else if (event.key === 'End') next = last
     if (next === null) return
     event.preventDefault()
     this.stopAuto()
-    this.select(next, true)
-    this.tabTargets[next].focus()
+    const target = tabs[next]
+    this.select(this.tabTargets.indexOf(target), true)
+    target.focus()
+  }
+
+  // --- horizontal strip (mobile) -------------------------------------------
+  // Edge fades are class-driven from real scroll position so a fade only shows where there's more
+  // to scroll — never dimming the last card at the end, or a short (1-2 org) non-scrolling strip.
+  onScroll() {
+    if (this.scrollRaf) return
+    this.scrollRaf = requestAnimationFrame(() => {
+      this.scrollRaf = null
+      this.updateStrip()
+    })
+  }
+
+  updateStrip() {
+    if (!this.hasRailTarget) return
+    const rail = this.railTarget
+    const max = rail.scrollWidth - rail.clientWidth
+    rail.classList.toggle('is-overflowing', max > 1)
+    rail.classList.toggle('is-at-start', rail.scrollLeft <= 1)
+    rail.classList.toggle('is-at-end', rail.scrollLeft >= max - 1)
   }
 
   // --- count-up ------------------------------------------------------------

--- a/app/views/marketing/funders.html.erb
+++ b/app/views/marketing/funders.html.erb
@@ -525,7 +525,9 @@
         </div>
 
         <%# --- rail: selectable list of orgs, ending in the open-door wildcard --- %>
-        <div class="mk-portfolio__rail" role="tablist" aria-label="Organizations on HCB" aria-orientation="vertical">
+        <div class="mk-portfolio__rail" role="tablist" aria-label="Organizations on HCB"
+             aria-orientation="vertical" data-funders-portfolio-target="rail"
+             data-action="scroll->funders-portfolio#onScroll">
         <% recipients.each_with_index do |org, i| %>
           <button type="button" class="mk-portfolio__item" role="tab" id="mk-port-tab-<%= i %>"
                   aria-controls="mk-port-panel-<%= i %>" aria-selected="<%= i.zero? %>"
@@ -562,9 +564,19 @@
         </button>
       </div>
 
-        <%# Mobile-only cue: on narrow screens the rail stacks above a single visible panel, so
-            signal that the rail is interactive (hidden ≥880px where rail + stage sit side by side). %>
-        <p class="mk-portfolio__hint" aria-hidden="true">Tap any organization to see its story&nbsp;&darr;</p>
+        <%# Mobile-only position dots beneath the swipe strip: one per real org (the wildcard is
+            lifted out of the strip into a standalone CTA below), updated by the controller as you
+            select. Decorative — the rail itself is the real control — so it's aria-hidden. %>
+        <div class="mk-portfolio__dots" aria-hidden="true">
+          <% recipients.each_index do |i| %>
+            <span class="mk-portfolio__dot<%= " is-active" if i.zero? %>" data-funders-portfolio-target="dot"></span>
+          <% end %>
+        </div>
+
+        <%# Mobile-only cue: below 880px the rail is a horizontal swipeable strip above the active
+            org's card, so advertise the swipe (some users won't realize more orgs sit off-screen)
+            as well as the tap (hidden ≥880px where the rail + stage sit side by side). %>
+        <p class="mk-portfolio__hint" aria-hidden="true">Swipe to browse organizations&nbsp;&middot; tap to read its story</p>
       </div>
 
       <%# --- stage: one detail panel per org, plus the open-door wildcard panel --- %>
@@ -690,6 +702,21 @@
           </div>
         </div>
       </div>
+
+      <%# Mobile-only closing CTA: below 880px the open-door wildcard is lifted out of the swipe
+          strip (its tab + panel are hidden there) and shown here as a standalone statement, set
+          apart by its eyebrow so it reads as "and beyond this list", not more detail about the
+          selected org above it. Desktop keeps the in-stage wildcard tab/panel. %>
+      <aside class="mk-portfolio__open-cta">
+        <p class="mk-eyebrow">Beyond this list</p>
+        <h3 class="mk-portfolio__name">Your pick doesn&rsquo;t have to be on here, or on HCB yet.</h3>
+        <p class="mk-portfolio__what">
+          Fund any of the <%= @stats[:organizations] %> organizations already here, a brand-new
+          project that isn&rsquo;t a 501(c)(3) yet, or an idea that&rsquo;s still just a team of one.
+          You bring the pick; we get them running in days.
+        </p>
+        <a class="marketing-btn marketing-btn--primary" href="#talk-to-us">Talk to our team</a>
+      </aside>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## The Problem

On mobile, the For Funders "organizations on HCB" portfolio explorer rendered its org nav as a full vertical stack of cards, so the nav took the whole screen and the detail card sat a full screen below it. Picking an org and reading its story were never visible together.

## Changes (mobile only, <880px)

Below `880px` the nav is now a **horizontal, swipeable strip** above the active org's card, with **position dots** beneath it. Desktop (≥880px) and every other section are unchanged.

- **Horizontal strip** — the rail becomes a horizontal overflow strip with free momentum scroll (no snap, which felt jumpy). Chips are fixed-width so the next card peeks as a scroll affordance; the caret is hidden and long names clamp to one line.
- **Scroll-aware edge fades** — fades are driven from real scroll position, so a fade only shows where there's actually more to scroll: both edges mid-scroll, the last card stays crisp at the end, and no fade on a short non-scrolling strip.
- **Position dots** — one per org under the strip; the count signals how many orgs there are and the active dot tracks the selected one.
- **Wildcard → standalone CTA** — the open-door "Something not here yet" wildcard is lifted out of the strip into a standalone closing CTA below the content, set apart by a "Beyond this list" eyebrow so it reads as a closing statement rather than detail about the selected org.
- **Shorter detail banner** so the org's story shares the screen with the strip.
- `aria-orientation` is set from the breakpoint and updated live on resize/rotate (it was hardcoded `vertical`).
- Lifting the wildcard out of the tabs removes an orphan tabpanel (a `role="tabpanel"` whose only label was a now-hidden tab) and an arrow-key dead stop; keyboard nav walks only visible tabs.
- The active chip is kept in view by nudging the rail's own `scrollLeft`, never `scrollIntoView` (which would scroll the whole page).

<img width="397" height="854" alt="image" src="https://github.com/user-attachments/assets/dc81a0f5-f9ed-484f-9334-035c76edfe60" />
