### PR TITLE
[Event] Add `refresh_ledgers!`

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -475,7 +475,7 @@ class Event < ApplicationRecord
   end
 
   after_update if: -> { can_front_balance_changed? } do
-    ledger.refresh_all!
+    refresh_ledgers!
   end
 
   # Explanation: https://github.com/norman/friendly_id/blob/0500b488c5f0066951c92726ee8c3dcef9f98813/lib/friendly_id/reserved.rb#L13-L28
@@ -580,6 +580,13 @@ class Event < ApplicationRecord
     # We're including only pending charges on emburse_cards so organizers have a conservative estimate of their balance
     pending_t = self.emburse_transactions.pending.where("amount < 0").sum(:amount)
     completed_t + pending_t
+  end
+
+  def refresh_ledgers!
+    ledger.refresh_all!
+    Ledger.where(card_grant: self.card_grants).find_each do |ledger|
+      ledger.refresh_all!
+    end
   end
 
   def total_raised


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This is a useful method to have in the console. Also, now that card grant event is included in the check for `can_front_balance?`, we need to refresh card grants.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

