### PR TITLE
Gracefully handle external API failures on hot-path call sites

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1764,7 +1764,7 @@ class AdminController < Admin::BaseController
   end
 
   def pending_identity_vault_verifications_task_size
-    client = Faraday.new do |c|
+    client = Faraday.new(request: { open_timeout: 5, timeout: 8 }) do |c|
       c.response :json
       c.response :raise_error
     end
@@ -1777,7 +1777,7 @@ class AdminController < Admin::BaseController
 
   def hackathons_task_size
     hackathons = Faraday
-                 .new(ssl: { verify: false }) { |c| c.response :json }
+                 .new(ssl: { verify: false }, request: { open_timeout: 5, timeout: 8 }) { |c| c.response :json }
                  .get("https://dash.hackathons.hackclub.com/api/v1/stats/hackathons")
                  .body
 

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -123,34 +123,38 @@ class Event
       league = league.to_s.downcase
       team_number = team_number.to_s
 
-      conn = Faraday.new(url: TBA_BASE_URL) do |f|
-        f.headers["X-TBA-Auth-Key"] = Credentials.fetch(:THE_BLUE_ALLIANCE, :API_KEY)
-      end
-
-      team_key = "frc#{team_number}"
-      team_response = conn.get("team/#{team_key}")
-
-      return nil unless team_response.success?
-
-      team_data = JSON.parse(team_response.body)
-
-      avatar = nil
-      media_response = conn.get("team/#{team_key}/media/#{Date.today.year}")
-      if media_response.success?
-        media = JSON.parse(media_response.body)
-        avatar_media = media.find { |m| m["type"] == "avatar" }
-        if avatar_media
-          base64 = avatar_media.dig("details", "base64Image")
-          avatar = base64.present? ? "data:image/png;base64,#{base64}" : avatar_media["direct_url"].presence
+      # The Blue Alliance is a community-run service; if it's unreachable, report
+      # it and degrade to no team info rather than failing the request.
+      Rails.error.handle(context: { external_service: :the_blue_alliance }) do
+        conn = Faraday.new(url: TBA_BASE_URL) do |f|
+          f.headers["X-TBA-Auth-Key"] = Credentials.fetch(:THE_BLUE_ALLIANCE, :API_KEY)
         end
-      end
 
-      {
-        league: league,
-        team_number: team_number,
-        team_name: team_data["nickname"],
-        avatar: avatar
-      }
+        team_key = "frc#{team_number}"
+        team_response = conn.get("team/#{team_key}")
+
+        next nil unless team_response.success?
+
+        team_data = JSON.parse(team_response.body)
+
+        avatar = nil
+        media_response = conn.get("team/#{team_key}/media/#{Date.today.year}")
+        if media_response.success?
+          media = JSON.parse(media_response.body)
+          avatar_media = media.find { |m| m["type"] == "avatar" }
+          if avatar_media
+            base64 = avatar_media.dig("details", "base64Image")
+            avatar = base64.present? ? "data:image/png;base64,#{base64}" : avatar_media["direct_url"].presence
+          end
+        end
+
+        {
+          league: league,
+          team_number: team_number,
+          team_name: team_data["nickname"],
+          avatar: avatar
+        }
+      end
     end
 
     private

--- a/app/services/g_suite_service/verify.rb
+++ b/app/services/g_suite_service/verify.rb
@@ -85,12 +85,17 @@ module GSuiteService
 
     def verification_key_valid?(skip_g_verify: false)
       unless skip_g_verify
-        res = Faraday.get do |req|
-          req.url G_VERIFY_DOMAIN + domain
-          req.options.timeout = 60 # it may take heroku up to 30 seconds to cold start
-          req.headers["Authorization"] = Credentials.fetch(:GVERIFY)
+        # G-Verify is self-hosted and can be down; on any transport failure,
+        # report it and fall through to the direct DNS check below rather than
+        # raising.
+        res = Rails.error.handle(context: { external_service: :g_verify }) do
+          Faraday.get do |req|
+            req.url G_VERIFY_DOMAIN + domain
+            req.options.timeout = 60 # it may take heroku up to 30 seconds to cold start
+            req.headers["Authorization"] = Credentials.fetch(:GVERIFY)
+          end
         end
-        return true if res.success?
+        return true if res&.success?
       end
 
       # Some old G Suite domains did not have their verification key generated


### PR DESCRIPTION
## Summary of the problem
Several synchronous calls to external services run on the web request hot path. If one of these (especially self-hosted/lower-reliability services) is down or hangs, it 500s the page instead of degrading.

## Describe your changes
Wrap these hot-path calls so a vendor outage degrades gracefully and is reported via `Rails.error`:

- **G-Verify** (self-hosted): on a transport failure, fall through to the existing direct DNS check instead of raising.
- **The Blue Alliance**: degrade to `nil` (no enriched team info) on outage, matching the existing non-2xx contract.
- **Admin badge counts** (`dash.hackathons.hackclub.com`, `identity.hackclub.com`): add open/read timeouts so a hung self-hosted service fails fast into the existing rescue rather than holding the request thread ~60s.