### PR TITLE
Fix re-mapping Ledger::Items for admins

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1231,8 +1231,10 @@ class AdminController < Admin::BaseController
 
     safely do
       ledger = Ledger.find_or_create_by!(primary: true, event_id: params[:event_id])
-      Ledger::Mapping.find_or_create_by!(ledger:, ledger_item: @canonical_transaction.ledger_item) do |mapping|
-        mapping.on_primary_ledger = true
+
+      Ledger::Mapping.find_or_initialize_by(ledger_item: @canonical_transaction.ledger_item, on_primary_ledger: true).tap do |mapping|
+        mapping.ledger = ledger
+        mapping.save!
       end
     end
 


### PR DESCRIPTION
## Summary of the problem

Currently the `AdminController` logic for mapping `Ledger::Items` does not function properly when re-mapping an already-mapped transaction.


## Describe your changes

This PR updates the mapping logic to function properly when the `Ledger::Item` already has a primary ledger mapping.