### PR TITLE
[Ledger] Rename Item#date to #datetime (3/5): ignore the column

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -6,7 +6,6 @@
 #
 #  id                           :bigint           not null, primary key
 #  amount_cents                 :integer          not null
-#  date                         :datetime
 #  datetime                     :datetime         not null
 #  marked_no_or_lost_receipt_at :datetime
 #  memo                         :text             not null
@@ -24,6 +23,11 @@
 class Ledger
   class Item < ApplicationRecord
     self.table_name = "ledger_items"
+
+    # `date` was renamed to `datetime`. Ignore the column so Active Record's
+    # schema cache stops referencing it. This must ship and deploy before the
+    # follow-up PR drops the column.
+    self.ignored_columns += ["date"]
 
     include Hashid::Rails
     has_paper_trail
@@ -44,12 +48,6 @@ class Ledger
     validates_presence_of :amount_cents, :memo, :datetime
 
     monetize :amount_cents
-
-    # The `date` column is being renamed to `datetime` without downtime. While
-    # both columns exist, keep them in sync so either code version (reading
-    # `date` or `datetime`) sees consistent data during a rolling deploy. This
-    # callback is removed once `date` is dropped.
-    before_validation :sync_date_and_datetime
 
     def receipt_required?
       false
@@ -74,16 +72,6 @@ class Ledger
     def map!
       Ledger::Mapper.new(ledger_item: self).run
       write_amount_cents!
-    end
-
-    private
-
-    def sync_date_and_datetime
-      if datetime_changed? && !date_changed?
-        self.date = datetime
-      elsif date_changed? && !datetime_changed?
-        self.datetime = date
-      end
     end
 
   end

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -299,22 +299,6 @@ RSpec.describe Ledger::Item, type: :model do
     end
   end
 
-  describe "date/datetime synchronization" do
-    # Temporary dual-write while the `date` column is being renamed to
-    # `datetime`. Remove these specs once `date` is dropped.
-    it "copies date into datetime when only date is set" do
-      item = Ledger::Item.new(amount_cents: 0, memo: "Test", date: Time.current)
-      item.valid?
-      expect(item.datetime).to eq(item.date)
-    end
-
-    it "copies datetime into date when only datetime is set" do
-      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
-      item.valid?
-      expect(item.date).to eq(item.datetime)
-    end
-  end
-
   describe "#calculate_amount_cents" do
     let(:item) do
       i = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)


### PR DESCRIPTION
## Summary of the problem

Part of renaming `Ledger::Item#date` to `#datetime` without downtime. **PR 3 of 5**, stacked on #14002.

1. #14001 · add `datetime`, sync with `date`, backfill via maintenance task
2. #14002 · switch reads/writes to `datetime`, enforce `NOT NULL`
3. **This PR** · stop referencing `date` (`ignored_columns`)
4. #14007 · drop `date`
5. #14010 · remove the `date` `ignored_columns` entry

## Describe your changes

- Add `date` to `ignored_columns` so Active Record's schema cache stops selecting or writing it, and remove the now-unused dual-write callback.
- No migration. The column still exists (it's nullable as of PR 2) and is dropped in #14007.

`strong_migrations`' own guidance for removing a column is to ignore it, **deploy**, then drop it in a separate step. Splitting that out (this PR vs #14007) guarantees no running process references `date` when the drop migration runs, independent of deploy/migration timing.

> [!IMPORTANT]
> Merge/deploy #14002 first, and deploy this **before** #14007's drop migration runs.
