### PR TITLE
Bug fix `Ledger::Item#type_metadata`

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -99,7 +99,7 @@ class Ledger
         "PaypalTransfer": ["PayPal transfer", "paypal"],
         "Wire": ["Wire", "web"],
         "WiseTransfer": ["Wise transfer", "wise"],
-      }[linked_object_type] || ["Unknown", "bank-icon"]
+      }[linked_object_type&.to_sym] || ["Unknown", "bank-icon"]
     end
 
   end


### PR DESCRIPTION
## Summary of the problem

The key of the hash is a symbol, but we're passing in a string


## Describe your changes

Symbolize the string with `.to_sym`