### PR TITLE
Show error message when users don't have verified phone number

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -243,8 +243,9 @@ class CardGrantsController < ApplicationController
   def activate
     authorize @card_grant
 
-    unless current_user.phone_number_verified?
-      return redirect_to @card_grant, flash: { error: { "text" => "Please verify your phone number before activating your grant card.", "link_text" => "Go to settings", "link" => my_settings_path } }
+    unless @card_grant.user.phone_number_verified?
+      settings_path = current_user == @card_grant.user ? my_settings_path : edit_user_path(@card_grant.user)
+      return redirect_to @card_grant, flash: { error: { "text" => "Please verify your phone number before activating your grant card.", "link_text" => "Go to settings", "link" => settings_path } }
     end
 
     @card_grant.create_stripe_card(request.remote_ip)

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -243,6 +243,10 @@ class CardGrantsController < ApplicationController
   def activate
     authorize @card_grant
 
+    unless current_user.phone_number_verified?
+      return redirect_to @card_grant, flash: { error: "Please verify your phone number in your #{helpers.link_to("settings", my_settings_path)} before activating your grant card.".html_safe }
+    end
+
     @card_grant.create_stripe_card(request.remote_ip)
 
     redirect_to @card_grant

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -244,7 +244,7 @@ class CardGrantsController < ApplicationController
     authorize @card_grant
 
     unless current_user.phone_number_verified?
-      return redirect_to @card_grant, flash: { error: "Please verify your phone number in your #{helpers.link_to("settings", my_settings_path)} before activating your grant card.".html_safe }
+      return redirect_to @card_grant, flash: { error: { "text" => "Please verify your phone number before activating your grant card.", "link_text" => "Go to settings", "link" => my_settings_path } }
     end
 
     @card_grant.create_stripe_card(request.remote_ip)


### PR DESCRIPTION
<img width="1912" height="956" alt="image" src="https://github.com/user-attachments/assets/33ca317f-ab1c-4c4b-8372-b2c0dbdac572" />

Prevents HCB from crashing and showing a vague error message when users try to activate card grants but don't have a verified phone number