### PR TITLE
[Marketing] Ignore HQ organizations in count

### DIFF
--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -82,7 +82,7 @@ class MarketingController < ApplicationController
     Rails.cache.fetch(FUNDER_STATS_CACHE_KEY, expires_in: 12.hours) do
       {
         moved: humanized_money(CanonicalTransaction.included_in_stats.sum("ABS(amount_cents)")),
-        organizations: humanized_count(Event.where(demo_mode: false).count),
+        organizations: humanized_count(Event.not_omitted.not_hidden.not_demo_mode.approved.count),
         countries: "40+", # TODO(stats): compute from a real country source
         founded: "2018",
       }


### PR DESCRIPTION
## Summary of the problem

Marketing page includes a count of organizations, but it includes HQ org — it's not wrong, but we like to only talk about FSOs and exclude our own usage.

## Describe your changes

Exclude HQ