### PR TITLE
Fix `HcbCode#write_event_and_subledger_id`

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -746,7 +746,7 @@ class HcbCode < ApplicationRecord
     nil
   end
 
-  def write_event_and_subledger_id(event = events.first&.id, subledger = subledgers.first&.id)
+  def write_event_and_subledger_id(event = events.first, subledger = subledgers.first)
     update(event_id: event&.id, subledger_id: subledger&.id)
   end
 


### PR DESCRIPTION
## Summary of the problem

`HcbCode#write_event_and_subledger_id` had defaults configured that resulted in an error.


## Describe your changes

Remove the problematic `&.id`
