### PR TITLE
Remove stale ignored_columns entry on Event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -60,8 +60,6 @@
 #  fk_rails_...  (point_of_contact_id => users.id)
 #
 class Event < ApplicationRecord
-  self.ignored_columns += ["demo_mode_request_meeting_at"]
-
   MIN_WAITING_TIME_BETWEEN_FEES = 5.days
 
   include Hashid::Rails


### PR DESCRIPTION
## Summary of the problem

`self.ignored_columns` entries become dead config once their underlying column is dropped. `Event#demo_mode_request_meeting_at` was dropped from the database in #13665, but its `ignored_columns` guard was left behind (the repo's pattern has been to leave them). This removes that stale entry.

## Describe your changes

- Remove `self.ignored_columns += ["demo_mode_request_meeting_at"]` from `Event`. The column no longer exists, so this is a no-op for Active Record (verified: `annotaterb --frozen` is unchanged and the model still boots).

The other `ignored_columns` entries are intentionally **kept**, because their columns still exist and the ignore is load-bearing:

- `ApiToken#refresh_token` · the physical plaintext column is still present and is hidden so the `has_encrypted :refresh_token` virtual attribute can own the name.
- `IncreaseCheck#reissued_for_id` · column, index, and foreign key still exist; the ignore is the in-progress "ignore before drop" step.
