### PR TITLE
Rescue from NotAuthorizedError in events#index

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1235,6 +1235,8 @@ class EventsController < ApplicationController
 
     @ledger = @event.ledger
     @items = @ledger.items.includes(:canonical_transactions, :canonical_pending_transactions, :linked_object).order(datetime: :desc, created_at: :desc, id: :desc).page(params[:page]).per(@per)
+  rescue Pundit::NotAuthorizedError
+    return head :not_found
   end
 
   private


### PR DESCRIPTION
Handle Pundit::NotAuthorizedError in events controller.
