### PR TITLE
[Fields] Sanitize amount fields

### DIFF
--- a/app/javascript/controllers/truncate_decimal_controller.js
+++ b/app/javascript/controllers/truncate_decimal_controller.js
@@ -9,6 +9,28 @@ export default class extends Controller {
     places: { type: Number, default: 2 },
   }
 
+  connect() {
+    this.onPaste = this.sanitizePaste.bind(this)
+    this.element.addEventListener('paste', this.onPaste)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('paste', this.onPaste)
+  }
+
+  sanitizePaste(e) {
+    const text = (e.clipboardData || window.clipboardData)?.getData('text')
+    if (!text) return
+
+    const cleaned = text.replace(/[^0-9.]/g, '')
+    if (cleaned === text) return
+
+    e.preventDefault()
+    e.target.value = cleaned
+    e.target.dispatchEvent(new Event('input'))
+    this.truncate(e)
+  }
+
   truncate(e) {
     const split = e.target.value.split('.')
 


### PR DESCRIPTION
## Summary of the problem
@devramsean0 was saying that when you copy a number into the wise reimbursement like amount boxes, if there's a comma in it, it just deletes the value. We should be sanitizing the field instead stripping away stuff like commas or $s


## Describe your changes
sanitizes


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

