### PR TITLE
[Admin] Remove OnBoard ID and Boba task cards

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1795,8 +1795,6 @@ class AdminController < Admin::BaseController
         hackathons_task_size
       when :pending_bank_applications_airtable
         airtable_task_size :bank_applications
-      when :pending_onboard_id_airtable
-        airtable_task_size :onboard_id
       when :pending_stickers_airtable
         airtable_task_size :stickers
       when :pending_onepassword_airtable
@@ -1815,8 +1813,6 @@ class AdminController < Admin::BaseController
         airtable_task_size :feedback
       when :pending_google_workspace_waitlist_airtable
         airtable_task_size :google_workspace_waitlist
-      when :pending_boba_airtable
-        airtable_task_size :boba
       when :pending_you_ship_we_ship_airtable
         airtable_task_size :you_ship_we_ship
       when :pending_identity_vault_verifications
@@ -1854,7 +1850,6 @@ class AdminController < Admin::BaseController
     # This method could take upwards of 10 seconds. USE IT SPARINGLY
     pending_task :pending_hackathons_airtable
     pending_task :pending_bank_applications_airtable
-    pending_task :pending_onboard_id_airtable
     pending_task :pending_stickers_airtable
     pending_task :pending_onepassword_airtable
     pending_task :pending_domains_airtable

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -38,12 +38,6 @@ module StaticPagesHelper
 
   def airtable_info
     {
-      onboard_id: {
-        id: "app4Bs8Tjwvk5qcD4",
-        table: "Verifications%20-%20Depreciated",
-        query: { filterByFormula: "Status='Pending'" },
-        destination: "https://airtable.com/app4Bs8Tjwvk5qcD4/tblVZwB8QMUSDAd41/viwJ15CT6VHCZ0UZ4"
-      },
       bank_applications: {
         id: "apppALh5FEOKkhjLR",
         table: "Events",
@@ -109,12 +103,6 @@ module StaticPagesHelper
         table: "Users",
         query: { filterByFormula: "{Verification Status}='Unknown'" },
         destination: "https://airtable.com/appre1xwKlj49p0d4/tbl2Q2aCWqyBGi9mj/viwVYhUQYyNJOi0EH"
-      },
-      boba: {
-        id: "app05mIKwNPO2l1vT",
-        table: "Event%20Codes",
-        query: { filterByFormula: "Status='Under Review'" },
-        destination: "https://airtable.com/app05mIKwNPO2l1vT/tblcIuVemD63IbBuY/viw1Zo5lX8e7t2Vzu"
       },
       marketing_shipment_request: {
         id: "appK53aN0fz3sgJ4w",

--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -96,8 +96,6 @@
       <details>
         <summary>Old cards</summary>
         <ul class="grid text-left w-100 pt-2" id="old-card-grid">
-          <%= card_to "OnBoard ID", link_to_airtable_task(:onboard_id), async_badge: :pending_onboard_id_airtable %>
-          <%= card_to "Boba", link_to_airtable_task(:boba), async_badge: :pending_boba_airtable %>
           <%= card_to "YSWS verification", link_to_airtable_task(:you_ship_we_ship), async_badge: :pending_you_ship_we_ship_airtable %>
           <%= card_to "PVSA", link_to_airtable_task(:pvsa), async_badge: :pending_pvsa_airtable %>
           <%= render partial: "static_pages/card", locals: { task_path: events_path, human_name: "Organizations" } %>


### PR DESCRIPTION
## Summary of the problem
The OnBoard ID and Boba admin tool cards are deprecated and no longer used.

## Describe your changes
Removed the OnBoard ID and Boba cards from the admin tools page along with their backend Airtable task-size code (`airtable_info` entries and `pending_task` dispatch cases). The shared `airtable_task_size` method and other cards are untouched.