### PR TITLE
[Reimbursement][LEPM] Associate a specific payout method to a report

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -115,7 +115,7 @@ module Reimbursement
       authorize @report
 
       old_currency = @report.currency
-      new_currency = @report.user.default_payout_method.currency
+      new_currency = @report.payout_method.currency
 
       ActiveRecord::Base.transaction do
         @report.update!(currency: new_currency)
@@ -202,7 +202,7 @@ module Reimbursement
         end
 
         flash[:success] = {
-          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.user.default_payout_method.name}.",
+          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
           link: settings_payouts_path
         }
         if @report.user.can_update_payout_method?
@@ -304,7 +304,7 @@ module Reimbursement
           payout_holding.reload
           payout_holding.mark_settled!
         end
-        wise_payout_method = @report.user.default_payout_method&.details
+        wise_payout_method = @report.payout_method&.details
         wise_payout_method.update(wise_recipient_id: params[:wise_recipient_id])
         wise_transfer = clearinghouse.wise_transfers.create!(
           payment_for: "Reimbursement for #{@report.name}.",

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -101,7 +101,7 @@ module Reimbursement
 
     acts_as_paranoid
 
-    before_create :snapshot_payout_method
+    before_create :set_payout_method
 
     after_create_commit do
       ReimbursementMailer.with(report: self).invitation.deliver_later if inviter != user
@@ -436,7 +436,7 @@ module Reimbursement
 
     private
 
-    def snapshot_payout_method
+    def set_payout_method
       self.legal_entity_payout_method ||= user&.default_payout_method
     end
 

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -4,40 +4,43 @@
 #
 # Table name: reimbursement_reports
 #
-#  id                         :bigint           not null, primary key
-#  aasm_state                 :string           not null
-#  conversion_rate            :float            default(1.0), not null
-#  currency                   :string           default("USD"), not null
-#  deleted_at                 :datetime
-#  expense_number             :integer          default(0), not null
-#  invite_message             :text
-#  maximum_amount_cents       :integer
-#  name                       :text
-#  reimbursed_at              :datetime
-#  reimbursement_approved_at  :datetime
-#  reimbursement_requested_at :datetime
-#  rejected_at                :datetime
-#  submitted_at               :datetime
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  card_grant_id              :bigint
-#  event_id                   :bigint
-#  invited_by_id              :bigint
-#  reviewer_id                :bigint
-#  user_id                    :bigint           not null
+#  id                            :bigint           not null, primary key
+#  aasm_state                    :string           not null
+#  conversion_rate               :float            default(1.0), not null
+#  currency                      :string           default("USD"), not null
+#  deleted_at                    :datetime
+#  expense_number                :integer          default(0), not null
+#  invite_message                :text
+#  maximum_amount_cents          :integer
+#  name                          :text
+#  reimbursed_at                 :datetime
+#  reimbursement_approved_at     :datetime
+#  reimbursement_requested_at    :datetime
+#  rejected_at                   :datetime
+#  submitted_at                  :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  card_grant_id                 :bigint
+#  event_id                      :bigint
+#  invited_by_id                 :bigint
+#  legal_entity_payout_method_id :bigint
+#  reviewer_id                   :bigint
+#  user_id                       :bigint           not null
 #
 # Indexes
 #
-#  index_reimbursement_reports_on_card_grant_id  (card_grant_id)
-#  index_reimbursement_reports_on_event_id       (event_id)
-#  index_reimbursement_reports_on_invited_by_id  (invited_by_id)
-#  index_reimbursement_reports_on_reviewer_id    (reviewer_id)
-#  index_reimbursement_reports_on_user_id        (user_id)
+#  index_reimbursement_reports_on_card_grant_id                  (card_grant_id)
+#  index_reimbursement_reports_on_event_id                       (event_id)
+#  index_reimbursement_reports_on_invited_by_id                  (invited_by_id)
+#  index_reimbursement_reports_on_legal_entity_payout_method_id  (legal_entity_payout_method_id)
+#  index_reimbursement_reports_on_reviewer_id                    (reviewer_id)
+#  index_reimbursement_reports_on_user_id                        (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (event_id => events.id)
 #  fk_rails_...  (invited_by_id => users.id)
+#  fk_rails_...  (legal_entity_payout_method_id => legal_entity_payout_methods.id) ON DELETE => nullify
 #  fk_rails_...  (user_id => users.id)
 #
 module Reimbursement
@@ -66,6 +69,7 @@ module Reimbursement
     belongs_to :inviter, class_name: "User", foreign_key: "invited_by_id", optional: true, inverse_of: :created_reimbursement_reports
     belongs_to :reviewer, class_name: "User", optional: true, inverse_of: :assigned_reimbursement_reports
     belongs_to :card_grant, optional: true
+    belongs_to :legal_entity_payout_method, class_name: "LegalEntity::PayoutMethod", optional: true
 
     has_paper_trail ignore: :expense_number
     include HasPaperTrailHelpers
@@ -97,6 +101,8 @@ module Reimbursement
 
     acts_as_paranoid
 
+    before_create :snapshot_payout_method
+
     after_create_commit do
       ReimbursementMailer.with(report: self).invitation.deliver_later if inviter != user
       Reimbursement::OneDayReminderJob.set(wait: 1.day).perform_later(self)
@@ -117,7 +123,7 @@ module Reimbursement
       event :mark_submitted do
         transitions from: [:draft, :reimbursement_requested], to: :submitted do
           guard do
-            user.default_payout_method.present? && !user.onboarding? && event && !exceeds_maximum_amount? && !below_minimum_amount? &&
+            payout_method.present? && !user.onboarding? && event && !exceeds_maximum_amount? && !below_minimum_amount? &&
               expenses.any? && !missing_receipts? && !event.financially_frozen? && expenses.none? { |e| e.amount.zero? } &&
               !mismatched_currency? && payout_method_allowed?
           end
@@ -332,7 +338,7 @@ module Reimbursement
     end
 
     def mismatched_currency?
-      user.default_payout_method.present? && currency != user.default_payout_method.currency
+      payout_method.present? && currency != payout_method.currency
     end
 
     def exceeds_maximum_amount?
@@ -346,7 +352,7 @@ module Reimbursement
     end
 
     def below_minimum_amount?
-      user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
+      payout_method&.details.is_a?(LegalEntity::PayoutMethod::Wire) && amount_cents < minimum_wire_amount_cents
     end
 
     def from_public_reimbursement_form?
@@ -378,7 +384,7 @@ module Reimbursement
     def convert_to_wise_transfer!(as: User.system_user)
       raise "Can only convert reports in 'Reimbursement Requested' state" unless reimbursement_requested?
 
-      payout_method = user.default_payout_method&.details
+      payout_method = self.payout_method&.details
 
       account_holder =
         if payout_method.respond_to?(:account_holder)
@@ -424,7 +430,15 @@ module Reimbursement
       end
     end
 
+    def payout_method
+      legal_entity_payout_method || user&.default_payout_method
+    end
+
     private
+
+    def snapshot_payout_method
+      self.legal_entity_payout_method ||= user&.default_payout_method
+    end
 
     def reimburse!
       ActiveRecord::Base.transaction do
@@ -447,7 +461,7 @@ module Reimbursement
     end
 
     def payout_method_allowed?
-      user.default_payout_method.present? && !user.default_payout_method.unsupported?
+      payout_method.present? && !payout_method.unsupported?
     end
 
     def invalidate_cached_data

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -586,9 +586,9 @@ class User < ApplicationRecord
     return true if default_payout_method&.details.nil?
     return true unless default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
-    # Only reports still tracking the default (no snapshotted payout method)
-    # would be disrupted by replacing it; snapshotted reports keep their own
-    # payout method record, which an update leaves intact.
+    # Only reports still tracking the default (no payout method set on the
+    # report) would be disrupted by replacing it; reports that have their own
+    # payout method record keep it, which an update leaves intact.
     return false if reimbursement_reports.reimbursement_requested.where(legal_entity_payout_method_id: nil).any?
     return false if reimbursement_reports.joins(:payout_holding).where(payout_holding: { aasm_state: :pending }, reimbursement_reports: { legal_entity_payout_method_id: nil }).any?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -585,8 +585,12 @@ class User < ApplicationRecord
   def can_update_payout_method?
     return true if default_payout_method&.details.nil?
     return true unless default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
-    return false if reimbursement_reports.reimbursement_requested.any?
-    return false if reimbursement_reports.joins(:payout_holding).where({ payout_holding: { aasm_state: :pending } }).any?
+
+    # Only reports still tracking the default (no snapshotted payout method)
+    # would be disrupted by replacing it; snapshotted reports keep their own
+    # payout method record, which an update leaves intact.
+    return false if reimbursement_reports.reimbursement_requested.where(legal_entity_payout_method_id: nil).any?
+    return false if reimbursement_reports.joins(:payout_holding).where(payout_holding: { aasm_state: :pending }, reimbursement_reports: { legal_entity_payout_method_id: nil }).any?
 
     true
   end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -99,9 +99,9 @@ class LegalEntity
       end
 
       def switching_to_wise_while_processing?
-        # Only reports that still track the user's default (no snapshotted
-        # payout method) would be flipped to Wise by this change; reports with
-        # their own snapshot keep their original method and are unaffected.
+        # Only reports that still track the user's default (no payout method
+        # set on the report) would be flipped to Wise by this change; reports
+        # with their own payout method keep their original and are unaffected.
         @payout_method.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
           !@user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
           @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES, legal_entity_payout_method_id: nil).any?

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -86,7 +86,7 @@ class LegalEntity
              .joins(:payout_holding)
              .where(reimbursement_payout_holdings: { aasm_state: :failed })
              .where(legal_entity_payout_method_id: replaced_method.id)
