### PR TITLE
[Legal Entity] Switch Logic from User Payout to Default Personal Legal Entity

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -609,7 +609,6 @@ const initPayoutMethodToggles = function () {
   if (
     BK.thereIs('check_payout_method_inputs') &&
     BK.thereIs('ach_transfer_payout_method_inputs') &&
-    BK.thereIs('paypal_transfer_payout_method_inputs') &&
     BK.thereIs('wire_payout_method_inputs') &&
     BK.thereIs('wise_transfer_payout_method_inputs')
   ) {
@@ -617,56 +616,38 @@ const initPayoutMethodToggles = function () {
     const achTransferPayoutMethodInputs = BK.s(
       'ach_transfer_payout_method_inputs'
     )
-    const paypalTransferPayoutMethodInputs = BK.s(
-      'paypal_transfer_payout_method_inputs'
-    )
     const wirePayoutMethodInputs = BK.s('wire_payout_method_inputs')
     const wiseTransferPayoutMethodInputs = BK.s(
       'wise_transfer_payout_method_inputs'
     )
     $(document).on(
       'change',
-      '#user_payout_method_type_userpayoutmethodcheck',
+      '#user_payout_method_type_legalentitypayoutmethodcheck',
       e => {
         if (e.target.checked)
           checkPayoutMethodInputs.slideDown() &&
             achTransferPayoutMethodInputs.slideUp() &&
-            paypalTransferPayoutMethodInputs.slideUp() &&
             wirePayoutMethodInputs.slideUp() &&
             wiseTransferPayoutMethodInputs.slideUp()
       }
     )
     $(document).on(
       'change',
-      '#user_payout_method_type_userpayoutmethodachtransfer',
+      '#user_payout_method_type_legalentitypayoutmethodachtransfer',
       e => {
         if (e.target.checked)
           achTransferPayoutMethodInputs.slideDown() &&
             checkPayoutMethodInputs.slideUp() &&
-            paypalTransferPayoutMethodInputs.slideUp() &&
             wirePayoutMethodInputs.slideUp() &&
             wiseTransferPayoutMethodInputs.slideUp()
       }
     )
     $(document).on(
       'change',
-      '#user_payout_method_type_userpayoutmethodpaypaltransfer',
+      '#user_payout_method_type_legalentitypayoutmethodwire',
       e => {
         if (e.target.checked)
-          paypalTransferPayoutMethodInputs.slideDown() &&
-            checkPayoutMethodInputs.slideUp() &&
-            achTransferPayoutMethodInputs.slideUp() &&
-            wirePayoutMethodInputs.slideUp() &&
-            wiseTransferPayoutMethodInputs.slideUp()
-      }
-    )
-    $(document).on(
-      'change',
-      '#user_payout_method_type_userpayoutmethodwire',
-      e => {
-        if (e.target.checked)
-          paypalTransferPayoutMethodInputs.slideUp() &&
-            checkPayoutMethodInputs.slideUp() &&
+          checkPayoutMethodInputs.slideUp() &&
             achTransferPayoutMethodInputs.slideUp() &&
             wirePayoutMethodInputs.slideDown() &&
             wiseTransferPayoutMethodInputs.slideUp()
@@ -674,14 +655,13 @@ const initPayoutMethodToggles = function () {
     )
     $(document).on(
       'change',
-      '#user_payout_method_type_userpayoutmethodwisetransfer',
+      '#user_payout_method_type_legalentitypayoutmethodwisetransfer',
       e => {
         if (e.target.checked)
           wiseTransferPayoutMethodInputs.slideDown() &&
             checkPayoutMethodInputs.slideUp() &&
             achTransferPayoutMethodInputs.slideUp() &&
-            wirePayoutMethodInputs.slideUp() &&
-            paypalTransferPayoutMethodInputs.slideUp()
+            wirePayoutMethodInputs.slideUp()
       }
     )
   }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -528,7 +528,10 @@ class AdminController < Admin::BaseController
 
     @unprocessed_wise_report_ids = Reimbursement::Report
                                    .where(id: Reimbursement::PayoutHolding.settled.or(Reimbursement::PayoutHolding.pending).select(:reimbursement_reports_id))
-                                   .where(user_id: User.where(payout_method_type: "User::PayoutMethod::WiseTransfer").select(:id))
+                                   .where(user_id: User.joins(legal_entities: :payout_methods)
+                                                       .where(legal_entities: { entity_type: "person" })
+                                                       .where(legal_entity_payout_methods: { default: true, details_type: "LegalEntity::PayoutMethod::WiseTransfer" })
+                                                       .select(:id))
                                    .select(:id)
                                    .pluck(:id)
 

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -144,7 +144,7 @@ class MyController < ApplicationController
 
     @reports = @reports.search(params[:q]) if params[:q].present?
 
-    @payout_method = current_user.payout_method
+    @payout_method = current_user.default_payout_method_details
   end
 
   def reimbursements_icon
@@ -155,7 +155,7 @@ class MyController < ApplicationController
 
   def payroll
     @jobs = current_user.jobs
-    @payout_method = current_user.payout_method
+    @payout_method = current_user.default_payout_method_details
   end
 
   def feed

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -144,7 +144,7 @@ class MyController < ApplicationController
 
     @reports = @reports.search(params[:q]) if params[:q].present?
 
-    @payout_method = current_user.default_payout_method_details
+    @payout_method = current_user.default_payout_method&.details
   end
 
   def reimbursements_icon
@@ -155,7 +155,7 @@ class MyController < ApplicationController
 
   def payroll
     @jobs = current_user.jobs
-    @payout_method = current_user.default_payout_method_details
+    @payout_method = current_user.default_payout_method&.details
   end
 
   def feed

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -304,20 +304,20 @@ module Reimbursement
           payout_holding.reload
           payout_holding.mark_settled!
         end
-        payout_method = @report.user.default_payout_method_details
-        payout_method.update(wise_recipient_id: params[:wise_recipient_id])
+        wise_payout_method = @report.user.default_payout_method&.details
+        wise_payout_method.update(wise_recipient_id: params[:wise_recipient_id])
         wise_transfer = clearinghouse.wise_transfers.create!(
           payment_for: "Reimbursement for #{@report.name}.",
-          address_line1: payout_method.address_line1,
-          address_line2: payout_method.address_line2,
-          address_city: payout_method.address_city,
-          address_state: payout_method.address_state,
-          address_postal_code: payout_method.address_postal_code,
-          recipient_country: payout_method.recipient_country,
+          address_line1: wise_payout_method.address_line1,
+          address_line2: wise_payout_method.address_line2,
+          address_city: wise_payout_method.address_city,
+          address_state: wise_payout_method.address_state,
+          address_postal_code: wise_payout_method.address_postal_code,
+          recipient_country: wise_payout_method.recipient_country,
           recipient_email: @report.user.email,
           recipient_name: @report.user.full_name,
-          bank_name: payout_method.bank_name,
-          recipient_information: payout_method.recipient_information,
+          bank_name: wise_payout_method.bank_name,
+          recipient_information: wise_payout_method.recipient_information,
           currency: @report.currency,
           user: User.system_user,
           usd_amount_cents: payout_holding.amount_cents,

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -16,7 +16,7 @@ module Reimbursement
     def create
       @event = Event.find(report_params[:event_id])
       user = User.create_with(creation_method: :reimbursement_report).find_or_create_by!(email: report_params[:email])
-      @report = @event.reimbursement_reports.build(report_params.except(:email, :receipt_id, :value).merge(user:, inviter: organizer_signed_in? ? current_user : nil, currency: user.payout_method&.currency || "USD"))
+      @report = @event.reimbursement_reports.build(report_params.except(:email, :receipt_id, :value).merge(user:, inviter: organizer_signed_in? ? current_user : nil, currency: user.default_payout_method&.currency || "USD"))
 
       authorize @report
 
@@ -115,7 +115,7 @@ module Reimbursement
       authorize @report
 
       old_currency = @report.currency
-      new_currency = @report.user.payout_method.currency
+      new_currency = @report.user.default_payout_method.currency
 
       ActiveRecord::Base.transaction do
         @report.update!(currency: new_currency)
@@ -202,7 +202,7 @@ module Reimbursement
         end
 
         flash[:success] = {
-          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.payout_method.name}.",
+          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.default_payout_method.name}.",
           link: settings_payouts_path
         }
         if @report.user.can_update_payout_method?
@@ -304,19 +304,20 @@ module Reimbursement
           payout_holding.reload
           payout_holding.mark_settled!
         end
-        @report.user.payout_method.update(wise_recipient_id: params[:wise_recipient_id])
+        payout_method = @report.user.default_payout_method_details
+        payout_method.update(wise_recipient_id: params[:wise_recipient_id])
         wise_transfer = clearinghouse.wise_transfers.create!(
           payment_for: "Reimbursement for #{@report.name}.",
-          address_line1: @report.user.payout_method.address_line1,
-          address_line2: @report.user.payout_method.address_line2,
-          address_city: @report.user.payout_method.address_city,
-          address_state: @report.user.payout_method.address_state,
-          address_postal_code: @report.user.payout_method.address_postal_code,
-          recipient_country: @report.user.payout_method.recipient_country,
+          address_line1: payout_method.address_line1,
+          address_line2: payout_method.address_line2,
+          address_city: payout_method.address_city,
+          address_state: payout_method.address_state,
+          address_postal_code: payout_method.address_postal_code,
+          recipient_country: payout_method.recipient_country,
           recipient_email: @report.user.email,
           recipient_name: @report.user.full_name,
-          bank_name: @report.user.payout_method.bank_name,
-          recipient_information: @report.user.payout_method.recipient_information,
+          bank_name: payout_method.bank_name,
+          recipient_information: payout_method.recipient_information,
           currency: @report.currency,
           user: User.system_user,
           usd_amount_cents: payout_holding.amount_cents,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -329,6 +329,11 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(user_params)
 
+    payout_method_type = params.dig(:user, :payout_method_type)
+    if payout_method_type.present? && @user.can_update_payout_method?
+      @user.build_default_payout_method(payout_method_type, payout_method_details_params)
+    end
+
     if @user.use_two_factor_authentication_changed?
       return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
     end
@@ -381,14 +386,26 @@ class UsersController < ApplicationController
       return redirect_back_or_to edit_user_path(@user)
     end
 
-    if @user.save
+    payout_method = @user.new_default_payout_method
+    saved = ActiveRecord::Base.transaction do
+      user_ok = @user.save
+      pm_ok = true
+      if payout_method
+        pm_ok = payout_method.details.save && payout_method.save
+      end
+      raise ActiveRecord::Rollback unless user_ok && pm_ok
+
+      true
+    end
+
+    if saved
       confetti! if !@user.seasonal_themes_enabled_before_last_save && @user.seasonal_themes_enabled? # confetti if the user enables seasonal themes
 
       if @user.full_name_before_last_save.blank?
         flash[:success] = "Profile created!"
         redirect_to(return_to || root_path)
       else
-        if @user.payout_method&.saved_changes? && @user == current_user
+        if payout_method&.saved_changes? && @user == current_user
           flash[:success] = "Your payout details have been updated. We'll use this information for all payouts going forward."
         elsif email_update&.requested?
           flash[:success] = "We've sent a verification link to your new email (#{params[:user][:email]}) and a authorization link to your old email (#{@user.email}), please click them both to confirm this change."
@@ -409,8 +426,11 @@ class UsersController < ApplicationController
         return
       end
 
-      if @user.payout_method&.errors&.any?
-        flash.now[:error] = @user.payout_method.errors.full_messages.to_sentence
+      payout_method_errors = @user.errors[:payout_method] +
+                             (payout_method&.errors&.full_messages || []) +
+                             (payout_method&.details&.errors&.full_messages || [])
+      if payout_method_errors.any?
+        flash.now[:error] = payout_method_errors.to_sentence
         render :edit_payout, status: :unprocessable_entity
         return
       end
@@ -524,82 +544,58 @@ class UsersController < ApplicationController
       }
     end
 
-    if @user.can_update_payout_method?
-      attributes << :payout_method_type
-      if params.require(:user)[:payout_method_type] == User::PayoutMethod::Check.name
-        attributes << {
-          payout_method_attributes: [
-            :address_line1,
-            :address_line2,
-            :address_city,
-            :address_state,
-            :address_postal_code,
-            :address_country
-          ]
-        }
-      end
-
-      if params.require(:user)[:payout_method_type] == User::PayoutMethod::Wire.name
-        attributes << {
-          payout_method_wire: [
-            :address_line1,
-            :address_line2,
-            :address_city,
-            :address_state,
-            :address_postal_code,
-            :recipient_country,
-            :recipient_name,
-            :bic_code,
-            :account_number
-          ] + Wire.recipient_information_accessors
-        }
-      end
-
-      if params.require(:user)[:payout_method_type] == User::PayoutMethod::WiseTransfer.name
-        attributes << {
-          payout_method_wise_transfer: [
-            :address_line1,
-            :address_line2,
-            :address_city,
-            :address_state,
-            :address_postal_code,
-            :recipient_country,
-            :currency,
-          ] + User::PayoutMethod::WiseTransfer.recipient_information_accessors
-        }
-      end
-
-      if params.require(:user)[:payout_method_type] == User::PayoutMethod::AchTransfer.name
-        attributes << {
-          payout_method_attributes: [
-            :account_number,
-            :routing_number
-          ]
-        }
-      end
-
-      if params.require(:user)[:payout_method_type] == User::PayoutMethod::PaypalTransfer.name
-        attributes << {
-          payout_method_attributes: [
-            :recipient_email
-          ]
-        }
-      end
-    end
-
     if superadmin_signed_in?
       attributes << :access_level
     end
 
-    p = params.require(:user).permit(attributes)
+    params.require(:user).permit(attributes)
+  end
 
-    # The Wire payout method attributes are under the `payout_method_wire` param instead of `payout_method_attributes` to prevent conflict with existing keys for other payout methods such as AchTransfer.
-    # Rails requires that DOM form inputs have unique names.
-    p[:payout_method_attributes] = p.delete(:payout_method_wire) if p[:payout_method_wire]
-    # Same thing for Wise transfer payouts
-    p[:payout_method_attributes] = p.delete(:payout_method_wise_transfer) if p[:payout_method_wise_transfer]
 
-    p
+  def payout_method_details_params
+    return {} unless @user.can_update_payout_method?
+
+    permitted =
+      case params.dig(:user, :payout_method_type)
+      when LegalEntity::PayoutMethod::Check.name
+        params.require(:user).permit(payout_method_attributes: [
+                                       :address_line1,
+                                       :address_line2,
+                                       :address_city,
+                                       :address_state,
+                                       :address_postal_code,
+                                       :address_country
+                                     ])[:payout_method_attributes]
+      when LegalEntity::PayoutMethod::Wire.name
+        params.require(:user).permit(payout_method_wire: [
+          :address_line1,
+          :address_line2,
+          :address_city,
+          :address_state,
+          :address_postal_code,
+          :recipient_country,
+          :recipient_name,
+          :bic_code,
+          :account_number
+        ] + LegalEntity::PayoutMethod::Wire.recipient_information_accessors)[:payout_method_wire]
+      when LegalEntity::PayoutMethod::WiseTransfer.name
+        params.require(:user).permit(payout_method_wise_transfer: [
+          :address_line1,
+          :address_line2,
+          :address_city,
+          :address_state,
+          :address_postal_code,
+          :recipient_country,
+          :currency,
+        ] + LegalEntity::PayoutMethod::WiseTransfer.recipient_information_accessors)[:payout_method_wise_transfer]
+      when LegalEntity::PayoutMethod::AchTransfer.name
+        params.require(:user).permit(payout_method_attributes: [
+                                       :account_number,
+                                       :routing_number
+                                     ])[:payout_method_attributes]
+      end
+
+    permitted || {}
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -330,9 +330,7 @@ class UsersController < ApplicationController
     @user.assign_attributes(user_params)
 
     payout_method_type = params.dig(:user, :payout_method_type)
-    if payout_method_type.present? && @user.can_update_payout_method?
-      @user.build_default_payout_method(payout_method_type, payout_method_details_params)
-    end
+    update_payout_method = payout_method_type.present? && @user.can_update_payout_method?
 
     if @user.use_two_factor_authentication_changed?
       return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
@@ -386,17 +384,23 @@ class UsersController < ApplicationController
       return redirect_back_or_to edit_user_path(@user)
     end
 
-    payout_method = @user.new_default_payout_method
+    payout_update = nil
     saved = ActiveRecord::Base.transaction do
       user_ok = @user.save
-      pm_ok = true
-      if payout_method
-        pm_ok = payout_method.details.save && payout_method.save
+      payout_ok = true
+      if update_payout_method
+        payout_update = LegalEntity::PayoutMethodService::Update.new(
+          user: @user,
+          details_type: payout_method_type,
+          details_attrs: payout_method_details_params
+        )
+        payout_ok = payout_update.run
       end
-      raise ActiveRecord::Rollback unless user_ok && pm_ok
+      raise ActiveRecord::Rollback unless user_ok && payout_ok
 
       true
     end
+    @payout_method = payout_update&.payout_method
 
     if saved
       confetti! if !@user.seasonal_themes_enabled_before_last_save && @user.seasonal_themes_enabled? # confetti if the user enables seasonal themes
@@ -405,7 +409,7 @@ class UsersController < ApplicationController
         flash[:success] = "Profile created!"
         redirect_to(return_to || root_path)
       else
-        if payout_method&.saved_changes? && @user == current_user
+        if @payout_method&.saved_changes? && @user == current_user
           flash[:success] = "Your payout details have been updated. We'll use this information for all payouts going forward."
         elsif email_update&.requested?
           flash[:success] = "We've sent a verification link to your new email (#{params[:user][:email]}) and a authorization link to your old email (#{@user.email}), please click them both to confirm this change."
@@ -426,11 +430,8 @@ class UsersController < ApplicationController
         return
       end
 
-      payout_method_errors = @user.errors[:payout_method] +
-                             (payout_method&.errors&.full_messages || []) +
-                             (payout_method&.details&.errors&.full_messages || [])
-      if payout_method_errors.any?
-        flash.now[:error] = payout_method_errors.to_sentence
+      if payout_update&.error_messages&.any?
+        flash.now[:error] = payout_update.error_messages.to_sentence
         render :edit_payout, status: :unprocessable_entity
         return
       end

--- a/app/models/legal_entity/payout_method.rb
+++ b/app/models/legal_entity/payout_method.rb
@@ -38,7 +38,7 @@ class LegalEntity
     self.table_name = "legal_entity_payout_methods"
 
     belongs_to :legal_entity
-    belongs_to :details, polymorphic: true, dependent: :destroy
+    belongs_to :details, polymorphic: true, dependent: :destroy, autosave: true
 
     before_save :unset_other_defaults, if: -> { default? && will_save_change_to_default? }
 

--- a/app/models/legal_entity/payout_method.rb
+++ b/app/models/legal_entity/payout_method.rb
@@ -47,12 +47,20 @@ class LegalEntity
     # type-specific presentation lives on the detail record
     delegate :kind, :icon, :name, :human_kind, :title_kind, :currency, to: :details
 
+    def self.unsupported?(details_class)
+      UNSUPPORTED_METHODS.key?(details_class)
+    end
+
+    def self.unsupported_details(details_class)
+      UNSUPPORTED_METHODS[details_class]
+    end
+
     def unsupported?
-      UNSUPPORTED_METHODS.key?(details.class)
+      self.class.unsupported?(details.class)
     end
 
     def unsupported_details
-      UNSUPPORTED_METHODS[details.class]
+      self.class.unsupported_details(details.class)
     end
 
     private

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -346,7 +346,7 @@ module Reimbursement
     end
 
     def below_minimum_amount?
-      user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
+      user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
     end
 
     def from_public_reimbursement_form?
@@ -378,7 +378,7 @@ module Reimbursement
     def convert_to_wise_transfer!(as: User.system_user)
       raise "Can only convert reports in 'Reimbursement Requested' state" unless reimbursement_requested?
 
-      payout_method = user.default_payout_method_details
+      payout_method = user.default_payout_method&.details
 
       account_holder =
         if payout_method.respond_to?(:account_holder)

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -117,7 +117,7 @@ module Reimbursement
       event :mark_submitted do
         transitions from: [:draft, :reimbursement_requested], to: :submitted do
           guard do
-            user.payout_method.present? && !user.onboarding? && event && !exceeds_maximum_amount? && !below_minimum_amount? &&
+            user.default_payout_method.present? && !user.onboarding? && event && !exceeds_maximum_amount? && !below_minimum_amount? &&
               expenses.any? && !missing_receipts? && !event.financially_frozen? && expenses.none? { |e| e.amount.zero? } &&
               !mismatched_currency? && payout_method_allowed?
           end
@@ -332,7 +332,7 @@ module Reimbursement
     end
 
     def mismatched_currency?
-      user.payout_method.present? && currency != user.payout_method.currency
+      user.default_payout_method.present? && currency != user.default_payout_method.currency
     end
 
     def exceeds_maximum_amount?
@@ -346,7 +346,7 @@ module Reimbursement
     end
 
     def below_minimum_amount?
-      user.payout_method.is_a?(User::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
+      user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
     end
 
     def from_public_reimbursement_form?
@@ -378,9 +378,11 @@ module Reimbursement
     def convert_to_wise_transfer!(as: User.system_user)
       raise "Can only convert reports in 'Reimbursement Requested' state" unless reimbursement_requested?
 
+      payout_method = user.default_payout_method_details
+
       account_holder =
-        if user.payout_method.respond_to?(:account_holder)
-          user.payout_method.account_holder.presence
+        if payout_method.respond_to?(:account_holder)
+          payout_method.account_holder.presence
         end
 
       ActiveRecord::Base.transaction do
@@ -392,14 +394,14 @@ module Reimbursement
           payment_for: name,
           recipient_name: account_holder || user.full_name,
           recipient_email: user.email,
-          address_city: user.payout_method.address_city,
-          address_line1: user.payout_method.address_line1,
-          address_line2: user.payout_method.address_line2,
-          address_postal_code: user.payout_method.address_postal_code,
-          address_state: user.payout_method.address_state,
-          bank_name: user.payout_method.bank_name,
-          recipient_country: user.payout_method.recipient_country,
-          recipient_information: user.payout_method.recipient_information,
+          address_city: payout_method.address_city,
+          address_line1: payout_method.address_line1,
+          address_line2: payout_method.address_line2,
+          address_postal_code: payout_method.address_postal_code,
+          address_state: payout_method.address_state,
+          bank_name: payout_method.bank_name,
+          recipient_country: payout_method.recipient_country,
+          recipient_information: payout_method.recipient_information,
         )
 
         comments.create!(content: "Converted to Wise transfer by @#{as.email} for processing: #{Rails.application.routes.url_helpers.hcb_code_url(wise_transfer.local_hcb_code)}", user: User.system_user)
@@ -445,7 +447,7 @@ module Reimbursement
     end
 
     def payout_method_allowed?
-      user.payout_method.present? && !user.payout_method.unsupported?
+      user.default_payout_method.present? && !user.default_payout_method.unsupported?
     end
 
     def invalidate_cached_data

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -439,10 +439,6 @@ class User < ApplicationRecord
     personal_legal_entity&.default_payout_method
   end
 
-  def default_payout_method_details
-    default_payout_method&.details
-  end
-
   # Builds (but does not save) a new default LegalEntity::PayoutMethod.
   # Memoized so the controller and form can read validation errors back off it.
   attr_reader :new_default_payout_method
@@ -608,8 +604,8 @@ class User < ApplicationRecord
   end
 
   def can_update_payout_method?
-    return true if default_payout_method_details.nil?
-    return true unless default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+    return true if default_payout_method&.details.nil?
+    return true unless default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
     return false if reimbursement_reports.reimbursement_requested.any?
     return false if reimbursement_reports.joins(:payout_holding).where({ payout_holding: { aasm_state: :pending } }).any?
 
@@ -772,7 +768,7 @@ class User < ApplicationRecord
     # Block switching to Wise while reports are being processed, but allow
     # re-saving an existing Wise method.
     if pm.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-       !default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
+       !default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
        reimbursement_reports.where(aasm_state: %i[submitted reimbursement_requested reimbursement_approved]).any?
       errors.add(:payout_method, "cannot be changed to Wise transfer with reports that are being processed. Please reach out to the HCB team if you need this changed.")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,7 +173,6 @@ class User < ApplicationRecord
   # but this is a convenient way to set up the association.
 
   belongs_to :payout_method, polymorphic: true, optional: true
-  validate :valid_payout_method
   validate :auditors_must_be_verified
   accepts_nested_attributes_for :payout_method
 
@@ -432,26 +431,11 @@ class User < ApplicationRecord
   end
 
   def personal_legal_entity
-    legal_entities.find_by(entity_type: :person)
+    @personal_legal_entity ||= legal_entities.find_by(entity_type: :person)
   end
 
   def default_payout_method
     personal_legal_entity&.default_payout_method
-  end
-
-  # Builds (but does not save) a new default LegalEntity::PayoutMethod.
-  # Memoized so the controller and form can read validation errors back off it.
-  attr_reader :new_default_payout_method
-
-  def build_default_payout_method(details_type, details_attrs)
-    details_class = details_type&.safe_constantize
-    return unless LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
-
-    @new_default_payout_method = LegalEntity::PayoutMethod.new(
-      legal_entity: personal_legal_entity,
-      default: true,
-      details: details_class.new(details_attrs)
-    )
   end
 
   def email_address_with_name(full_name: false)
@@ -753,24 +737,6 @@ class User < ApplicationRecord
       # turn all this stuff off until they reverify
       self.phone_number_verified = false
       self.use_sms_auth = false
-    end
-  end
-
-  def valid_payout_method
-    pm = new_default_payout_method
-    return unless pm
-
-    if pm.unsupported?
-      reason = pm.unsupported_details[:reason]
-      errors.add(:payout_method, "is invalid. #{reason} Please choose another option.")
-    end
-
-    # Block switching to Wise while reports are being processed, but allow
-    # re-saving an existing Wise method.
-    if pm.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-       !default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-       reimbursement_reports.where(aasm_state: %i[submitted reimbursement_requested reimbursement_approved]).any?
-      errors.add(:payout_method, "cannot be changed to Wise transfer with reports that are being processed. Please reach out to the HCB team if you need this changed.")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,6 +178,13 @@ class User < ApplicationRecord
 
   has_many :legal_entity_users
   has_many :legal_entities, through: :legal_entity_users
+  # A user always has exactly one person-type legal entity (created in
+  # create_legal_entity and enforced by LegalEntityUser#user_only_has_one_person_entity).
+  # Modeled as a has_one so it can be eager-loaded (e.g. includes(:personal_legal_entity)).
+  # has_one :through requires a singular intermediate, so we hop through a
+  # person-scoped has_one join row rather than the legal_entity_users collection.
+  has_one :person_legal_entity_user, -> { where(legal_entity_id: LegalEntity.where(entity_type: :person).select(:id)) }, class_name: "LegalEntityUser", inverse_of: :user
+  has_one :personal_legal_entity, through: :person_legal_entity_user, source: :legal_entity
 
   has_encrypted :birthday, type: :date
 
@@ -428,10 +435,6 @@ class User < ApplicationRecord
 
   memo_wise def transactions_missing_receipt_count(from: nil, to: nil)
     transactions_missing_receipt(from:, to:).size
-  end
-
-  def personal_legal_entity
-    @personal_legal_entity ||= legal_entities.find_by(entity_type: :person)
   end
 
   def default_payout_method

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -437,12 +437,12 @@ class User < ApplicationRecord
     self.payout_method = payout_method_type.constantize.new(params)
   end
 
-  def person_legal_entity
+  def personal_legal_entity
     legal_entities.find_by(entity_type: :person)
   end
 
   def default_payout_method
-    person_legal_entity&.default_payout_method
+    personal_legal_entity&.default_payout_method
   end
 
   def default_payout_method_details
@@ -458,7 +458,7 @@ class User < ApplicationRecord
     return unless LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
 
     @new_default_payout_method = LegalEntity::PayoutMethod.new(
-      legal_entity: person_legal_entity,
+      legal_entity: personal_legal_entity,
       default: true,
       details: details_class.new(details_attrs)
     )
@@ -775,7 +775,7 @@ class User < ApplicationRecord
       errors.add(:payout_method, "is invalid. #{reason} Please choose another option.")
     end
 
-    # Block switching *to* Wise while reports are being processed, but allow
+    # Block switching to Wise while reports are being processed, but allow
     # re-saving an existing Wise method.
     if pm.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
        !default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,11 +178,8 @@ class User < ApplicationRecord
 
   has_many :legal_entity_users
   has_many :legal_entities, through: :legal_entity_users
-  # A user always has exactly one person-type legal entity (created in
-  # create_legal_entity and enforced by LegalEntityUser#user_only_has_one_person_entity).
-  # Modeled as a has_one so it can be eager-loaded (e.g. includes(:personal_legal_entity)).
-  # has_one :through requires a singular intermediate, so we hop through a
-  # person-scoped has_one join row rather than the legal_entity_users collection.
+  # The user's single person-type legal entity, as a preloadable has_one.
+  # has_one :through needs a singular intermediate, so hop through a person-scoped join row.
   has_one :person_legal_entity_user, -> { where(legal_entity_id: LegalEntity.where(entity_type: :person).select(:id)) }, class_name: "LegalEntityUser", inverse_of: :user
   has_one :personal_legal_entity, through: :person_legal_entity_user, source: :legal_entity
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,12 +431,6 @@ class User < ApplicationRecord
     transactions_missing_receipt(from:, to:).size
   end
 
-  def build_payout_method(params)
-    return unless payout_method_type
-
-    self.payout_method = payout_method_type.constantize.new(params)
-  end
-
   def personal_legal_entity
     legal_entities.find_by(entity_type: :person)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -437,6 +437,33 @@ class User < ApplicationRecord
     self.payout_method = payout_method_type.constantize.new(params)
   end
 
+  def person_legal_entity
+    legal_entities.find_by(entity_type: :person)
+  end
+
+  def default_payout_method
+    person_legal_entity&.default_payout_method
+  end
+
+  def default_payout_method_details
+    default_payout_method&.details
+  end
+
+  # Builds (but does not save) a new default LegalEntity::PayoutMethod.
+  # Memoized so the controller and form can read validation errors back off it.
+  attr_reader :new_default_payout_method
+
+  def build_default_payout_method(details_type, details_attrs)
+    details_class = details_type&.safe_constantize
+    return unless LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
+
+    @new_default_payout_method = LegalEntity::PayoutMethod.new(
+      legal_entity: person_legal_entity,
+      default: true,
+      details: details_class.new(details_attrs)
+    )
+  end
+
   def email_address_with_name(full_name: false)
     display_name = full_name ? (self.full_name.presence || name) : name
     ActionMailer::Base.email_address_with_name(email, display_name)
@@ -587,8 +614,8 @@ class User < ApplicationRecord
   end
 
   def can_update_payout_method?
-    return true if payout_method.nil?
-    return true unless payout_method.is_a?(User::PayoutMethod::WiseTransfer)
+    return true if default_payout_method_details.nil?
+    return true unless default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
     return false if reimbursement_reports.reimbursement_requested.any?
     return false if reimbursement_reports.joins(:payout_holding).where({ payout_holding: { aasm_state: :pending } }).any?
 
@@ -740,18 +767,19 @@ class User < ApplicationRecord
   end
 
   def valid_payout_method
-    if payout_method_type_changed? && payout_method_type.present? && User::PayoutMethod::SUPPORTED_METHODS.none? { |method| payout_method.is_a?(method) }
-      # I'm using `try` here in the slim chance that `payout_method` is some
-      # random model and doesn't include `User::PayoutMethod::Shared`.
-      if payout_method.try(:unsupported?)
-        reason = payout_method.unsupported_details[:reason]
-        errors.add(:payout_method, "is invalid. #{reason} Please choose another option.")
-      else
-        errors.add(:payout_method, "is invalid. Please choose another option.")
-      end
+    pm = new_default_payout_method
+    return unless pm
+
+    if pm.unsupported?
+      reason = pm.unsupported_details[:reason]
+      errors.add(:payout_method, "is invalid. #{reason} Please choose another option.")
     end
 
-    if payout_method_type_changed? && payout_method.is_a?(User::PayoutMethod::WiseTransfer) && reimbursement_reports.where(aasm_state: %i[submitted reimbursement_requested reimbursement_approved]).any?
+    # Block switching *to* Wise while reports are being processed, but allow
+    # re-saving an existing Wise method.
+    if pm.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
+       !default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
+       reimbursement_reports.where(aasm_state: %i[submitted reimbursement_requested reimbursement_approved]).any?
       errors.add(:payout_method, "cannot be changed to Wise transfer with reports that are being processed. Please reach out to the HCB team if you need this changed.")
     end
   end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -27,7 +27,9 @@ class LegalEntity
         apply_business_rules
         return false if @payout_method.errors.any?
 
-        persist
+        # autosave: true on :details saves the detail record and the payout
+        # method together, atomically, even inside the controller's transaction.
+        @payout_method.save
       end
 
       def run!
@@ -37,7 +39,12 @@ class LegalEntity
       def error_messages
         return [] unless @payout_method
 
-        (@payout_method.errors.full_messages +
+        # Read base errors off the payout method (unsupported type, the Wise
+        # guards) and field errors off the details record. Autosave also mirrors
+        # the field errors onto the parent as "details.<attr>" ("Details routing
+        # number must be 9 digits"); reading the child instead keeps the clean
+        # "Routing number must be 9 digits" wording without duplication.
+        (@payout_method.errors.full_messages_for(:base) +
           (@payout_method.details&.errors&.full_messages || [])).uniq
       end
 
@@ -72,18 +79,6 @@ class LegalEntity
         @payout_method.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
           !@user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
           @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES).any?
-      end
-
-      def persist
-        saved = false
-        # requires_new so that, when called inside an outer transaction (e.g.
-        # alongside the user save in UsersController#update), a failure rolls
-        # back only this savepoint and returns false to the caller.
-        ActiveRecord::Base.transaction(requires_new: true) do
-          saved = @payout_method.details.save && @payout_method.save
-          raise ActiveRecord::Rollback unless saved
-        end
-        saved
       end
 
     end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -44,9 +44,11 @@ class LegalEntity
       private
 
       def build_payout_method
-        details_class = @details_type&.safe_constantize
+        # Resolve the user-supplied type against the allowlist by name rather
+        # than constantizing it, so arbitrary class names can never be loaded.
+        details_class = LegalEntity::PayoutMethod::ALL_METHODS.find { |klass| klass.name == @details_type }
         pm = LegalEntity::PayoutMethod.new(legal_entity: @user.personal_legal_entity, default: true)
-        pm.details = details_class.new(@details_attrs) if LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
+        pm.details = details_class.new(@details_attrs) if details_class
         pm
       end
 

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class LegalEntity
+  module PayoutMethodService
+    # Builds, validates, and persists a user's default personal-legal-entity
+    # payout method. Encapsulates the business rules that previously lived
+    # across User#build_default_payout_method, User#valid_payout_method,
+    # User#can_update_payout_method?, and the UsersController#update transaction.
+    #
+    # On failure, #run returns false and the (unsaved) payout method, exposed
+    # via #payout_method, carries the relevant errors.
+    class Update
+      # Report states that count as "being processed" for the purpose of
+      # blocking a switch to Wise.
+      PROCESSING_STATES = %i[submitted reimbursement_requested reimbursement_approved].freeze
+
+      attr_reader :payout_method
+
+      def initialize(user:, details_type:, details_attrs: {})
+        @user = user
+        @details_type = details_type
+        @details_attrs = details_attrs || {}
+      end
+
+      def run
+        @payout_method = build_payout_method
+        apply_business_rules
+        return false if @payout_method.errors.any?
+
+        persist
+      end
+
+      def run!
+        run || raise(ActiveRecord::RecordInvalid, @payout_method)
+      end
+
+      def error_messages
+        return [] unless @payout_method
+
+        (@payout_method.errors.full_messages +
+          (@payout_method.details&.errors&.full_messages || [])).uniq
+      end
+
+      private
+
+      def build_payout_method
+        details_class = @details_type&.safe_constantize
+        pm = LegalEntity::PayoutMethod.new(legal_entity: @user.personal_legal_entity, default: true)
+        pm.details = details_class.new(@details_attrs) if LegalEntity::PayoutMethod::ALL_METHODS.include?(details_class)
+        pm
+      end
+
+      def apply_business_rules
+        unless @user.can_update_payout_method?
+          @payout_method.errors.add(:base, "can't be changed while a reimbursement is being processed. Please reach out to the HCB team if you need this changed.")
+          return
+        end
+
+        if @payout_method.details.nil?
+          @payout_method.errors.add(:base, "is invalid. Please choose another method.")
+          return
+        end
+
+        if switching_to_wise_while_processing?
+          @payout_method.errors.add(:base, "cannot be changed to Wise transfer with reports that are being processed. Please reach out to the HCB team if you need this changed.")
+        end
+      end
+
+      def switching_to_wise_while_processing?
+        @payout_method.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
+          !@user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
+          @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES).any?
+      end
+
+      def persist
+        saved = false
+        # requires_new so that, when called inside an outer transaction (e.g.
+        # alongside the user save in UsersController#update), a failure rolls
+        # back only this savepoint and returns false to the caller.
+        ActiveRecord::Base.transaction(requires_new: true) do
+          saved = @payout_method.details.save && @payout_method.save
+          raise ActiveRecord::Rollback unless saved
+        end
+        saved
+      end
+
+    end
+  end
+
+end

--- a/app/services/payroll_service/nightly.rb
+++ b/app/services/payroll_service/nightly.rb
@@ -6,7 +6,7 @@ module PayrollService
       Employee::Payment.approved.find_each(batch_size: 100) do |payment|
         next if payment.payout.present?
 
-        payout_method = payment.employee.user.default_payout_method_details
+        payout_method = payment.employee.user.default_payout_method&.details
 
         case payout_method
         when LegalEntity::PayoutMethod::Check

--- a/app/services/payroll_service/nightly.rb
+++ b/app/services/payroll_service/nightly.rb
@@ -6,21 +6,23 @@ module PayrollService
       Employee::Payment.approved.find_each(batch_size: 100) do |payment|
         next if payment.payout.present?
 
-        case payment.employee.user.payout_method
-        when User::PayoutMethod::Check
+        payout_method = payment.employee.user.default_payout_method_details
+
+        case payout_method
+        when LegalEntity::PayoutMethod::Check
           safely do
             check = payment.employee.event.increase_checks.build(
               memo: "Payment for \"#{payment.title}\"."[0...40],
               amount: payment.amount_cents,
               payment_for: "Payment for \"#{payment.title}\".",
               recipient_name: payment.employee.user.full_name,
-              address_line1: payment.employee.user.payout_method.address_line1,
-              address_line2: payment.employee.user.payout_method.address_line2,
-              address_city: payment.employee.user.payout_method.address_city,
-              address_state: payment.employee.user.payout_method.address_state,
+              address_line1: payout_method.address_line1,
+              address_line2: payout_method.address_line2,
+              address_city: payout_method.address_city,
+              address_state: payout_method.address_state,
               recipient_email: payment.employee.user.email,
               send_email_notification: false,
-              address_zip: payment.employee.user.payout_method.address_postal_code,
+              address_zip: payout_method.address_postal_code,
               user: User.system_user
             )
 
@@ -38,7 +40,7 @@ module PayrollService
 
             check.send_check! if payment.previously_paid?
           end
-        when User::PayoutMethod::AchTransfer
+        when LegalEntity::PayoutMethod::AchTransfer
           safely do
             ach_transfer = payment.employee.event.ach_transfers.build(
               amount: payment.amount_cents,
@@ -46,9 +48,9 @@ module PayrollService
               recipient_name: payment.employee.user.full_name,
               recipient_email: payment.employee.user.email,
               send_email_notification: false,
-              routing_number: payment.employee.user.payout_method.routing_number,
-              account_number: payment.employee.user.payout_method.account_number,
-              bank_name: (ColumnService.get("/institutions/#{payment.employee.user.payout_method.routing_number}")["full_name"] rescue "Bank Account"),
+              routing_number: payout_method.routing_number,
+              account_number: payout_method.account_number,
+              bank_name: (ColumnService.get("/institutions/#{payout_method.routing_number}")["full_name"] rescue "Bank Account"),
               creator: User.system_user,
               company_entry_description: "SALARY",
             )
@@ -73,26 +75,6 @@ module PayrollService
                 payment.mark_failed!
               end
             end
-          end
-        when User::PayoutMethod::PaypalTransfer
-          safely do
-            paypal_transfer = payment.employee.event.paypal_transfers.build(
-              amount_cents: payment.amount_cents,
-              payment_for: "Payment for \"#{payment.title}\".",
-              memo: "Payment for \"#{payment.title}\".",
-              recipient_email: payment.employee.user.payout_method.recipient_email,
-              recipient_name: payment.employee.user.name,
-              user: User.system_user
-            )
-            paypal_transfer.save!
-            payment.payout = paypal_transfer
-            payment.save!
-            ::ReceiptService::Create.new(
-              uploader: payment.employee.user,
-              attachments: [payment.invoice.file.blob],
-              upload_method: :employee_payment,
-              receiptable: paypal_transfer.local_hcb_code
-            ).run!
           end
         else
           raise ArgumentError, "🚨⚠️ unsupported payout method!"

--- a/app/services/reimbursement/expense_payout_service/nightly.rb
+++ b/app/services/reimbursement/expense_payout_service/nightly.rb
@@ -5,13 +5,13 @@ module Reimbursement
     class Nightly
       def run
         Reimbursement::ExpensePayout.pending.find_each(batch_size: 100) do |expense_payout|
-          next if expense_payout.expense.report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name
+          next if expense_payout.expense.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::ExpensePayoutService::ProcessSingle.new(expense_payout_id: expense_payout.id).run
         end
 
         Reimbursement::PayoutHolding.pending.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name
+          next if payout_holding.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::PayoutHoldingService::ProcessSingle.new(payout_holding_id: payout_holding.id).run
         end
@@ -23,7 +23,7 @@ module Reimbursement
         end
 
         Reimbursement::PayoutHolding.in_transit.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name
+          next if payout_holding.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           if payout_holding.canonical_transactions.any? || payout_holding.canonical_pending_transaction.present?
             payout_holding.mark_settled!

--- a/app/services/reimbursement/expense_payout_service/nightly.rb
+++ b/app/services/reimbursement/expense_payout_service/nightly.rb
@@ -5,13 +5,13 @@ module Reimbursement
     class Nightly
       def run
         Reimbursement::ExpensePayout.pending.find_each(batch_size: 100) do |expense_payout|
-          next if expense_payout.expense.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if expense_payout.expense.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::ExpensePayoutService::ProcessSingle.new(expense_payout_id: expense_payout.id).run
         end
 
         Reimbursement::PayoutHolding.pending.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if payout_holding.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::PayoutHoldingService::ProcessSingle.new(payout_holding_id: payout_holding.id).run
         end
@@ -23,7 +23,7 @@ module Reimbursement
         end
 
         Reimbursement::PayoutHolding.in_transit.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if payout_holding.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           if payout_holding.canonical_transactions.any? || payout_holding.canonical_pending_transaction.present?
             payout_holding.mark_settled!

--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -9,28 +9,30 @@ module Reimbursement
           payout_holding.with_lock do
             next unless payout_holding.settled?
 
-            case payout_holding.report.user.payout_method
-            when User::PayoutMethod::Wire
+            payout_method = payout_holding.report.user.default_payout_method_details
+
+            case payout_method
+            when LegalEntity::PayoutMethod::Wire
               Rails.error.handle do
                 wire = clearinghouse.wires.build(
                   memo: "Reimbursement for #{payout_holding.report.name}.",
                   payment_for: "Reimbursement for #{payout_holding.report.name}."[0...140],
                   amount_cents: payout_holding.amount_cents,
-                  address_line1: payout_holding.report.user.payout_method.address_line1,
-                  address_line2: payout_holding.report.user.payout_method.address_line2,
-                  address_city: payout_holding.report.user.payout_method.address_city,
-                  address_state: payout_holding.report.user.payout_method.address_state,
-                  address_postal_code: payout_holding.report.user.payout_method.address_postal_code,
-                  recipient_country: payout_holding.report.user.payout_method.recipient_country,
+                  address_line1: payout_method.address_line1,
+                  address_line2: payout_method.address_line2,
+                  address_city: payout_method.address_city,
+                  address_state: payout_method.address_state,
+                  address_postal_code: payout_method.address_postal_code,
+                  recipient_country: payout_method.recipient_country,
                   recipient_email: payout_holding.report.user.email,
                   send_email_notification: false,
-                  recipient_name: payout_holding.report.user.payout_method.recipient_name.presence || payout_holding.report.user.full_name,
-                  account_number: payout_holding.report.user.payout_method.account_number,
-                  bic_code: payout_holding.report.user.payout_method.bic_code,
-                  recipient_information: payout_holding.report.user.payout_method.recipient_information.merge({
-                                                                                                                purpose_code: Wire.reimbursement_purpose_code_for(payout_holding.report.user.payout_method.recipient_country),
-                                                                                                                remittance_info: Wire.reimbursement_remittance_info_for(payout_holding.report.user.payout_method.recipient_country),
-                                                                                                              }),
+                  recipient_name: payout_method.recipient_name.presence || payout_holding.report.user.full_name,
+                  account_number: payout_method.account_number,
+                  bic_code: payout_method.bic_code,
+                  recipient_information: payout_method.recipient_information.merge({
+                                                                                     purpose_code: Wire.reimbursement_purpose_code_for(payout_method.recipient_country),
+                                                                                     remittance_info: Wire.reimbursement_remittance_info_for(payout_method.recipient_country),
+                                                                                   }),
                   currency: "USD",
                   user: User.system_user
                 )
@@ -52,20 +54,20 @@ module Reimbursement
                   payout_holding.mark_sent!
                 end
               end
-            when User::PayoutMethod::Check
+            when LegalEntity::PayoutMethod::Check
               Rails.error.handle do
                 check = clearinghouse.increase_checks.build(
                   memo: "Reimbursement for #{payout_holding.report.name}."[0...40],
                   amount: payout_holding.amount_cents,
                   payment_for: "Reimbursement for #{payout_holding.report.name}.",
                   recipient_name: payout_holding.report.user.full_name,
-                  address_line1: payout_holding.report.user.payout_method.address_line1,
-                  address_line2: payout_holding.report.user.payout_method.address_line2,
-                  address_city: payout_holding.report.user.payout_method.address_city,
-                  address_state: payout_holding.report.user.payout_method.address_state,
+                  address_line1: payout_method.address_line1,
+                  address_line2: payout_method.address_line2,
+                  address_city: payout_method.address_city,
+                  address_state: payout_method.address_state,
                   recipient_email: payout_holding.report.user.email,
                   send_email_notification: false,
-                  address_zip: payout_holding.report.user.payout_method.address_postal_code,
+                  address_zip: payout_method.address_postal_code,
                   user: User.system_user
                 )
                 check.save!
@@ -80,7 +82,7 @@ module Reimbursement
                   Rails.error.unexpected "[reimbursements / check issuing] #{message}. report ID: #{payout_holding.report.id}"
                 end
               end
-            when User::PayoutMethod::AchTransfer
+            when LegalEntity::PayoutMethod::AchTransfer
               Rails.error.handle do
                 ach_transfer = clearinghouse.ach_transfers.build(
                   amount: payout_holding.amount_cents,
@@ -88,9 +90,9 @@ module Reimbursement
                   recipient_name: payout_holding.report.user.full_name,
                   recipient_email: payout_holding.report.user.email,
                   send_email_notification: false,
-                  routing_number: payout_holding.report.user.payout_method.routing_number,
-                  account_number: payout_holding.report.user.payout_method.account_number,
-                  bank_name: (ColumnService.get("/institutions/#{payout_holding.report.user.payout_method.routing_number}")["full_name"] rescue "Bank Account"),
+                  routing_number: payout_method.routing_number,
+                  account_number: payout_method.account_number,
+                  bank_name: (ColumnService.get("/institutions/#{payout_method.routing_number}")["full_name"] rescue "Bank Account"),
                   creator: User.system_user,
                   company_entry_description: "REIMBURSE"
                 )
@@ -110,22 +112,7 @@ module Reimbursement
                   payout_holding.mark_sent!
                 end
               end
-            when User::PayoutMethod::PaypalTransfer
-              Rails.error.handle do
-                paypal_transfer = clearinghouse.paypal_transfers.build(
-                  amount_cents: payout_holding.amount_cents,
-                  payment_for: "Reimbursement for #{payout_holding.report.name}.",
-                  memo: "Reimbursement for #{payout_holding.report.name}.",
-                  recipient_email: payout_holding.report.user.payout_method.recipient_email,
-                  recipient_name: payout_holding.report.user.name,
-                  user: User.system_user,
-                )
-                paypal_transfer.save!
-                payout_holding.paypal_transfer = paypal_transfer
-                payout_holding.save!
-                payout_holding.mark_sent!
-              end
-            when User::PayoutMethod::WiseTransfer
+            when LegalEntity::PayoutMethod::WiseTransfer
               if payout_holding.created_at < 20.minutes.ago
                 Rails.error.unexpected "🚨 WiseTransfer payout holding (#{payout_holding.id}) created more than 20 minutes ago but still unsent."
               end

--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -9,7 +9,7 @@ module Reimbursement
           payout_holding.with_lock do
             next unless payout_holding.settled?
 
-            payout_method = payout_holding.report.user.default_payout_method_details
+            payout_method = payout_holding.report.user.default_payout_method&.details
 
             case payout_method
             when LegalEntity::PayoutMethod::Wire

--- a/app/views/employee/payment_mailer/approved.html.erb
+++ b/app/views/employee/payment_mailer/approved.html.erb
@@ -9,15 +9,6 @@
 
 <% payout_method = @employee.user&.payout_method&.details %>
 <p>
-<<<<<<< Updated upstream
-  <% if @employee.user&.default_payout_method&.kind == "check" %>
-    You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.
-  <% elsif @employee.user&.default_payout_method&.kind == "ach_transfer" %>
-    You'll receive an ACH transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
-  <% elsif @employee.user&.default_payout_method&.kind == "paypal_transfer" %>
-    You'll receive an PayPal transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
-  <% elsif @employee.user&.default_payout_method&.kind == "international_wire" %>
-=======
   <% if payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.
   <% elsif payout_method&.kind == "ach_transfer" %>
@@ -25,7 +16,6 @@
   <% elsif payout_method&.kind == "paypal_transfer" %>
     You'll receive an PayPal transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
   <% elsif payout_method&.kind == "international_wire" %>
->>>>>>> Stashed changes
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/employee/payment_mailer/approved.html.erb
+++ b/app/views/employee/payment_mailer/approved.html.erb
@@ -7,7 +7,9 @@
   <em><%= @payment.title %></em>.
 </p>
 
+<% payout_method = @employee.user&.payout_method&.details %>
 <p>
+<<<<<<< Updated upstream
   <% if @employee.user&.default_payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.
   <% elsif @employee.user&.default_payout_method&.kind == "ach_transfer" %>
@@ -15,6 +17,15 @@
   <% elsif @employee.user&.default_payout_method&.kind == "paypal_transfer" %>
     You'll receive an PayPal transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
   <% elsif @employee.user&.default_payout_method&.kind == "international_wire" %>
+=======
+  <% if payout_method&.kind == "check" %>
+    You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.
+  <% elsif payout_method&.kind == "ach_transfer" %>
+    You'll receive an ACH transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
+  <% elsif payout_method&.kind == "paypal_transfer" %>
+    You'll receive an PayPal transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
+  <% elsif payout_method&.kind == "international_wire" %>
+>>>>>>> Stashed changes
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/employee/payment_mailer/approved.html.erb
+++ b/app/views/employee/payment_mailer/approved.html.erb
@@ -8,13 +8,13 @@
 </p>
 
 <p>
-  <% if @employee.user&.payout_method&.kind == "check" %>
+  <% if @employee.user&.default_payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.
-  <% elsif @employee.user&.payout_method&.kind == "ach_transfer" %>
+  <% elsif @employee.user&.default_payout_method&.kind == "ach_transfer" %>
     You'll receive an ACH transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
-  <% elsif @employee.user&.payout_method&.kind == "paypal_transfer" %>
+  <% elsif @employee.user&.default_payout_method&.kind == "paypal_transfer" %>
     You'll receive an PayPal transfer of <%= render_money @payment.amount_cents %> from us in approximately 2-3 business days.
-  <% elsif @employee.user&.payout_method&.kind == "international_wire" %>
+  <% elsif @employee.user&.default_payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/employee/payment_mailer/approved.html.erb
+++ b/app/views/employee/payment_mailer/approved.html.erb
@@ -7,7 +7,7 @@
   <em><%= @payment.title %></em>.
 </p>
 
-<% payout_method = @employee.user&.payout_method&.details %>
+<% payout_method = @employee.user&.default_payout_method&.details %>
 <p>
   <% if payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @payment.amount_cents %> from us in approximately 10-12 business days.

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -245,7 +245,7 @@
                 <span class="bold warning">⚠️ Warning</span>: this organization is currently financially frozen.
               <% end %>
             <% end %>
-            <% if report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+            <% if report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
               <button class="btn bg-info whitespace-nowrap" data-behavior="modal_trigger" data-modal="convert_to_wise_transfer" id="submit_button">
                 <%= inline_icon "thumbsup" %>
                 Approve & send Wise reimbursement
@@ -287,8 +287,8 @@
                     </strong>
                   </div>
 
-                  <% if report.user.default_payout_method_details.wise_recipient_id.present? %>
-                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method_details.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+                  <% if report.user.default_payout_method&.details.wise_recipient_id.present? %>
+                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method&.details.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>
@@ -395,7 +395,7 @@
           <%= button_hint %>
         </div>
       <% end %>
-      <% if report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+      <% if report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <div class="card mt-2">
           <%= turbo_frame_tag :wise_transfer_breakdown, loading: :lazy, src: reimbursement_report_wise_transfer_breakdown_path(report) do %>
             Fetching latest estimate...

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -288,7 +288,7 @@
                   </div>
 
                   <% if report.user.default_payout_method&.details.wise_recipient_id.present? %>
-                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method&.details.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method&.details&.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -246,11 +246,7 @@
                 <span class="bold warning">⚠️ Warning</span>: this organization is currently financially frozen.
               <% end %>
             <% end %>
-<<<<<<< Updated upstream
-            <% if report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
-=======
             <% if payout_method.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
->>>>>>> Stashed changes
               <button class="btn bg-info whitespace-nowrap" data-behavior="modal_trigger" data-modal="convert_to_wise_transfer" id="submit_button">
                 <%= inline_icon "thumbsup" %>
                 Approve & send Wise reimbursement

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -85,7 +85,7 @@
       <% end %>
 
       <div style="flex-grow: 1;" class="flex sm:justify-end" id="action-right">
-        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.unsupported?) || report.mismatched_currency? %>
+        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.details.unsupported?) || report.mismatched_currency? %>
           <% if user == current_user %>
             <%= link_to settings_payouts_path, class: "btn bg-warning h-9 min-h-9", data: { behavior: "modal_trigger", modal: "edit_payout" } do %>
               <%= inline_icon "profile" %>
