### PR TITLE
[LEPM] Remove unnecessary logic after backfill complete

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -202,7 +202,7 @@ module Reimbursement
         end
 
         flash[:success] = {
-          text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
+          text: "Your report has been submitted for review and your payout method can no longer be changed. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
         }
       rescue => e
         flash[:error] = e.message

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -202,7 +202,7 @@ module Reimbursement
         end
 
         flash[:success] = {
-          text: "Your report has been submitted for review and your payout method can no longer be changed. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
+          text: "Your report has been submitted for review and your payout method can no longer be changed for this report. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
         }
       rescue => e
         flash[:error] = e.message

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -203,11 +203,9 @@ module Reimbursement
 
         flash[:success] = {
           text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
-          link: settings_payouts_path
+          link: settings_payouts_path,
+          link_text: "If needed, you can still edit your payout settings."
         }
-        if @report.user.can_update_payout_method?
-          flash[:success][:link_text] = "If needed, you can still edit your payout settings."
-        end
       rescue => e
         flash[:error] = e.message
       end

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -203,8 +203,6 @@ module Reimbursement
 
         flash[:success] = {
           text: "Your report has been submitted for review. When it's approved, you'll be reimbursed via #{@report.payout_method.name}.",
-          link: settings_payouts_path,
-          link_text: "If needed, you can still edit your payout settings."
         }
       rescue => e
         flash[:error] = e.message

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -330,7 +330,7 @@ class UsersController < ApplicationController
     @user.assign_attributes(user_params)
 
     payout_method_type = params.dig(:user, :payout_method_type)
-    update_payout_method = payout_method_type.present? && @user.can_update_payout_method?
+    update_payout_method = payout_method_type.present?
 
     if @user.use_two_factor_authentication_changed?
       return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
@@ -554,8 +554,6 @@ class UsersController < ApplicationController
 
 
   def payout_method_details_params
-    return {} unless @user.can_update_payout_method?
-
     permitted =
       case params.dig(:user, :payout_method_type)
       when LegalEntity::PayoutMethod::Check.name

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -330,7 +330,6 @@ class UsersController < ApplicationController
     @user.assign_attributes(user_params)
 
     payout_method_type = params.dig(:user, :payout_method_type)
-    update_payout_method = payout_method_type.present?
 
     if @user.use_two_factor_authentication_changed?
       return unless enforce_sudo_mode # rubocop:disable Style/SoleNestedConditional
@@ -388,7 +387,7 @@ class UsersController < ApplicationController
     saved = ActiveRecord::Base.transaction do
       user_ok = @user.save
       payout_ok = true
