### PR TITLE
Guard user-settable int4 amount columns against overflow

### DIFF
--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -102,7 +102,7 @@ class CardGrant < ApplicationRecord
   serialize :banned_categories, coder: CommaSeparatedCoder
 
   validates_presence_of :amount_cents, :email
-  validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }, on: :create
+  validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }, on: :create, integer_column: true
 
   MAXIMUM_PURPOSE_LENGTH = 30
   validates :purpose, length: { maximum: MAXIMUM_PURPOSE_LENGTH }

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -80,7 +80,7 @@ class CheckDeposit < ApplicationRecord
   validates :front, size: { less_than_or_equal_to: 20.megabytes }, if: -> { attachment_changes["front"].present? }
   validates :back, size: { less_than_or_equal_to: 20.megabytes }, if: -> { attachment_changes["back"].present? }
 
-  validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }, presence: true
+  validates :amount_cents, numericality: { greater_than: 0, message: "can't be zero!" }, presence: true, integer_column: true
   validates :front, attached: true, content_type: [:png, :jpeg], on: :create
   validates :back, attached: true, content_type: [:png, :jpeg], on: :create
   validates_uniqueness_of :column_id, allow_nil: true

--- a/app/models/donation/goal.rb
+++ b/app/models/donation/goal.rb
@@ -28,7 +28,7 @@ class Donation
 
     belongs_to :event
 
-    validates :amount_cents, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+    validates :amount_cents, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, integer_column: true
     validates :tracking_since, presence: true
 
     validates_uniqueness_of_without_deleted :event_id

--- a/app/models/donation/tier.rb
+++ b/app/models/donation/tier.rb
@@ -31,7 +31,7 @@ class Donation
     belongs_to :event
 
     validates :name, :amount_cents, presence: true
-    validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+    validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }, integer_column: true
     validate :maximum_tiers_limit
     validate :amount_is_whole_dollar
 

--- a/app/models/reimbursement/expense.rb
+++ b/app/models/reimbursement/expense.rb
@@ -35,7 +35,7 @@ module Reimbursement
     include ApplicationHelper
     belongs_to :report, inverse_of: :expenses, foreign_key: "reimbursement_report_id", touch: true
     monetize :amount_cents, as: "amount", with_model_currency: :currency
-    validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
+    validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }, integer_column: true
     attribute :expense_number, :integer
     has_one :expense_payout
     has_one :event, through: :report

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -73,7 +73,7 @@ module Reimbursement
     monetize :maximum_amount_cents, allow_nil: true
     monetize :amount_to_reimburse_cents, allow_nil: true, with_model_currency: :currency
     monetize :amount_cents, as: "amount", allow_nil: true, with_model_currency: :currency
-    validates :maximum_amount_cents, numericality: { greater_than: 0 }, allow_nil: true
+    validates :maximum_amount_cents, numericality: { greater_than: 0 }, allow_nil: true, integer_column: true
     has_many :expenses, foreign_key: "reimbursement_report_id", inverse_of: :report, dependent: :destroy
     has_one :payout_holding, inverse_of: :report
     alias_attribute :report_name, :name

--- a/app/validators/integer_column_validator.rb
+++ b/app/validators/integer_column_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Rejects integer values that won't fit in their database column, before they reach Postgres
+# on save (which would otherwise raise ActiveModel::RangeError -> 500). The range is derived
+# from the column's byte size, so the limit never has to be hardcoded.
+#
+#   validates :amount_cents, integer_column: true
+class IntegerColumnValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+
+    column = record.class.columns_hash[attribute.to_s]
+    return unless column&.type == :integer
+
+    bits = (column.limit || 4) * 8
+    if value > 2**(bits - 1) - 1
+      record.errors.add(attribute, "is too big")
+    elsif value < -(2**(bits - 1))
+      record.errors.add(attribute, "is too small")
+    end
+  end
+
+end

--- a/spec/services/card_grant_service/bulk_create_spec.rb
+++ b/spec/services/card_grant_service/bulk_create_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe CardGrantService::BulkCreate do
             csv_file: csv_file_from_content(csv_content),
             sent_by:
           ).run
-        }.to raise_error(ActiveModel::RangeError)
+        }.to raise_error(ActiveRecord::RecordInvalid, /Amount cents is too big/)
 
         expect(CardGrant.count).to eq(initial_count)
       end

--- a/spec/validators/integer_column_validator_spec.rb
+++ b/spec/validators/integer_column_validator_spec.rb
@@ -3,18 +3,18 @@
 require "rails_helper"
 
 RSpec.describe IntegerColumnValidator do
-  INT4_MAX = 2_147_483_647
-  INT4_MIN = -2_147_483_648
+  int4_max = 2_147_483_647
+  int4_min = -2_147_483_648
 
   # Each user-settable int4 column this validator guards.
