### PR TITLE
Enhance help_message with nonprofit details

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -254,7 +254,8 @@ module ApplicationHelper
   end
 
   def help_message
-    content_tag :span, "Contact the HCB team at #{help_email} or call #{help_phone} for urgent requests.".html_safe
+    message = "Contact the HCB team at #{help_email} or call #{help_phone} for urgent requests.<br/><small>HCB is operated by The Hack Foundation (d.b.a. Hack Club), a 501(c)(3) nonprofit with EIN 81-2908499.</small>"
+    content_tag :span, message.html_safe
   end
 
   def help_email


### PR DESCRIPTION
Updated help_message to include additional information about HCB and its operation.

<img width="1254" height="315" alt="image" src="https://github.com/user-attachments/assets/113bbd35-a4c6-49ae-9bb5-89140f355167" />
