### PR TITLE
Create backfill HcbCode event IDs maintenance task

### DIFF
--- a/app/tasks/maintenance/backfill_hcb_code_event_ids_task.rb
+++ b/app/tasks/maintenance/backfill_hcb_code_event_ids_task.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillHcbCodeEventIdsTask < MaintenanceTasks::Task
+    class AnomalyError < StandardError; end
+
+    def collection
+      HcbCode.all
+    end
+
+    def process(hcb_code)
+      previous_event_id = hcb_code.event_id
+      previous_subledger_id = hcb_code.subledger_id
+
+      hcb_code.send :write_event_and_subledger_id
+
+      hcb_code.reload
+
+      if hcb_code.event_id != previous_event_id || hcb_code.subledger_id != previous_subledger_id
+        Rails.error.report AnomalyError.new("HcbCode #{hcb_code.id} had its event_id or subledger_id changed from #{previous_event_id}/#{previous_subledger_id} to #{hcb_code.event_id}/#{hcb_code.subledger_id}")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Summary of the problem

HcbCode event_ids need to be backfilled because our production data is not the most accurate. Inaccurate production data will mess with our migration to the new transaction engine.


## Describe your changes

Create a maintenance task for backfilling HcbCode event_id.