### PR TITLE
[Payout Settings] Make icons black in light mode

### DIFF
--- a/app/assets/stylesheets/components/_payout_methods.scss
+++ b/app/assets/stylesheets/components/_payout_methods.scss
@@ -41,6 +41,10 @@
   &__icon {
     border: 0;
     background: rgba(map-get($palette, muted), 0.125);
-    color: #fff;
+    color: map-get($palette, black);
+
+    [data-dark='true'] & {
+      color: #fff;
+    }
   }
 }


### PR DESCRIPTION
<img width="997" height="618" alt="image" src="https://github.com/user-attachments/assets/ab7dcd77-f03c-4302-b168-e51bd29fb3cd" />

currently barely visible