### PR TITLE
[PayoutMethod] Make `default_payout_method` an association

### DIFF
--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -32,9 +32,7 @@ class LegalEntity < ApplicationRecord
   has_many :users, through: :legal_entity_users
 
   has_many :payout_methods, class_name: "LegalEntity::PayoutMethod"
-
-  def default_payout_method
-    payout_methods.find_by(default: true)
-  end
+  # At most one default per entity is enforced by a partial unique index.
+  has_one :default_payout_method, -> { where(default: true) }, class_name: "LegalEntity::PayoutMethod", inverse_of: :legal_entity
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,10 +178,10 @@ class User < ApplicationRecord
 
   has_many :legal_entity_users
   has_many :legal_entities, through: :legal_entity_users
-  # The user's single person-type legal entity, as a preloadable has_one.
   # has_one :through needs a singular intermediate, so hop through a person-scoped join row.
   has_one :person_legal_entity_user, -> { where(legal_entity_id: LegalEntity.where(entity_type: :person).select(:id)) }, class_name: "LegalEntityUser", inverse_of: :user
   has_one :personal_legal_entity, through: :person_legal_entity_user, source: :legal_entity
+  has_one :default_payout_method, through: :personal_legal_entity
 
   has_encrypted :birthday, type: :date
 
@@ -432,10 +432,6 @@ class User < ApplicationRecord
 
   memo_wise def transactions_missing_receipt_count(from: nil, to: nil)
     transactions_missing_receipt(from:, to:).size
-  end
-
-  def default_payout_method
-    personal_legal_entity&.default_payout_method
   end
 
   def email_address_with_name(full_name: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,9 +169,8 @@ class User < ApplicationRecord
   has_one :unverified_totp, -> { where(aasm_state: :unverified) }, class_name: "User::Totp", inverse_of: :user
   has_one :totp, -> { where(aasm_state: :verified) }, class_name: "User::Totp", inverse_of: :user
 
-  # a user does not actually belong to its payout method,
-  # but this is a convenient way to set up the association.
-
+  # Legacy: payout methods now live on the personal legal entity (default_payout_method).
+  # Kept only so the payout form's `fields_for :payout_method` yields payout_method_attributes params.
   belongs_to :payout_method, polymorphic: true, optional: true
   validate :auditors_must_be_verified
   accepts_nested_attributes_for :payout_method


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Follow-up to #13976. After moving payouts to the personal legal entity, `default_payout_method` is on the hot path but wasn't preloadable:

- `LegalEntity#default_payout_method` was an uncached `find_by(default: true)`, and `User#default_payout_method` delegated to it.
- A reimbursement report's show page reads `user.default_payout_method` ~15 times for a single user, so each render fired a query per call.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

- Replaced `LegalEntity#default_payout_method` with `has_one :default_payout_method, -> { where(default: true) }` (cached per instance; the partial unique index already guarantees at most one default per entity).
- Replaced `User#default_payout_method` with `has_one :default_payout_method, through: :personal_legal_entity`, so the whole chain is preloadable via `includes(default_payout_method: :details)`.
- All call sites only read the value (`.details`, `.present?`, `.currency`, etc.), so they're unchanged.

Measured impact:
- Report show page: ~15 repeated calls for one user drop from ~15 queries to **2** (entity + default, both cached).
- Batch reads across users with `includes(default_payout_method: :details)`: **0** extra queries.

No controller `includes` were added: the hot path is the single-user show page (caching covers it) and no list view renders per-user payout data today. The associations make preloading available if that changes.

Also corrected a stale comment on the legacy `belongs_to :payout_method`, noting it's retained only for the payout form's `fields_for` field naming.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
