### PR TITLE
Prevent async org comboboxes from committing a wrong or blank organization

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -106,11 +106,14 @@ class DisbursementsController < ApplicationController
   end
 
   def create
-    @source_event = Event.find_by_public_id(disbursement_params[:source_event_id])
-    @destination_event = Event.find_by_public_id(disbursement_params[:event_id]) || Event.friendly.find(disbursement_params[:event_id])
+    @source_event = resolve_transfer_event(disbursement_params[:source_event_id])
+    @destination_event = resolve_transfer_event(disbursement_params[:event_id])
     @disbursement = Disbursement.new(destination_event: @destination_event, source_event: @source_event)
 
     authorize @disbursement
+
+    raise ArgumentError, "You must select an organization to send from." if @source_event.nil?
+    raise ArgumentError, "You must select an organization to send to." if @destination_event.nil?
 
     if admin_signed_in? && disbursement_params["scheduled_on(1i)"].present?
       scheduled_on = Date.new(disbursement_params["scheduled_on(1i)"].to_i,
@@ -255,6 +258,17 @@ class DisbursementsController < ApplicationController
   end
 
   private
+
+  # Resolve a transfer's source/destination event from its submitted id. Both
+  # fields are resolved the same way so blank input produces a friendly "you must
+  # select an organization" error (see #create) rather than a nil dereference or a
+  # raised RecordNotFound. A blank id returns nil; a present id is looked up by
+  # public_id, falling back to a friendly slug.
+  def resolve_transfer_event(id)
+    return nil if id.blank?
+
+    Event.find_by_public_id(id) || Event.friendly.find(id)
+  end
 
   # Only allow a trusted parameter "white list" through.
   def disbursement_params

--- a/app/javascript/controllers/disbursement_form_controller.js
+++ b/app/javascript/controllers/disbursement_form_controller.js
@@ -1,0 +1,108 @@
+/*
+  Guards the "Send an HCB transfer" form (DisbursementsController#new) against
+  submitting a blank source/destination organization.
+
+  The org pickers are async comboboxes (hotwire_combobox) whose value is a hidden
+  field committed only after a deliberate selection. Wrong-org auto-commits are
+  prevented at the source (see strict_hw_combobox.js). What remains is a timing
+  race: a user can hit submit during an in-flight search, before any value has
+  committed, and send a blank organization. We block that here with a friendly,
+  inline message and focus the offending picker.
+
+  This is a UX guard only — the server remains authoritative for presence,
+  authorization, and balance (see DisbursementsController#create), so a submit
+  with JS disabled or via the API is still validated.
+*/
+
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['error']
+
+  connect() {
+    // Turbo caches the DOM; a restored page must not show a stale error.
+    this.reset()
+  }
+
+  onSubmit(event) {
+    const source = this.#hiddenField('source_event_id')
+    const destination = this.#hiddenField('event_id')
+
+    if (this.#isBlank(source)) {
+      this.#block(
+        event,
+        'source_event_id',
+        'You must select an organization to send from.'
+      )
+    } else if (this.#isBlank(destination)) {
+      this.#block(
+        event,
+        'event_id',
+        'You must select an organization to send to.'
+      )
+    }
+  }
+
+  // Clears a stale error whenever the form is edited.
+  reset() {
+    this.#clearError()
+  }
+
+  #hiddenField(name) {
+    return this.element.querySelector(`input[name="disbursement[${name}]"]`)
+  }
+
+  #visibleField(name) {
+    return this.element.querySelector(`#disbursement_${name}`)
+  }
+
+  #isBlank(hiddenField) {
+    return !hiddenField || hiddenField.value.trim() === ''
+  }
+
+  #block(event, name, message) {
+    // Never block silently. If the error region is missing (removed/renamed/
+    // outside this controller), don't preventDefault into a dead-end with no
+    // message — let the submit through and rely on the authoritative server
+    // validation (DisbursementsController#create redirects with a flash error).
+    if (!this.hasErrorTarget) {
+      console.error(
+        'disbursement-form: missing error target; deferring blank-org validation to the server'
+      )
+      return
+    }
+
+    event.preventDefault()
+
+    // Reveal the alert region *before* writing its text so the text mutation
+    // happens inside a visible role="alert" region and is announced reliably.
+    this.errorTarget.hidden = false
+    this.errorTarget.textContent = message
+
+    const visible = this.#visibleField(name)
+    if (visible) {
+      // Associate the message with the field so a screen reader reads it when
+      // focus lands here — reliable regardless of live-region timing. (We leave
+      // aria-invalid to the combobox controller, which owns it.)
+      if (this.errorTarget.id) {
+        visible.setAttribute('aria-describedby', this.errorTarget.id)
+      }
+      visible.focus()
+    }
+  }
+
+  #clearError() {
+    if (this.hasErrorTarget && !this.errorTarget.hidden) {
+      this.errorTarget.hidden = true
+      this.errorTarget.textContent = ''
+
+      // Drop the association we added in #block (only from fields pointing at
+      // our error, so we never clobber another describedby).
+      if (this.errorTarget.id) {
+        this.element
+          .querySelectorAll(`[aria-describedby="${this.errorTarget.id}"]`)
+          .forEach(el => el.removeAttribute('aria-describedby'))
+      }
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,7 +5,7 @@ import { Application } from '@hotwired/stimulus'
 import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers'
 import { installErrorHandler } from '@appsignal/stimulus'
 import { appsignal } from '../appsignal'
-import HwComboboxController from '@josefarias/hotwire_combobox'
+import StrictHwComboboxController from './strict_hw_combobox'
 
 const application = Application.start()
 
@@ -13,4 +13,4 @@ installErrorHandler(appsignal, application)
 
 const context = require.context('.', true, /_controller\.js$/)
 application.load(definitionsFromContext(context))
-application.register('hw-combobox', HwComboboxController)
+application.register('hw-combobox', StrictHwComboboxController)

--- a/app/javascript/controllers/strict_hw_combobox.js
+++ b/app/javascript/controllers/strict_hw_combobox.js
@@ -1,0 +1,202 @@
+/*
+  StrictHwComboboxController — a drop-in subclass of the hotwire_combobox
+  controller that fixes a money-movement footgun in async (server-search)
+  comboboxes, without adding any UI friction.
+
+  THE PROBLEM (async combobox only)
+
+  As you type, the gem commits the FIRST server result to the hidden form field
+  even when you never deliberately chose it:
+
+    1. While typing: `_selectOnQuery` reaches
+       `else if (this._isOpen && this._visibleOptionElements[0])` and calls
+       `_select(firstOption, _softAutocomplete)`, writing the hidden value.
+       `_softAutocomplete` only rewrites the VISIBLE input when the option label
+       starts with what you typed, so a fuzzy server match (type "bank", server
+       matches "HCB Operations" on some other field) commits silently — the
+       visible text never changes.
+    2. On close / Enter / blur: `_lockInSelection` uses
+       `_ensurableOption = _selectedOptionElement || _visibleOptionElements[0]`,
+       so even with (1) suppressed, blurring would still lock in the first result.
+
+  On the transfer form this means a user can send from/to the wrong (but
+  authorized) organization without ever picking it. See
+  app/controllers/disbursements_controller.rb and
+  app/views/disbursements/_select_organization.html.erb.
+
+  THE FIX
+
+  Both paths already have a reliable signal for "did the user mean this option":
+  the gem's own case-insensitive prefix test, `startsWith(optionDisplay, typed)`.
+
+    - Type a prefix ("hack club h" -> "Hack Club HQ") — the option starts with
+      your query, so committing + inline-autocompleting is the normal, wanted
+      typeahead. We leave it untouched.
+    - Type a fuzzy substring ("bank" -> "HCB Operations") — the option does NOT
+      start with your query, so we keep the form value EMPTY until you click a
+      row, arrow to one, or type a real prefix. A blank submit is then caught by
+      the disbursement-form#onSubmit hidden-value guard (while the picker is
+      open, before the gem clears the typed text), by native `required` (after
+      close clears that text), and authoritatively by the server.
+
+  Clicking and arrow-navigating are unaffected (they go through
+  `selectOnClick` / `_selectIndex`, which force an explicit selection).
+
+  SCOPE / SAFETY
+
+  Behavior only changes when `data-hw-combobox-strict-value="true"` is present
+  (set by the transfer org pickers). Every other combobox — admin filters,
+  `name_when_new` pickers — is byte-for-byte unchanged. Strict mode is only used
+  where new options are disallowed, so the override can ignore the new-option
+  branch of `_selectOnQuery`.
+
+  This wraps `super`; it does not copy gem method bodies. It couples only to a
+  few internal names (`_selectOnQuery`, `_ensurableOption`, `_isAsync`,
+  `_isOpen`, `_typedQuery`, `_visibleOptionElements`, `_selectedOptionElement`,
+  `_resetOptionsAndNotify`, `_markInvalid`, `autocompletableAttributeValue`, the
+  `hw:lockInSelection` inputType). The gem version is pinned exactly in
+  package.json; `connect()` asserts these names still exist and throws loudly if
+  an upgrade removes them, rather than silently reverting to the buggy behavior.
+*/
+
+import HwComboboxController from '@josefarias/hotwire_combobox'
+
+export default class StrictHwComboboxController extends HwComboboxController {
+  // Stimulus aggregates static `values` up the prototype chain, so this ADDS to
+  // the gem's values rather than replacing them. Reads
+  // `data-hw-combobox-strict-value`.
+  static values = { strict: Boolean }
+
+  // Fail LOUD, not silent. Every override below couples to gem-internal method
+  // and getter names. If a future gem upgrade renames any of them, the couplings
+  // would otherwise degrade silently *toward* the unsafe auto-commit this fix
+  // exists to prevent (e.g. a renamed `_typedQuery` reads `undefined` -> `''` ->
+  // `startsWith('')` is always true -> suppression never fires). We assert the
+  // contract at connect time so the failure surfaces via the app's Stimulus
+  // error handler (AppSignal, see index.js) instead of quietly re-arming the
+  // footgun. Only runs for strict pickers; the gem is pinned exactly in
+  // package.json, so this can only trip on a deliberate upgrade.
+  //
+  // NOTE: this asserts the coupled names still EXIST, not that their behavior is
+  // unchanged. A gem upgrade that keeps a name but alters its semantics (e.g.
+  // `_typedQuery` starts returning the autocompleted rather than typed text) can
+  // still regress silently. Re-verify the actual suppression behavior on upgrade,
+  // not just a green boot.
+  connect() {
+    super.connect()
+    if (this.strictValue) this.#assertGemContract()
+  }
+
+  get _strict() {
+    return this.strictValue
+  }
+
+  // Case-insensitive: does this option's display start with what the user typed?
+  // `_typedQuery` is the unselected (actually-typed) portion of the input, so an
+  // in-progress inline autocomplete doesn't fool it.
+  _optionPrefixMatchesTypedQuery(option) {
+    const display = (
+      option.getAttribute(this.autocompletableAttributeValue) || ''
+    ).toLowerCase()
+    return display.startsWith((this._typedQuery || '').toLowerCase())
+  }
+
+  // Path 1 — while typing. Suppress the silent commit of a fuzzy first result;
+  // let everything else (deletes, new options, prefix matches, the closed-dialog
+  // case, lock-in) fall through to the gem unchanged.
+  _selectOnQuery(inputType) {
+    if (this._shouldSuppressSilentAutoCommit(inputType)) {
+      // Mirror the gem's own no-selectable-option branch (selection.js): clear
+      // the value AND mark the field invalid, so aria-invalid/aria-errormessage
+      // reflect the empty value while the fuzzy result is showing.
+      this._resetOptionsAndNotify() // keep the form value empty until a real pick
+      this._markInvalid()
+      return
+    }
+
+    super._selectOnQuery(inputType)
+  }
+
+  _shouldSuppressSilentAutoCommit(inputType) {
+    if (!this._strict || !this._isAsync || !this._isOpen) return false
+    if (inputType === 'hw:lockInSelection') return false
+    if ((inputType || '').startsWith('delete')) return false // let the gem deselect
+    if (this._selectedOptionElement) return false // an explicit pick already stands
+
+    const option = this._visibleOptionElements[0]
+    return !!option && !this._optionPrefixMatchesTypedQuery(option)
+  }
+
+  // Path 2 — on close / Enter / blur. Only lock in an option the user explicitly
+  // selected (clicked/arrowed) or a genuine prefix match; never an arbitrary
+  // fuzzy first result. Returning null leaves the value blank, and the gem's
+  // `_clearInvalidQuery` then clears the leftover typed text.
+  get _ensurableOption() {
+    const option = super._ensurableOption
+    if (!option || !this._strict || !this._isAsync) return option
+    if (this._selectedOptionElement) return option
+
+    return this._optionPrefixMatchesTypedQuery(option) ? option : null
+  }
+
+  // Throws if any gem-internal name the overrides depend on has gone missing.
+  // The overridden names (_selectOnQuery, _ensurableOption) are checked on the
+  // gem's prototype chain specifically — our own overrides must not mask a
+  // removal, since `super` would then be undefined.
+  #assertGemContract() {
+    const gemProto = Object.getPrototypeOf(Object.getPrototypeOf(this))
+    const required = [
+      '_selectOnQuery',
+      '_ensurableOption',
+      '_resetOptionsAndNotify',
+      '_markInvalid',
+      '_isAsync',
+      '_isOpen',
+      '_typedQuery',
+      '_visibleOptionElements',
+      '_selectedOptionElement',
+    ]
+
+    const missing = required.filter(
+      name => !this.#protoChainHas(gemProto, name)
+    )
+
+    if (
+      typeof this.autocompletableAttributeValue !== 'string' ||
+      this.autocompletableAttributeValue === ''
+    ) {
+      missing.push('autocompletableAttributeValue')
+    }
+
+    if (missing.length > 0) {
+      throw new Error(
+        `StrictHwCombobox: hotwire_combobox contract broken (missing: ${missing.join(', ')}). ` +
+          'The strict transfer-org guard is inert, so a fuzzy search result could silently ' +
+          'commit the wrong organization. Re-verify strict_hw_combobox.js against the upgraded gem.'
+      )
+    }
+
+    // Strict mode assumes new options are disallowed (see the suppress branch,
+    // which treats a non-prefix-matching first result as "no valid selection").
+    // On a picker that allows new options, that would silently swallow a
+    // legitimately typed new value. We don't use the two together today; fail
+    // loud if someone ever wires them up rather than shipping a broken picker.
+    if (this.nameWhenNewValue) {
+      throw new Error(
+        'StrictHwCombobox: strict mode is incompatible with name_when_new — a typed ' +
+          'new option would be suppressed. Remove data-hw-combobox-strict-value or name_when_new.'
+      )
+    }
+  }
+
+  #protoChainHas(startProto, name) {
+    for (
+      let proto = startProto;
+      proto && proto !== Object.prototype;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      if (Object.getOwnPropertyDescriptor(proto, name)) return true
+    }
+    return false
+  }
+}