-             .update_all(legal_entity_payout_method_id: @payout_method.id, updated_at: Time.current)
+             .update(legal_entity_payout_method: @payout_method)
       end
 
       def switching_to_wise_while_processing?

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -82,16 +82,20 @@ class LegalEntity
       def repoint_failed_and_draft_reports(replaced_method)
         return unless replaced_method
 
-        @user.reimbursement_reports
-             .joins(:payout_holding)
-             .where(reimbursement_payout_holdings: { aasm_state: :failed })
-             .where(legal_entity_payout_method_id: replaced_method.id)
-             .update(legal_entity_payout_method: @payout_method)
+        on_replaced_method = @user.reimbursement_reports.where(legal_entity_payout_method_id: replaced_method.id)
 
-        @user.reimbursement_reports
-             .where(aasm_state: :draft)
-             .where(legal_entity_payout_method_id: replaced_method.id)
-             .update(legal_entity_payout_method: @payout_method)
+        failed = on_replaced_method.joins(:payout_holding).where(reimbursement_payout_holdings: { aasm_state: :failed })
+        draft = on_replaced_method.where(aasm_state: :draft)
+
+        # update! runs validations and records the change in paper_trail; each
+        # is wrapped in safely so a single report that can't be repointed is
+        # reported rather than silently skipped, without aborting the user's
+        # payout-method change or the other repoints.
+        (failed + draft).each do |report|
+          safely do
+            report.update!(legal_entity_payout_method: @payout_method)
+          end
+        end
       end
 
       def switching_to_wise_while_processing?

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -27,9 +27,15 @@ class LegalEntity
         apply_business_rules
         return false if @payout_method.errors.any?
 