@@ -95,8 +95,8 @@
                   <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.default_payout_method.currency %>.
                 <% else %>
                   <span class="bold">Your next step:</span> before you can be reimbursed, you need to
-                  <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
-                    update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
+                  <% if user.default_payout_method.present? && user.default_payout_method.details.unsupported? %>
+                    update your payout information. <%= user.default_payout_method.details.unsupported_details[:reason] %>
                   <% else %>
                     provide HCB your payout information.
                   <% end %>
@@ -119,8 +119,8 @@
               <%= report.payout_holding&.failed? ? "Edit" : "Add" %> <%= user.first_name %>'s payout information
               <% button_hint = capture do %>
                 <span class="bold">Status:</span> before <%= user.first_name %> can be reimbursed, they need to
-                <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
-                  update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
+                <% if user.default_payout_method.present? && user.default_payout_method.details.unsupported? %>
+                  update your payout information. <%= user.default_payout_method.details.unsupported_details[:reason] %>
                 <% else %>
                   add their payout information.
                 <% end %>
@@ -288,13 +288,8 @@
                     </strong>
                   </div>
 
-<<<<<<< Updated upstream
-                  <% if report.user.default_payout_method&.details.wise_recipient_id.present? %>
-                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method&.details&.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
-=======
                   <% if payout_method.wise_recipient_id.present? %>
                     <%= link_to "https://wise.com/send#?contact=#{payout_method.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
