### PR TITLE
[Reimbursements] Update report currency if payout is changed 

### DIFF
--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -72,7 +72,7 @@ class LegalEntity
       if default && draft_report.any?
         draft_report.find_each do |report|
           report.update!(legal_entity_payout_method: default)
-          report.convert_report_currency!(@payout_method.currency) if report.mismatched_currency?
+          report.convert_report_currency!(default.currency) if report.mismatched_currency?
         end
       end
 

--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -72,6 +72,7 @@ class LegalEntity
       if default && draft_report.any?
         draft_report.find_each do |report|
           report.update!(legal_entity_payout_method: default)
+          report.convert_report_currency!(@payout_method.currency) if report.mismatched_currency?
         end
       end
 

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -116,7 +116,7 @@ module Reimbursement
 
       new_currency = @report.payout_method.currency
 
-      convert_report_currency!(new_currency)
+      @report.convert_report_currency!(new_currency)
 
       flash[:success] = "Report successfully updated to #{new_currency}."
     rescue ActiveRecord::RecordInvalid => e
@@ -131,7 +131,7 @@ module Reimbursement
 
         ActiveRecord::Base.transaction do
           @report.update!(legal_entity_payout_method: new_method)
-          convert_report_currency!(new_method.currency) if @report.mismatched_currency?
+          @report.convert_report_currency!(new_method.currency) if @report.mismatched_currency?
         end
 
         flash[:success] = "Payout method saved."
@@ -444,21 +444,6 @@ module Reimbursement
     end
 
     private
-
-    def convert_report_currency!(new_currency)
-      old_currency = @report.currency
-
-      ActiveRecord::Base.transaction do
-        @report.update!(currency: new_currency)
-
-        @report.expenses.each do |expense|
-          fractional = Money.from_amount(expense.value, old_currency).cents
-          full = Money.from_cents(fractional, new_currency).amount
-
-          expense.update!(value: full)
-        end
-      end
-    end
 
     def set_report_user_and_event
       @report = Reimbursement::Report.find(params[:report_id] || params[:id])

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -348,6 +348,21 @@ module Reimbursement
       payout_method.present? && currency != payout_method.currency
     end
 
+    def convert_report_currency!(new_currency)
+      old_currency = @report.currency
+
+      ActiveRecord::Base.transaction do
+        @report.update!(currency: new_currency)
+
+        @report.expenses.each do |expense|
+          fractional = Money.from_amount(expense.value, old_currency).cents
+          full = Money.from_cents(fractional, new_currency).amount
+
+          expense.update!(value: full)
+        end
+      end
+    end
+
     def exceeds_maximum_amount?
       maximum_amount_cents && amount_cents > maximum_amount_cents && currency == "USD"
     end

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -349,12 +349,12 @@ module Reimbursement
     end
 
     def convert_report_currency!(new_currency)
-      old_currency = @report.currency
+      old_currency = currency
 
       ActiveRecord::Base.transaction do
-        @report.update!(currency: new_currency)
+        update!(currency: new_currency)
 
-        @report.expenses.each do |expense|
+        expenses.each do |expense|
           fractional = Money.from_amount(expense.value, old_currency).cents
           full = Money.from_cents(fractional, new_currency).amount
 

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -74,7 +74,7 @@ class LegalEntity
         # payout-method change or the other repoints.
         (failed + draft).each do |report|
           safely do
-            report.convert_report_currency!(@payout_method.currency)
+            report.convert_report_currency!(@payout_method.currency) if report.currency != @payout_method.currency
             report.update!(legal_entity_payout_method: @payout_method)
           end
         end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -74,8 +74,8 @@ class LegalEntity
         # payout-method change or the other repoints.
         (failed + draft).each do |report|
           safely do
-            report.convert_report_currency!(@payout_method.currency) if report.mismatched_currency?
             report.update!(legal_entity_payout_method: @payout_method)
+            report.convert_report_currency!(@payout_method.currency) if report.mismatched_currency?
           end
         end
       end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -74,7 +74,7 @@ class LegalEntity
         # payout-method change or the other repoints.
         (failed + draft).each do |report|
           safely do
-            report.convert_report_currency!(@payout_method.currency) if report.currency != @payout_method.currency
+            report.convert_report_currency!(@payout_method.currency) if report.mismatched_currency?
             report.update!(legal_entity_payout_method: @payout_method)
           end
         end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -74,7 +74,7 @@ class LegalEntity
         # payout-method change or the other repoints.
         (failed + draft).each do |report|
           safely do
-            report.update!(legal_entity_payout_method: @payout_method)
+            report.update!(legal_entity_payout_method: @payout_method, currency: @payout_method.details.currency)
           end
         end
       end

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -74,7 +74,8 @@ class LegalEntity
         # payout-method change or the other repoints.
         (failed + draft).each do |report|
           safely do
-            report.update!(legal_entity_payout_method: @payout_method, currency: @payout_method.details.currency)
+            report.convert_report_currency!(@payout_method.currency)
+            report.update!(legal_entity_payout_method: @payout_method)
           end
         end
       end


### PR DESCRIPTION
## Summary of the problem
If a report is on USD and we delete the payout method for it, it'll get reassigned to the default but if the default is in GBP then the report currency doesn't change.


## Describe your changes
converts on repoint


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

