### PR TITLE
[Payroll Positions][Nightly] Safety net for any expired jobs which haven't ran

### DIFF
--- a/app/jobs/payroll/position/expire_nightly_job.rb
+++ b/app/jobs/payroll/position/expire_nightly_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Payroll
+  class Position
+    class ExpireNightlyJob < ApplicationJob
+      queue_as :low
+
+      def perform
+        Payroll::Position.onboarded.where(end_date: ...Date.current).find_each do |position|
+          Payroll::Position::ExpireJob.perform_later(position)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -103,6 +103,10 @@ payroll_nightly_job:
   cron: "*/5 * * * *" # run every 5 minutes
   class: "Payroll::NightlyJob"
 
+payroll_position_expire_nightly_job:
+  cron: "0 0 * * *" # run every 1 day
+  class: "Payroll::Position::ExpireNightlyJob"
+
 bank_fee_nightly_job:
   cron: "*/30 2-23 * * *" # run every 30 minutes
   class: "BankFee::NightlyJob"


### PR DESCRIPTION
Re-enqueues Payroll::Position::ExpireJob for any onboarded position past its end date, in case the scheduled expire job was dropped.
