### PR TITLE
[codex] Support restricted read-only admin API access

### DIFF
--- a/app/controllers/api/v4/card_grants_controller.rb
+++ b/app/controllers/api/v4/card_grants_controller.rb
@@ -19,6 +19,8 @@ module Api
         end
       end
 
+      require_oauth2_scope "read", :index
+
       def create
         sent_by = current_user
 
@@ -76,6 +78,8 @@ module Api
         authorize @card_grant
       end
 
+      require_oauth2_scope "read", :show
+
       def topup
         authorize @card_grant
 
@@ -120,6 +124,8 @@ module Api
 
         @hcb_codes = paginate_cursor(@hcb_codes, &:public_id)
       end
+
+      require_oauth2_scope "read", :transactions
 
       private
 

--- a/app/controllers/api/v4/check_deposits_controller.rb
+++ b/app/controllers/api/v4/check_deposits_controller.rb
@@ -14,12 +14,16 @@ module Api
         render :index, status: :ok
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         @check_deposit = CheckDeposit.find_by_public_id!(params[:id])
         authorize @check_deposit
 
         render :show, status: :ok
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         check_deposit_params = params.permit(:front, :back, :amount_cents).merge(created_by: current_user)

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -12,9 +12,13 @@ module Api
         @checks = @event.increase_checks.order(created_at: :desc)
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         @check = authorize IncreaseCheck.find_by_public_id!(params[:id])
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         check_params = params.require(:check).permit(

--- a/app/controllers/api/v4/comments_controller.rb
+++ b/app/controllers/api/v4/comments_controller.rb
@@ -8,6 +8,8 @@ module Api
         @comments = policy_scope(@hcb_code.comments).includes(:user).order(created_at: :asc)
       end
 
+      require_oauth2_scope "read", :index
+
       def create
         @hcb_code = HcbCode.find_by_public_id!(params[:transaction_id])
 

--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -7,8 +7,15 @@ module Api
       skip_after_action :verify_authorized, only: [:index]
 
       def index
-        @events = current_user.events.not_hidden.includes(:users).order("organizer_positions.created_at DESC")
+        @events =
+          if can_admin?(:read)
+            Event.not_hidden.includes(:users).order(created_at: :desc)
+          else
+            current_user.events.not_hidden.includes(:users).order("organizer_positions.created_at DESC")
+          end
       end
+
+      require_oauth2_scope "organizations:read", :index
 
       def sub_organizations
         authorize @event, :sub_organizations_in_v4?

--- a/app/controllers/api/v4/invoices_controller.rb
+++ b/app/controllers/api/v4/invoices_controller.rb
@@ -11,10 +11,14 @@ module Api
         @invoices = authorize(@event.invoices.order(created_at: :desc))
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         @invoice = Invoice.find_by_public_id!(params[:id])
         authorize @invoice
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         authorize @event, :create?, policy_class: InvoicePolicy

--- a/app/controllers/api/v4/organizer_position_invites_controller.rb
+++ b/app/controllers/api/v4/organizer_position_invites_controller.rb
@@ -19,9 +19,13 @@ module Api
         end
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         authorize @invitation
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         authorize @event, :can_invite_user?

--- a/app/controllers/api/v4/sponsors_controller.rb
+++ b/app/controllers/api/v4/sponsors_controller.rb
@@ -12,10 +12,14 @@ module Api
         @sponsors = @event.sponsors.order(created_at: :desc)
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         @sponsor = Sponsor.find_by_public_id!(params[:id])
         authorize @sponsor
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         authorize @event

--- a/app/controllers/api/v4/stripe_cards_controller.rb
+++ b/app/controllers/api/v4/stripe_cards_controller.rb
@@ -16,9 +16,13 @@ module Api
         end
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         @stripe_card = authorize StripeCard.find_by_public_id!(params[:id])
       end
+
+      require_oauth2_scope "read", :show
 
       def transactions
         @stripe_card = authorize StripeCard.find_by_public_id!(params[:id])
@@ -28,6 +32,8 @@ module Api
 
         @hcb_codes = paginate_cursor(@hcb_codes, &:public_id)
       end
+
+      require_oauth2_scope "read", :transactions
 
       def create
         event = Event.find_by_public_id(params[:card][:organization_id]) || Event.friendly.find(params[:card][:organization_id])
@@ -127,6 +133,8 @@ module Api
 
         @designs += StripeCard::PersonalizationDesign.unlisted.available if can_admin?(:read)
       end
+
+      require_oauth2_scope "read", :card_designs
 
       def freeze
         @stripe_card = authorize StripeCard.find_by_public_id!(params[:id])

--- a/app/controllers/api/v4/tags_controller.rb
+++ b/app/controllers/api/v4/tags_controller.rb
@@ -13,9 +13,13 @@ module Api
         @tags = @event.tags.order(created_at: :desc)
       end
 
+      require_oauth2_scope "read", :index
+
       def show
         authorize @tag
       end
+
+      require_oauth2_scope "read", :show
 
       def create
         @tag = @event.tags.build(params.permit(:label, :color, :emoji))

--- a/app/controllers/api/v4/transactions_controller.rb
+++ b/app/controllers/api/v4/transactions_controller.rb
@@ -102,6 +102,8 @@ module Api
         @suggested_memos = ::HcbCodeService::SuggestedMemos.new(hcb_code: @hcb_code, event: @event).run.first(4)
       end
 
+      require_oauth2_scope "ledgers:read", :memo_suggestions
+
       def mark_no_receipt
         @hcb_code = HcbCode.find_by_public_id!(params[:id])
         authorize @hcb_code, :mark_no_or_lost?, policy_class: ReceiptablePolicy

--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -11,6 +11,8 @@ module Api
         render :show
       end
 
+      require_oauth2_scope "read", :me
+
       def revoke
         @current_token.update(revoked_at: Time.now)
         render json: {
@@ -51,6 +53,8 @@ module Api
 
         render json: icons.compact_blank
       end
+
+      require_oauth2_scope "read", :available_icons
 
     end
   end

--- a/dev-docs/v4-api/scopes.md
+++ b/dev-docs/v4-api/scopes.md
@@ -123,6 +123,7 @@ Multiple `require_oauth2_scope` calls for the same action **accumulate** — the
 
 | Pattern | When to use | Examples |
 |---------|-------------|----------|
+| `read` | Coarse read-only access for GET endpoints that do not have a narrower resource scope | current user profile, cards, tags |
 | `<resource>:read` | Read-only access to a resource | `ledgers:read`, `organizations:read` |
 | `<resource>:write` | Mutating a resource (create/update/destroy) | `receipts:write`, `card_grants:write` |
 | `<capability>` | A narrow, single-purpose capability that doesn't map cleanly to read/write of one resource | `user_lookup`, `event_followers` |
@@ -131,7 +132,7 @@ Multiple `require_oauth2_scope` calls for the same action **accumulate** — the
 Guidelines:
 
 - `read` and `write` are **independent** — granting `:write` does not imply `:read`. Declare each where needed.
-- Prefer the `<resource>:<action>` shape. Reach for a bare capability scope only when the access doesn't correspond to CRUD on a single resource.
+- Prefer the `<resource>:<action>` shape. Use coarse `read` for existing GET endpoints that do not yet have a useful resource-specific scope. Reach for a bare capability scope only when the access doesn't correspond to CRUD on a single resource.
 
 ---
 

--- a/dev-docs/v4-api/standards.md
+++ b/dev-docs/v4-api/standards.md
@@ -464,7 +464,13 @@ To gain admin permissions via the API, the token must explicitly carry an admin 
 | `admin:read`   | Grants read-only access to admin-level data (e.g. all organizations, internal fields). |
 | `admin:write`  | Grants the ability to perform write actions reserved for admins.     |
 
-`admin:write` does **not** imply `admin:read` — both scopes must be granted independently if both are needed. 
+`admin:write` does **not** imply `admin:read` — both scopes must be granted independently if both are needed.
+
+A true read-only admin token should include `restricted` plus the read scopes it needs, for example:
+
+```text
+restricted read admin:read organizations:read ledgers:read receipts:read user_lookup event_followers
+```
 
 ### Implementation Notes
 

--- a/spec/controllers/api/v4/users_controller_spec.rb
+++ b/spec/controllers/api/v4/users_controller_spec.rb
@@ -3,13 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Api::V4::UsersController do
+  let(:admin_read_only_scopes) { "restricted read admin:read organizations:read ledgers:read receipts:read user_lookup event_followers" }
+
+  def authenticate(user:, scopes:)
+    token = create(:api_token, user:, scopes:)
+    request.headers["Authorization"] = "Bearer #{token.token}"
+  end
+
   # `#show` is gated by `require_admin_scope!(:read)`.
   describe "#show" do
     let(:target) { create(:user, full_name: "Target User") }
 
     def get_show(viewer:, scopes:)
-      token = create(:api_token, user: viewer, scopes:)
-      request.headers["Authorization"] = "Bearer #{token.token}"
+      authenticate(user: viewer, scopes:)
       get(:show, params: { id: target.public_id }, as: :json)
     end
 
@@ -31,6 +37,33 @@ RSpec.describe Api::V4::UsersController do
       get_show(viewer: create(:user, access_level: :admin), scopes: "admin:read")
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it "allows a restricted read-only admin token" do
+      get_show(viewer: create(:user, access_level: :admin), scopes: admin_read_only_scopes)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "#me" do
+    it "allows a restricted token with the coarse read scope" do
+      authenticate(user: create(:user), scopes: "restricted read")
+
+      get(:me, as: :json)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "#revoke" do
+    it "rejects restricted read-only tokens because revoke is a write action" do
+      authenticate(user: create(:user), scopes: admin_read_only_scopes)
+
+      post(:revoke, as: :json)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body).to eq("error" => "not_authorized")
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds the server-side pieces needed for read-only admin HCB API access from restricted OAuth tokens.

- Adds read scope declarations to existing GET endpoints so `restricted` tokens can read them without opening write access.
- Lets admin-read API contexts list all non-hidden organizations while preserving the existing member-only organization list for normal users.
- Documents the intended read-only admin scope set and adds controller coverage for restricted read-only admin behavior.

## Validation

- `mise exec ruby@3.4.9 -- ruby -c ...` on the modified controllers and spec passed.
- Full Rails spec run was previously blocked locally by Postgres not running on `/tmp/.s.PGSQL.5432`.

## Deployment note

The OAuth application used by the hosted bridge needs to allow the read-only admin scope set before `hcb login --admin` can request it successfully.