+        # The method this update supersedes — captured before save, since
+        # saving the new default unsets the old one.
+        replaced_method = @user.default_payout_method
+
         # autosave: true on :details saves the detail record and the payout
         # method together, atomically, even inside the controller's transaction.
-        @payout_method.save
+        saved = @payout_method.save
+        repoint_failed_reports(replaced_method) if saved
+        saved
       end
 
       def run!
@@ -75,10 +81,23 @@ class LegalEntity
         end
       end
 
+      def repoint_failed_reports(replaced_method)
+        return unless replaced_method
+
+        @user.reimbursement_reports
+             .joins(:payout_holding)
+             .where(reimbursement_payout_holdings: { aasm_state: :failed })
+             .where(legal_entity_payout_method_id: replaced_method.id)
+             .update_all(legal_entity_payout_method_id: @payout_method.id, updated_at: Time.current)
+      end
+
       def switching_to_wise_while_processing?
+        # Only reports that still track the user's default (no snapshotted
+        # payout method) would be flipped to Wise by this change; reports with
+        # their own snapshot keep their original method and are unaffected.
         @payout_method.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
           !@user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-          @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES).any?
+          @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES, legal_entity_payout_method_id: nil).any?
       end
 
     end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -32,7 +32,7 @@ class LegalEntity
         # autosave: true on :details saves the detail record and the payout
         # method together, atomically, even inside the controller's transaction.
         saved = @payout_method.save
-        repoint_failed_reports(replaced_method) if saved
+        repoint_failed_and_draft_reports(replaced_method) if saved
         saved
       end
 
@@ -79,12 +79,17 @@ class LegalEntity
         end
       end
 
-      def repoint_failed_reports(replaced_method)
+      def repoint_failed_and_draft_reports(replaced_method)
         return unless replaced_method
 
         @user.reimbursement_reports
              .joins(:payout_holding)
              .where(reimbursement_payout_holdings: { aasm_state: :failed })
+             .where(legal_entity_payout_method_id: replaced_method.id)
+             .update(legal_entity_payout_method: @payout_method)
+
+        @user.reimbursement_reports
+             .where(aasm_state: :draft)
              .where(legal_entity_payout_method_id: replaced_method.id)
              .update(legal_entity_payout_method: @payout_method)
       end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -27,8 +27,6 @@ class LegalEntity
         apply_business_rules
         return false if @payout_method.errors.any?
 
-        # The method this update supersedes — captured before save, since
-        # saving the new default unsets the old one.
         replaced_method = @user.default_payout_method
 
         # autosave: true on :details saves the detail record and the payout

--- a/app/services/reimbursement/expense_payout_service/nightly.rb
+++ b/app/services/reimbursement/expense_payout_service/nightly.rb
@@ -5,13 +5,13 @@ module Reimbursement
     class Nightly
       def run
         Reimbursement::ExpensePayout.pending.find_each(batch_size: 100) do |expense_payout|
-          next if expense_payout.expense.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if expense_payout.expense.report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::ExpensePayoutService::ProcessSingle.new(expense_payout_id: expense_payout.id).run
         end
 
         Reimbursement::PayoutHolding.pending.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if payout_holding.report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           Reimbursement::PayoutHoldingService::ProcessSingle.new(payout_holding_id: payout_holding.id).run
         end
@@ -23,7 +23,7 @@ module Reimbursement
         end
 
         Reimbursement::PayoutHolding.in_transit.find_each(batch_size: 100) do |payout_holding|
-          next if payout_holding.report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
+          next if payout_holding.report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
 
           if payout_holding.canonical_transactions.any? || payout_holding.canonical_pending_transaction.present?
             payout_holding.mark_settled!

--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -9,7 +9,7 @@ module Reimbursement
           payout_holding.with_lock do
             next unless payout_holding.settled?
 
-            payout_method = payout_holding.report.user.default_payout_method&.details
+            payout_method = payout_holding.report.payout_method&.details
 
             case payout_method
             when LegalEntity::PayoutMethod::Wire

