### PR TITLE
[Ledger] Rename Item#date to #datetime (2/5): switch reads/writes + NOT NULL

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1141,7 +1141,7 @@ class EventsController < ApplicationController
     authorize @event
 
     @ledger = @event.ledger
-    @items = @ledger.items.order(date: :desc, created_at: :desc, id: :desc).page(params[:page])
+    @items = @ledger.items.order(datetime: :desc, created_at: :desc, id: :desc).page(params[:page])
   end
 
   private

--- a/app/controllers/ledgers_controller.rb
+++ b/app/controllers/ledgers_controller.rb
@@ -6,7 +6,7 @@ class LedgersController < ApplicationController
     authorize @ledger
 
     # TODO: Replace with Ledger::Query
-    @items = @ledger.items.order(date: :desc, created_at: :desc, id: :desc).page(params[:page])
+    @items = @ledger.items.order(datetime: :desc, created_at: :desc, id: :desc).page(params[:page])
   end
 
 end

--- a/app/jobs/one_time_jobs/backfill_ledger_event.rb
+++ b/app/jobs/one_time_jobs/backfill_ledger_event.rb
@@ -32,7 +32,7 @@ module OneTimeJobs
           item = Ledger::Item.find_or_create_by!(short_code: hcb_code.short_code) do |li|
             li.amount_cents = hcb_code.amount_cents
             li.memo = hcb_code.memo
-            li.date = hcb_code.date || hcb_code.created_at
+            li.datetime = hcb_code.date || hcb_code.created_at
             li.marked_no_or_lost_receipt_at = hcb_code.marked_no_or_lost_receipt_at
           end
 

--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -163,7 +163,7 @@ class CanonicalPendingTransaction < ApplicationRecord
 
   after_create_commit unless: -> { ledger_item.present? } do
     safely do
-      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
       update(ledger_item: li)
     end
   end

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -137,7 +137,7 @@ class CanonicalTransaction < ApplicationRecord
 
   after_create_commit unless: -> { ledger_item.present? } do
     safely do
-      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, date: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
       update(ledger_item: li)
     end
   end

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -6,8 +6,8 @@
 #
 #  id                           :bigint           not null, primary key
 #  amount_cents                 :integer          not null
-#  date                         :datetime         not null
-#  datetime                     :datetime
+#  date                         :datetime
+#  datetime                     :datetime         not null
 #  marked_no_or_lost_receipt_at :datetime
 #  memo                         :text             not null
 #  short_code                   :text
@@ -41,7 +41,7 @@ class Ledger
     has_many :canonical_pending_transactions, foreign_key: "ledger_item_id", inverse_of: :ledger_item
     has_many :all_ledgers, through: :ledger_mappings, source: :ledger, class_name: "::Ledger"
 
-    validates_presence_of :amount_cents, :memo, :date
+    validates_presence_of :amount_cents, :memo, :datetime
 
     monetize :amount_cents
 

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= item.hashid %></td>
-  <td><%= item.date.strftime("%b %e, %Y") %></td>
+  <td><%= item.datetime.strftime("%b %e, %Y") %></td>
   <td><%= truncate(item.memo, length: 80) %></td>
   <td class="nowrap"><%= item.amount.format %></td>
   <td><%= item.short_code %></td>

--- a/app/views/ledger/items/show.html.erb
+++ b/app/views/ledger/items/show.html.erb
@@ -25,7 +25,7 @@
       Date
     </strong>
     <div>
-      <%= @item.date.strftime("%b %e, %Y") %>
+      <%= @item.datetime.strftime("%b %e, %Y") %>
   </div>
   <div>
     <strong>

--- a/db/migrate/20260625150400_add_datetime_not_null_check_to_ledger_items.rb
+++ b/db/migrate/20260625150400_add_datetime_not_null_check_to_ledger_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDatetimeNotNullCheckToLedgerItems < ActiveRecord::Migration[8.0]
+  def change
+    # Add the NOT NULL guard as a check constraint first (NOT VALID) so it
+    # doesn't scan/lock the table. It's validated in a later migration before
+    # being promoted to a real NOT NULL on the column.
+    add_check_constraint :ledger_items, "datetime IS NOT NULL", name: "ledger_items_datetime_null", validate: false
+  end
+
+end

--- a/db/migrate/20260625150500_enforce_datetime_not_null_on_ledger_items.rb
+++ b/db/migrate/20260625150500_enforce_datetime_not_null_on_ledger_items.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class EnforceDatetimeNotNullOnLedgerItems < ActiveRecord::Migration[8.0]
+  def up
+    # Validating the check constraint lets Postgres set NOT NULL on the column
+    # without a second full scan.
+    validate_check_constraint :ledger_items, name: "ledger_items_datetime_null"
+    change_column_null :ledger_items, :datetime, false
+    remove_check_constraint :ledger_items, name: "ledger_items_datetime_null"
+
+    # `datetime` is now the source of truth. Drop NOT NULL on the legacy `date`
+    # column so it can stop being written once `date` is dropped.
+    change_column_null :ledger_items, :date, true
+  end
+
+  def down
+    change_column_null :ledger_items, :date, false
+    add_check_constraint :ledger_items, "datetime IS NOT NULL", name: "ledger_items_datetime_null", validate: false
+    change_column_null :ledger_items, :datetime, true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1578,8 +1578,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
   create_table "ledger_items", force: :cascade do |t|
     t.integer "amount_cents", null: false
     t.datetime "created_at", null: false
