### PR TITLE
[Spelling] Replace all occurrences of 'a HCB ...' with 'an HCB ...'

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -116,9 +116,9 @@ class StaticPagesController < ApplicationController
           "View the organization's account & routing numbers": :manager
         },
         "HCB transfers": {
-          "Create a HCB Transfer": :manager,
-          "Cancel a HCB Transfer": :manager,
-          "View a HCB Transfer": :reader
+          "Create an HCB Transfer": :manager,
+          "Cancel an HCB Transfer": :manager,
+          "View an HCB Transfer": :reader
         },
         _preface: "As a general rule, only managers can create/modify financial transfers"
       },

--- a/app/javascript/components/tour/TourOverlay.js
+++ b/app/javascript/components/tour/TourOverlay.js
@@ -44,7 +44,7 @@ const tours = {
     } else {
       steps.push({
         attachTo: 'playground_mode',
-        text: "You're in Playground Mode— a HCB staff member will reach out shortly to get you set up.",
+        text: "You're in Playground Mode— an HCB staff member will reach out shortly to get you set up.",
         placement: 'bottom',
       })
     }

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -606,7 +606,7 @@ class HcbCode < ApplicationRecord
   # 1) it doesn't consider event plan
   # 2) it doesn't consider the amount of the HCB code
   #
