### PR TITLE
[Ledger] Rename Item#date to #datetime (5/5): remove ignored_columns

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -23,11 +23,6 @@ class Ledger
   class Item < ApplicationRecord
     self.table_name = "ledger_items"
 
-    # `date` was renamed to `datetime` and dropped. Keep it ignored so a
-    # process still on older code can't select the column while this drop
-    # propagates. Safe to remove in a later cleanup.
-    self.ignored_columns += ["date"]
-
     include Hashid::Rails
     has_paper_trail
 


### PR DESCRIPTION
## Summary of the problem

Cleanup follow-up to the `Ledger::Item#date` to `#datetime` rename. **PR 5 of 5**, stacked on #14007.

1. #14001 · add `datetime`, sync, backfill task
2. #14002 · switch reads/writes, enforce `NOT NULL`
3. #14003 · stop referencing `date` (`ignored_columns`)
4. #14007 · drop `date`
5. **This PR** · remove the `date` `ignored_columns` entry

## Describe your changes

Now that #14007 has dropped the column and fully propagated, `ignored_columns += ["date"]` names a column that no longer exists. It's dead config, so remove it.

> [!IMPORTANT]
> Merge/deploy after #14007 is fully rolled out.
