### PR TITLE
Map CTs with CanonicalTransaction#calculated_ledger_item

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -477,9 +477,7 @@ class CanonicalTransaction < ApplicationRecord
     safely do
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item
-          puts calculated_ledger_item
-          puts local_hcb_code
-          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id}) - #{linked_object_v2&.ledger_item&.id} #{short_code}")
+          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
         end
 
         li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -135,14 +135,7 @@ class CanonicalTransaction < ApplicationRecord
                             end
   end
 
-  after_create_commit unless: -> { ledger_item.present? } do
-    safely do
-      ActiveRecord::Base.transaction do
-        li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
-        update!(ledger_item: li)
-      end
-    end
-  end
+  after_create_commit :find_or_create_ledger_item, unless: -> { ledger_item.present? }
 
   after_commit if: -> { ledger_item.present? } do
     ledger_item.map!
@@ -471,6 +464,23 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   private
+
+  def find_or_create_ledger_item
+    safely do
+      ActiveRecord::Base.transaction do
+        if calculated_ledger_item != local_hcb_code.ledger_item
+          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
+        end
+
+        li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+        update!(ledger_item: li)
+      end
+    end
+  end
+
+  def calculated_ledger_item
+    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || Ledger::Item.find_by(linked_object:)
+  end
 
   def hashed_transaction
     @hashed_transaction ||= begin

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -487,7 +487,7 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def calculated_ledger_item
-    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || linked_object_v2&.ledger_item
+    @calculated_ledger_item ||= Ledger::Item.find_by(short_code:) || linked_object_v2&.ledger_item
   end
 
   def hashed_transaction

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -487,6 +487,7 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def calculated_ledger_item
+    puts "Short code: #{Ledger::Item.find_by(short_code:)&.id}, Linked object: #{Ledger::Item.find_by(linked_object: linked_object_v2)&.id}"
     @calculated_ledger_item = Ledger::Item.find_by(short_code:) || Ledger::Item.find_by(linked_object: linked_object_v2)
   end
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -477,7 +477,7 @@ class CanonicalTransaction < ApplicationRecord
     safely do
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item
-          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
+          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id}) - #{linked_object_v2&.ledger_item&.id} #{short_code}")
         end
 
         li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
@@ -487,8 +487,7 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def calculated_ledger_item
-    puts "Short code: #{Ledger::Item.find_by(short_code:)&.id}, Linked object: #{Ledger::Item.find_by(linked_object: linked_object_v2)&.id}"
-    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || Ledger::Item.find_by(linked_object: linked_object_v2)
+    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || linked_object_v2&.ledger_item
   end
 
   def hashed_transaction

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -477,6 +477,8 @@ class CanonicalTransaction < ApplicationRecord
     safely do
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item
+          puts calculated_ledger_item
+          puts local_hcb_code
           Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id}) - #{linked_object_v2&.ledger_item&.id} #{short_code}")
         end
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -135,7 +135,7 @@ class CanonicalTransaction < ApplicationRecord
                             end
   end
 
-  after_create_commit :find_or_create_ledger_item, unless: -> { ledger_item.present? }
+  after_create_commit :assign_ledger_item, unless: -> { ledger_item.present? }
 
   after_commit if: -> { ledger_item.present? } do
     ledger_item.map!
@@ -473,7 +473,7 @@ class CanonicalTransaction < ApplicationRecord
 
   private
 
-  def find_or_create_ledger_item
+  def assign_ledger_item
     safely do
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -190,6 +190,14 @@ class CanonicalTransaction < ApplicationRecord
     @linked_object ||= TransactionEngine::SyntaxSugarService::LinkedObject.new(canonical_transaction: self).run
   end
 
+  def linked_object_v2
+    if column_id = column_transaction_id
+      AchTransfer.find_by(column_id:) || Wire.find_by(column_id:) || CheckDeposit.find_by(column_id:) || IncreaseCheck.find_by(column_id:)
+    else
+      transaction_source&.try(:card_charge)
+    end
+  end
+
   def raw_plaid_transaction
     transaction_source if transaction_source_type == RawPlaidTransaction.name
   end
@@ -479,7 +487,7 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   def calculated_ledger_item
-    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || Ledger::Item.find_by(linked_object:)
+    @calculated_ledger_item = Ledger::Item.find_by(short_code:) || Ledger::Item.find_by(linked_object: linked_object_v2)
   end
 
   def hashed_transaction

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -293,7 +293,7 @@ class Ledger
       # No linked objects will be changed.
       return if linked_object.present?
 
-      linked_object = (canonical_pending_transactions.order(date: :asc).map(&:linked_object) + canonical_transactions.order(date: :asc).map(&:linked_object)).compact.first
+      linked_object = (canonical_pending_transactions.order(date: :asc).map(&:linked_object) + canonical_transactions.order(date: :asc).map(&:linked_object_v2)).compact.first
 
       update!(linked_object:) if linked_object.present?
     end


### PR DESCRIPTION
## Summary of the problem

Mapping CTs to Ledger::Items currently relies on HcbCode. This functionally works, however it violates our goal of removing our dependency on HcbCode.


## Describe your changes

This PR maps CTs to Ledger::Items via the new method CanonicalTransaction#calculate_ledger_item, which finds a Ledger::Item from the new linked_object_v2 or the short code.