### PR TITLE
[v4 API] Look up receipts and transactions by public ID

### DIFF
--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -31,7 +31,7 @@ module Api
       require_oauth2_scope "receipts:write", :create
 
       def destroy
-        @receipt = Receipt.find_by_public_id!(params[:id]) || Receipt.find_by_hash_id!(params[:id]) #TODO: remove hash ID after mobile app update
+        @receipt = Receipt.find_by_public_id(params[:id]) || Receipt.find_by_hash_id!(params[:id]) # TODO: remove hash ID after mobile app update
         authorize @receipt
 
         @receipt.destroy!

--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -5,7 +5,7 @@ module Api
     class ReceiptsController < ApplicationController
       def index
         if params[:transaction_id].present?
-          @hcb_code = HcbCode.find_by_public_id(params[:transaction_id])
+          @hcb_code = HcbCode.find_by_public_id!(params[:transaction_id])
           authorize @hcb_code, :show?
           @receipts = @hcb_code.receipts.includes(:user)
         else
@@ -18,7 +18,7 @@ module Api
 
       def create
         if params[:transaction_id].present?
-          @hcb_code = HcbCode.find_by_public_id(params[:transaction_id])
+          @hcb_code = HcbCode.find_by_public_id!(params[:transaction_id])
           authorize @hcb_code, :upload?, policy_class: ReceiptablePolicy
         else
           skip_authorization
@@ -31,7 +31,7 @@ module Api
       require_oauth2_scope "receipts:write", :create
 
       def destroy
-        @receipt = Receipt.find(params[:id])
+        @receipt = Receipt.find_by_public_id!(params[:id])
         authorize @receipt
 
         @receipt.destroy!

--- a/app/controllers/api/v4/receipts_controller.rb
+++ b/app/controllers/api/v4/receipts_controller.rb
@@ -31,7 +31,7 @@ module Api
       require_oauth2_scope "receipts:write", :create
 
       def destroy
-        @receipt = Receipt.find_by_public_id!(params[:id])
+        @receipt = Receipt.find_by_public_id!(params[:id]) || Receipt.find_by_hash_id!(params[:id]) #TODO: remove hash ID after mobile app update
         authorize @receipt
 
         @receipt.destroy!


### PR DESCRIPTION
## Summary of the problem

The v4 receipts controller looked records up by **raw primary key**, even though the API returns and documents prefixed **public IDs** (`rct_…`, `txn_…`). This broke documented flows:

- **`DELETE /api/v4/receipts/:id`** used `Receipt.find(params[:id])`. That can't decode an `rct_…` id, so deleting a receipt using the `id` returned from a listing raised `RecordNotFound` → **404 on a valid id**. (Verified: `Receipt.find("rct_g9dIr8")` → `RecordNotFound`, while `find_by_public_id!` resolves it.)
- **`POST /api/v4/receipts`** and **`GET /api/v4/receipts`** used the non-bang `find_by_public_id`, which returns `nil` for a bad `transaction_id`. That `nil` then reached authorization:
  - `index`: `authorize nil, :show?` → `Pundit::NotDefinedError`, which isn't rescued → unhandled **500**.
  - `create` (non-admin): `ReceiptablePolicy#upload?` calls `.event` on a `nil` record → `NoMethodError` → unhandled **500**.
  - `create` (admin): `user&.admin?` short-circuits the policy, so a bad `txn_…` **silently creates a receipt in the Receipt Bin** (201) instead of erroring.

None of these produce the documented `404 resource_not_found`.

## Describe your changes

Switch all three lookups to the bang public-ID variants so a bad id raises `RecordNotFound`, which the v4 error handler renders as the documented `404 resource_not_found` — matching the rest of the v4 API (e.g. `transactions#show`, `mark_no_receipt`).

- `destroy`: `Receipt.find(params[:id])` → `Receipt.find_by_public_id!(params[:id])`
- `create` / `index`: `HcbCode.find_by_public_id(...)` → `HcbCode.find_by_public_id!(...)`

No behavior change for valid ids. Three-line change; no request spec exists for this controller yet — happy to add one in a follow-up.