### PR TITLE
[PayoutHolding] Use safe nav on CPT decline in `reverse!`

### DIFF
--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -114,7 +114,12 @@ module Reimbursement
 
         mark_reversed!
 
-        canonical_pending_transaction.decline!
+        # This is the created_at of the first payout holding that had a CPT
+        if self.created_at < DateTime.parse("2024-08-09 00:45:12.992236000 UTC +00:00")
+          canonical_pending_transaction&.decline!
+        else
+          canonical_pending_transaction.decline!
+        end
 
         # these are reversed because this is reverse!
         sender_bank_account_id = ColumnService::Accounts.id_of(book_transfer_receiving_account)

--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -115,7 +115,7 @@ module Reimbursement
         mark_reversed!
 
         # This is the created_at of the first payout holding that had a CPT
-        if self.created_at < DateTime.parse("2024-08-09 00:45:12.992236000 UTC +00:00")
+        if self.created_at <= DateTime.parse("2024-08-09 00:45:12.992236000 UTC +00:00")
           canonical_pending_transaction&.decline!
         else
           canonical_pending_transaction.decline!


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Failed reimbursements from before `2024-08-09 00:45:12.992236000 UTC +00:00` were unable to be cancelled because they would error from missing a CPT.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use safe nav when calling cancel on CPTs from before this date.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