-    t.datetime "date", null: false
-    t.datetime "datetime"
+    t.datetime "date"
+    t.datetime "datetime", null: false
     t.datetime "marked_no_or_lost_receipt_at"
     t.text "memo", null: false
     t.text "short_code"

--- a/spec/factories/ledger/item_factory.rb
+++ b/spec/factories/ledger/item_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :ledger_item, class: "Ledger::Item" do
     amount_cents { 1000 }
     memo { "Test ledger item" }
-    date { Time.current }
+    datetime { Time.current }
     short_code { ::HcbCodeService::Generate::ShortCode.new.run }
     marked_no_or_lost_receipt_at { nil }
 

--- a/spec/models/canonical_pending_transaction_spec.rb
+++ b/spec/models/canonical_pending_transaction_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CanonicalPendingTransaction, type: :model do
     end
 
     it "does not create a ledger_item when one is already provided" do
-      existing_item = Ledger::Item.new(memo: "Existing", amount_cents: 500, date: Time.current)
+      existing_item = Ledger::Item.new(memo: "Existing", amount_cents: 500, datetime: Time.current)
       existing_item.save(validate: false)
 
       cpt = create(:canonical_pending_transaction, ledger_item: existing_item)

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -51,7 +51,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -68,7 +68,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -90,21 +90,21 @@ RSpec.describe Ledger::Item, type: :model do
 
   describe "validations" do
     it "requires amount_cents" do
-      item = Ledger::Item.new(memo: "Test", date: Time.current)
+      item = Ledger::Item.new(memo: "Test", datetime: Time.current)
       expect(item).not_to be_valid
       expect(item.errors[:amount_cents]).to include("can't be blank")
     end
 
     it "requires memo" do
-      item = Ledger::Item.new(amount_cents: 1000, date: Time.current)
+      item = Ledger::Item.new(amount_cents: 1000, datetime: Time.current)
       expect(item).not_to be_valid
       expect(item.errors[:memo]).to include("can't be blank")
     end
 
-    it "requires date" do
+    it "requires datetime" do
       item = Ledger::Item.new(amount_cents: 1000, memo: "Test")
       expect(item).not_to be_valid
-      expect(item.errors[:date]).to include("can't be blank")
+      expect(item.errors[:datetime]).to include("can't be blank")
     end
 
     describe "primary_ledger association" do
@@ -112,7 +112,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         expect(item).to be_valid
         expect(item.primary_ledger).to be_nil
@@ -130,7 +130,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -155,7 +155,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save!
 
@@ -179,7 +179,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -201,7 +201,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -235,7 +235,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -274,7 +274,7 @@ RSpec.describe Ledger::Item, type: :model do
         item = Ledger::Item.new(
           amount_cents: 1000,
           memo: "Test",
-          date: Time.current
+          datetime: Time.current
         )
         item.save(validate: false)
 
@@ -317,7 +317,7 @@ RSpec.describe Ledger::Item, type: :model do
 
   describe "#calculate_amount_cents" do
     let(:item) do
-      i = Ledger::Item.new(amount_cents: 0, memo: "Test", date: Time.current)
+      i = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
       i.save(validate: false)
       i
     end
@@ -336,7 +336,7 @@ RSpec.describe Ledger::Item, type: :model do
 
   describe "#write_amount_cents!" do
     it "updates amount_cents from calculate_amount_cents" do
-      item = Ledger::Item.new(amount_cents: 999, memo: "Test", date: Time.current)
+      item = Ledger::Item.new(amount_cents: 999, memo: "Test", datetime: Time.current)
       item.save(validate: false)
 
       create(:canonical_transaction, amount_cents: -500, ledger_item_id: item.id)

--- a/spec/services/ledger/mapper_spec.rb
+++ b/spec/services/ledger/mapper_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Ledger::Mapper do
   let(:item) do
-    i = Ledger::Item.new(amount_cents: 1000, memo: "Test", date: Time.current)
+    i = Ledger::Item.new(amount_cents: 1000, memo: "Test", datetime: Time.current)
     i.save(validate: false)
     i
   end


### PR DESCRIPTION
## Summary of the problem

Part of renaming `Ledger::Item#date` to `#datetime` without downtime. **PR 2 of 5**, stacked on #14001.

1. #14001 · add `datetime`, sync with `date`, backfill via maintenance task
2. **This PR** · switch reads/writes to `datetime`, enforce `NOT NULL`
3. #14003 · stop referencing `date` (`ignored_columns`)
4. #14007 · drop `date`
5. #14010 · remove the `date` `ignored_columns` entry

## Describe your changes

- Point all application code at `datetime`: the `create_ledger_item!` writers, the `order(...)` clauses, the ledger item views, the backfill job, and the presence validation.
- Promote `datetime` to `NOT NULL` using a validated check constraint (no long table lock), then drop `NOT NULL` on the legacy `date` column so it can stop being written in PR 3.
- The dual-write callback stays, so in-flight requests on the PR 1 release keep `date` populated during the rolling deploy.

> [!IMPORTANT]
> The `BackfillLedgerItemDatetime` task from #14001 must finish before this PR's `NOT NULL` migration runs.