->>>>>>> Stashed changes
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>
@@ -349,11 +344,7 @@
             <% else %>
               <%= link_to reimbursement_report_admin_approve_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", method: :post, data: { turbo_confirm: } do %>
                 <%= inline_icon "thumbsup" %>
-<<<<<<< Updated upstream
-                Approve <%= report.user.default_payout_method.human_kind %> reimbursement
-=======
                 Approve <%= payout_method.human_kind %> reimbursement
->>>>>>> Stashed changes
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -1,4 +1,5 @@
 <% member_viewing = !OrganizerPosition.role_at_least?(current_user, report.event, :manager) && current_user != report.user && !admin_signed_in? %>
+<% payout_method = report.user.payout_method&.details %>
 
 <div id="action-wrapper" class="mt-5">
   <% button_hint = "" %>
@@ -245,7 +246,11 @@
                 <span class="bold warning">⚠️ Warning</span>: this organization is currently financially frozen.
               <% end %>
             <% end %>
+<<<<<<< Updated upstream
             <% if report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+=======
+            <% if payout_method.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+>>>>>>> Stashed changes
               <button class="btn bg-info whitespace-nowrap" data-behavior="modal_trigger" data-modal="convert_to_wise_transfer" id="submit_button">
                 <%= inline_icon "thumbsup" %>
                 Approve & send Wise reimbursement
