### PR TITLE
[Admin] Fixed alternating styling on failed reimbursements page 

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -643,7 +643,7 @@ video {
 }
 
 .admin-bg-warning {
-  background: #ec3750;
+  background: #ec3750 !important;
 }
 
 /* Table column width utility classes adapted from Tailwind CSS https://tailwindcss.com/docs/width  */


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
fixes #13973

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Added !important as without it, alternating rows are created


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
with !important
<img width="1283" height="847" alt="image" src="https://github.com/user-attachments/assets/38bc3b6d-b9e1-453b-a76b-0b35c3212c83" />
without !important
<img width="1297" height="827" alt="image" src="https://github.com/user-attachments/assets/9d0e1e48-0573-4e9a-ad71-5f66e3cb0a83" />