--- a/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
+++ b/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillReimbursementReportPayoutMethodsTask < MaintenanceTasks::Task
+    def collection
+      Reimbursement::Report.where(legal_entity_payout_method_id: nil)
+    end
+
+    def process(report)
+      payout_method = report.user&.default_payout_method
+      return unless payout_method
+
+      report.update_columns(legal_entity_payout_method_id: payout_method.id, updated_at: Time.current)
+    end
+
+  end
+end

--- a/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
+++ b/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
@@ -10,7 +10,7 @@ module Maintenance
       payout_method = report.user&.default_payout_method
       return unless payout_method
 
-      report.update_columns(legal_entity_payout_method_id: payout_method.id, updated_at: Time.current)
+      report.update(legal_entity_payout_method: payout_method)
     end
 
   end

--- a/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
+++ b/app/tasks/maintenance/backfill_reimbursement_report_payout_methods_task.rb
@@ -3,14 +3,22 @@
 module Maintenance
   class BackfillReimbursementReportPayoutMethodsTask < MaintenanceTasks::Task
     def collection
-      Reimbursement::Report.where(legal_entity_payout_method_id: nil)
+      # Exclude reports that have already paid out (reimbursed, reversed): they
+      # may have used a payout method the user has since changed, so associating
+      # their current default would mislabel them. Every other state hasn't paid
+      # out, so the current default is the method they'd be reimbursed through,
+      # matching how the payout resolved the method before it was set on the
+      # report.
+      Reimbursement::Report
+        .where(legal_entity_payout_method_id: nil)
+        .where.not(aasm_state: [:reimbursed, :reversed])
     end
 
     def process(report)
       payout_method = report.user&.default_payout_method
       return unless payout_method
 
-      report.update(legal_entity_payout_method: payout_method)
+      report.update!(legal_entity_payout_method: payout_method)
     end
 
   end

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -1,5 +1,5 @@
 <% member_viewing = !OrganizerPosition.role_at_least?(current_user, report.event, :manager) && current_user != report.user && !admin_signed_in? %>
-<% payout_method = report.user.default_payout_method&.details %>
+<% payout_method = report.payout_method&.details %>
 
 <div id="action-wrapper" class="mt-5">
   <% button_hint = "" %>
@@ -79,24 +79,24 @@
         <div style="flex-grow: 1;" class="flex sm:justify-end">
           <%= link_to reimbursement_report_update_currency_path(report), method: :post, class: "btn bg-secondary" do %>
             <%= inline_icon "transactions" %>
-            Switch to <%= user.default_payout_method&.currency %>
+            Switch to <%= report.payout_method&.currency %>
           <% end %>
         </div>
       <% end %>
 
       <div style="flex-grow: 1;" class="flex sm:justify-end" id="action-right">
-        <% if !user.default_payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (user.default_payout_method.present? && user.default_payout_method.unsupported?) || report.mismatched_currency? %>
+        <% if !report.payout_method.present? || user.onboarding? || report.payout_holding&.failed? || (report.payout_method.present? && report.payout_method.unsupported?) || report.mismatched_currency? %>
           <% if user == current_user %>
             <%= link_to settings_payouts_path, class: "btn bg-warning h-9 min-h-9", data: { behavior: "modal_trigger", modal: "edit_payout" } do %>
               <%= inline_icon "profile" %>
-              <%= report.payout_holding&.failed? || user.default_payout_method.present? ? "Edit" : "Add" %> payout information
+              <%= report.payout_holding&.failed? || report.payout_method.present? ? "Edit" : "Add" %> payout information
               <% button_hint = capture do %>
                 <% if report.mismatched_currency? %>
-                  <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= user.default_payout_method.currency %>.
+                  <span class="bold warning">Warning</span>: your report is is in <%= report.currency %>, but your payouts are configured for <%= report.payout_method.currency %>.
                 <% else %>
                   <span class="bold">Your next step:</span> before you can be reimbursed, you need to
-                  <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
-                    update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
+                  <% if report.payout_method.present? && report.payout_method.unsupported? %>
+                    update your payout information. <%= report.payout_method.unsupported_details[:reason] %>
                   <% else %>
                     provide HCB your payout information.
                   <% end %>
@@ -109,7 +109,7 @@
                 <%= inline_icon "send" %>
                 Submit & request review
                 <% button_hint = capture do %>
-                  <span class="bold warning">Warning</span>: this report is is in <%= report.currency %>, but the user's payouts are configured for <%= user.default_payout_method.currency %>.
+                  <span class="bold warning">Warning</span>: this report is is in <%= report.currency %>, but the user's payouts are configured for <%= report.payout_method.currency %>.
                 <% end %>
               </div>
             </div>
@@ -119,14 +119,14 @@
               <%= report.payout_holding&.failed? ? "Edit" : "Add" %> <%= user.first_name %>'s payout information
               <% button_hint = capture do %>
                 <span class="bold">Status:</span> before <%= user.first_name %> can be reimbursed, they need to
-                <% if user.default_payout_method.present? && user.default_payout_method.unsupported? %>
-                  update your payout information. <%= user.default_payout_method.unsupported_details[:reason] %>
+                <% if report.payout_method.present? && report.payout_method.unsupported? %>
+                  update your payout information. <%= report.payout_method.unsupported_details[:reason] %>
                 <% else %>
                   add their payout information.
                 <% end %>
               <% end %>
             <% end %>