@@ -287,8 +292,13 @@
                     </strong>
                   </div>
 
+<<<<<<< Updated upstream
                   <% if report.user.default_payout_method&.details.wise_recipient_id.present? %>
                     <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method&.details&.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+=======
+                  <% if payout_method.wise_recipient_id.present? %>
+                    <%= link_to "https://wise.com/send#?contact=#{payout_method.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+>>>>>>> Stashed changes
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>
@@ -343,7 +353,11 @@
             <% else %>
               <%= link_to reimbursement_report_admin_approve_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", method: :post, data: { turbo_confirm: } do %>
                 <%= inline_icon "thumbsup" %>
+<<<<<<< Updated upstream
                 Approve <%= report.user.default_payout_method.human_kind %> reimbursement
+=======
+                Approve <%= payout_method.human_kind %> reimbursement
+>>>>>>> Stashed changes
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -1,5 +1,5 @@
 <% member_viewing = !OrganizerPosition.role_at_least?(current_user, report.event, :manager) && current_user != report.user && !admin_signed_in? %>
-<% payout_method = report.user.payout_method&.details %>
+<% payout_method = report.user.default_payout_method&.details %>
 
 <div id="action-wrapper" class="mt-5">
   <% button_hint = "" %>
@@ -85,7 +85,7 @@
       <% end %>
 
       <div style="flex-grow: 1;" class="flex sm:justify-end" id="action-right">
