### PR TITLE
[Admin] Don't open admin tools menu from comment mention

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -195,7 +195,7 @@ module UsersHelper
                 avi + name
               end
 
-    if user && viewer&.auditor?
+    if user && viewer&.auditor? && !options[:disable_admin_menu]
       button = content_tag(
         :span,
         content,

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -16,7 +16,7 @@
   <ul role="listbox" class="mention-suggestions card" hidden popover>
     <% commentable.comment_mentionable(current_user:).each do |u| %>
       <li role="option" class="cursor-pointer mention-suggestion" data-value="@<%= u.email %>" data-search="<%= u.name %>">
-        <%= user_mention u, disable_tooltip: true %>
+        <%= user_mention u, disable_tooltip: true, disable_admin_menu: true %>
       </li>
     <% end %>
   </ul>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsersHelper, type: :helper do
+  describe "#user_mention" do
+    let(:auditor) { create(:user, :make_admin) }
+    let(:mentioned_user) { create(:user) }
+
+    before { allow(helper).to receive(:current_user).and_return(auditor) }
+
+    # The admin tools menu (Email / Copy email / Settings) is intended for mentions
+    # displayed inside posted comments, where an auditor clicks a teammate to act on them.
+    it "renders the admin tools menu for an auditor viewing a mention" do
+      html = helper.user_mention(mentioned_user)
+
+      expect(html).to include('data-controller="menu"')
+      expect(html).to include("Copy email")
+    end
+
+    # The same helper renders each option in the "@" mention autocomplete dropdown. There,
+    # clicking an avatar must select the mention, not pop open the admin tools menu.
+    it "omits the admin tools menu when disable_admin_menu is set" do
+      html = helper.user_mention(mentioned_user, disable_admin_menu: true)
+
+      expect(html).not_to include('data-controller="menu"')
+      expect(html).not_to include("Copy email")
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

When an auditor types `@` in a comment field, a dropdown of users to mention appears. Clicking the avatar of an option in that dropdown incorrectly opened the admin tools menu (Email / Copy email / Settings) instead of selecting the mention.

The root cause is that the `user_mention` helper wraps a mention in that admin-only menu whenever the viewer is an auditor. The mention autocomplete dropdown renders each suggestion through the same helper, so every option carried the `click->menu#toggle` action and popped the menu on click.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

- Added a `disable_admin_menu` option to `user_mention` that skips the admin tools menu wrapper.
- Passed `disable_admin_menu: true` when rendering the `@` mention dropdown suggestions in `comments/_form`, so the menu only appears on mentions in posted comments (where it's intended).
- Added a helper spec covering both cases: the admin menu still renders for an auditor viewing a normal mention, and is omitted when `disable_admin_menu` is set.


Reported by Kris