-      if update_payout_method
+      if payout_method_type.present?
         payout_update = LegalEntity::PayoutMethodService::Update.new(
           user: @user,
           details_type: payout_method_type,

--- a/app/models/legal_entity/payout_method/ach_transfer.rb
+++ b/app/models/legal_entity/payout_method/ach_transfer.rb
@@ -38,6 +38,10 @@ class LegalEntity
         "ACH Transfer"
       end
 
+      def payout_summary
+        "ACH transfer to account ending in ••••#{account_number.to_s.last(4)}"
+      end
+
       def currency
         "USD"
       end

--- a/app/models/legal_entity/payout_method/check.rb
+++ b/app/models/legal_entity/payout_method/check.rb
@@ -52,6 +52,10 @@ class LegalEntity
         "Check"
       end
 
+      def payout_summary
+        "check mailed to #{[address_line1, address_line2].compact_blank.join(", ")}"
+      end
+
       def currency
         "USD"
       end

--- a/app/models/legal_entity/payout_method/wire.rb
+++ b/app/models/legal_entity/payout_method/wire.rb
@@ -50,6 +50,10 @@ class LegalEntity
         "International Wire"
       end
 
+      def payout_summary
+        "international wire to account ending in ••••#{account_number.to_s.last(4)}"
+      end
+
       def currency
         "USD"
       end

--- a/app/models/legal_entity/payout_method/wise_transfer.rb
+++ b/app/models/legal_entity/payout_method/wise_transfer.rb
@@ -48,6 +48,10 @@ class LegalEntity
         "Wise Transfer"
       end
 
+      def payout_summary
+        ["wise transfer", ("to #{bank_name}" if bank_name.present?), ("(#{currency})" if currency.present?)].compact.join(" ")
+      end
+
     end
 
   end

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -81,6 +81,9 @@ module Reimbursement
     has_many :expenses, foreign_key: "reimbursement_report_id", inverse_of: :report, dependent: :destroy
     has_one :payout_holding, inverse_of: :report
     alias_attribute :report_name, :name
+
+    alias payout_method legal_entity_payout_method
+
     attribute :name, :string, default: -> { "Expenses from #{Time.now.strftime("%B %e, %Y")}" }
 
     scope :search, ->(q) { joins("LEFT JOIN users AS u2 on u2.id = reimbursement_reports.user_id").where("u2.full_name ILIKE :query OR reimbursement_reports.name ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
@@ -428,10 +431,6 @@ module Reimbursement
 
         wise_transfer
       end
-    end
-
-    def payout_method
-      legal_entity_payout_method
     end
 
     private

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -431,7 +431,7 @@ module Reimbursement
     end
 
     def payout_method
-      legal_entity_payout_method || user&.default_payout_method
+      legal_entity_payout_method
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -582,18 +582,6 @@ class User < ApplicationRecord
     admin_override_pretend? && !use_two_factor_authentication
   end
 
-  def can_update_payout_method?
-    return true if default_payout_method&.details.nil?
-    return true unless default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer)
-
-    # Only reports still tracking the default (no payout method set on the
-    # report) would be disrupted by replacing it; reports that have their own
-    # payout method record keep it, which an update leaves intact.
-    return false if reimbursement_reports.reimbursement_requested.where(legal_entity_payout_method_id: nil).any?
-    return false if reimbursement_reports.joins(:payout_holding).where(payout_holding: { aasm_state: :pending }, reimbursement_reports: { legal_entity_payout_method_id: nil }).any?
-
-    true
-  end
 
   def managed_active_teenagers_count
     User.active_teenager.joins(organizer_positions: :event).where(events: { id: managed_events }).distinct.count

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -4,16 +4,12 @@ class LegalEntity
   module PayoutMethodService
     # Builds, validates, and persists a user's default personal-legal-entity
     # payout method. Encapsulates the business rules that previously lived
-    # across User#build_default_payout_method, User#valid_payout_method,
-    # User#can_update_payout_method?, and the UsersController#update transaction.
+    # across User#build_default_payout_method, User#valid_payout_method, and
+    # the UsersController#update transaction.
     #
     # On failure, #run returns false and the (unsaved) payout method, exposed
     # via #payout_method, carries the relevant errors.
     class Update
-      # Report states that count as "being processed" for the purpose of
-      # blocking a switch to Wise.
-      PROCESSING_STATES = %i[submitted reimbursement_requested reimbursement_approved].freeze
-
       attr_reader :payout_method
 
       def initialize(user:, details_type:, details_attrs: {})
@@ -43,8 +39,8 @@ class LegalEntity
       def error_messages
         return [] unless @payout_method
 
-        # Read base errors off the payout method (unsupported type, the Wise
-        # guards) and field errors off the details record. Autosave also mirrors
+        # Read base errors off the payout method (unsupported type, invalid
+        # method) and field errors off the details record. Autosave also mirrors
         # the field errors onto the parent as "details.<attr>" ("Details routing
         # number must be 9 digits"); reading the child instead keeps the clean
         # "Routing number must be 9 digits" wording without duplication.
@@ -64,18 +60,8 @@ class LegalEntity
       end
 
       def apply_business_rules
-        unless @user.can_update_payout_method?
-          @payout_method.errors.add(:base, "can't be changed while a reimbursement is being processed. Please reach out to the HCB team if you need this changed.")
-          return
-        end
-
         if @payout_method.details.nil?
           @payout_method.errors.add(:base, "is invalid. Please choose another method.")
-          return
-        end
-
-        if switching_to_wise_while_processing?
-          @payout_method.errors.add(:base, "cannot be changed to Wise transfer with reports that are being processed. Please reach out to the HCB team if you need this changed.")
         end
       end
 
@@ -96,15 +82,6 @@ class LegalEntity
             report.update!(legal_entity_payout_method: @payout_method)
           end
         end
-      end
-
-      def switching_to_wise_while_processing?
-        # Only reports that still track the user's default (no payout method
-        # set on the report) would be flipped to Wise by this change; reports
-        # with their own payout method keep their original and are unaffected.
-        @payout_method.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-          !@user.default_payout_method&.details.is_a?(LegalEntity::PayoutMethod::WiseTransfer) &&
-          @user.reimbursement_reports.where(aasm_state: PROCESSING_STATES, legal_entity_payout_method_id: nil).any?
       end
 
     end

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -198,6 +198,9 @@
             Submit & request review
             <% button_hint = capture do %>
               <span class="bold">Your next step:</span> after adding all of your expenses, submit the report to request a review.
+              <% if payout_method.present? %>
+                <br>You will be reimbursed via <strong><%= payout_method.payout_summary %></strong>.
+              <% end %>
             <% end %>
           </button>
         <% elsif report.submitted? && report.currency != "USD" && report.wise_transfer_may_exceed_balance? && policy(report).request_reimbursement? %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -190,6 +190,9 @@
             Submit & request review
             <% button_hint = capture do %>
               <span class="bold">Your next step:</span> after adding all of your expenses, submit the report to request a review.
+              <% if payout_method.present? && user == current_user %>
+                <br>You will be reimbursed via <strong><%= payout_method.payout_summary %></strong>.
+              <% end %>
             <% end %>
           <% end %>
         <% elsif report.draft? %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -198,7 +198,7 @@
             Submit & request review
             <% button_hint = capture do %>
               <span class="bold">Your next step:</span> after adding all of your expenses, submit the report to request a review.
-              <% if payout_method.present? %>
+              <% if payout_method.present? && user == current_user %>
                 <br>You will be reimbursed via <strong><%= payout_method.payout_summary %></strong>.
               <% end %>
             <% end %>

--- a/app/views/users/edit_payout.html.erb
+++ b/app/views/users/edit_payout.html.erb
@@ -14,18 +14,6 @@
       <% end %>
     </p>
     <%= render "application/flash", klass: "max-w-full mb3" %>
-    <% if @user.can_update_payout_method? %>
-      <%= render "users/payout_form", user: @user, attempted: @payout_method %>
-    <% else %>
-      <%= render "application/callout",
-          type: "info",
-          title: "Changing your payout method is currently disabled." do %>
-      We are currently processing a payout to you using Wise. At this time, you can not update your payout method.
-      <strong>Something wrong?</strong> <%= help_message %>
-      <% end %>
-      <% admin_tool do %>
-        <%= render "payout_form", user: @user %>
-      <% end %>
-    <% end %>
+    <%= render "users/payout_form", user: @user, attempted: @payout_method %>
   </section>
 </turbo-frame>

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -46,18 +46,6 @@ RSpec.describe Reimbursement::Report, type: :model do
 
         expect(report.reload.payout_method).to eq(original_pm)
       end
-<<<<<<< HEAD
-
-      it "falls back to the user's current default for legacy reports with no payout method set" do
-        report = create(:reimbursement_report, user:)
-        report.update_columns(legal_entity_payout_method_id: nil)
-
-        pm = user.personal_legal_entity.payout_methods.create!(default: true, details: build_ach)
-
-        expect(report.reload.payout_method).to eq(pm)
-      end
-=======
->>>>>>> 852538b21 ([LEPM] Remove unnecessary logic after backfill complete)
     end
   end
 end

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Reimbursement::Report, type: :model do
 
         expect(report.reload.payout_method).to eq(original_pm)
       end
+<<<<<<< HEAD
 
       it "falls back to the user's current default for legacy reports with no payout method set" do
         report = create(:reimbursement_report, user:)
@@ -55,6 +56,8 @@ RSpec.describe Reimbursement::Report, type: :model do
 
         expect(report.reload.payout_method).to eq(pm)
       end
+=======
+>>>>>>> 852538b21 ([LEPM] Remove unnecessary logic after backfill complete)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -530,45 +530,6 @@ RSpec.describe User, type: :model do
         expect(user.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
       end
     end
-
-
-    describe "#can_update_payout_method?" do
-      it "is true when there is no payout method" do
-        expect(user.can_update_payout_method?).to be(true)
-      end
-
-      it "is false when the default is Wise and a reimbursement tracking the default is being processed" do
-        user.personal_legal_entity.payout_methods.create!(
-          default: true,
-          details: LegalEntity::PayoutMethod::WiseTransfer.new(
-            address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",
-            address_postal_code: "M5V2T6", recipient_country: "CA", currency: "CAD"
-          )
-        )
-        event = create(:event)
-        # Legacy report with no payout method set still resolves its method from the default.
-        report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
-        report.update_columns(legal_entity_payout_method_id: nil)
-
-        expect(user.can_update_payout_method?).to be(false)
-      end
-
-      it "is true when the default is Wise but processing reports have their own payout method set" do
-        user.personal_legal_entity.payout_methods.create!(
-          default: true,
-          details: LegalEntity::PayoutMethod::WiseTransfer.new(
-            address_line1: "1 Main St", address_city: "Toronto", address_state: "ON",
-            address_postal_code: "M5V2T6", recipient_country: "CA", currency: "CAD"
-          )
-        )
-        event = create(:event)
-        # Set at creation, so an update leaves its payout method intact.
-        report = create(:reimbursement_report, user:, event:, aasm_state: :reimbursement_requested)
-        expect(report.legal_entity_payout_method).to be_present
-
-        expect(user.can_update_payout_method?).to be(true)
-      end
-    end
   end
 
   describe ".search_name" do

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -101,26 +101,8 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(user.reload.default_payout_method).to be_nil
     end
 
-    it "blocks switching to Wise while a report tracking the default is being processed" do
+    it "allows switching to Wise" do
       seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
-      # Legacy report with no payout method set still resolves its method from the default.
-      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
-      report.update_columns(legal_entity_payout_method_id: nil)
-
-      service = described_class.new(
-        user:,
-        details_type: "LegalEntity::PayoutMethod::WiseTransfer",
-        details_attrs: valid_wise_attrs
-      )
-
-      expect(service.run).to be(false)
-      expect(service.error_messages.join(" ")).to match(/wise/i)
-      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::AchTransfer)
-    end
-
-    it "allows switching to Wise when processing reports have their own payout method set" do
-      seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
-      # Set at creation, so it keeps ACH regardless of the new default.
       report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
       expect(report.legal_entity_payout_method).to be_present
 
@@ -252,6 +234,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(report.reload.legal_entity_payout_method).to eq(old_pm)
     end
 
+<<<<<<< HEAD
     it "blocks any change while a Wise payout tracking the default is being processed" do
       seed_default(LegalEntity::PayoutMethod::WiseTransfer.new(valid_wise_attrs))
       # Legacy report with no payout method set still resolves its method from the default.
@@ -267,6 +250,8 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(service.run).to be(false)
       expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::WiseTransfer)
     end
+=======
+>>>>>>> 852538b21 ([LEPM] Remove unnecessary logic after backfill complete)
   end
 
   describe "#run!" do

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -233,25 +233,6 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
       expect(report.reload.legal_entity_payout_method).to eq(old_pm)
     end
-
-<<<<<<< HEAD
-    it "blocks any change while a Wise payout tracking the default is being processed" do
-      seed_default(LegalEntity::PayoutMethod::WiseTransfer.new(valid_wise_attrs))
-      # Legacy report with no payout method set still resolves its method from the default.
-      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_requested)
-      report.update_columns(legal_entity_payout_method_id: nil)
-
-      service = described_class.new(
-        user:,
-        details_type: "LegalEntity::PayoutMethod::AchTransfer",
-        details_attrs: valid_ach_attrs
-      )
-
-      expect(service.run).to be(false)
-      expect(user.reload.default_payout_method.details).to be_a(LegalEntity::PayoutMethod::WiseTransfer)
-    end
-=======
->>>>>>> 852538b21 ([LEPM] Remove unnecessary logic after backfill complete)
   end
 
   describe "#run!" do


### PR DESCRIPTION
## Summary of the problem
We no longer need to check if a user "can update payout method" as they can always do it (for now) and no need to check for current processing Wise reimbursement


## Describe your changes
removed da 😵 code


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

