### PR TITLE
[CPT] Prevent declining when the CPT is already settled

### DIFF
--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -20,9 +20,20 @@
 class CanonicalPendingDeclinedMapping < ApplicationRecord
   belongs_to :canonical_pending_transaction
 
+  validate :not_already_settled, on: :create
+
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
     canonical_pending_transaction.ledger_item.map!
     canonical_pending_transaction.ledger_item.refresh!
+  end
+
+  private
+
+  def not_already_settled
+    return unless canonical_pending_transaction&.canonical_pending_settled_mappings&.exists?
+
+    errors.add(:canonical_pending_transaction, "already has a settled mapping")
+    Rails.error.unexpected "Attempted to create a decline mapping for CPT ##{canonical_pending_transaction.id}, but it already has a settle mapping."
   end
 
 end

--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -195,7 +195,8 @@ class CanonicalPendingTransaction < ApplicationRecord
 
     create_canonical_pending_declined_mapping!
     true
-  rescue ActiveRecord::RecordNotUnique
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+    Rails.error.report(e)
     false
   end
 

--- a/app/models/check_deposit.rb
+++ b/app/models/check_deposit.rb
@@ -66,7 +66,6 @@ class CheckDeposit < ApplicationRecord
   end
 
   after_update if: -> { increase_status_previously_changed?(to: "returned") } do
-    canonical_pending_transaction.decline!
     local_hcb_code.canonical_transactions.each do |ct|
       fee = ct.fee
       fee.amount_cents_as_decimal = 0

--- a/app/models/reimbursement/expense_payout.rb
+++ b/app/models/reimbursement/expense_payout.rb
@@ -104,10 +104,7 @@ module Reimbursement
       raise ArgumentError, "must be a settled expense payout" unless settled?
 
       ActiveRecord::Base.transaction do
-
         mark_reversed!
-
-        canonical_pending_transaction.decline!
 
         # these are reversed because this is reverse!
         sender_bank_account_id = ColumnService::Accounts.id_of(book_transfer_receiving_account)

--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -112,15 +112,7 @@ module Reimbursement
       raise ArgumentError, "must have settled expense payouts" unless expense_payouts.all? { |ep| ep.settled? }
 
       ActiveRecord::Base.transaction do
-
         mark_reversed!
-
-        # This is the created_at of the first payout holding that had a CPT
-        if self.created_at <= DateTime.parse("2024-08-09 00:45:12.992236000 UTC +00:00")
-          canonical_pending_transaction&.decline!
-        else
-          canonical_pending_transaction.decline!
-        end
 
         # these are reversed because this is reverse!
         sender_bank_account_id = ColumnService::Accounts.id_of(book_transfer_receiving_account)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
A declined CPT should never have CTs. If a CPT has CTs then that means it has settled.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove places where CPTs get declined after settling. Add a validation to prevent creation of CPDMs and alert if it happens.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

