### PR TITLE
[Ledger] Ledger::Item show page bug fix

### DIFF
--- a/app/views/ledger/items/show.html.erb
+++ b/app/views/ledger/items/show.html.erb
@@ -1,4 +1,4 @@
-<% if @item.primary_ledger.event.present? %>
+<% if @item.primary_ledger&.event.present? %>
   <% @event = @item.primary_ledger.event %>
   <%= render "events/nav" %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem

We're not currently using safe navigation, which results in an error when `primary_ledger` is `nil`.


## Describe your changes

This PR adds safe navigation to prevent the aforementioned error.