### PR TITLE
[Ledger::Item] Fix fallback to CT memo

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -178,10 +178,10 @@ class Ledger
           hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
           hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
         end
-        ledger_item.update!(custom_memo: memo)
+        update!(custom_memo: memo)
       end
 
-      item.refresh!
+      refresh!
     end
 
     def map!

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -83,11 +83,6 @@ class Ledger
     end
 
     def calculate_system_memo
-      # Ledger items created from a raw transaction (e.g. by
-      # CanonicalPendingTransaction's after_create) may not have a linked
-      # object yet. Return nil so refresh! keeps the existing memo.
-      return nil if linked_object.nil? && !["CheckDeposit", "RawPendingStripeTransaction", "RawStripeTransaction"].include?(transaction_type)
-
       case transaction_type
       when "Invoice"
         "Invoice to #{linked_object.smart_memo}"

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -83,6 +83,11 @@ class Ledger
     end
 
     def calculate_system_memo
+      # Ledger items created from a raw transaction (e.g. by
+      # CanonicalPendingTransaction's after_create) may not have a linked
+      # object yet. Return nil so refresh! keeps the existing memo.
+      return nil if linked_object.nil? && !["CheckDeposit", "RawPendingStripeTransaction", "RawStripeTransaction"].include?(transaction_type)
+
       case transaction_type
       when "Invoice"
         "Invoice to #{linked_object.smart_memo}"

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -151,8 +151,6 @@ class Ledger
         network_id = stripe_merchant&.dig("network_id")
         merchant_name = YellowPages::Merchant.lookup(network_id:).name if network_id.present?
         merchant_name || stripe_merchant&.dig("name") || "Card charge at unknown merchant"
-      else
-        self.canonical_transactions.first&.memo || self.canonical_pending_transactions.first&.memo
       end
     end
 
@@ -171,7 +169,7 @@ class Ledger
       self.receipt_required = calculate_receipt_required
       # TODO: only update this when the transaction gets its first CPT and then first CT assigned. currently it updates on every refresh
       self.system_memo = calculate_system_memo
-      self.memo = self.custom_memo || self.system_memo || "Transaction"
+      self.memo = self.custom_memo || self.system_memo || self.canonical_transactions.first&.memo || self.canonical_pending_transactions.first&.memo || "Transaction"
 
       save!
     end


### PR DESCRIPTION
We were returning nil too early so we will move the CT and CPT fallback back to the memo cache line.