### PR TITLE
[Reimbursements] Only allow admins or reimbursee to change payout

### DIFF
--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -80,7 +80,7 @@ module Reimbursement
     end
 
     def update_payout_method?
-      (admin || manager || creator) && record.can_change_payout_method?
+      (admin || creator) && record.can_change_payout_method?
     end
 
     def admin_approve?


### PR DESCRIPTION
Managers should not be able to change payout settings