### PR TITLE
[Ledger] Rename Item#date to #datetime (4/5): drop the column

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -16,7 +16,6 @@
 # Indexes
 #
 #  index_ledger_items_on_amount_cents  (amount_cents)
-#  index_ledger_items_on_date          (date)
 #  index_ledger_items_on_datetime      (datetime)
 #  index_ledger_items_on_short_code    (short_code) UNIQUE
 #
@@ -24,9 +23,9 @@ class Ledger
   class Item < ApplicationRecord
     self.table_name = "ledger_items"
 
-    # `date` was renamed to `datetime`. Ignore the column so Active Record's
-    # schema cache stops referencing it. This must ship and deploy before the
-    # follow-up PR drops the column.
+    # `date` was renamed to `datetime` and dropped. Keep it ignored so a
+    # process still on older code can't select the column while this drop
+    # propagates. Safe to remove in a later cleanup.
     self.ignored_columns += ["date"]
 
     include Hashid::Rails

--- a/db/migrate/20260625150600_remove_date_from_ledger_items.rb
+++ b/db/migrate/20260625150600_remove_date_from_ledger_items.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveDateFromLedgerItems < ActiveRecord::Migration[8.0]
+  def change
+    # Final step of the date -> datetime rename. The column is no longer read
+    # or written (see Ledger::Item.ignored_columns), so it's safe to drop along
+    # with its index. safety_assured: the column is already ignored by the app.
+    safety_assured do
+      remove_column :ledger_items, :date, :datetime
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1578,14 +1578,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
   create_table "ledger_items", force: :cascade do |t|
     t.integer "amount_cents", null: false
     t.datetime "created_at", null: false
-    t.datetime "date"
     t.datetime "datetime", null: false
     t.datetime "marked_no_or_lost_receipt_at"
     t.text "memo", null: false
     t.text "short_code"
     t.datetime "updated_at", null: false
     t.index ["amount_cents"], name: "index_ledger_items_on_amount_cents"
-    t.index ["date"], name: "index_ledger_items_on_date"
     t.index ["datetime"], name: "index_ledger_items_on_datetime"
     t.index ["short_code"], name: "index_ledger_items_on_short_code", unique: true
   end


### PR DESCRIPTION
## Summary of the problem

Part of renaming `Ledger::Item#date` to `#datetime` without downtime. **PR 4 of 5**, stacked on #14003.

1. #14001 · add `datetime`, sync with `date`, backfill via maintenance task
2. #14002 · switch reads/writes to `datetime`, enforce `NOT NULL`
3. #14003 · stop referencing `date` (`ignored_columns`)
4. **This PR** · drop `date`
5. #14010 · remove the `date` `ignored_columns` entry

## Describe your changes

- Drop the `date` column and its index.
- Keep `date` in `ignored_columns` so a process still on #14003's predecessor code can't select the column mid-deploy. The `ignored_columns` entry itself is removed in the follow-up #14010.

> [!IMPORTANT]
> #14003 must be fully deployed before this drop migration runs.