-        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.details.unsupported?) || report.mismatched_currency? %>
+        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.unsupported?) || report.mismatched_currency? %>
           <% if user == current_user %>
             <%= link_to settings_payouts_path, class: "btn bg-warning h-9 min-h-9", data: { behavior: "modal_trigger", modal: "edit_payout" } do %>
               <%= inline_icon "profile" %>
@@ -95,8 +95,8 @@
                   <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.default_payout_method.currency %>.
                 <% else %>
                   <span class="bold">Your next step:</span> before you can be reimbursed, you need to
-                  <% if user.default_payout_method.present? && user.default_payout_method.details.unsupported? %>
-                    update your payout information. <%= user.default_payout_method.details.unsupported_details[:reason] %>
+                  <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
+                    update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
                   <% else %>
                     provide HCB your payout information.
                   <% end %>
@@ -119,8 +119,8 @@
               <%= report.payout_holding&.failed? ? "Edit" : "Add" %> <%= user.first_name %>'s payout information
               <% button_hint = capture do %>
                 <span class="bold">Status:</span> before <%= user.first_name %> can be reimbursed, they need to
-                <% if user.default_payout_method.present? && user.default_payout_method.details.unsupported? %>
-                  update your payout information. <%= user.default_payout_method.details.unsupported_details[:reason] %>
+                <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
+                  update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
                 <% else %>
                   add their payout information.
                 <% end %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -78,24 +78,24 @@
         <div style="flex-grow: 1;" class="flex sm:justify-end">
           <%= link_to reimbursement_report_update_currency_path(report), method: :post, class: "btn bg-secondary" do %>
             <%= inline_icon "transactions" %>
-            Switch to <%= user.payout_method&.currency %>
+            Switch to <%= user.default_payout_method&.currency %>
           <% end %>
         </div>
       <% end %>
 
       <div style="flex-grow: 1;" class="flex sm:justify-end" id="action-right">
-        <% if !user.payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.payout_method.present? && user.payout_method.unsupported?) || report.mismatched_currency? %>
+        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.unsupported?) || report.mismatched_currency? %>
           <% if user == current_user %>
             <%= link_to settings_payouts_path, class: "btn bg-warning h-9 min-h-9", data: { behavior: "modal_trigger", modal: "edit_payout" } do %>
               <%= inline_icon "profile" %>
-              <%= report.payout_holding&.failed? || user.payout_method.present? ? "Edit" : "Add" %> payout information
+              <%= report.payout_holding&.failed? || user.default_payout_method.present? ? "Edit" : "Add" %> payout information
               <% button_hint = capture do %>
                 <% if report.mismatched_currency? %>
-                  <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.payout_method.currency %>.
+                  <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.default_payout_method.currency %>.
                 <% else %>
                   <span class="bold">Your next step:</span> before you can be reimbursed, you need to
-                  <% if user.payout_method.present? && user.payout_method.unsupported? %>
-                    update your payout information. <%= user.payout_method.unsupported_details[:reason] %>
+                  <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
+                    update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
                   <% else %>
                     provide HCB your payout information.
                   <% end %>
@@ -108,7 +108,7 @@
                 <%= inline_icon "send" %>
                 Submit & request review
                 <% button_hint = capture do %>
-                  <span class="bold warning">Warning</span>: this report is is in <%= report.currency %>, but the user's payouts are configured for <%= user.payout_method.currency %>.
+                  <span class="bold warning">Warning</span>: this report is is in <%= report.currency %>, but the user's payouts are configured for <%= user.default_payout_method.currency %>.
                 <% end %>
               </div>
             </div>
@@ -118,14 +118,14 @@
               <%= report.payout_holding&.failed? ? "Edit" : "Add" %> <%= user.first_name %>'s payout information
               <% button_hint = capture do %>
                 <span class="bold">Status:</span> before <%= user.first_name %> can be reimbursed, they need to
-                <% if user.payout_method.present? && user.payout_method.unsupported? %>
-                  update your payout information. <%= user.payout_method.unsupported_details[:reason] %>
+                <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
+                  update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
                 <% else %>
                   add their payout information.
                 <% end %>
               <% end %>
             <% end %>
-          <% elsif !user.payout_method.present? %>
+          <% elsif !user.default_payout_method.present? %>
             <div class="tooltipped tooltipped--n" aria-label="<%= user.name %> is missing payout information.">
               <div class="btn bg-info disabled whitespace-nowrap">
                 <%= inline_icon "send" %>
@@ -139,11 +139,11 @@
           <% if report.payout_holding&.failed? %>
             <% if user == current_user %>
               <% button_hint = capture do %>
-                <span class="bold">Warning:</span> your <%= user.payout_method.human_kind %> information was flagged as invalid, please edit your payout settings and HCB will retry the payment.
+                <span class="bold">Warning:</span> your <%= user.default_payout_method.human_kind %> information was flagged as invalid, please edit your payout settings and HCB will retry the payment.
               <% end %>
             <% else %>
               <% button_hint = capture do %>
-                <span class="bold">Warning:</span> <%= user.first_name %>'s <%= user.payout_method.human_kind %> information was flagged as invalid, please ask them to edit their payout settings and HCB will retry the payment.
+                <span class="bold">Warning:</span> <%= user.first_name %>'s <%= user.default_payout_method.human_kind %> information was flagged as invalid, please ask them to edit their payout settings and HCB will retry the payment.
               <% end %>
             <% end %>
           <% end %>
@@ -245,7 +245,7 @@
                 <span class="bold warning">⚠️ Warning</span>: this organization is currently financially frozen.
               <% end %>
             <% end %>
-            <% if report.user.payout_method.is_a?(User::PayoutMethod::WiseTransfer) %>
+            <% if report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
               <button class="btn bg-info whitespace-nowrap" data-behavior="modal_trigger" data-modal="convert_to_wise_transfer" id="submit_button">
                 <%= inline_icon "thumbsup" %>
                 Approve & send Wise reimbursement
@@ -287,8 +287,8 @@
                     </strong>
                   </div>
 
-                  <% if report.user.payout_method.wise_recipient_id.present? %>
-                    <%= link_to "https://wise.com/send#?contact=#{report.user.payout_method.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
+                  <% if report.user.default_payout_method_details.wise_recipient_id.present? %>
+                    <%= link_to "https://wise.com/send#?contact=#{report.user.default_payout_method_details.wise_recipient_id}", class: "btn btn-small tooltipped tooltipped--w bg-[#9FE870] text-[#163300] flex-shrink-0", style: "color: #163300!important; background: #9FE870", target: "_blank", "aria-label": "Use recipient information from previous transfer" do %>
                       <%= inline_icon "wise" %>
                       Open <%= report.user.full_name %> on Wise
                     <% end %>
@@ -343,7 +343,7 @@
             <% else %>
               <%= link_to reimbursement_report_admin_approve_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", method: :post, data: { turbo_confirm: } do %>
                 <%= inline_icon "thumbsup" %>
-                Approve <%= report.user.payout_method.human_kind %> reimbursement
+                Approve <%= report.user.default_payout_method.human_kind %> reimbursement
               <% end %>
             <% end %>
           <% end %>
