### PR TITLE
Explain forced transparency and cascade it to suborganizations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -490,6 +490,8 @@ class Event < ApplicationRecord
     end
   end
 
+  after_update_commit :cascade_transparency_to_subevents, if: -> { is_public_previously_changed? && is_public? }
+
   # We can't do this through a normal dependent: :destroy since ActiveRecord does not support deleting records through indirect has_many associations
   # https://github.com/rails/rails/commit/05bcb8cecc8573f28ad080839233b4bb9ace07be
   after_destroy_commit do
@@ -1010,6 +1012,15 @@ class Event < ApplicationRecord
 
   def move_friendly_id_error_to_slug
     errors.add :slug, *errors.delete(:friendly_id) if errors[:friendly_id].present?
+  end
+
+  def cascade_transparency_to_subevents
+    # When this event becomes transparent, its subevents must become transparent too
+    # (enforced by enforce_transparency_eligibility). Update them now instead of waiting
+    # for each subevent's next save. Each subevent update recurses to its own subevents.
+    subevents.not_transparent.find_each do |subevent|
+      subevent.update!(is_public: true)
+    end
   end
 
   def enforce_transparency_eligibility

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -117,11 +117,16 @@
       <span style="font-weight: 700">Make <%= possessive(event.name) %> finances transparent</span>
       <div class="field--checkbox--switch ml-auto">
         <%= form.label :is_public do %>
-          <%= form.check_box :is_public, data: { action: "change->accordion#toggle", accordion_target: "checkbox" }, disabled:, switch: true %>
+          <%= form.check_box :is_public, data: { action: "change->accordion#toggle", accordion_target: "checkbox" }, disabled: disabled || !event.eligible_for_disabling_transparency?, switch: true %>
           <span class="slider"></span>
         <% end %>
       </div>
     </div>
+    <% unless event.eligible_for_disabling_transparency? %>
+      <%= render "callout", type: "info", title: "Transparency is turned on because #{event.parent&.name || "this organization's parent"} is transparent." do %>
+        Transparent parent organizations require their suborganizations to also be transparent, so this setting can't be turned off here.
+      <% end %>
+    <% end %>
     <ul class="mt0 pl4 mb2">
       <li>Unauthenticated users will be able to access a <strong>read-only</strong> version of your account.</li>
       <li>None of HCB’s pages will change for signed in team members.</li>


### PR DESCRIPTION
## Summary of the problem

When an organization's parent is transparent, HCB forces the suborganization to be transparent too (via `enforce_transparency_eligibility`). But the UI gave no indication why — the transparency switch still appeared toggleable, and a parent's transparency change only propagated to a child the next time that child's own record was saved, so existing suborganizations could sit out of sync.

## Describe your changes

- **Settings UI** (`app/views/events/settings/_details.html.erb`): the transparency switch is now disabled when a public parent forces transparency on, and an info callout explains why ("Transparency is turned on because <parent> is transparent … this setting can't be turned off here").
- **Cascade** (`app/models/event.rb`): added an `after_update_commit :cascade_transparency_to_subevents` that fires when `is_public` flips on. It updates any not-yet-transparent subevents to transparent immediately (recursing through nested subevents via each subevent's own commit callback), rather than waiting for each subevent's next save.

Slack thread: https://hackclub.slack.com/archives/C047Y01MHJQ/p1783345165037109?thread_ts=1783343944.900019&cid=C047Y01MHJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CveziU4pF6MFuMzbQHgpC4)_