### PR TITLE
Check ledger items in anomaly script and exclude empty HcbCodes

### DIFF
--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -4,13 +4,22 @@ module Admin
   class DetectLogicalTransactionAnomaliesJob < ApplicationJob
     queue_as :low
 
+    def initialize
+      @event_id = 183
+    end
+
     def perform
       hcb_codes = []
-      HcbCode.where(event_id: 183).find_each do |hcb_code|
-        hcb_codes << hcb_code.id if hcb_code.ledger_item.nil? || hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents
+      HcbCode.where(event_id: @event_id).find_each do |hcb_code|
+        hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents || (hcb_code.ledger_item.nil? && hcb_code.smart_amount_cents.nonzero?)
       end
 
-      AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(id: hcb_codes)).deliver_now
+      ledger_items = []
+      Ledger::Item.where.not(id: HcbCode.where(event_id: @event_id).select(:ledger_item_id)).find_each do |ledger_item|
+        ledger_items << ledger_item.id
+      end
+
+      AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(id: hcb_codes), ledger_items: LedgerItem.where(id: ledger_items)).deliver_now
     end
 
   end

--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -4,22 +4,22 @@ module Admin
   class DetectLogicalTransactionAnomaliesJob < ApplicationJob
     queue_as :low
 
-    def initialize
-      @event_id = 183
-    end
-
     def perform
       hcb_codes = []
-      HcbCode.where(event_id: @event_id).find_each do |hcb_code|
+      HcbCode.where(event_id:).find_each do |hcb_code|
         hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents || (hcb_code.ledger_item.nil? && hcb_code.no_transactions?)
       end
 
       ledger_items = []
-      Ledger::Item.where.not(id: HcbCode.where(event_id: @event_id).select(:ledger_item_id)).find_each do |ledger_item|
+      Ledger::Item.where.not(id: HcbCode.where(event_id:).select(:ledger_item_id)).find_each do |ledger_item|
         ledger_items << ledger_item.id
       end
 
       AdminMailer.logical_transaction_anomalies(hcb_codes: HcbCode.where(id: hcb_codes), ledger_items: LedgerItem.where(id: ledger_items)).deliver_now
+    end
+
+    def event_id
+      183
     end
 
   end

--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -11,7 +11,7 @@ module Admin
     def perform
       hcb_codes = []
       HcbCode.where(event_id: @event_id).find_each do |hcb_code|
-        hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents || (hcb_code.ledger_item.nil? && hcb_code.smart_amount_cents.nonzero?)
+        hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents || (hcb_code.ledger_item.nil? && hcb_code.no_transactions?)
       end
 
       ledger_items = []

--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -7,7 +7,7 @@ module Admin
     def perform
       hcb_codes = []
       HcbCode.where(event_id:).find_each do |hcb_code|
-        hcb_codes << hcb_code.id if hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents || (hcb_code.ledger_item.nil? && hcb_code.no_transactions?)
+        hcb_codes << hcb_code.id if (hcb_code.ledger_item.nil? && hcb_code.no_transactions?) || hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents
       end
 
       ledger_items = []

--- a/app/views/admin_mailer/logical_transaction_anomalies.html.erb
+++ b/app/views/admin_mailer/logical_transaction_anomalies.html.erb
@@ -1,10 +1,20 @@
 These logical transactions have discrepancies in their amounts between the old and new transaction engine:
 
-<% @hcb_codes.find_each do |hcb_code| %>
-  <p>Old transaction engine amount (HCB Code <%= link_to hcb_code.hashid, hcb_code_url(hcb_code) %>): <%= hcb_code.smart_amount_cents %></p>
-  <% if hcb_code.ledger_item.nil? %>
-    <p>Missing Ledger::Item record</p>
-  <% else %>
-    <p>New transaction engine amount (Ledger::Item <%= link_to hcb_code.ledger_item.hashid, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
+<ul>
+  <% @hcb_codes.find_each do |hcb_code| %>
+    <li>
+      <p>Old transaction engine amount (HCB Code <%= link_to hcb_code.hashid, hcb_code_url(hcb_code) %>): <%= hcb_code.smart_amount_cents %></p>
+      <% if hcb_code.ledger_item.nil? %>
+        <p>Missing Ledger::Item record</p>
+      <% else %>
+        <p>New transaction engine amount (Ledger::Item <%= link_to hcb_code.ledger_item.hashid, ledger_item_url(hcb_code.ledger_item) %>): <%= hcb_code.ledger_item.amount_cents %></p>
+      <% end %>
+    </li>
   <% end %>
-<% end %>
+  <% @ledger_items.find_each do |ledger_item| %>
+    <li>
+      <p>Missing HCB Code</p>
+      <p>New transaction engine amount (Ledger::Item <%= link_to ledger_item.hashid, ledger_item_url(ledger_item) %>): <%= ledger_item.amount_cents %></p>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
## Summary of the problem

We want to also detect anomalies from the perspective of ledger items (similar to a full outer join). However, we also want to exclude HcbCodes without canonical transactions that are missing a ledger item.


## Describe your changes

This PR includes ledger item anomalies in the script and excludes empty HCB codes.