### PR TITLE
Use LE names in payment mailers

### DIFF
--- a/app/views/payment/attempt_mailer/failed_payee.html.erb
+++ b/app/views/payment/attempt_mailer/failed_payee.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @payment.payee.display_name %>,</p>
+<p>Hello <%= @payment.legal_entity.name %>,</p>
 
 <p>
   Your payment of <%= @payment.amount.format(with_currency: true) %> from <%= @payment.event.name %>

--- a/app/views/payment_mailer/missing_payout_method.html.erb
+++ b/app/views/payment_mailer/missing_payout_method.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @payment.payee.display_name %>,</p>
+<p>Hello <%= @payment.legal_entity.name %>,</p>
 
 <% if @initial %>
   <%= render partial: "initial_message", locals: { payment: @payment } %>

--- a/app/views/payment_mailer/missing_tax_information.html.erb
+++ b/app/views/payment_mailer/missing_tax_information.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @payment.payee.display_name %>,</p>
+<p>Hello,</p>
 
 <%= render partial: "initial_message", locals: { payment: @payment } %>
 

--- a/app/views/payment_mailer/sent.html.erb
+++ b/app/views/payment_mailer/sent.html.erb
@@ -1,4 +1,4 @@
-<p>Hello <%= @payment.payee.display_name %>,</p>
+<p>Hello <%= @payment.legal_entity.name %>,</p>
 
 <p>
   Your payment of <%= @payment.amount.format(with_currency: true) %> from <%= @payment.event.name %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The recipient doesn't need to be able to see that the organizer has entered in for them. Let's use the name they set when filling out their LE.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use LE names instead

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

