### PR TITLE
Fix transaction_source_type on CPT

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -436,11 +436,15 @@ class CanonicalPendingTransaction < ApplicationRecord
     types = %w[RawPendingBankFeeTransaction RawPendingColumnTransaction RawPendingDonationTransaction
                RawPendingIncomingDisbursementTransaction RawPendingInvoiceTransaction
                RawPendingOutgoingAchTransaction RawPendingOutgoingCheckTransaction
-               RawPendingOutgoingDisbursementTransaction RawPendingStripeTransaction]
+               RawPendingOutgoingDisbursementTransaction RawPendingStripeTransaction
+               ReimbursementExpensePayout ReimbursementPayoutHolding CheckDeposit
+               IncreaseCheck PaypalTransfer Wire WiseTransfer]
 
     types.each do |type|
       return type if send("#{type.underscore}_id").present?
     end
+
+    nil
   end
 
   private


### PR DESCRIPTION
## Summary of the problem

`transaction_source_type` will output an array if any of the missing types are the source.


## Describe your changes

Add the remaining transaction source types and include a `nil` fallback