### PR TITLE
[Sub organizations] Remove co-signer email field if HackClubAffiliate

### DIFF
--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -31,10 +31,12 @@
     <%= form.email_field :email, placeholder: "Running this project yourself? Use #{current_user.email}", value: params[:email] %>
   </div>
 
-  <div class="field">
-    <%= form.label :cosigner_email, "Co-signer email", class: "bold" %>
-    <%= form.email_field :cosigner_email, placeholder: "Include this if the organizer is under 18", value: params[:cosigner_email] %>
-  </div>
+  <% unless event.plan.is_a?(Event::Plan::HackClubAffiliate) %>
+    <div class="field">
+      <%= form.label :cosigner_email, "Co-signer email", class: "bold" %>
+      <%= form.email_field :cosigner_email, placeholder: "Include this if the organizer is under 18", value: params[:cosigner_email] %>
+    </div>
+  <% end %>
 
   <div id="add_scoped_tag_field" class="field" data-controller="menu text-filter" data-menu-update-on-resize-value="true" data-menu-content-id-value="scoped_tag_menu" data-menu-append-to-value="#add_scoped_tag_field">
     <%= form.label "scoped_tags[]", "Tags", class: "bold" %>


### PR DESCRIPTION
We shouldn't show it for `HackClubAffiliate` organizations as they're exempt from this and will error out. 