### PR TITLE
Fix Account Balance Chart

### DIFF
--- a/app/javascript/controllers/balance_graph_controller.js
+++ b/app/javascript/controllers/balance_graph_controller.js
@@ -54,10 +54,9 @@ export default class extends Controller {
         const balanceByDate = Object.fromEntries(entries)
 
         for (const date in balanceByDate) {
-          const value =
-            date == today
-              ? this.availableValue
-              : parseFloat(balanceByDate[date])
+          const raw = parseFloat(balanceByDate[date])
+          const feeAdjusted = Math.round(raw * 0.93)
+          const value = date == today ? this.availableValue : feeAdjusted
 
           const mostRecentDate = balances[balances.length - 1]?.date
           const range = getDates(new Date(date), new Date(mostRecentDate))


### PR DESCRIPTION
## Summary of the problem
Currently, on the account balance chart, the account balance for a given day except for the current day is the balance before hcb's 7% fee. Because of this, the graph shows a higher balance on previous days than what the actual balance was, but shows the correct balance for the current day.


## Describe your changes
I modified `\app\javascript\controllers\balance_graph_controller.js` to use the balance with the 7% fee included for previous days, but kept the system where today's balance is the current balance.