### PR TITLE
[Reimbursements] Update payout info for reimbursements with no prev. payout

### DIFF
--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -80,9 +80,7 @@ class LegalEntity
       end
 
       def repoint_failed_and_draft_reports(replaced_method)
-        return unless replaced_method
-
-        on_replaced_method = @user.reimbursement_reports.where(legal_entity_payout_method_id: replaced_method.id)
+        on_replaced_method = @user.reimbursement_reports.where(legal_entity_payout_method_id: replaced_method&.id)
 
         failed = on_replaced_method.joins(:payout_holding).where(reimbursement_payout_holdings: { aasm_state: :failed })
         draft = on_replaced_method.where(aasm_state: :draft)


### PR DESCRIPTION
## Summary of the problem
Currently, if we set payout info and a reimbursement report doesn't have a prev. payout info then the `repoint_failed_and_draft_reports` will return early. 


## Describe your changes
It should be returning nil instead which would check for reports with no LEPM id and update those too. 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

