### PR TITLE
[v4] Add support for admin resource scopes

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -46,8 +46,8 @@ module Api
         @current_user = current_token&.user
       end
 
-      def require_admin_scope!(level)
-        unless can_admin?(level)
+      def require_admin_scope!(level, resource: nil)
+        unless can_admin?(level, resource: resource)
           skip_authorization
           render json: { error: "not_authorized" }, status: :forbidden
         end

--- a/app/controllers/concerns/api/v4/admin_scope_checkable.rb
+++ b/app/controllers/concerns/api/v4/admin_scope_checkable.rb
@@ -11,16 +11,19 @@ module Api
       # to be an admin" handling stays identical between controller-level gates
       # and Pundit policies.
       #
-      #   :read  → token has "admin:read"  scope AND user is an auditor (auditors, admins, superadmins)
-      #   :write → token has "admin:write" scope AND user is an admin (admins, superadmins)
-      def can_admin?(level)
+      #   :read  → token has "admin:read"  (or "admin.<resource>:read")  scope AND user is an auditor
+      #   :write → token has "admin:write" (or "admin.<resource>:write") scope AND user is an admin
+      #
+      # Pass `resource` to also accept the narrower "admin.<resource>:<level>" scope
+      # (e.g. resource: "comments") alongside the blanket "admin:<level>" scope.
+      def can_admin?(level, resource: nil)
         return false unless current_user
 
         context = ApiAdminContext.new(current_user, current_token)
 
         case level.to_sym
-        when :read  then context.auditor?
-        when :write then context.admin?
+        when :read  then context.auditor?(resource: resource)
+        when :write then context.admin?(resource: resource)
         else false
         end
       end

--- a/app/models/api_admin_context.rb
+++ b/app/models/api_admin_context.rb
@@ -9,14 +9,20 @@ class ApiAdminContext
     @token = token
   end
 
-  # In the v4 API we ignore the "pretend not to be admin" preference
-  def admin?(override_pretend: true)
-    @user.admin?(override_pretend: override_pretend) && @token&.scopes&.include?("admin:write")
+  # In the v4 API we ignore the "pretend not to be admin" preference.
+  #
+  # resource, if given, also accepts the narrower "admin.<resource>:write" scope
+  # in place of the blanket "admin:write" (e.g. "admin.comments:write").
+  def admin?(override_pretend: true, resource: nil)
+    @user.admin?(override_pretend: override_pretend) && has_admin_scope?(:write, resource)
   end
 
-  # In the v4 API we ignore the "pretend not to be admin" preference
-  def auditor?(override_pretend: true)
-    @user.auditor?(override_pretend: override_pretend) && @token&.scopes&.include?("admin:read")
+  # In the v4 API we ignore the "pretend not to be admin" preference.
+  #
+  # resource, if given, also accepts the narrower "admin.<resource>:read" scope
+  # in place of the blanket "admin:read" (e.g. "admin.comments:read").
+  def auditor?(override_pretend: true, resource: nil)
+    @user.auditor?(override_pretend: override_pretend) && has_admin_scope?(:read, resource)
   end
 
   # Same auditor-level roles as #auditor?, so gated behind admin:read too.
@@ -40,5 +46,14 @@ class ApiAdminContext
     @user.is_a?(klass) || super
   end
   alias kind_of? is_a?
+
+  private
+
+  # The blanket "admin:<level>" scope always satisfies any resource; a
+  # resource-specific "admin.<resource>:<level>" scope satisfies only that resource.
+  def has_admin_scope?(level, resource)
+    scopes = @token&.scopes || []
+    scopes.include?("admin:#{level}") || (resource.present? && scopes.include?("admin.#{resource}:#{level}"))
+  end
 
 end

--- a/app/models/api_admin_context.rb
+++ b/app/models/api_admin_context.rb
@@ -49,8 +49,6 @@ class ApiAdminContext
 
   private
 
-  # The blanket "admin:<level>" scope always satisfies any resource; a
-  # resource-specific "admin.<resource>:<level>" scope satisfies only that resource.
   def has_admin_scope?(level, resource)
     scopes = @token&.scopes || []
     scopes.include?("admin:#{level}") || (resource.present? && scopes.include?("admin.#{resource}:#{level}"))

--- a/dev-docs/v4-api/scopes.md
+++ b/dev-docs/v4-api/scopes.md
@@ -127,6 +127,7 @@ Multiple `require_oauth2_scope` calls for the same action **accumulate** — the
 | `<resource>:write` | Mutating a resource (create/update/destroy) | `receipts:write`, `card_grants:write` |
 | `<capability>` | A narrow, single-purpose capability that doesn't map cleanly to read/write of one resource | `user_lookup`, `event_followers` |
 | `admin:read` / `admin:write` | Admin-level data or actions (see [Admin Scopes](#admin-scopes)) | `admin:read`, `admin:write` |
+| `admin.<resource>:read` / `admin.<resource>:write` | Admin-level access narrowed to a single resource, accepted alongside the blanket `admin:read`/`admin:write` (see [Admin Scopes](#admin-scopes)) | `admin.comments:read` |
 
 Guidelines:
 

--- a/dev-docs/v4-api/standards.md
+++ b/dev-docs/v4-api/standards.md
@@ -466,6 +466,19 @@ To gain admin permissions via the API, the token must explicitly carry an admin 
 
 `admin:write` does **not** imply `admin:read` — both scopes must be granted independently if both are needed. 
 
+### Resource-Scoped Admin Scopes
+
+An action can also accept a narrower `admin.<resource>:read` / `admin.<resource>:write` scope instead of the blanket `admin:read` / `admin:write` (e.g. `admin.receipts:write`). Both `can_admin?` and `require_admin_scope!` take an optional `resource:` to check it. Pick the call site based on what's being gated:
+
+| Gating... | Use | Example |
+|---|---|---|
+| A whole action, or whether an object appears in a list at all | `require_admin_scope!(level, resource:)` in a `before_action` | `before_action -> { require_admin_scope!(:read, resource: "receipts") }, only: [:admin_index]` |
+| An extra field on an object already being rendered | `can_admin?(level, resource:)` directly in the jbuilder partial | `if can_admin?(:read, resource: "receipts")` around `json._debug { ... }`, same as the blanket-scope `if can_admin?(:read)` in `transactions/_transaction.json.jbuilder` |
+
+List filtering always happens in the controller — no `json.array!` in this API filters mid-render.
+
+Only introduce a resource-scoped admin scope when an action needs access narrower than "all admin data" — most endpoints should keep using the blanket scopes.
+
 ### Implementation Notes
 
 - Always check for the admin scope explicitly. Do not fall back to checking if the authenticated user is an admin.


### PR DESCRIPTION
## Summary of the problem
Currently, we only have `admin:read` and `admin:write`


## Describe your changes
This adds the ability to do `admin.resource:action` such as `admin.comments:read` by adding ability to pass a resource into existing `can_admin?` and `require_admin_scope!`

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