--- a/app/views/disbursements/_form.html.erb
+++ b/app/views/disbursements/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% disabled = source_event.present? && !policy(source_event).create_transfer? %>
 
-<%= form_with(model: disbursement, local: true, url: disbursements_path, html: { "x-data" => "{fee: null, event_id: null}" }) do |form| %>
+<%= form_with(model: disbursement, local: true, url: disbursements_path, html: { "x-data" => "{fee: null, event_id: null}", data: { controller: "disbursement-form", action: "submit->disbursement-form#onSubmit hw-combobox:selection->disbursement-form#reset input->disbursement-form#reset" } }) do |form| %>
   <%= form_errors(disbursement, "Disbursements") %>
 
   <div data-scroll-seek-target="section">
@@ -26,6 +26,8 @@
         <%= inline_icon "view-forward", class: "mt-[30px]" %>
         <%= render partial: "disbursements/select_organization", locals: { form: form, field_name: "event_id", disabled: disabled, label: "To", source_event: source_event } %>
       </div>
+
+      <p id="disbursement_form_error" data-disbursement-form-target="error" class="error mb-2" role="alert" hidden></p>
 
       <div class="flex items-center justify-between">
         <%= form.label :amount, "Amount" %>

--- a/app/views/disbursements/_select_organization.html.erb
+++ b/app/views/disbursements/_select_organization.html.erb
@@ -13,5 +13,5 @@
 
 <div class="field flex-1">
   <%= form.label field_name, label %>
