### PR TITLE
[CPDM] Destroy CPSMs when created

### DIFF
--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -20,6 +20,17 @@
 class CanonicalPendingDeclinedMapping < ApplicationRecord
   belongs_to :canonical_pending_transaction
 
+  after_create_commit do
+    # Sometimes a reimbursement report will be reversed after the money has
+    # moved from the organization to HCB Reimbursement Clearinghouse. Upon reversal,
+    # HCB creates a CanonicalPendingDeclinedMapping for the CanonicalPendingTransaction.
+    # So, we need to destroy the settle mapping if it's going to be declined.
+    if canonical_pending_transaction.canonical_pending_settled_mappings.any?
+      canonical_pending_transaction.canonical_pending_settled_mappings.destroy_all
+      Rails.error.unexpected "CPT ##{canonical_pending_transaction.id} had both a decline and a settle mapping. The settle mapping was destroyed."
+    end
+  end
+
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
     canonical_pending_transaction.ledger_item.map!
     canonical_pending_transaction.ledger_item.refresh!


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
When reimbursement reports are reversed, they created declined mappings on the expense payouts and payout holding despite already having a settled mapping.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Destroy settled mappings when a declined mapping is created.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