@@ -395,7 +395,7 @@
           <%= button_hint %>
         </div>
       <% end %>
-      <% if report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name %>
+      <% if report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <div class="card mt-2">
           <%= turbo_frame_tag :wise_transfer_breakdown, loading: :lazy, src: reimbursement_report_wise_transfer_breakdown_path(report) do %>
             Fetching latest estimate...

--- a/app/views/reimbursement/reports/_create_form.html.erb
+++ b/app/views/reimbursement/reports/_create_form.html.erb
@@ -38,10 +38,10 @@
         </div>
       </fieldset>
       <div id="currency_wrapper">
-        <% if current_user.payout_method_type == User::PayoutMethod::WiseTransfer.name %>
+        <% if current_user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
           <div class="field">
             <%= form.label :currency, "Currency", class: "mt-4 bold" %>
-            <%= form.select :currency, [current_user.payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
+            <%= form.select :currency, [current_user.default_payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
           </div>
         <% end %>
       </div>
@@ -76,17 +76,17 @@
       <%= form.label :event_id, "Organization", class: "mt1 bold" %>
       <%= form.select(:event_id, current_user.reimbursement_event_options) %>
 
-      <% if current_user.payout_method_type == User::PayoutMethod::WiseTransfer.name %>
+      <% if current_user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <%= form.label :currency, "Currency", class: "mt-4 bold" %>
-        <%= form.select :currency, [current_user.payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
+        <%= form.select :currency, [current_user.default_payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
       <% end %>
 
       <% if defined?(receipt) %>
-        <% payout_currency = current_user.payout_method&.currency || "USD" %>
+        <% payout_currency = current_user.default_payout_method&.currency || "USD" %>
 
         <%= form.label :value, "Amount", class: "mt1 bold" %>
         <div class="flex items-center">
-          <span class="bold muted flex self-end items-center justify-center" style="width: 1rem; height: 48px;"><%= Money::Currency.new(current_user.payout_method&.currency || "USD").symbol %></span>
+          <span class="bold muted flex self-end items-center justify-center" style="width: 1rem; height: 48px;"><%= Money::Currency.new(current_user.default_payout_method&.currency || "USD").symbol %></span>
           <div class="ml1">
             <% value = Money.from_cents(receipt.extracted_total_amount_cents, payout_currency).amount if (receipt.extracted_currency || "USD") == payout_currency && receipt.extracted_total_amount_cents.present? %>
 

--- a/app/views/reimbursement/reports/_create_form.html.erb
+++ b/app/views/reimbursement/reports/_create_form.html.erb
@@ -38,7 +38,7 @@
         </div>
       </fieldset>
       <div id="currency_wrapper">
-        <% if current_user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+        <% if current_user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
           <div class="field">
             <%= form.label :currency, "Currency", class: "mt-4 bold" %>
             <%= form.select :currency, [current_user.default_payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
@@ -76,7 +76,7 @@
       <%= form.label :event_id, "Organization", class: "mt1 bold" %>
       <%= form.select(:event_id, current_user.reimbursement_event_options) %>
 
-      <% if current_user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+      <% if current_user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <%= form.label :currency, "Currency", class: "mt-4 bold" %>
         <%= form.select :currency, [current_user.default_payout_method.currency], {}, class: "tooltipped tooltipped--n", "aria-label": "To change the currency, please update your payout settings", disabled: "disabled" %>
       <% end %>

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (report:) %>
 
 <% user = report.user %>
-<% payout_method = user.default_payout_method_details %>
+<% payout_method = user.default_payout_method&.details %>
 
 <h3 class="mt-0">Payout information</h3>
 

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (report:) %>
 
 <% user = report.user %>
-<% payout_method = user.payout_method %>
+<% payout_method = user.default_payout_method_details %>
 
 <h3 class="mt-0">Payout information</h3>
 
@@ -27,7 +27,7 @@
         <td><%= user.email %></td>
       </tr>
 
-      <% if payout_method.is_a?(User::PayoutMethod::AchTransfer) %>
+      <% if payout_method.is_a?(LegalEntity::PayoutMethod::AchTransfer) %>
         <tr>
           <td>Routing number:</td>
           <td><%= payout_method.routing_number %></td>
@@ -37,7 +37,7 @@
           <td><%= payout_method.account_number %></td>
         </tr>
 
-      <% elsif payout_method.is_a?(User::PayoutMethod::Check) %>
+      <% elsif payout_method.is_a?(LegalEntity::PayoutMethod::Check) %>
         <tr>
           <td>Address (Line 1):</td>
           <td><%= payout_method.address_line1 %></td>
@@ -65,7 +65,7 @@
           <td><%= payout_method.address_country %></td>
         </tr>
 
-      <% elsif payout_method.is_a?(User::PayoutMethod::Wire) %>
+      <% elsif payout_method.is_a?(LegalEntity::PayoutMethod::Wire) %>
         <tr>
           <td>Currency:</td>
           <td><%= payout_method.currency %></td>
@@ -113,7 +113,7 @@
           <% end %>
         <% end %>
 
-      <% elsif payout_method.is_a?(User::PayoutMethod::WiseTransfer) %>
+      <% elsif payout_method.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <tr>
           <td>Currency:</td>
           <td><%= payout_method.currency %></td>

--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -1,5 +1,7 @@
 <%# locals: (report:) %>
 
+<% payout_method = report.user.default_payout_method_details %>
+
 <table class="w-full table-fixed my-6">
   <tbody>
     <tr>
@@ -24,13 +26,13 @@
     <tr>
       <td>Name on account:</td>
       <td>
-        <%= report.user.payout_method.account_holder %>
+        <%= payout_method.account_holder %>
       </td>
     </tr>
     <tr>
       <td>Bank name:</td>
       <td>
-        <%= report.user.payout_method.bank_name %>
+        <%= payout_method.bank_name %>
       </td>
     </tr>
     <tr>
@@ -39,38 +41,38 @@
     </tr>
     <tr>
       <td>Address (Line 1):</td>
-      <td><%= report.user.payout_method.address_line1 %></td>
+      <td><%= payout_method.address_line1 %></td>
     </tr>
     <tr>
       <td>Address (Line 2):</td>
-      <td><%= report.user.payout_method.address_line2 %></td>
+      <td><%= payout_method.address_line2 %></td>
     </tr>
     <tr>
       <td>City:</td>
-      <td><%= report.user.payout_method.address_city %></td>
+      <td><%= payout_method.address_city %></td>
     </tr>
     <tr>
       <td>State:</td>
-      <td><%= report.user.payout_method.address_state %></td>
+      <td><%= payout_method.address_state %></td>
     </tr>
     <tr>
       <td>Postal code:</td>
-      <td><%= report.user.payout_method.address_postal_code %></td>
+      <td><%= payout_method.address_postal_code %></td>
     </tr>
     <tr>
       <td>Recipient country:</td>
-      <td><%= report.user.payout_method.recipient_country %></td>
+      <td><%= payout_method.recipient_country %></td>
     </tr>
     <% WiseTransfer.recipient_information_accessors.each do |key| %>
-      <% if report.user.payout_method.recipient_information[key].presence != nil %>
+      <% if payout_method.recipient_information[key].presence != nil %>
         <tr>
           <td><%= key.humanize %></td>
-          <td><%= report.user.payout_method.recipient_information[key] %></td>
+          <td><%= payout_method.recipient_information[key] %></td>
         </tr>
-      <% elsif report.user.payout_method.read_attribute(key.to_sym).present? %>
+      <% elsif payout_method.read_attribute(key.to_sym).present? %>
         <tr>
           <td><%= key.humanize %></td>
-          <td><%= report.user.payout_method.read_attribute(key.to_sym) %></td>
+          <td><%= payout_method.read_attribute(key.to_sym) %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (report:) %>
 
-<% payout_method = report.user.default_payout_method_details %>
+<% payout_method = report.user.default_payout_method&.details %>
 
 <table class="w-full table-fixed my-6">
   <tbody>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -170,7 +170,7 @@
   <% end %>
 <% end %>
 
-<% if @report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
+<% if @report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
   <% admin_tool("mt-4") do %>
     <h3 class="mt-0">Process Wise reimbursement</h3>
 
@@ -218,7 +218,7 @@
   <%= render partial: "reimbursement/reports/blankslate", locals: { report: @report } %>
 </div>
 
-<% if @report.user.payout_method_type == User::PayoutMethod::WiseTransfer.name && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
+<% if @report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
   <%= render "application/callout",
       type: "info",
       icon: "wise",

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -170,7 +170,7 @@
   <% end %>
 <% end %>
 
-<% if @report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
+<% if @report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
   <% admin_tool("mt-4") do %>
     <h3 class="mt-0">Process Wise reimbursement</h3>
 
@@ -218,7 +218,7 @@
   <%= render partial: "reimbursement/reports/blankslate", locals: { report: @report } %>
 </div>
 
-<% if @report.user.default_payout_method_details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
+<% if @report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
   <%= render "application/callout",
       type: "info",
       icon: "wise",

--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -8,15 +8,15 @@
 </p>
 
 <p>
-  <% if @report.user&.payout_method&.kind == "check" %>
+  <% if @report.user&.default_payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.
-  <% elsif @report.user&.payout_method&.kind == "ach_transfer" %>
+  <% elsif @report.user&.default_payout_method&.kind == "ach_transfer" %>
     You'll receive an ACH transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
-  <% elsif @report.user&.payout_method&.kind == "paypal_transfer" %>
+  <% elsif @report.user&.default_payout_method&.kind == "paypal_transfer" %>
     You'll receive an PayPal transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
-  <% elsif @report.user&.payout_method&.kind == "international_wire" %>
+  <% elsif @report.user&.default_payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
-  <% elsif @report.user&.payout_method&.kind == "wise_transfer" %>
+  <% elsif @report.user&.default_payout_method&.kind == "wise_transfer" %>
     You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.amount.currency.iso_code %> from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -9,17 +9,6 @@
 
 <% payout_method = @report.user&.payout_method&.details %>
 <p>
-<<<<<<< Updated upstream
-  <% if @report.user&.default_payout_method&.kind == "check" %>
-    You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.
-  <% elsif @report.user&.default_payout_method&.kind == "ach_transfer" %>
-    You'll receive an ACH transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
-  <% elsif @report.user&.default_payout_method&.kind == "paypal_transfer" %>
-    You'll receive an PayPal transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
-  <% elsif @report.user&.default_payout_method&.kind == "international_wire" %>
-    You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
-  <% elsif @report.user&.default_payout_method&.kind == "wise_transfer" %>
-=======
   <% if payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.
   <% elsif payout_method&.kind == "ach_transfer" %>
@@ -29,7 +18,6 @@
   <% elsif payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% elsif payout_method&.kind == "wise_transfer" %>
->>>>>>> Stashed changes
     You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.amount.currency.iso_code %> from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -7,7 +7,7 @@
   <em><%= link_to @report.name, @report %></em>.
 </p>
 
-<% payout_method = @report.user&.payout_method&.details %>
+<% payout_method = @report.user&.default_payout_method&.details %>
 <p>
   <% if payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.

--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -7,7 +7,9 @@
   <em><%= link_to @report.name, @report %></em>.
 </p>
 
+<% payout_method = @report.user&.payout_method&.details %>
 <p>
+<<<<<<< Updated upstream
   <% if @report.user&.default_payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.
   <% elsif @report.user&.default_payout_method&.kind == "ach_transfer" %>
@@ -17,6 +19,17 @@
   <% elsif @report.user&.default_payout_method&.kind == "international_wire" %>
     You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
   <% elsif @report.user&.default_payout_method&.kind == "wise_transfer" %>
+=======
+  <% if payout_method&.kind == "check" %>
+    You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.
+  <% elsif payout_method&.kind == "ach_transfer" %>
+    You'll receive an ACH transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
+  <% elsif payout_method&.kind == "paypal_transfer" %>
+    You'll receive an PayPal transfer of <%= render_money @report.amount_to_reimburse %> from us in approximately 2-3 business days.
+  <% elsif payout_method&.kind == "international_wire" %>
+    You'll receive an international wire transfer of <%= render_money @report.amount_to_reimburse %> USD from us in approximately 2-3 business days.
+  <% elsif payout_method&.kind == "wise_transfer" %>
+>>>>>>> Stashed changes
     You'll receive a bank transfer via Wise of <%= @report.amount_to_reimburse.format %> <%= @report.amount.currency.iso_code %> from us in approximately 2-3 business days.
   <% else %>
     We don't have a payout method on file for you, <%= link_to "please configure one here", settings_payouts_url %>

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -1,4 +1,4 @@
-<% payout_method = user.new_default_payout_method&.details || user.default_payout_method_details %>
+<% payout_method = user.new_default_payout_method&.details || user.default_payout_method&.details %>
 <% selected_type = payout_method&.class&.name %>
 <%= form_with model: user, html: {
       "x-data": "{ country: #{payout_method.instance_of?(LegalEntity::PayoutMethod::Wire) ? "'#{payout_method.recipient_country}'" : "null"} }"

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -1,5 +1,7 @@
+<% payout_method = user.new_default_payout_method&.details || user.default_payout_method_details %>
+<% selected_type = payout_method&.class&.name %>
 <%= form_with model: user, html: {
-      "x-data": "{ country: #{user.payout_method.instance_of?(User::PayoutMethod::Wire) ? "'#{user.payout_method.recipient_country}'" : "null"} }"
+      "x-data": "{ country: #{payout_method.instance_of?(LegalEntity::PayoutMethod::Wire) ? "'#{payout_method.recipient_country}'" : "null"} }"
     } do |form| %>
   <% if user.full_name.blank? %>
     <div class="heading h3 pb2 bold">Firstly, we need to know your name:</div>
@@ -13,24 +15,25 @@
   <fieldset>
     <legend class="heading h3 pb2 bold">How would you like to be reimbursed?</legend>
     <div class="field field--options mb-4" style="max-width: none;">
-      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::AchTransfer, title: "ACH transfer", description: "United States", icon: "payment-transfer" %>
+      <%= render "users/payout_form/option", form:, model: LegalEntity::PayoutMethod::AchTransfer, title: "ACH transfer", description: "United States", icon: "payment-transfer", checked: selected_type == LegalEntity::PayoutMethod::AchTransfer.name %>
 
-      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::Check, title: "Mailed check", description: "United States", icon: "email" %>
+      <%= render "users/payout_form/option", form:, model: LegalEntity::PayoutMethod::Check, title: "Mailed check", description: "United States", icon: "email", checked: selected_type == LegalEntity::PayoutMethod::Check.name %>
 
-      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::WiseTransfer, title: "Wise transfer", description: "International", icon: "wise" %>
+      <%= render "users/payout_form/option", form:, model: LegalEntity::PayoutMethod::WiseTransfer, title: "Wise transfer", description: "International", icon: "wise", checked: selected_type == LegalEntity::PayoutMethod::WiseTransfer.name %>
 
-      <%= render "users/payout_form/option", form:, model: User::PayoutMethod::Wire, title: "Wire transfer", description: "International", icon: "web" do %>
+      <%= render "users/payout_form/option", form:, model: LegalEntity::PayoutMethod::Wire, title: "Wire transfer", description: "International", icon: "web", checked: selected_type == LegalEntity::PayoutMethod::Wire.name do %>
         <div class="badge badge--corner bg-info m1 mt0" style="width: fit-content;">$500 minimum</div>
       <% end %>
     </div>
   </fieldset>
-  <% if user.payout_method&.errors&.any? %>
+  <% pm_errors = user.new_default_payout_method %>
+  <% if pm_errors && (pm_errors.errors.any? || pm_errors.details&.errors&.any?) %>
     <p class="error">
-      <%= user.payout_method.errors.full_messages.to_sentence %>.
+      <%= (pm_errors.errors.full_messages + (pm_errors.details&.errors&.full_messages || [])).to_sentence %>.
     </p>
   <% end %>
-  <section data-behavior="check_payout_method_inputs" class="<%= "hidden" unless user.payout_method.instance_of?(User::PayoutMethod::Check) %>">
-    <%= form.fields_for :payout_method, user.payout_method.instance_of?(User::PayoutMethod::Check) ? user.payout_method : User::PayoutMethod::Check.new do |form| %>
+  <section data-behavior="check_payout_method_inputs" class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::Check) %>">
+    <%= form.fields_for :payout_method, payout_method.instance_of?(LegalEntity::PayoutMethod::Check) ? payout_method : LegalEntity::PayoutMethod::Check.new do |form| %>
       <%= render "application/callout",
         type: "info",
         icon: "email",
@@ -78,8 +81,8 @@
     <% end %>
   </section>
 
-  <section data-behavior="wire_payout_method_inputs" class="<%= "hidden" unless user.payout_method.instance_of?(User::PayoutMethod::Wire) %>">
-    <%= form.fields_for :payout_method_wire, user.payout_method.instance_of?(User::PayoutMethod::Wire) ? user.payout_method : User::PayoutMethod::Wire.new do |form| %>
+  <section data-behavior="wire_payout_method_inputs" class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::Wire) %>">
+    <%= form.fields_for :payout_method_wire, payout_method.instance_of?(LegalEntity::PayoutMethod::Wire) ? payout_method : LegalEntity::PayoutMethod::Wire.new do |form| %>
       <%= render "application/callout",
         type: "info",
         icon: "web",
@@ -109,8 +112,8 @@
     <% end %>
   </section>
 
-  <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "hidden" unless user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= user.payout_method.try(:currency) ? "'#{user.payout_method.currency}'" : "null" %>, amount: null, account_type: <%= user.payout_method.try(:account_type) ? "'#{user.payout_method.account_type}'" : "null" %>, use_same_email_for_interac: <%= user.payout_method.try(:use_same_email_for_interac) ? "'#{user.payout_method.use_same_email_for_interac}'" : "false" %>, email: null }">
-    <%= form.fields_for :payout_method_wise_transfer, user.payout_method.instance_of?(User::PayoutMethod::WiseTransfer) ? user.payout_method : User::PayoutMethod::WiseTransfer.new do |form| %>
+  <section data-behavior="wise_transfer_payout_method_inputs" class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::WiseTransfer) %>" x-data="{ currency: <%= payout_method.try(:currency) ? "'#{payout_method.currency}'" : "null" %>, amount: null, account_type: <%= payout_method.try(:account_type) ? "'#{payout_method.account_type}'" : "null" %>, use_same_email_for_interac: <%= payout_method.try(:use_same_email_for_interac) ? "'#{payout_method.use_same_email_for_interac}'" : "false" %>, email: null }">
+    <%= form.fields_for :payout_method_wise_transfer, payout_method.instance_of?(LegalEntity::PayoutMethod::WiseTransfer) ? payout_method : LegalEntity::PayoutMethod::WiseTransfer.new do |form| %>
       <%= render "application/callout",
         type: "info",
         icon: "wise",
@@ -129,7 +132,7 @@
 
       <%= form.hidden_field :wise_recipient_id, value: "" %>
 
-      <%= render partial: "wise_transfers/currency_specific_details", locals: { form:, disabled: false, model: User::PayoutMethod::WiseTransfer } %>
+      <%= render partial: "wise_transfers/currency_specific_details", locals: { form:, disabled: false, model: LegalEntity::PayoutMethod::WiseTransfer } %>
 
       <div class="actions inline-block mt1">
         <%= form.submit "Save" %>
@@ -137,33 +140,11 @@
     <% end %>
   </section>
 
-  <section data-behavior="paypal_transfer_payout_method_inputs" class="<%= "hidden" unless user.payout_method.instance_of?(User::PayoutMethod::PaypalTransfer) %>">
-    <%= render "application/callout", type: "error", title: "Due to integration issues, transfers via PayPal are currently unavailable.", footer: :questions do %>
-      Please update your payout method to either an ACH transfer or a mailed check.
-    <% end %>
-
-    <%= render "application/callout",
-        type: "info",
-        title: "Important info about PayPal reimbursements" do %>
-        <p>PayPal will charge domestic recipients 3% on the money sent to them via a HCB reimbursement.</p>
-        <p>Outside of the US, PayPal will charge recipients both a $5 flat fee as well as ~10% fee. Governments may tax these transfers and recipients may have to pay an additional withdrawal fee.</p>
-    <% end %>
-    <%= form.fields_for :payout_method, user.payout_method.instance_of?(User::PayoutMethod::PaypalTransfer) ? user.payout_method : User::PayoutMethod::PaypalTransfer.new do |form| %>
-      <div class="field">
-        <%= form.label :recipient_email, "PayPal email" %>
-        <%= form.email_field :recipient_email, placeholder: "fionah@gmail.com" %>
-      </div>
-
-      <div class="actions inline-block mt1">
-        <%= form.submit "Save" %>
-      </div>
-    <% end %>
-  </section>
-  <% if user.payout_method.instance_of?(User::PayoutMethod::AchTransfer) %>
-    <% errored = !user.payout_method.valid? %>
-    <% r_no = user.payout_method.routing_number %>
+  <% if payout_method.instance_of?(LegalEntity::PayoutMethod::AchTransfer) %>
+    <% errored = !payout_method.valid? %>
+    <% r_no = payout_method.routing_number %>
     <% obfuscated_routing_number = "•" * [r_no.length - 4, 0].max + r_no[[-4, -1 * r_no.length].max..] %>
-    <% a_no = user.payout_method.account_number %>
+    <% a_no = payout_method.account_number %>
     <% obfuscated_account_number = "•" * [a_no.length - 4, 0].max + a_no[[-4, -1 * a_no.length].max..] %>
   <% else %>
     <% errored = false %>
@@ -174,7 +155,7 @@
   <% end %>
   <section
     data-behavior="ach_transfer_payout_method_inputs"
-    class="<%= "hidden" unless user.payout_method.instance_of?(User::PayoutMethod::AchTransfer) %>"
+    class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::AchTransfer) %>"
     x-data="
     {
       routingNumber: '<%= errored ? r_no : obfuscated_routing_number %>',
@@ -192,7 +173,7 @@
         }
       }
     }">