-  <%= form.combobox field_name.to_sym, search_path, value: default_value, placeholder: "Select one...", disabled: disabled, class: "!max-w-full" %>
+  <%= form.combobox field_name.to_sym, search_path, value: default_value, placeholder: "Select one...", disabled: disabled, required: true, class: "!max-w-full", data: { hw_combobox_strict_value: true } %>
 </div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo-rails": "^8.0.16",
     "@hugocxl/react-to-image": "^0.0.9",
-    "@josefarias/hotwire_combobox": "^0.4.1",
+    "@josefarias/hotwire_combobox": "0.4.1",
     "@oddbird/popover-polyfill": "^0.6.1",
     "@shopify/draggable": "^1.1.4",
     "@stripe/stripe-js": "^8.2.0",

--- a/spec/controllers/disbursements_controller_spec.rb
+++ b/spec/controllers/disbursements_controller_spec.rb
@@ -78,6 +78,56 @@ RSpec.describe DisbursementsController do
       expect(disbursement.source_transaction_category.slug).to eq("donations")
       expect(disbursement.destination_transaction_category.slug).to eq("fundraising")
     end
+
+    it "redirects with an error when the source organization is blank" do
+      sender = create(:user)
+      destination_event = create(:event)
+      create(:organizer_position, user: sender, event: destination_event)
+
+      create_session(sender, verified: true)
+
+      expect do
+        post(
+          :create,
+          params: {
+            disbursement: {
+              name: "Boba Drops",
+              source_event_id: "",
+              event_id: destination_event.public_id,
+              amount: "123.45"
+            }
+          }
+        )
+      end.not_to change(Disbursement, :count)
+
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:error]).to eq("You must select an organization to send from.")
+    end
+
+    it "redirects with a friendly error when the destination organization is blank" do
+      sender = create(:user)
+      source_event = create(:event, :with_positive_balance)
+      create(:organizer_position, user: sender, event: source_event)
+
+      create_session(sender, verified: true)
+
+      expect do
+        post(
+          :create,
+          params: {
+            disbursement: {
+              name: "Boba Drops",
+              source_event_id: source_event.public_id,
+              event_id: "",
+              amount: "123.45"
+            }
+          }
+        )
+      end.not_to change(Disbursement, :count)
+
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:error]).to eq("You must select an organization to send to.")
+    end
   end
 
   describe "#set_transaction_categories" do