-          <% elsif !user.default_payout_method.present? %>
+          <% elsif !report.payout_method.present? %>
             <div class="tooltipped tooltipped--n" aria-label="<%= user.name %> is missing payout information.">
               <div class="btn bg-info disabled whitespace-nowrap">
                 <%= inline_icon "send" %>
@@ -140,11 +140,11 @@
           <% if report.payout_holding&.failed? %>
             <% if user == current_user %>
               <% button_hint = capture do %>
-                <span class="bold">Warning:</span> your <%= user.default_payout_method.human_kind %> information was flagged as invalid, please edit your payout settings and HCB will retry the payment.
+                <span class="bold">Warning:</span> your <%= report.payout_method.human_kind %> information was flagged as invalid, please edit your payout settings and HCB will retry the payment.
               <% end %>
             <% else %>
               <% button_hint = capture do %>
-                <span class="bold">Warning:</span> <%= user.first_name %>'s <%= user.default_payout_method.human_kind %> information was flagged as invalid, please ask them to edit their payout settings and HCB will retry the payment.
+                <span class="bold">Warning:</span> <%= user.first_name %>'s <%= report.payout_method.human_kind %> information was flagged as invalid, please ask them to edit their payout settings and HCB will retry the payment.
               <% end %>
             <% end %>
           <% end %>
@@ -396,7 +396,7 @@
           <%= button_hint %>
         </div>
       <% end %>
-      <% if report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
+      <% if report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) %>
         <div class="card mt-2">
           <%= turbo_frame_tag :wise_transfer_breakdown, loading: :lazy, src: reimbursement_report_wise_transfer_breakdown_path(report) do %>
             Fetching latest estimate...

--- a/app/views/reimbursement/reports/_payout_information.html.erb
+++ b/app/views/reimbursement/reports/_payout_information.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (report:) %>
 
 <% user = report.user %>
-<% payout_method = user.default_payout_method&.details %>
+<% payout_method = report.payout_method&.details %>
 
 <h3 class="mt-0">Payout information</h3>
 

--- a/app/views/reimbursement/reports/_wise_information.html.erb
+++ b/app/views/reimbursement/reports/_wise_information.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (report:) %>
 
-<% payout_method = report.user.default_payout_method&.details %>
+<% payout_method = report.payout_method&.details %>
 
 <table class="w-full table-fixed my-6">
   <tbody>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -170,7 +170,7 @@
   <% end %>
 <% end %>
 
-<% if @report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
+<% if @report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.payout_holding && @report.payout_holding.wise_transfer.nil? %>
   <% admin_tool("mt-4") do %>
     <h3 class="mt-0">Process Wise reimbursement</h3>
 
@@ -218,7 +218,7 @@
   <%= render partial: "reimbursement/reports/blankslate", locals: { report: @report } %>
 </div>
 
-<% if @report.user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
+<% if @report.payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) && @report.expenses.select { |e| e.type == Reimbursement::Expense::Fee.name }.empty? %>
   <%= render "application/callout",
       type: "info",
       icon: "wise",

--- a/app/views/reimbursement_mailer/reimbursement_approved.html.erb
+++ b/app/views/reimbursement_mailer/reimbursement_approved.html.erb
@@ -7,7 +7,7 @@
   <em><%= link_to @report.name, @report %></em>.
 </p>
 
-<% payout_method = @report.user&.default_payout_method&.details %>
+<% payout_method = @report.payout_method&.details %>
 <p>
   <% if payout_method&.kind == "check" %>
     You'll receive a check for <%= render_money @report.amount_to_reimburse %> from us in approximately 10-12 business days.

--- a/db/migrate/20260629120000_add_legal_entity_payout_method_to_reimbursement_reports.rb
+++ b/db/migrate/20260629120000_add_legal_entity_payout_method_to_reimbursement_reports.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddLegalEntityPayoutMethodToReimbursementReports < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :reimbursement_reports, :legal_entity_payout_method, index: { algorithm: :concurrently }
+
+    add_foreign_key :reimbursement_reports, :legal_entity_payout_methods,
+                    column: :legal_entity_payout_method_id, on_delete: :nullify, validate: false
+  end
+
+end

--- a/db/migrate/20260629120100_validate_legal_entity_payout_method_fk_on_reimbursement_reports.rb
+++ b/db/migrate/20260629120100_validate_legal_entity_payout_method_fk_on_reimbursement_reports.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateLegalEntityPayoutMethodFkOnReimbursementReports < ActiveRecord::Migration[8.0]
+  def change
+    validate_foreign_key :reimbursement_reports, :legal_entity_payout_methods
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_29_120100) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1364,7 +1364,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
     t.text "secondary_hash"
     t.text "unique_bank_identifier"
     t.datetime "updated_at", null: false
-    t.index ["duplicate_of_hashed_transaction_id"], name: "index_hashed_transactions_on_duplicate_of_hashed_transaction_id"
+    t.index ["duplicate_of_hashed_transaction_id"], name: "idx_on_duplicate_of_hashed_transaction_id_6a29e8a078"
     t.index ["raw_csv_transaction_id"], name: "index_hashed_transactions_on_raw_csv_transaction_id"
     t.index ["raw_increase_transaction_id"], name: "index_hashed_transactions_on_raw_increase_transaction_id"
     t.index ["raw_plaid_transaction_id"], name: "index_hashed_transactions_on_raw_plaid_transaction_id"
