### PR TITLE
Remove unused `Event#frozen?`

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -787,10 +787,6 @@ class Event < ApplicationRecord
     !engaged?
   end
 
-  def frozen?
-    Flipper.enabled?(:frozen, self)
-  end
-
   def revenue_fee
     configured = plan&.revenue_fee
     return configured if configured.present?


### PR DESCRIPTION
Remove unused `Event#frozen?`; it was superseded by `Event#financially_frozen?`