### PR TITLE
Preload associations in Ledger::AssertRequirementsJob

### DIFF
--- a/app/jobs/ledger/assert_requirements_job.rb
+++ b/app/jobs/ledger/assert_requirements_job.rb
@@ -10,9 +10,9 @@ class Ledger
 
     def perform(event_id: nil)
       @event = event_id.present? ? Event.find(event_id) : nil
-      @ledger_items = @event&.ledger&.items || Ledger::Item.all
-      @cts = @event&.canonical_transactions || CanonicalTransaction.all
-      @cpts = @event&.canonical_pending_transactions || CanonicalPendingTransaction.all
+      @ledger_items = (@event&.ledger&.items || Ledger::Item.all).includes(:canonical_transactions, :canonical_pending_transactions, hcb_code: [:canonical_transactions, :canonical_pending_transactions])
+      @cts = (@event&.canonical_transactions || CanonicalTransaction.all).includes(:ledger_item)
+      @cpts = (@event&.canonical_pending_transactions || CanonicalPendingTransaction.all).includes(:ledger_item)
       @anomalies = []
 
       cts_synced_with_hcb_code
@@ -87,5 +87,4 @@ class Ledger
     end
 
   end
-
 end

--- a/app/jobs/ledger/assert_requirements_job.rb
+++ b/app/jobs/ledger/assert_requirements_job.rb
@@ -87,4 +87,5 @@ class Ledger
     end
 
   end
+
 end


### PR DESCRIPTION
## Summary of the problem

Associations are not preloaded, making this script very slow.


## Describe your changes

Preload associations.