### PR TITLE
`touch` `CanonicalPendingTransaction` from `CanonicalPendingEventMapping` `after_create`

### DIFF
--- a/app/models/canonical_pending_event_mapping.rb
+++ b/app/models/canonical_pending_event_mapping.rb
@@ -35,4 +35,8 @@ class CanonicalPendingEventMapping < ApplicationRecord
     canonical_pending_transaction.local_hcb_code&.write_event_and_subledger_id(event, subledger)
   end
 
+  after_create do
+    canonical_pending_transaction.touch
+  end
+
 end


### PR DESCRIPTION
## Summary of the problem

`CanonicalPendingTransaction` is not getting `touch`ed


## Describe your changes

`touch` `CanonicalPendingTransaction` from `CanonicalPendingEventMapping` `after_create`