### PR TITLE
[Ledger::Item] Cache comment count

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -30,7 +30,7 @@ class Comment < ApplicationRecord
 
   set_public_id_prefix :cmt
 
-  belongs_to :commentable, polymorphic: true
+  belongs_to :commentable, polymorphic: true, touch: true
   belongs_to :user
 
   has_one_attached :file

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -6,11 +6,13 @@
 #
 #  id                           :bigint           not null, primary key
 #  amount_cents                 :integer          not null
+#  comment_count                :integer          default(0), not null
 #  custom_memo                  :text
 #  datetime                     :datetime         not null
 #  linked_object_type           :string
 #  marked_no_or_lost_receipt_at :datetime
 #  memo                         :text             not null
+#  not_admin_only_comment_count :integer          default(0), not null
 #  receipt_count                :integer          default(0), not null
 #  receipt_required             :boolean
 #  short_code                   :text
@@ -215,6 +217,8 @@ class Ledger
 
       self.amount_cents = calculate_amount_cents
       self.author = calculate_author
+      self.comment_count = comments.count
+      self.not_admin_only_comment_count = comments.not_admin_only.count
       self.receipt_count = receipts.count
       self.receipt_required = calculate_receipt_required
       # TODO: only update this when the transaction gets its first CPT and then first CT assigned. currently it updates on every refresh

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -10,7 +10,7 @@
   </td>
   <td class="nowrap">
     <span class="flex items-center justify-end">
-      <%= list_badge_for auditor_signed_in? ? item.comments.count : item.comments.not_admin_only.count, "comment", "post", optional: true %>
+      <%= list_badge_for auditor_signed_in? ? item.comment_count : item.not_admin_only_comment_count, "comment", "post", optional: true %>
       <%= list_badge_for item.receipt_count, "receipt", "payment-docs", optional: item.receipt_optional?, required: item.missing_receipt? %>
     </span>
   </td>

--- a/db/migrate/20260708205326_add_comment_counts_to_ledger_items.rb
+++ b/db/migrate/20260708205326_add_comment_counts_to_ledger_items.rb
@@ -1,0 +1,6 @@
+class AddCommentCountsToLedgerItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ledger_items, :comment_count, :integer, default: 0, null: false
+    add_column :ledger_items, :not_admin_only_comment_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_08_143909) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_08_205326) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1578,6 +1578,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_08_143909) do
   create_table "ledger_items", force: :cascade do |t|
     t.integer "amount_cents", null: false
     t.bigint "author_id"
+    t.integer "comment_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.text "custom_memo"
     t.datetime "datetime", null: false
@@ -1585,6 +1586,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_08_143909) do
     t.string "linked_object_type"
     t.datetime "marked_no_or_lost_receipt_at"
     t.text "memo", null: false
+    t.integer "not_admin_only_comment_count", default: 0, null: false
     t.integer "receipt_count", default: 0, null: false
     t.boolean "receipt_required"
     t.text "short_code"


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We don't want to load comments with the ledger.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Cache comment count in `comment_count` and `not_admin_only_comment_count`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