-  GUARDED = {
+  guarded = {
     Donation::Goal         => :amount_cents,
     Donation::Tier         => :amount_cents,
     Reimbursement::Report  => :maximum_amount_cents,
     Reimbursement::Expense => :amount_cents,
     CheckDeposit           => :amount_cents,
     CardGrant              => :amount_cents
-  }.freeze
+  }
 
   # Run validations and return the errors on the guarded column. The record need not be
   # otherwise valid; we only assert on the integer-range errors.
@@ -26,11 +26,11 @@ RSpec.describe IntegerColumnValidator do
 
   describe "behavior (via Donation::Goal#amount_cents)" do
     it "rejects a value too big for the column" do
-      expect(range_errors(Donation::Goal, :amount_cents, INT4_MAX + 1)).to include("is too big")
+      expect(range_errors(Donation::Goal, :amount_cents, int4_max + 1)).to include("is too big")
     end
 
     it "rejects a value too small for the column" do
-      expect(range_errors(Donation::Goal, :amount_cents, INT4_MIN - 1)).to include("is too small")
+      expect(range_errors(Donation::Goal, :amount_cents, int4_min - 1)).to include("is too small")
     end
 
     it "accepts an in-range value" do
@@ -47,7 +47,7 @@ RSpec.describe IntegerColumnValidator do
   end
 
   describe "is wired onto every user-settable int4 money column" do
-    GUARDED.each do |model, column|
+    guarded.each do |model, column|
       it "guards #{model}##{column}" do
         expect(model.validators_on(column).map(&:class)).to include(IntegerColumnValidator)
       end

--- a/spec/validators/integer_column_validator_spec.rb
+++ b/spec/validators/integer_column_validator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IntegerColumnValidator do
+  INT4_MAX = 2_147_483_647
+  INT4_MIN = -2_147_483_648
+
+  # Each user-settable int4 column this validator guards.
+  GUARDED = {
+    Donation::Goal         => :amount_cents,
+    Donation::Tier         => :amount_cents,
+    Reimbursement::Report  => :maximum_amount_cents,
+    Reimbursement::Expense => :amount_cents,
+    CheckDeposit           => :amount_cents,
+    CardGrant              => :amount_cents
+  }.freeze
+
+  # Run validations and return the errors on the guarded column. The record need not be
+  # otherwise valid; we only assert on the integer-range errors.
+  def range_errors(model, column, value)
+    record = model.new(column => value)
+    record.valid?(:create)
+    record.errors[column]
+  end
+
+  describe "behavior (via Donation::Goal#amount_cents)" do
+    it "rejects a value too big for the column" do
+      expect(range_errors(Donation::Goal, :amount_cents, INT4_MAX + 1)).to include("is too big")
+    end
+
+    it "rejects a value too small for the column" do
+      expect(range_errors(Donation::Goal, :amount_cents, INT4_MIN - 1)).to include("is too small")
+    end
+
+    it "accepts an in-range value" do
+      errors = range_errors(Donation::Goal, :amount_cents, 500_00)
+      expect(errors).not_to include("is too big")
+      expect(errors).not_to include("is too small")
+    end
+
+    it "accepts nil" do
+      errors = range_errors(Donation::Goal, :amount_cents, nil)
+      expect(errors).not_to include("is too big")
+      expect(errors).not_to include("is too small")
+    end
+  end
+
+  describe "is wired onto every user-settable int4 money column" do
+    GUARDED.each do |model, column|
+      it "guards #{model}##{column}" do
+        expect(model.validators_on(column).map(&:class)).to include(IntegerColumnValidator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

A user can type a number larger than a 32-bit integer into several amount/quantity fields. On save the value overflows the `int4` column and ActiveRecord raises `ActiveModel::RangeError` (a 500) instead of a validation error. Affected, user-settable money columns with no upper bound: `Donation::Goal`, `Donation::Tier`, `Reimbursement::Report#maximum_amount_cents`, `Reimbursement::Expense`, `CheckDeposit`, and `CardGrant`. (Found while fixing the same class of bug on the event application form.)

## Describe your changes

- Add `IntegerColumnValidator` (`app/validators/integer_column_validator.rb`), an `ActiveModel::EachValidator` that derives the valid range from the column's own byte size, so the limit is never hardcoded. Adds an `is too big` / `is too small` error.
- Apply `integer_column: true` to the affected `*_cents` columns on the six models above (alongside their existing lower-bound validations).
- Spec covering the validator's behavior and confirming it is wired on each model.

Out of scope: transfers (ACH/PayPal/Wire/Increase reject `amount > balance` on create, so they can't overflow) and admin-only fields. `Event::Application`'s equivalent fix ships with the event-application prefill work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
