### PR TITLE
[v4 API] Add `organizations:read` scope to Org Index path

### DIFF
--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -6,6 +6,8 @@ module Api
       before_action :set_event, except: [:index, :create_sub_organization]
       skip_after_action :verify_authorized, only: [:index]
 
+      require_oauth2_scope "organizations:read", :index
+
       def index
         @events = current_user.events.not_hidden.includes(:users).order("organizer_positions.created_at DESC")
       end

--- a/app/controllers/api/v4/events_controller.rb
+++ b/app/controllers/api/v4/events_controller.rb
@@ -6,11 +6,11 @@ module Api
       before_action :set_event, except: [:index, :create_sub_organization]
       skip_after_action :verify_authorized, only: [:index]
 
-      require_oauth2_scope "organizations:read", :index
-
       def index
         @events = current_user.events.not_hidden.includes(:users).order("organizer_positions.created_at DESC")
       end
+
+      require_oauth2_scope "organizations:read", :index
 
       def sub_organizations
         authorize @event, :sub_organizations_in_v4?


### PR DESCRIPTION
## Summary of the problem

@mattsoh wants to index orgs, but no scope allows such permissions.

## Describe your changes

Allow `organiations:read` to index orgs