@@ -2320,6 +2320,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
     t.integer "expense_number", default: 0, null: false
     t.text "invite_message"
     t.bigint "invited_by_id"
+    t.bigint "legal_entity_payout_method_id"
     t.integer "maximum_amount_cents"
     t.text "name"
     t.datetime "reimbursed_at"
@@ -2333,6 +2334,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
     t.index ["card_grant_id"], name: "index_reimbursement_reports_on_card_grant_id"
     t.index ["event_id"], name: "index_reimbursement_reports_on_event_id"
     t.index ["invited_by_id"], name: "index_reimbursement_reports_on_invited_by_id"
+    t.index ["legal_entity_payout_method_id"], name: "index_reimbursement_reports_on_legal_entity_payout_method_id"
     t.index ["reviewer_id"], name: "index_reimbursement_reports_on_reviewer_id"
     t.index ["user_id"], name: "index_reimbursement_reports_on_user_id"
   end
@@ -3045,6 +3047,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_26_192306) do
   add_foreign_key "reimbursement_expenses", "reimbursement_reports"
   add_foreign_key "reimbursement_expenses", "users", column: "approved_by_id"
   add_foreign_key "reimbursement_reports", "events"
+  add_foreign_key "reimbursement_reports", "legal_entity_payout_methods", on_delete: :nullify
   add_foreign_key "reimbursement_reports", "users"
   add_foreign_key "reimbursement_reports", "users", column: "invited_by_id"
   add_foreign_key "sponsors", "events"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1364,7 +1364,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_29_120100) do
     t.text "secondary_hash"
     t.text "unique_bank_identifier"
     t.datetime "updated_at", null: false
-    t.index ["duplicate_of_hashed_transaction_id"], name: "idx_on_duplicate_of_hashed_transaction_id_6a29e8a078"
+    t.index ["duplicate_of_hashed_transaction_id"], name: "index_hashed_transactions_on_duplicate_of_hashed_transaction_id"
     t.index ["raw_csv_transaction_id"], name: "index_hashed_transactions_on_raw_csv_transaction_id"
     t.index ["raw_increase_transaction_id"], name: "index_hashed_transactions_on_raw_increase_transaction_id"
     t.index ["raw_plaid_transaction_id"], name: "index_hashed_transactions_on_raw_plaid_transaction_id"

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reimbursement::Report, type: :model do
+  def build_ach
+    LegalEntity::PayoutMethod::AchTransfer.new(account_number: "12345678", routing_number: "021000021")
+  end
+
+  describe "payout method association" do
+    let(:user) { create(:user) }
+
+    describe "snapshotting on create" do
+      it "snapshots the user's default payout method onto the report" do
+        pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
+
+        report = create(:reimbursement_report, user:)
+
+        expect(report.legal_entity_payout_method).to eq(pm)
+        expect(report.payout_method).to eq(pm)
+      end
+
+      it "leaves the column null when the user has no default" do
+        report = create(:reimbursement_report, user:)
+
+        expect(report.legal_entity_payout_method).to be_nil
+      end
+
+      it "does not overwrite an explicitly-assigned payout method" do
+        default_pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
+        other_pm = user.personal_legal_entity.payout_methods.create!(default: false, details: build_ach)
+
+        report = create(:reimbursement_report, user:, legal_entity_payout_method: other_pm)
+
+        expect(report.legal_entity_payout_method).to eq(other_pm)
+        expect(report.legal_entity_payout_method).not_to eq(default_pm)
+      end
+    end
+
+    describe "#payout_method" do
+      it "returns the snapshotted method even after the user's default changes" do
+        original_pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
+        report = create(:reimbursement_report, user:)
+
+        user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
+
+        expect(report.reload.payout_method).to eq(original_pm)
+      end
+
+      it "falls back to the user's current default for legacy reports with no snapshot" do
+        report = create(:reimbursement_report, user:)
+        report.update_columns(legal_entity_payout_method_id: nil)
+
+        pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
+
+        expect(report.reload.payout_method).to eq(pm)
+      end
+    end
+  end
+end

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Reimbursement::Report, type: :model do
   describe "payout method association" do
     let(:user) { create(:user) }
 
-    describe "snapshotting on create" do
-      it "snapshots the user's default payout method onto the report" do
+    describe "setting the payout method on create" do
+      it "sets the user's default payout method on the report" do
         pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
 
         report = create(:reimbursement_report, user:)
@@ -38,7 +38,7 @@ RSpec.describe Reimbursement::Report, type: :model do
     end
 
     describe "#payout_method" do
-      it "returns the snapshotted method even after the user's default changes" do
+      it "returns the method set on the report even after the user's default changes" do
         original_pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
         report = create(:reimbursement_report, user:)
 
@@ -47,7 +47,7 @@ RSpec.describe Reimbursement::Report, type: :model do
         expect(report.reload.payout_method).to eq(original_pm)
       end
 