@@ -161,6 +211,44 @@ RSpec.describe DisbursementsController do
       disbursement.reload
       expect(disbursement.source_transaction_category.slug).to eq("donations")
       expect(disbursement.destination_transaction_category.slug).to eq("rent")
+    end
+  end
+
+  describe "#new" do
+    it "renders the source and destination organization comboboxes as required" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      get(:new)
+
+      expect(response).to have_http_status(:ok)
+
+      html = Nokogiri::HTML(response.body)
+      source_combobox = html.at_css("input#disbursement_source_event_id[role='combobox']")
+      destination_combobox = html.at_css("input#disbursement_event_id[role='combobox']")
+
+      expect(source_combobox).to be_present
+      expect(destination_combobox).to be_present
+      expect(source_combobox["required"]).to be_present
+      expect(destination_combobox["required"]).to be_present
+    end
+
+    it "opts the organization comboboxes into strict selection" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      get(:new)
+
+      expect(response).to have_http_status(:ok)
+
+      html = Nokogiri::HTML(response.body)
+      source_fieldset = html.at_css("fieldset[data-async-id='disbursement_source_event_id']")
+      destination_fieldset = html.at_css("fieldset[data-async-id='disbursement_event_id']")
+
+      expect(source_fieldset).to be_present
+      expect(destination_fieldset).to be_present
+      expect(source_fieldset["data-hw-combobox-strict-value"]).to eq("true")
+      expect(destination_fieldset["data-hw-combobox-strict-value"]).to eq("true")
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,7 +1196,7 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@josefarias/hotwire_combobox@^0.4.1":
+"@josefarias/hotwire_combobox@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@josefarias/hotwire_combobox/-/hotwire_combobox-0.4.1.tgz#d3536ffba107cbaf4111c19e4a8453202d1ef80a"
   integrity sha512-JvfGC7osghQ8jl/ZkJjAEvvMj4ZecguhjNGcaqmPEBRDhPjSOhYziO9PsOXPUgjqcpLZx654VufWnYu1+aR8xQ==