-    <%= form.fields_for :payout_method, user.payout_method.instance_of?(User::PayoutMethod::AchTransfer) ? user.payout_method : User::PayoutMethod::AchTransfer.new do |form| %>
+    <%= form.fields_for :payout_method, payout_method.instance_of?(LegalEntity::PayoutMethod::AchTransfer) ? payout_method : LegalEntity::PayoutMethod::AchTransfer.new do |form| %>
       <%= render "application/callout",
         type: "info",
         icon: "payment-transfer",

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -29,7 +29,7 @@
   </fieldset>
   <% if attempted && (attempted.errors.any? || attempted.details&.errors&.any?) %>
     <p class="error">
-      <%= (attempted.errors.full_messages + (attempted.details&.errors&.full_messages || [])).to_sentence %>.
+      <%= (attempted.errors.full_messages_for(:base) + (attempted.details&.errors&.full_messages || [])).to_sentence %>.
     </p>
   <% end %>
   <section data-behavior="check_payout_method_inputs" class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::Check) %>">

--- a/app/views/users/_payout_form.html.erb
+++ b/app/views/users/_payout_form.html.erb
@@ -1,4 +1,5 @@
-<% payout_method = user.new_default_payout_method&.details || user.default_payout_method&.details %>
+<% attempted = local_assigns[:attempted] %>
+<% payout_method = attempted&.details || user.default_payout_method&.details %>
 <% selected_type = payout_method&.class&.name %>
 <%= form_with model: user, html: {
       "x-data": "{ country: #{payout_method.instance_of?(LegalEntity::PayoutMethod::Wire) ? "'#{payout_method.recipient_country}'" : "null"} }"
@@ -26,10 +27,9 @@
       <% end %>
     </div>
   </fieldset>
-  <% pm_errors = user.new_default_payout_method %>
-  <% if pm_errors && (pm_errors.errors.any? || pm_errors.details&.errors&.any?) %>
+  <% if attempted && (attempted.errors.any? || attempted.details&.errors&.any?) %>
     <p class="error">
-      <%= (pm_errors.errors.full_messages + (pm_errors.details&.errors&.full_messages || [])).to_sentence %>.
+      <%= (attempted.errors.full_messages + (attempted.details&.errors&.full_messages || [])).to_sentence %>.
     </p>
   <% end %>
   <section data-behavior="check_payout_method_inputs" class="<%= "hidden" unless payout_method.instance_of?(LegalEntity::PayoutMethod::Check) %>">

--- a/app/views/users/edit_payout.html.erb
+++ b/app/views/users/edit_payout.html.erb
@@ -15,7 +15,7 @@
     </p>
     <%= render "application/flash", klass: "max-w-full mb3" %>
     <% if @user.can_update_payout_method? %>
-      <%= render "users/payout_form", user: @user %>
+      <%= render "users/payout_form", user: @user, attempted: @payout_method %>
     <% else %>
       <%= render "application/callout",
           type: "info",

--- a/app/views/users/payout_form/_option.html.erb
+++ b/app/views/users/payout_form/_option.html.erb
@@ -1,15 +1,16 @@
-<%# locals: (form:, model:, title:, description:, icon:) %>
+<%# locals: (form:, model:, title:, description:, icon:, checked: false) %>
 
-<%= form.radio_button :payout_method_type, model.name, disabled: model.unsupported? %>
+<% unsupported = LegalEntity::PayoutMethod.unsupported?(model) %>
+<%= form.radio_button :payout_method_type, model.name, checked:, disabled: unsupported %>
 <%= form.label :payout_method_type, value: model.name do %>
   <%= inline_icon icon, size: 28 %>
   <strong><%= title %></strong>
 
   <%= yield %><%# in case you wanna add more flare to a specific option %>
 
-  <% if model.unsupported? %>
-    <div class="badge bg-warning m1 mt0 w-fit"><%= model.unsupported_details[:status_badge] %></div>
-    <small><%= model.unsupported_details[:reason] %></small>
+  <% if unsupported %>
+    <div class="badge bg-warning m1 mt0 w-fit"><%= LegalEntity::PayoutMethod.unsupported_details(model)[:status_badge] %></div>
+    <small><%= LegalEntity::PayoutMethod.unsupported_details(model)[:reason] %></small>
   <% else %>
     <small><%= description %></small>
   <% end %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -128,12 +128,38 @@ RSpec.describe UsersController do
       expect(user.reload.use_two_factor_authentication).to eq(false)
     end
 
+    it "saves the chosen payout method as the user's default legal entity payout method" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      patch(
+        :update,
+        params: {
+          id: user.id,
+          user: {
+            payout_method_type: "LegalEntity::PayoutMethod::AchTransfer",
+            payout_method_attributes: {
+              account_number: "12345678",
+              routing_number: "021000021"
+            }
+          }
+        }
+      )
+
+      expect(response).to have_http_status(:found)
+      default = user.reload.default_payout_method
+      expect(default).to be_present
+      expect(default).to be_default
+      expect(default.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+      expect(default.details.routing_number).to eq("021000021")
+    end
+
     it "does not allow saving an unsupported payout method" do
-      reason = "Due to integration issues, transfers via PayPal are currently unavailable in tests."
+      reason = "Checks are paused in tests."
       stub_const(
-        "User::PayoutMethod::UNSUPPORTED_METHODS",
+        "LegalEntity::PayoutMethod::UNSUPPORTED_METHODS",
         {
-          User::PayoutMethod::PaypalTransfer => {
+          LegalEntity::PayoutMethod::Check => {
             status_badge: "Unavailable",
             reason:
           },
@@ -148,17 +174,20 @@ RSpec.describe UsersController do
         params: {
           id: user.id,
           user: {
-            payout_method_type: "User::PayoutMethod::PaypalTransfer",
+            payout_method_type: "LegalEntity::PayoutMethod::Check",
             payout_method_attributes: {
-              recipient_email: "gary@hackclub.com"
+              address_line1: "1 Main St",
+              address_city: "New York",
+              address_state: "NY",
+              address_postal_code: "10001"
             }
           }
         }
       )
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(flash.to_h).to eq("error" => "#{reason} Please choose another method.")
-      expect(user.reload.payout_method_type).to eq(nil)
+      expect(flash.to_h["error"]).to include(reason)
+      expect(user.reload.default_payout_method).to be_nil
     end
   end
 

--- a/spec/mailers/reimbursement_mailer_spec.rb
+++ b/spec/mailers/reimbursement_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ReimbursementMailer do
         full_name: "Test User",
         email: "user@example.com",
       )
-      user.person_legal_entity.payout_methods.create!(
+      user.personal_legal_entity.payout_methods.create!(
         default: true,
         details: LegalEntity::PayoutMethod::WiseTransfer.new(
           address_line1: "123 Rue Main",

--- a/spec/mailers/reimbursement_mailer_spec.rb
+++ b/spec/mailers/reimbursement_mailer_spec.rb
@@ -5,16 +5,14 @@ require "rails_helper"
 RSpec.describe ReimbursementMailer do
   describe "#expenses_approved" do
     it "renders the list of expenses in their original currency" do
-      # This is temporarily required while we work to re-enable Wise transfers
-      # (which are the only payout method that supports multiple currencies)
-      stub_const("User::PayoutMethod::SUPPORTED_METHODS", [User::PayoutMethod::WiseTransfer])
-      stub_const("User::PayoutMethod::UNSUPPORTED_METHODS", {})
-
       user = create(
         :user,
         full_name: "Test User",
         email: "user@example.com",
-        payout_method: User::PayoutMethod::WiseTransfer.new(
+      )
+      user.person_legal_entity.payout_methods.create!(
+        default: true,
+        details: LegalEntity::PayoutMethod::WiseTransfer.new(
           address_line1: "123 Rue Main",
           address_city: "Shawinigan",
           address_state: "QC",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -490,10 +490,10 @@ RSpec.describe User, type: :model do
       LegalEntity::PayoutMethod::AchTransfer.new(account_number: "12345678", routing_number: "021000021")
     end
 
-    describe "#person_legal_entity" do
+    describe "#personal_legal_entity" do
       it "returns the user's person-type legal entity" do
-        expect(user.person_legal_entity).to be_present
-        expect(user.person_legal_entity).to be_person
+        expect(user.personal_legal_entity).to be_present
+        expect(user.personal_legal_entity).to be_person
       end
     end
 
@@ -504,7 +504,7 @@ RSpec.describe User, type: :model do
       end
 
       it "returns the person entity's default payout method and its details" do
-        pm = user.person_legal_entity.payout_methods.create!(default: true, details: build_ach)
+        pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
 
         expect(user.default_payout_method).to eq(pm)
         expect(user.default_payout_method_details).to eq(pm.details)
@@ -522,7 +522,7 @@ RSpec.describe User, type: :model do
         expect(pm).to be_a(LegalEntity::PayoutMethod)
         expect(pm).to be_default
         expect(pm).not_to be_persisted
-        expect(pm.legal_entity).to eq(user.person_legal_entity)
+        expect(pm.legal_entity).to eq(user.personal_legal_entity)
         expect(pm.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
         expect(user.new_default_payout_method).to eq(pm)
       end
@@ -541,7 +541,7 @@ RSpec.describe User, type: :model do
       end
 
       it "is false when the default is Wise and a reimbursement is being processed" do
-        user.person_legal_entity.payout_methods.create!(
+        user.personal_legal_entity.payout_methods.create!(
           default: true,
           details: LegalEntity::PayoutMethod::WiseTransfer.new(
             address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -512,28 +512,6 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe "#build_default_payout_method" do
-      it "builds an unsaved default LegalEntity::PayoutMethod of the given type" do
-        pm = user.build_default_payout_method(
-          "LegalEntity::PayoutMethod::AchTransfer",
-          { account_number: "12345678", routing_number: "021000021" }
-        )
-
-        expect(pm).to be_a(LegalEntity::PayoutMethod)
-        expect(pm).to be_default
-        expect(pm).not_to be_persisted
-        expect(pm.legal_entity).to eq(user.personal_legal_entity)
-        expect(pm.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
-        expect(user.new_default_payout_method).to eq(pm)
-      end
-
-      it "returns nil for a type that isn't a LegalEntity::PayoutMethod detail" do
-        expect(
-          user.build_default_payout_method("User::PayoutMethod::AchTransfer", { account_number: "1", routing_number: "2" })
-        ).to be_nil
-        expect(user.build_default_payout_method("NotARealClass", {})).to be_nil
-      end
-    end
 
     describe "#can_update_payout_method?" do
       it "is true when there is no payout method" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -483,6 +483,79 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "payout methods" do
+    let(:user) { create(:user) }
+
+    def build_ach
+      LegalEntity::PayoutMethod::AchTransfer.new(account_number: "12345678", routing_number: "021000021")
+    end
+
+    describe "#person_legal_entity" do
+      it "returns the user's person-type legal entity" do
+        expect(user.person_legal_entity).to be_present
+        expect(user.person_legal_entity).to be_person
+      end
+    end
+
+    describe "#default_payout_method / #default_payout_method_details" do
+      it "is nil when no default payout method exists" do
+        expect(user.default_payout_method).to be_nil
+        expect(user.default_payout_method_details).to be_nil
+      end
+
+      it "returns the person entity's default payout method and its details" do
+        pm = user.person_legal_entity.payout_methods.create!(default: true, details: build_ach)
+
+        expect(user.default_payout_method).to eq(pm)
+        expect(user.default_payout_method_details).to eq(pm.details)
+        expect(user.default_payout_method_details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+      end
+    end
+
+    describe "#build_default_payout_method" do
+      it "builds an unsaved default LegalEntity::PayoutMethod of the given type" do
+        pm = user.build_default_payout_method(
+          "LegalEntity::PayoutMethod::AchTransfer",
+          { account_number: "12345678", routing_number: "021000021" }
+        )
+
+        expect(pm).to be_a(LegalEntity::PayoutMethod)
+        expect(pm).to be_default
+        expect(pm).not_to be_persisted
+        expect(pm.legal_entity).to eq(user.person_legal_entity)
+        expect(pm.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+        expect(user.new_default_payout_method).to eq(pm)
+      end
+
+      it "returns nil for a type that isn't a LegalEntity::PayoutMethod detail" do
+        expect(
+          user.build_default_payout_method("User::PayoutMethod::AchTransfer", { account_number: "1", routing_number: "2" })
+        ).to be_nil
+        expect(user.build_default_payout_method("NotARealClass", {})).to be_nil
+      end
+    end
+
+    describe "#can_update_payout_method?" do
+      it "is true when there is no payout method" do
+        expect(user.can_update_payout_method?).to be(true)
+      end
+
+      it "is false when the default is Wise and a reimbursement is being processed" do
+        user.person_legal_entity.payout_methods.create!(
+          default: true,
+          details: LegalEntity::PayoutMethod::WiseTransfer.new(
+            address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",
+            address_postal_code: "M5V2T6", recipient_country: "CA", currency: "CAD"
+          )
+        )
+        event = create(:event)
+        create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
+
+        expect(user.can_update_payout_method?).to be(false)
+      end
+    end
+  end
+
   describe ".search_name" do
     it "finds user by ID" do
       user = create(:user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -495,6 +495,25 @@ RSpec.describe User, type: :model do
         expect(user.personal_legal_entity).to be_present
         expect(user.personal_legal_entity).to be_person
       end
+
+      it "returns the person entity, never a business entity the user also belongs to" do
+        business = create(:legal_entity, :business)
+        user.legal_entity_users.create!(legal_entity: business)
+
+        expect(user.reload.personal_legal_entity).to be_person
+        expect(user.personal_legal_entity).not_to eq(business)
+      end
+    end
+
+    describe "#person_legal_entity_user" do
+      it "returns the join row for the person-type legal entity" do
+        create(:legal_entity, :business).tap { |b| user.legal_entity_users.create!(legal_entity: b) }
+
+        expect(user.reload.person_legal_entity_user).to eq(
+          user.legal_entity_users.find_by(legal_entity: user.personal_legal_entity)
+        )
+        expect(user.person_legal_entity_user.legal_entity).to be_person
+      end
     end
 
     describe "#default_payout_method" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -497,18 +497,18 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe "#default_payout_method / #default_payout_method_details" do
+    describe "#default_payout_method" do
       it "is nil when no default payout method exists" do
         expect(user.default_payout_method).to be_nil
-        expect(user.default_payout_method_details).to be_nil
+        expect(user.default_payout_method&.details).to be_nil
       end
 
       it "returns the person entity's default payout method and its details" do
         pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
 
         expect(user.default_payout_method).to eq(pm)
-        expect(user.default_payout_method_details).to eq(pm.details)
-        expect(user.default_payout_method_details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+        expect(user.default_payout_method.details).to eq(pm.details)
+        expect(user.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
       end
     end
 

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -67,6 +67,23 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(user.reload.default_payout_method).to be_nil
     end
 
+    it "does not instantiate an arbitrary class named by the type" do
+      # Guards against code injection: a real but non-allowlisted class must be
+      # rejected by name without being resolved or instantiated.
+      user # create before spying (FactoryBot legitimately calls User.new)
+      allow(User).to receive(:new).and_call_original
+
+      service = described_class.new(
+        user:,
+        details_type: "User",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(false)
+      expect(user.reload.default_payout_method).to be_nil
+      expect(User).not_to have_received(:new)
+    end
+
     it "surfaces detail validation errors without persisting" do
       service = described_class.new(
         user:,

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LegalEntity::PayoutMethodService::Update do
+  let(:user) { create(:user) }
+
+  def valid_ach_attrs
+    { account_number: "12345678", routing_number: "021000021" }
+  end
+
+  def valid_wise_attrs
+    {
+      address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",
+      address_postal_code: "M5V2T6", recipient_country: "CA", currency: "CAD"
+    }
+  end
+
+  def seed_default(details)
+    user.personal_legal_entity.payout_methods.create!(default: true, details:)
+  end
+
+  describe "#run" do
+    it "creates the chosen method as the user's default when none exists" do
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(true)
+
+      default = user.reload.default_payout_method
+      expect(default).to be_present
+      expect(default).to be_default
+      expect(default.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+      expect(default.details.routing_number).to eq("021000021")
+    end
+
+    it "replaces the existing default and unsets the previous one" do
+      old = seed_default(LegalEntity::PayoutMethod::Check.new(
+                           address_line1: "1 Main St", address_city: "New York",
+                           address_state: "NY", address_postal_code: "10001"
+                         ))
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(true)
+      expect(user.personal_legal_entity.payout_methods.where(default: true).count).to eq(1)
+      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+      expect(old.reload).not_to be_default
+    end
+
+    it "fails without persisting when the type is not a supported payout method" do
+      service = described_class.new(
+        user:,
+        details_type: "User::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(false)
+      expect(service.error_messages).to be_present
+      expect(user.reload.default_payout_method).to be_nil
+    end
+
+    it "surfaces detail validation errors without persisting" do
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: { account_number: "12345678", routing_number: "nope" }
+      )
+
+      expect(service.run).to be(false)
+      expect(service.error_messages.join(" ")).to match(/routing number/i)
+      expect(user.reload.default_payout_method).to be_nil
+    end
+
+    it "blocks switching to Wise while a report is being processed" do
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::WiseTransfer",
+        details_attrs: valid_wise_attrs
+      )
+
+      expect(service.run).to be(false)
+      expect(service.error_messages.join(" ")).to match(/wise/i)
+      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
+    end
+
+    it "blocks any change while the current Wise payout is being processed" do
+      seed_default(LegalEntity::PayoutMethod::WiseTransfer.new(valid_wise_attrs))
+      create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(false)
+      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::WiseTransfer)
+    end
+  end
+
+  describe "#run!" do
+    it "raises ActiveRecord::RecordInvalid when the update is invalid" do
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: { account_number: "12345678", routing_number: "nope" }
+      )
+
+      expect { service.run! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
Now that we have person legal entity payout methods we should move off user payout methods and instead use the default personal legal entity payout that we backfilled in #13963. 


## Describe your changes
- Essentially replaces `user.payout_method` to `user.default_payout_method_details`
- Removes old Paypal logic
- Directly create LE payout methods on reimbursement settings page


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