-      it "falls back to the user's current default for legacy reports with no snapshot" do
+      it "falls back to the user's current default for legacy reports with no payout method set" do
         report = create(:reimbursement_report, user:)
         report.update_columns(legal_entity_payout_method_id: nil)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -537,7 +537,7 @@ RSpec.describe User, type: :model do
         expect(user.can_update_payout_method?).to be(true)
       end
 
-      it "is false when the default is Wise and a reimbursement is being processed" do
+      it "is false when the default is Wise and a reimbursement tracking the default is being processed" do
         user.personal_legal_entity.payout_methods.create!(
           default: true,
           details: LegalEntity::PayoutMethod::WiseTransfer.new(
@@ -546,9 +546,27 @@ RSpec.describe User, type: :model do
           )
         )
         event = create(:event)
-        create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
+        # Legacy report with no snapshot still resolves its method from the default.
+        report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
+        report.update_columns(legal_entity_payout_method_id: nil)
 
         expect(user.can_update_payout_method?).to be(false)
+      end
+
+      it "is true when the default is Wise but processing reports have their own snapshotted method" do
+        user.personal_legal_entity.payout_methods.create!(
+          default: true,
+          details: LegalEntity::PayoutMethod::WiseTransfer.new(
+            address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",
+            address_postal_code: "M5V2T6", recipient_country: "CA", currency: "CAD"
+          )
+        )
+        event = create(:event)
+        # Snapshotted at creation, so an update leaves its payout method intact.
+        report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
+        expect(report.legal_entity_payout_method).to be_present
+
+        expect(user.can_update_payout_method?).to be(true)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -546,14 +546,14 @@ RSpec.describe User, type: :model do
           )
         )
         event = create(:event)
-        # Legacy report with no snapshot still resolves its method from the default.
+        # Legacy report with no payout method set still resolves its method from the default.
         report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
         report.update_columns(legal_entity_payout_method_id: nil)
 
         expect(user.can_update_payout_method?).to be(false)
       end
 
-      it "is true when the default is Wise but processing reports have their own snapshotted method" do
+      it "is true when the default is Wise but processing reports have their own payout method set" do
         user.personal_legal_entity.payout_methods.create!(
           default: true,
           details: LegalEntity::PayoutMethod::WiseTransfer.new(
@@ -562,7 +562,7 @@ RSpec.describe User, type: :model do
           )
         )
         event = create(:event)
-        # Snapshotted at creation, so an update leaves its payout method intact.
+        # Set at creation, so an update leaves its payout method intact.
         report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
         expect(report.legal_entity_payout_method).to be_present
 

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -191,6 +191,53 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(on_other.reload.legal_entity_payout_method).to eq(other_method)
     end
 
+    it "re-points draft reports to the corrected method" do
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :draft)
+      old_pm = report.legal_entity_payout_method
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(true)
+      new_pm = user.reload.default_payout_method
+      expect(new_pm).not_to eq(old_pm)
+      expect(report.reload.legal_entity_payout_method).to eq(new_pm)
+    end
+
+    it "only re-points draft reports tied to the method being replaced" do
+      other_method = user.personal_legal_entity.payout_methods.create!(
+        default: false,
+        details: LegalEntity::PayoutMethod::Wire.new(
+          account_number: "GB29NWBK60161331926819", bic_code: "NWBKGB2L", recipient_country: 1,
+          address_line1: "1 Main St", address_city: "London", address_state: "England",
+          address_postal_code: "SW1A 1AA"
+        )
+      )
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      replaced_default = user.default_payout_method
+
+      # Draft using the default (will be corrected by this update).
+      on_default = create(:reimbursement_report, user:, event: create(:event), aasm_state: :draft)
+      # Draft pinned to a different method (must stay put).
+      on_other = create(:reimbursement_report, user:, event: create(:event), aasm_state: :draft)
+      on_other.update_columns(legal_entity_payout_method_id: other_method.id)
+
+      described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      ).run
+
+      new_default = user.reload.default_payout_method
+      expect(new_default).not_to eq(replaced_default)
+      expect(on_default.reload.legal_entity_payout_method).to eq(new_default)
+      expect(on_other.reload.legal_entity_payout_method).to eq(other_method)
+    end
+
     it "leaves healthy in-flight reports pinned to their snapshot on update" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
   end
 
   describe "#run" do