@@ -6477,16 +6477,7 @@ stimulus-use@^0.52.3:
   resolved "https://registry.yarnpkg.com/stimulus-use/-/stimulus-use-0.52.3.tgz#d6f35fa93277274957a2ed98a7b04b4d702cb1d6"
   integrity sha512-stZ5dID6FUrGCR/ChWUa0FT5Z8iqkzT6lputOAb50eF+Ayg7RzJj4U/HoRlp2NV333QfvoRidru9HLbom4hZVw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7307,16 +7298,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

The "Send an HCB transfer" **From** / **To** pickers are async `hotwire_combobox` fields. As you type, the gem silently commits the **first server result** to the hidden field even on a *fuzzy* match where the visible text never changes (e.g. typing `bank` commits "HCB Operations"), and it can lock one in on blur. So a transfer could be sent from/to the **wrong (but authorized) organization** without a deliberate choice — which is why users reported "I selected an org" yet the wrong or blank one was submitted. The same gap let a **blank** org through when a form was submitted during the in-flight search, surfacing as a `NoMethodError` 500 in `DisbursementsController#create`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Fix the auto-commit **at the source**, inside the combobox, with no added confirmation step:

- **`StrictHwComboboxController`** (`strict_hw_combobox.js`) — a thin subclass of the gem controller, registered under `hw-combobox`, gated by `data-hw-combobox-strict-value="true"` set only on the transfer org pickers. It wraps `super` and overrides two seams so a value commits only on a **deliberate pick** (click / arrow) or a **genuine prefix match**:
  - `_selectOnQuery` — suppress the silent commit of a fuzzy first result while typing.
  - `_ensurableOption` — never lock in a fuzzy first result on close / Enter / blur.
  It reuses the gem's own case-insensitive `startsWith` test, so prefix typing (`hack club h` → `Hack Club HQ`) keeps its inline-autocomplete with zero friction. Every other combobox (admin filters, etc.) is byte-for-byte unchanged — the override early-returns without the flag.
- **Server stays authoritative** — `#create` resolves source *and* destination symmetrically and returns a friendly error for a blank/unresolved either side instead of 500-ing.
- **Slim client guard** — `disbursement_form_controller.js` blocks the in-flight-race blank submit with an inline, `aria-describedby`-associated message; the server remains the source of truth.
- **Upgrade safety** — pin `@josefarias/hotwire_combobox` to exact `0.4.1`; `connect()` asserts the coupled gem internals still exist and throws (surfaced via AppSignal) on an upgrade rather than silently reverting.

**Testing:** `spec/controllers/disbursements_controller_spec.rb` green (10 examples, incl. a test asserting the strict flag renders through the real gem). Verified live in the browser across every path — fuzzy typing stays blank + `aria-invalid`, prefix commits + autocompletes, typing over a prior pick clears the stale value, Escape/close never locks in a wrong org, explicit click commits. No JS/system-test harness exists in the repo, so the strict behavior is covered by the boot-time contract assertion + manual verification.