-  # this is because these two things are expensive to compute on a HCB code.
+  # this is because these two things are expensive to compute on an HCB code.
 
   scope :receipt_required, -> {
     joins("LEFT JOIN canonical_pending_transactions ON canonical_pending_transactions.hcb_code = hcb_codes.hcb_code")

--- a/app/models/user/email_update.rb
+++ b/app/models/user/email_update.rb
@@ -109,7 +109,7 @@ class User
 
     def non_hcb_email
       if GSuiteAccount.where(address: replacement).any? || GSuiteAlias.where(address: replacement).any?
-        errors.add(:email, "must not be provided through a HCB account's Google Workspace")
+        errors.add(:email, "must not be provided through an HCB account's Google Workspace")
       end
     end
 

--- a/app/views/card_grants/_transactions.html.erb
+++ b/app/views/card_grants/_transactions.html.erb
@@ -9,7 +9,7 @@
         <% hcb_codes.each do |hcb_code| %>
           <% if hcb_code.canonical_transactions.any? %>
             <% if hcb_code.canonical_transactions.all? { |ct| ct.canonical_event_mapping&.subledger&.present? } %>
-              <%# passing in a HCB code allows for all CTs of a HCB code to show up as one ledger item
+              <%# passing in an HCB code allows for all CTs of an HCB code to show up as one ledger item
                   but should only be done if all CTs are on the subledger. An example of when they're not
                   is grant topups / withdrawals. %>
               <%= render partial: "canonical_transactions/canonical_transaction", locals: { ct: hcb_code, authorless: true, receipt_upload_button: !is_public, receipt_upload_button_disabled: !hcb_code.receipt_required?, show_tags: true } %>

--- a/app/views/disbursements/new.html.erb
+++ b/app/views/disbursements/new.html.erb
@@ -1,4 +1,4 @@
-<% title "Send a HCB transfer" %>
+<% title "Send an HCB transfer" %>
 <% @back_url = @source_event ? event_transfers_path(@source_event) : nil %>
 
 <% content_for :sidebar_footer do %>

--- a/app/views/organizer_position_deletion_requests/new.html.erb
+++ b/app/views/organizer_position_deletion_requests/new.html.erb
@@ -13,7 +13,7 @@
   We understand there are situations where you need to remove a team member from HCB,
   and we’ve seen that many of these situations require nuance and context that only humans can provide.
   Because of this, all removal requests from team members who haven't signed the contract are sent to
-  a HCB team member for review.
+  an HCB team member for review.
 </p>
 
 <p><strong>We’ll contact you with any next steps or clarification after you submit your request.</strong></p>

--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -180,7 +180,7 @@ Internally, we use [Doppler](https://www.doppler.com/) to manage our credentials
 
 ### Production data
 
-We've transitioned to using development keys and seed data in development, but historically we have used production keys and data on development machines. We do not recommend rolling back to using production data & keys in development, but if absolutely necessary a HCB engineer can take the following steps:
+We've transitioned to using development keys and seed data in development, but historically we have used production keys and data on development machines. We do not recommend rolling back to using production data & keys in development, but if absolutely necessary an HCB engineer can take the following steps:
 
 - Use a `DOPPLER_TOKEN` with development access, this can be generated [here](https://dashboard.doppler.com/workplace/2818669764d639172564/projects/hcb/configs/development/access).
 

--- a/dev-docs/guides/card_transactions.md
+++ b/dev-docs/guides/card_transactions.md
@@ -31,7 +31,7 @@ If the authorisation expires (the merchant doesn’t explicitly void it but they
 
 Eventually the authorisation will continue being updated until the `amount` is 0.
 
-Alright, so what does it mean for the merchant to “capture” an authorisation? Essentially it’s when a merchant confirms they intend to charge this customer and provide a final amount. When the authorisation is captured, Stripe creates a “transaction” and sets the status of the authorisation to closed. I wrote about how we import Stripe transactions in “How a transaction gets mapped to an event and a HCB code on HCB.” That guide describes how the [`CanonicalPendingTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_pending_transaction.rb) I described above becomes a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb).
+Alright, so what does it mean for the merchant to “capture” an authorisation? Essentially it’s when a merchant confirms they intend to charge this customer and provide a final amount. When the authorisation is captured, Stripe creates a “transaction” and sets the status of the authorisation to closed. I wrote about how we import Stripe transactions in “How a transaction gets mapped to an event and an HCB code on HCB.” That guide describes how the [`CanonicalPendingTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_pending_transaction.rb) I described above becomes a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb).
 
 Capturing has a couple of edge cases:
 

--- a/dev-docs/guides/stripe_service_fees.md
+++ b/dev-docs/guides/stripe_service_fees.md
@@ -4,6 +4,6 @@ Stripe charges us all sorts of fees to use their platform, especially when it co
 
 Now, we run [`StripeServiceFeeJob`](https://github.com/hackclub/hcb/blob/main/app/jobs/stripe_service_fee_job.rb) every week to list out those fees we’re charged (they are all negative balance transactions on our Stripe account) and top up our Stripe account to cover that fee.
 
-These top ups are auto-mapped to the “Hack Club Bank” organisation on HCB and they're associated with a HCB code via a short code.
+These top ups are auto-mapped to the “Hack Club Bank” organisation on HCB and they're associated with an HCB code via a short code.
 
 \- [@sampoder](https://github.com/sampoder)

--- a/dev-docs/guides/transaction_imports.md
+++ b/dev-docs/guides/transaction_imports.md
@@ -8,7 +8,7 @@ After a [`RawColumnTransaction`](https://github.com/hackclub/hcb/blob/main/app/m
 
 Each type of transfer has a different HCB code. HCB “calculates” the correct HCB code for a transfer in [`TransactionGroupingEngine::Calculate::HcbCode`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_grouping_engine/calculate/hcb_code.rb) and then writes that HCB code to the [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `hcb_code` column inside of `CanonicalTransaction#write_hcb_code`.
 
-If this is an account number transaction of some other “unknown” transfer type that has came from Column, it will be give an HCB code starting with “HCB-000”. There won’t be a linked object in these cases.
+If this is an account number transaction of some other “unknown” transfer type that has come from Column, it will be given an HCB code starting with “HCB-000”. There won’t be a linked object in these cases.
 
 [`TransactionGroupingEngine::Calculate::HcbCode`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_grouping_engine/calculate/hcb_code.rb) depends on `CanonicalTransaction#linked_object`, which is determined in [`TransactionEngine::SyntaxSugarService::LinkedObject`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_engine/syntax_sugar_service/linked_object.rb).
 
@@ -62,7 +62,7 @@ Incoming fee reimbursements (refunding people for the credit card fees Stripe de
 
 ### HCB Short Codes (Reimbursements, Invoices, Fees, Stripe Fee Reimbursements and Donations)
 
-HCB short codes are a bit like dark magic. Essentially, if a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `memo` contains a “short code” (`/HCB-\w{5}/`, eg `HCB-ABCDE`), we can use that to uniquely map it to an HCB code. Critically, this is different from an HCB code’s hash ID which you see in URLs. an HCB code’s short code is generated before create in `HcbCode#generate_and_set_short_code`.
+HCB short codes are a bit like dark magic. Essentially, if a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `memo` contains a “short code” (`/HCB-\w{5}/`, eg `HCB-ABCDE`), we can use that to uniquely map it to an HCB code. Critically, this is different from an HCB code’s hash ID which you see in URLs. An HCB code’s short code is generated before creation in `HcbCode#generate_and_set_short_code`.
 
 The logic for this mapping is in [`EventMappingEngine::Map::HcbCodes::Short`](https://github.com/hackclub/hcb/blob/main/app/services/event_mapping_engine/map/hcb_codes/short.rb). It handles setting the [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `hcb_code` and mapping it to an event (as well as a subledger, if needed). The event and subledger are determined by the HCB code’s pre-linked [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s and/or [`CanonicalPendingTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_pending_transaction.rb)s.
 

--- a/dev-docs/guides/transaction_imports.md
+++ b/dev-docs/guides/transaction_imports.md
@@ -1,4 +1,4 @@
-# How a transaction gets mapped to an event and a HCB code on HCB.
+# How a transaction gets mapped to an event and an HCB code on HCB.
 Or at least my attempt to describe this. Some transaction types have been deprecated and are not described in this guide, though the code may still exist in the codebase.
 ### Column Transactions
 
@@ -8,7 +8,7 @@ After a [`RawColumnTransaction`](https://github.com/hackclub/hcb/blob/main/app/m
 
 Each type of transfer has a different HCB code. HCB “calculates” the correct HCB code for a transfer in [`TransactionGroupingEngine::Calculate::HcbCode`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_grouping_engine/calculate/hcb_code.rb) and then writes that HCB code to the [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `hcb_code` column inside of `CanonicalTransaction#write_hcb_code`.
 
-If this is an account number transaction of some other “unknown” transfer type that has came from Column, it will be give a HCB code starting with “HCB-000”. There won’t be a linked object in these cases.
+If this is an account number transaction of some other “unknown” transfer type that has came from Column, it will be give an HCB code starting with “HCB-000”. There won’t be a linked object in these cases.
 
 [`TransactionGroupingEngine::Calculate::HcbCode`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_grouping_engine/calculate/hcb_code.rb) depends on `CanonicalTransaction#linked_object`, which is determined in [`TransactionEngine::SyntaxSugarService::LinkedObject`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_engine/syntax_sugar_service/linked_object.rb).
 
@@ -62,7 +62,7 @@ Incoming fee reimbursements (refunding people for the credit card fees Stripe de
 
 ### HCB Short Codes (Reimbursements, Invoices, Fees, Stripe Fee Reimbursements and Donations)
 
-HCB short codes are a bit like dark magic. Essentially, if a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `memo` contains a “short code” (`/HCB-\w{5}/`, eg `HCB-ABCDE`), we can use that to uniquely map it to a HCB code. Critically, this is different from a HCB code’s hash ID which you see in URLs. A HCB code’s short code is generated before create in `HcbCode#generate_and_set_short_code`.
+HCB short codes are a bit like dark magic. Essentially, if a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `memo` contains a “short code” (`/HCB-\w{5}/`, eg `HCB-ABCDE`), we can use that to uniquely map it to an HCB code. Critically, this is different from an HCB code’s hash ID which you see in URLs. an HCB code’s short code is generated before create in `HcbCode#generate_and_set_short_code`.
 
 The logic for this mapping is in [`EventMappingEngine::Map::HcbCodes::Short`](https://github.com/hackclub/hcb/blob/main/app/services/event_mapping_engine/map/hcb_codes/short.rb). It handles setting the [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s `hcb_code` and mapping it to an event (as well as a subledger, if needed). The event and subledger are determined by the HCB code’s pre-linked [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb)s and/or [`CanonicalPendingTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_pending_transaction.rb)s.
 
@@ -92,7 +92,7 @@ Afterwards, [`TransactionEngine::Nightly`](https://github.com/hackclub/hcb/blob/
 
 Still inside of [`TransactionEngine::Nightly`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_engine/nightly.rb), after these transactions are hashed, they are “canonized” by [`TransactionEngine::CanonicalTransactionService::Import::All`](https://github.com/hackclub/hcb/blob/main/app/services/transaction_engine/canonical_transaction_service/import/all.rb). That is to say that a [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb) was created.
 
-This [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb) is mapped to a HCB code using the aforementioned `CanonicalTransaction#write_hcb_code`. See above for a description of that method.
+This [`CanonicalTransaction`](https://github.com/hackclub/hcb/blob/main/app/models/canonical_transaction.rb) is mapped to an HCB code using the aforementioned `CanonicalTransaction#write_hcb_code`. See above for a description of that method.
 
 [`EventMappingEngine::Map::StripeTransactions`](https://github.com/hackclub/hcb/blob/main/app/services/event_mapping_engine/map/stripe_transactions.rb) then calls [`EventMappingEngine::Map::Single::Stripe`](https://github.com/hackclub/hcb/blob/main/app/services/event_mapping_engine/map/single/stripe.rb) on each of these unmapped (no event) Stripe transactions. The event ID is determined by the [`StripeCard`](https://github.com/hackclub/hcb/blob/main/app/models/stripe_card.rb)s event. The [`StripeCard`](https://github.com/hackclub/hcb/blob/main/app/models/stripe_card.rb) is determined by Stripe card ID (`stripe_transaction["card"]`, the `stripe_id` field on [`StripeCard`](https://github.com/hackclub/hcb/blob/main/app/models/stripe_card.rb))
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

[grammar](https://www.scribbr.com/commonly-confused-words/a-vs-an/)

see specifically 'A or an before acronyms'

and yes I know it seems like I have nothing better to do

do also note that there is inconsistent use of 'a HCB' and 'an HCB'

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

change all 'a HCB ...' to 'an HCB ...'

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

