### PR TITLE
[Ledger] Rename Item#date to #datetime (1/5): add column + backfill

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  amount_cents                 :integer          not null
 #  date                         :datetime         not null
+#  datetime                     :datetime
 #  marked_no_or_lost_receipt_at :datetime
 #  memo                         :text             not null
 #  short_code                   :text
@@ -17,6 +18,7 @@
 #
 #  index_ledger_items_on_amount_cents  (amount_cents)
 #  index_ledger_items_on_date          (date)
+#  index_ledger_items_on_datetime      (datetime)
 #  index_ledger_items_on_short_code    (short_code) UNIQUE
 #
 class Ledger
@@ -43,6 +45,12 @@ class Ledger
 
     monetize :amount_cents
 
+    # The `date` column is being renamed to `datetime` without downtime. While
+    # both columns exist, keep them in sync so either code version (reading
+    # `date` or `datetime`) sees consistent data during a rolling deploy. This
+    # callback is removed once `date` is dropped.
+    before_validation :sync_date_and_datetime
+
     def receipt_required?
       false
     end
@@ -66,6 +74,16 @@ class Ledger
     def map!
       Ledger::Mapper.new(ledger_item: self).run
       write_amount_cents!
+    end
+
+    private
+
+    def sync_date_and_datetime
+      if datetime_changed? && !date_changed?
+        self.date = datetime
+      elsif date_changed? && !datetime_changed?
+        self.datetime = date
+      end
     end
 
   end

--- a/app/tasks/maintenance/backfill_ledger_item_datetime_task.rb
+++ b/app/tasks/maintenance/backfill_ledger_item_datetime_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Backfills Ledger::Item#datetime from the legacy #date column during the
+  # date -> datetime rename. Run this after deploying the column add (and its
+  # sync callback) and before enforcing NOT NULL on datetime.
+  #
+  # Processed in batches so each iteration is a single UPDATE rather than a
+  # query per row.
+  class BackfillLedgerItemDatetimeTask < MaintenanceTasks::Task
+    def collection
+      Ledger::Item.where(datetime: nil).in_batches(of: 1000)
+    end
+
+    def process(batch)
+      batch.update_all("datetime = date")
+    end
+
+  end
+end

--- a/db/migrate/20260625150100_add_datetime_to_ledger_items.rb
+++ b/db/migrate/20260625150100_add_datetime_to_ledger_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDatetimeToLedgerItems < ActiveRecord::Migration[8.0]
+  def change
+    # Renaming `date` -> `datetime` without downtime: add the new column
+    # nullable first. It's backfilled and kept in sync in later steps before
+    # becoming NOT NULL and replacing `date`.
+    add_column :ledger_items, :datetime, :datetime
+  end
+
+end

--- a/db/migrate/20260625150200_add_index_to_ledger_items_on_datetime.rb
+++ b/db/migrate/20260625150200_add_index_to_ledger_items_on_datetime.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIndexToLedgerItemsOnDatetime < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ledger_items, :datetime, algorithm: :concurrently
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1579,12 +1579,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
     t.integer "amount_cents", null: false
     t.datetime "created_at", null: false
     t.datetime "date", null: false
+    t.datetime "datetime"
     t.datetime "marked_no_or_lost_receipt_at"
     t.text "memo", null: false
     t.text "short_code"
     t.datetime "updated_at", null: false
     t.index ["amount_cents"], name: "index_ledger_items_on_amount_cents"
     t.index ["date"], name: "index_ledger_items_on_date"
+    t.index ["datetime"], name: "index_ledger_items_on_datetime"
     t.index ["short_code"], name: "index_ledger_items_on_short_code", unique: true
   end
 

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -299,6 +299,22 @@ RSpec.describe Ledger::Item, type: :model do
     end
   end
 
+  describe "date/datetime synchronization" do
+    # Temporary dual-write while the `date` column is being renamed to
+    # `datetime`. Remove these specs once `date` is dropped.
+    it "copies date into datetime when only date is set" do
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", date: Time.current)
+      item.valid?
+      expect(item.datetime).to eq(item.date)
+    end
+
+    it "copies datetime into date when only datetime is set" do
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.valid?
+      expect(item.date).to eq(item.datetime)
+    end
+  end
+
   describe "#calculate_amount_cents" do
     let(:item) do
       i = Ledger::Item.new(amount_cents: 0, memo: "Test", date: Time.current)


### PR DESCRIPTION
## Summary of the problem

`Ledger::Item#date` is a `datetime` column, so the name `date` is misleading. We want to rename it to `datetime`. The table is written on every canonical (pending) transaction, so the rename has to be safe across a rolling deploy where old and new code run against the same schema at once.

This is **PR 1 of 5** in a stacked, zero-downtime rename:
1. **This PR** · add `datetime`, sync with `date`, backfill via maintenance task
2. #14002 · switch reads/writes to `datetime`, enforce `NOT NULL`
3. #14003 · stop referencing `date` (`ignored_columns`)
4. #14007 · drop `date`
5. #14010 · remove the `date` `ignored_columns` entry

## Describe your changes

- Add the nullable `datetime` column and index it concurrently.
- Keep `date` and `datetime` in sync with a `before_validation` callback, so requests on either release read consistent data during the deploy.
- Backfill existing rows with the `BackfillLedgerItemDatetime` maintenance task (batched `update_all`), rather than inline in a migration, so it's throttled and resumable on the live table.

No reads or writes are switched over yet. The `date` column remains the source of truth until PR 2.

> [!IMPORTANT]
> After this deploys, run the `BackfillLedgerItemDatetime` maintenance task to completion **before** merging/deploying PR 2 (which enforces `NOT NULL` on `datetime`).