+    before do
+      stub_request(:get, /api\.column\.com\/institutions/)
+        .to_return(status: 200, body: { country_code: "GB" }.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
     it "creates the chosen method as the user's default when none exists" do
       service = described_class.new(
         user:,

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -96,9 +96,11 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(user.reload.default_payout_method).to be_nil
     end
 
-    it "blocks switching to Wise while a report is being processed" do
+    it "blocks switching to Wise while a report tracking the default is being processed" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
-      create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      # Legacy report with no snapshot still resolves its method from the default.
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      report.update_columns(legal_entity_payout_method_id: nil)
 
       service = described_class.new(
         user:,
@@ -111,9 +113,96 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
     end
 
-    it "blocks any change while the current Wise payout is being processed" do
+    it "allows switching to Wise when processing reports have their own snapshotted method" do
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      # Snapshotted at creation, so it keeps ACH regardless of the new default.
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      expect(report.legal_entity_payout_method).to be_present
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::WiseTransfer",
+        details_attrs: valid_wise_attrs
+      )
+
+      expect(service.run).to be(true)
+      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::WiseTransfer)
+    end
+
+    it "re-points reports with a failed payout to the corrected method" do
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursed)
+      old_pm = report.legal_entity_payout_method
+      Reimbursement::PayoutHolding.insert_all([{
+                                                reimbursement_reports_id: report.id, amount_cents: 100,
+                                                aasm_state: "failed", created_at: Time.current, updated_at: Time.current
+                                              }])
+
+      service = described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      )
+
+      expect(service.run).to be(true)
+      new_pm = user.reload.default_payout_method
+      expect(new_pm).not_to eq(old_pm)
+      expect(report.reload.legal_entity_payout_method).to eq(new_pm)
+    end
+
+    it "only re-points failed reports tied to the method being replaced" do
+      other_method = user.personal_legal_entity.payout_methods.create!(
+        default: false,
+        details: LegalEntity::PayoutMethod::Wire.new(
+          account_number: "GB29NWBK60161331926819", bic_code: "NWBKGB2L", recipient_country: 1
+        )
+      )
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      replaced_default = user.default_payout_method
+
+      # Failed report using the default (will be corrected by this update).
+      on_default = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursed)
+      # Failed report pinned to a different method (must stay put).
+      on_other = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursed)
+      on_other.update_columns(legal_entity_payout_method_id: other_method.id)
+      [on_default, on_other].each do |report|
+        Reimbursement::PayoutHolding.insert_all([{
+                                                  reimbursement_reports_id: report.id, amount_cents: 100,
+                                                  aasm_state: "failed", created_at: Time.current, updated_at: Time.current
+                                                }])
+      end
+
+      described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      ).run
+
+      new_default = user.reload.default_payout_method
+      expect(new_default).not_to eq(replaced_default)
+      expect(on_default.reload.legal_entity_payout_method).to eq(new_default)
+      expect(on_other.reload.legal_entity_payout_method).to eq(other_method)
+    end
+
+    it "leaves healthy in-flight reports pinned to their snapshot on update" do
+      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      old_pm = report.legal_entity_payout_method
+
+      described_class.new(
+        user:,
+        details_type: "LegalEntity::PayoutMethod::AchTransfer",
+        details_attrs: valid_ach_attrs
+      ).run
+
+      expect(report.reload.legal_entity_payout_method).to eq(old_pm)
+    end
+
+    it "blocks any change while a Wise payout tracking the default is being processed" do
       seed_default(LegalEntity::PayoutMethod::WiseTransfer.new(valid_wise_attrs))
-      create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      # Legacy report with no snapshot still resolves its method from the default.
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
+      report.update_columns(legal_entity_payout_method_id: nil)
 
       service = described_class.new(
         user:,

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
     it "blocks switching to Wise while a report tracking the default is being processed" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
-      # Legacy report with no snapshot still resolves its method from the default.
+      # Legacy report with no payout method set still resolves its method from the default.
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
       report.update_columns(legal_entity_payout_method_id: nil)
 
@@ -118,9 +118,9 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
     end
 
-    it "allows switching to Wise when processing reports have their own snapshotted method" do
+    it "allows switching to Wise when processing reports have their own payout method set" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
-      # Snapshotted at creation, so it keeps ACH regardless of the new default.
+      # Set at creation, so it keeps ACH regardless of the new default.
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
       expect(report.legal_entity_payout_method).to be_present
 
@@ -238,7 +238,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(on_other.reload.legal_entity_payout_method).to eq(other_method)
     end
 
-    it "leaves healthy in-flight reports pinned to their snapshot on update" do
+    it "leaves healthy in-flight reports pinned to their own payout method on update" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
       old_pm = report.legal_entity_payout_method
@@ -254,7 +254,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
     it "blocks any change while a Wise payout tracking the default is being processed" do
       seed_default(LegalEntity::PayoutMethod::WiseTransfer.new(valid_wise_attrs))
-      # Legacy report with no snapshot still resolves its method from the default.
+      # Legacy report with no payout method set still resolves its method from the default.
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
       report.update_columns(legal_entity_payout_method_id: nil)
 

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -159,7 +159,9 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       other_method = user.personal_legal_entity.payout_methods.create!(
         default: false,
         details: LegalEntity::PayoutMethod::Wire.new(
-          account_number: "GB29NWBK60161331926819", bic_code: "NWBKGB2L", recipient_country: 1
+          account_number: "GB29NWBK60161331926819", bic_code: "NWBKGB2L", recipient_country: 1,
+          address_line1: "1 Main St", address_city: "London", address_state: "England",
+          address_postal_code: "SW1A 1AA"
         )
       )
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))


### PR DESCRIPTION
## Summary of the problem
Right now we're just pulling the default payout method from the user directly for payout methods. We want to associate a specific payout method to a report. Currently, this will look like either passing in a payout method on create or it will use the default. This will give better support for the future once we support multiple payout methods in which it'll be easier to identify which payout method a report uses. 


## Describe your changes
Added a new payout method ID column to reimbursement reports and updated to use it. If a reimbursement report payout details needs to be updated we will repoint the report to the latest payout method. In future we will have them mutate the existing payout report they used (we wont create a new payout method on update). We could also support switching payout settings in reimbursement page when a report is failed or hasn't been submitted/approved yet. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

