### PR TITLE
[Payments] Hide transfers with payment attempts on payments page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -649,12 +649,12 @@ class EventsController < ApplicationController
     # The search query name was historically `search`. It has since been renamed
     # to `q`. This following line retains backwards compatibility.
     @payments = @event.payments.includes(:payee)
-    @ach_transfers = @event.ach_transfers
+    @ach_transfers = @event.ach_transfers.where(payment_attempt: nil)
     @paypal_transfers = @event.paypal_transfers
-    @wires = @event.wires
-    @wise_transfers = @event.wise_transfers
+    @wires = @event.wires.where(payment_attempt: nil)
+    @wise_transfers = @event.wise_transfers.where(payment_attempt: nil)
     @checks = @event.checks.includes(:lob_address)
-    @increase_checks = @event.increase_checks
+    @increase_checks = @event.increase_checks.where(payment_attempt: nil)
     @disbursements = @event.outgoing_disbursements.includes(:destination_event)
 
     @disbursements = @disbursements.not_card_grant_related


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Currently, when a payment gets sent, both the payment row and the payout appear on the payments page.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Hide any transfers with payment attempts on the payments page

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

