### PR TITLE
Fix backfill ledger script

### DIFF
--- a/app/jobs/one_time_jobs/backfill_ledger_event.rb
+++ b/app/jobs/one_time_jobs/backfill_ledger_event.rb
@@ -18,7 +18,6 @@ module OneTimeJobs
                          subledger: { card_grant: :ledger },
                          event: :ledger
                        )
-                       .where.missing(:ledger_item)
 
       hcb_codes.find_each do |hcb_code|
         safely do


### PR DESCRIPTION
## Summary of the problem

This scope is redundant and skips partially-backfilled transactions.


## Describe your changes

Remove an extra filter that's not needed.