### PR TITLE
[Flipper] Cache flag reads and add HQ actor groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem "api-pagination"
 
 gem "flipper" # feature flags
 gem "flipper-active_record"
+gem "flipper-active_support_cache_store" # caches flag reads via Rails.cache
 gem "flipper-ui"
 
 gem "pundit" # implements authorization policies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,9 @@ GEM
     flipper-active_record (1.3.5)
       activerecord (>= 4.2, < 9)
       flipper (~> 1.3.5)
+    flipper-active_support_cache_store (1.3.5)
+      activesupport (>= 4.2, < 9)
+      flipper (~> 1.3.5)
     flipper-ui (1.3.5)
       erubi (>= 1.0.0, < 2.0.0)
       flipper (~> 1.3.5)
@@ -996,6 +999,7 @@ DEPENDENCIES
   faraday
   flipper
   flipper-active_record
+  flipper-active_support_cache_store
   flipper-ui
   foreman
   friendly_id (~> 5.6.0)

--- a/app/jobs/user/subordinate_summary_job.rb
+++ b/app/jobs/user/subordinate_summary_job.rb
@@ -3,88 +3,16 @@
 # I absolutely HATE the term "subordinate". However, I decided to use it in this
 # context because it is more descriptive than "direct report". I am open to
 # suggestions for a better term.
+#
+# The org chart itself lives in HackClub::OrgChart.
 class User
   class SubordinateSummaryJob < ApplicationJob
     queue_as :low
 
-    HQ_ORG_TREE = {
-      "melanie": [
-        "sierra",
-        "usr_MVt1m1", # Alex DeForrest
-        "rhys",
-        "anish",
-        {
-          "gary": [
-            "manu", "ruien", "luke", "samuelf",
-            "usr_BetQLy", # Ian
-            "usr_Jptm3Z", # Sam Poder
-            "usr_73tAe4" # Albert
-          ],
-          "lucy": [
-            "sean", "mattsoh", "briyan", "kris", "georgia",
-            "usr_let591", # Alex Luo
-          ],
-          "paul": %w[sarvesh],
-        }
-      ]
-    }.freeze
-
     def perform
-      self.class.org_layers.each do |manager, subordinates|
+      HackClub::OrgChart.layers.each do |manager, subordinates|
         User::SubordinateSummaryMailer.weekly(manager:, subordinates:).deliver_later
       end
-    end
-
-    def self.org_layers
-      flatten(HQ_ORG_TREE)
-    end
-
-    def self.flatten(structure)
-      case structure
-      when Hash # person has subordinates
-        structure.reduce({}) do |layers, (manager, subordinates)|
-          layers.merge(
-            to_layer(manager, subordinates),
-            flatten(subordinates)
-          )
-        end
-      when Array # continue to next layer
-        structure.reduce({}) do |layers, person|
-          layers.merge(flatten(person))
-        end
-      else
-        # User has no subordinates
-        {}
-      end
-    end
-
-    def self.to_layer(manager, subordinates)
-      # Only get one level of subordinates (direct reports)
-      subordinates = subordinates.flat_map do |sub|
-        sub.is_a?(Hash) ? sub.keys : sub
-      end
-
-      # Convert them to User records
-      manager = to_user(manager)
-      subordinates = subordinates.map { |subordinate| to_user(subordinate) }.compact
-      return {} if manager.nil?
-
-      { manager => subordinates }
-    end
-
-    def self.to_user(key)
-      user = case key
-             when /\A#{User.get_public_id_prefix}.*\Z/
-               User.find_by_public_id(key)
-             else
-               User.find_by(email: "#{key}@hackclub.com")
-             end
-
-      if user.nil?
-        Rails.error.unexpected "[HQ Subordinate Summary Job] User not found for key: #{key}"
-      end
-
-      user
     end
 
   end

--- a/app/lib/flipper_groups.rb
+++ b/app/lib/flipper_groups.rb
@@ -77,7 +77,7 @@ module FlipperGroups
 
   def hcb_team_user_ids
     fetch_id_set("flipper_groups/hcb_team_user_ids/#{HackClub::OrgChart::DIGEST}") do
-      HackClub::OrgChart.user_ids.to_set
+      HackClub::OrgChart.user_ids(:melanie).to_set
     end
   end
 

--- a/app/lib/flipper_groups.rb
+++ b/app/lib/flipper_groups.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# Membership logic behind the Flipper groups registered in
+# config/initializers/flipper_groups.rb.
+#
+# Each predicate takes an already-unwrapped actor (the initializer unwraps
+# Flipper::Types::Actor before calling). A flag can be checked against a User or
+# an Event actor, so each predicate guards on the actor class it expects and any
+# other type falls through to false. This also avoids User/Event id collisions,
+# since ids only overlap across classes.
+#
+# The resolved id sets are cached because a flag using one of these groups may be
+# checked on every request. Membership changes come through the org tree in code
+# or through OrganizerPositions, neither of which we can cheaply invalidate on, so
+# a short TTL keeps the sets fresh enough. The cache keys embed a digest of their
+# code-defined source (the org tree, the HQ root ids) so a deploy that edits the
+# source busts the cache immediately rather than serving the old set for up to a
+# TTL after the new code ships.
+module FlipperGroups
+  # Root events representing Hack Club HQ. Their managers (and the managers of
+  # their descendants) are HQ-descendant users; the events themselves and their
+  # descendants are HQ-descendant organizations. Kept as ids so the set survives
+  # an event rename.
+  HQ_ROOT_EVENT_IDS = [183, 9511].freeze
+
+  CACHE_TTL = 1.hour
+
+  module_function
+
+  def hcb_team?(actor)
+    in_set?(actor, User, hcb_team_user_ids)
+  end
+
+  def hcb_engineer?(actor)
+    in_set?(actor, User, hcb_engineer_user_ids)
+  end
+
+  def hq_descendant_user?(actor)
+    return false unless actor.is_a?(User)
+    # Admins and auditors always qualify, ignoring an admin's "pretend to be a
+    # normal user" preference (this gates internal HQ tooling, not user-facing
+    # behavior, so pretend mode shouldn't hide it).
+    return true if actor.admin_override_pretend?
+
+    # Not cached across requests so a revoked OrganizerPosition takes effect
+    # immediately. Rails' per-request SQL query cache collapses repeated checks
+    # within a single request to one query.
+    managed_event_ids = actor.organizer_positions.manager_access.pluck(:event_id)
+    managed_event_ids.any? { |event_id| hq_event_ids.include?(event_id) }
+  end
+
+  def hq_descendant_organization?(actor)
+    in_set?(actor, Event, hq_event_ids)
+  end
+
+  def in_set?(actor, klass, ids)
+    actor.is_a?(klass) && ids.include?(actor.id)
+  end
+
+  def hcb_team_user_ids
+    fetch_id_set("flipper_groups/hcb_team_user_ids/#{HackClub::OrgChart::DIGEST}") do
+      HackClub::OrgChart.user_ids.to_set
+    end
+  end
+
+  def hcb_engineer_user_ids
+    fetch_id_set("flipper_groups/hcb_engineer_user_ids/#{HackClub::OrgChart::DIGEST}") do
+      HackClub::OrgChart.user_ids(:gary).to_set
+    end
+  end
+
+  # {183, 9511} plus their descendants (manager access flows downward), as a Set
+  # of ids. Ancestors are intentionally excluded: managing an ancestor does not
+  # mean managing HQ.
+  def hq_event_ids
+    fetch_id_set("flipper_groups/hq_event_ids/#{HQ_ROOT_EVENT_IDS.join('-')}") do
+      HQ_ROOT_EVENT_IDS.flat_map { |event_id|
+        event = Event.find_by(id: event_id)
+        if event.nil?
+          # A hardcoded root going missing is a real "someone should know" event,
+          # not something to swallow into an empty result.
+          Rails.error.report(StandardError.new("[FlipperGroups] HQ root event #{event_id} not found"))
+          next []
+        end
+
+        [event.id] + event.descendant_ids
+      }.uniq.to_set
+    end
+  end
+
+  # Reads an id set from the cache, recomputing on a miss. An unexpectedly-empty
+  # result is reported and returned WITHOUT being cached, so a transient failure
+  # (a DB blip, a missing root) self-heals on the next request instead of sticking
+  # for a full TTL. None of these sets are ever legitimately empty.
+  def fetch_id_set(cache_key)
+    cached = Rails.cache.read(cache_key)
+    return cached if cached.present?
+
+    ids = yield
+    if ids.empty?
+      Rails.error.report(StandardError.new("[FlipperGroups] #{cache_key} resolved to an empty set; not caching"))
+      return ids
+    end
+
+    Rails.cache.write(cache_key, ids, expires_in: CACHE_TTL)
+    ids
+  end
+end

--- a/app/lib/flipper_groups.rb
+++ b/app/lib/flipper_groups.rb
@@ -35,6 +35,24 @@ module FlipperGroups
     in_set?(actor, User, hcb_engineer_user_ids)
   end
 
+  # Any user with an @hackclub.com email. Matched directly off the address (no
+  # cached id set needed), exact-domain only: subdomains like
+  # someone@events.hackclub.com are not included.
+  def hackclub_email?(actor)
+    return false unless actor.is_a?(User)
+
+    actor.email.to_s.downcase.end_with?("@hackclub.com")
+  end
+
+  # Any admin, superadmin, or auditor. auditor? already returns true for the admin
+  # and superadmin roles, and it honors the "pretend to be a normal user"
+  # preference, so an admin in pretend mode does not match.
+  def admin_or_auditor?(actor)
+    return false unless actor.is_a?(User)
+
+    actor.auditor?
+  end
+
   def hq_descendant_user?(actor)
     return false unless actor.is_a?(User)
     # Admins and auditors always qualify, ignoring an admin's "pretend to be a

--- a/app/models/hack_club/org_chart.rb
+++ b/app/models/hack_club/org_chart.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module HackClub
+  # The HQ org chart: who reports to whom, as a nested hash keyed by email prefix
+  # ("gary" -> gary@hackclub.com) or usr_ public id. Consumed by the weekly
+  # subordinate-summary mailer and by the Flipper groups in FlipperGroups.
+  module OrgChart
+    TREE = {
+      "melanie": [
+        "sierra",
+        "usr_MVt1m1", # Alex DeForrest
+        "rhys",
+        "anish",
+        {
+          "gary": [
+            "manu", "ruien", "luke", "samuelf",
+            "usr_BetQLy", # Ian
+            "usr_Jptm3Z", # Sam Poder
+            "usr_73tAe4" # Albert
+          ],
+          "lucy": [
+            "sean", "mattsoh", "briyan", "kris", "georgia",
+            "usr_let591", # Alex Luo
+          ],
+          "paul": %w[sarvesh],
+        }
+      ]
+    }.freeze
+
+    # Short digest of the tree, folded into cache keys by callers (e.g.
+    # FlipperGroups) so a deploy that edits TREE naturally busts caches keyed on
+    # the resolved membership instead of serving the old set until the TTL lapses.
+    DIGEST = Digest::SHA256.hexdigest(TREE.to_s)[0, 12].freeze
+
+    # Every key (email prefix or usr_ public id) at or below `root_key`, inclusive
+    # of the root. With no argument, walks the whole tree.
+    def self.keys(root_key = nil)
+      structure = root_key ? subtree_for(TREE, root_key) : TREE
+      return [] if structure.nil?
+
+      keys_in(structure)
+    end
+
+    # The same keys resolved to ids of existing users. An unresolvable key is
+    # dropped (a stale key must not break a caller's flag check) but still
+    # reported, so a typo that silently removes someone from a group is visible
+    # in every environment rather than failing invisibly. `on_missing: :report`
+    # records without raising, unlike the mailer path's dev/test-raising default.
+    def self.user_ids(root_key = nil)
+      keys(root_key).filter_map { |key| to_user(key, on_missing: :report)&.id }
+    end
+
+    # Manager User => [direct-report Users], for every manager in the tree.
+    def self.layers
+      flatten(TREE)
+    end
+
+    def self.keys_in(structure)
+      case structure
+      when Hash # person has subordinates
+        structure.flat_map { |manager, subordinates| [manager] + keys_in(subordinates) }
+      when Array # continue to next layer
+        structure.flat_map { |person| keys_in(person) }
+      else # leaf: a person with no subordinates
+        [structure]
+      end
+    end
+    private_class_method :keys_in
+
+    # The sub-hash rooted at `target` (as `{ target => subordinates }`), or nil.
+    def self.subtree_for(structure, target)
+      case structure
+      when Hash
+        structure.each do |key, subordinates|
+          return { key => subordinates } if key == target
+
+          found = subtree_for(subordinates, target)
+          return found if found
+        end
+        nil
+      when Array
+        structure.each do |person|
+          found = subtree_for(person, target)
+          return found if found
+        end
+        nil
+      end
+    end
+    private_class_method :subtree_for
+
+    def self.flatten(structure)
+      case structure
+      when Hash # person has subordinates
+        structure.reduce({}) do |layers, (manager, subordinates)|
+          layers.merge(
+            to_layer(manager, subordinates),
+            flatten(subordinates)
+          )
+        end
+      when Array # continue to next layer
+        structure.reduce({}) do |layers, person|
+          layers.merge(flatten(person))
+        end
+      else # person has no subordinates
+        {}
+      end
+    end
+    private_class_method :flatten
+
+    def self.to_layer(manager, subordinates)
+      # Only the direct reports (one level down)
+      subordinates = subordinates.flat_map do |sub|
+        sub.is_a?(Hash) ? sub.keys : sub
+      end
+
+      manager = to_user(manager)
+      subordinates = subordinates.map { |subordinate| to_user(subordinate) }.compact
+      return {} if manager.nil?
+
+      { manager => subordinates }
+    end
+    private_class_method :to_layer
+
+    # Resolves a tree key to a User. A missing user is usually a typo in the tree.
+    # `on_missing:` controls how that's surfaced:
+    #   :raise  (default) - Rails.error.unexpected, which raises in dev/test and
+    #                       records in prod. For callers that can afford to fail
+    #                       loudly (the subordinate-summary mailer).
+    #   :report           - Rails.error.report, which records in every env and
+    #                       never raises. For callers that must not break on a
+    #                       stale key (flag-group checks).
+    def self.to_user(key, on_missing: :raise)
+      user = case key
+             when /\A#{User.get_public_id_prefix}.*\Z/
+               User.find_by_public_id(key)
+             else
+               User.find_by(email: "#{key}@hackclub.com")
+             end
+
+      if user.nil?
+        message = "[HackClub::OrgChart] User not found for key: #{key}"
+        case on_missing
+        when :raise then Rails.error.unexpected(message)
+        when :report then Rails.error.report(StandardError.new(message), context: { key: })
+        end
+      end
+
+      user
+    end
+    private_class_method :to_user
+  end
+end

--- a/app/models/hack_club/org_chart.rb
+++ b/app/models/hack_club/org_chart.rb
@@ -130,8 +130,7 @@ module HackClub
     #                       never raises. For callers that must not break on a
     #                       stale key (flag-group checks).
     def self.to_user(key, on_missing: :raise)
-      user = case key
-             when /\A#{User.get_public_id_prefix}.*\Z/
+      user = if key.to_s.start_with?(User.get_public_id_prefix)
                User.find_by_public_id(key)
              else
                User.find_by(email: "#{key}@hackclub.com")

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -136,30 +136,6 @@
       "note": "It generates a link to a stripe resource based on the model name and the id in 'has_stripe_dashboard_url.rb' which both should be safe."
     },
     {
-      "warning_type": "Denial of Service",
-      "warning_code": 76,
-      "fingerprint": "33fd4663b98a1d3c429121aff4c7300b51235ad04569ab3f07ef5f30de9a9292",
-      "check_name": "RegexDoS",
-      "message": "Model attribute used in regular expression",
-      "file": "app/jobs/user/subordinate_summary_job.rb",
-      "line": 77,
-      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
-      "code": "/\\A#{User.get_public_id_prefix}.*\\Z/",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "User::SubordinateSummaryJob",
-        "method": "s(:self).to_user"
-      },
-      "user_input": "User.get_public_id_prefix",
-      "confidence": "Medium",
-      "cwe_id": [
-        20,
-        185
-      ],
-      "note": "User.get_public_id_prefix calls a class method that returns :usr so this is safe"
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "41118d19fb5e498f2b4ac5a7b8a9cddca6f3e089ced5eebdcf598a1a4ff9bad7",

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 # Cache flag reads through Rails.cache (shared Redis in prod/staging) instead of
-# hitting Postgres on every check. All writes go through Flipper, which busts the
-# cache immediately, so the TTL is only a backstop against a lost invalidation.
+# hitting Postgres on every check. This caches a feature's stored gate config
+# (its boolean/actor/percentage/group values); writes go through Flipper, which
+# busts the cache immediately, so the TTL is only a backstop against a lost
+# invalidation. Note this does NOT cache group *membership*: group gates are
+# evaluated live per check, and their freshness is governed separately by
+# FlipperGroups' own TTL (see app/lib/flipper_groups.rb), not by this cache.
 # We intentionally don't preload: several flags carry thousands of actor gates, so
 # loading every gate per request would cost more than the per-flag reads it saves.
 Flipper.configure do |config|

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# Cache flag reads through Rails.cache (shared Redis in prod/staging) instead of
+# hitting Postgres on every check. All writes go through Flipper, which busts the
+# cache immediately, so the TTL is only a backstop against a lost invalidation.
+# We intentionally don't preload: several flags carry thousands of actor gates, so
+# loading every gate per request would cost more than the per-flag reads it saves.
+Flipper.configure do |config|
+  config.adapter do
+    Flipper::Adapters::ActiveSupportCacheStore.new(
+      Flipper::Adapters::ActiveRecord.new,
+      Rails.cache,
+      12.hours
+    )
+  end
+end
+
 Rails.application.configure do
   # @msw Disable preloading for feature-flags to save on db queries b/c we
   # aren't running many betas at the time of writing. If Flipper is used

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
   # Setting to `true` or `:raise` will raise error when a feature doesn't exist.
   # Use `:warn` to log a warning instead.
-  config.flipper.strict = false
+  config.flipper.strict = :warn
 
   # Don't limit to 100 actors per feature
   config.flipper.actor_limit = false

--- a/config/initializers/flipper_groups.rb
+++ b/config/initializers/flipper_groups.rb
@@ -10,5 +10,7 @@
 # Event actors.
 Flipper.register(:hcb_team)                    { |actor, _context| FlipperGroups.hcb_team?(actor.actor) }
 Flipper.register(:hcb_engineers)               { |actor, _context| FlipperGroups.hcb_engineer?(actor.actor) }
+Flipper.register(:hackclub_emails)             { |actor, _context| FlipperGroups.hackclub_email?(actor.actor) }
+Flipper.register(:admins_and_auditors)         { |actor, _context| FlipperGroups.admin_or_auditor?(actor.actor) }
 Flipper.register(:hq_descendant_users)         { |actor, _context| FlipperGroups.hq_descendant_user?(actor.actor) }
 Flipper.register(:hq_descendant_organizations) { |actor, _context| FlipperGroups.hq_descendant_organization?(actor.actor) }

--- a/config/initializers/flipper_groups.rb
+++ b/config/initializers/flipper_groups.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Flipper groups for enabling features across sets of actors. Membership lives in
+# FlipperGroups; here we only wire each group name to a predicate.
+#
+# Group blocks receive the actor wrapped in Flipper::Types::Actor, whose is_a? is
+# not delegated to the wrapped object, so we unwrap with `actor.actor` and let
+# FlipperGroups guard the type. Groups are only evaluated when a check passes an
+# actor; user groups match User actors and hq_descendant_organizations matches
+# Event actors.
+Flipper.register(:hcb_team)                    { |actor, _context| FlipperGroups.hcb_team?(actor.actor) }
+Flipper.register(:hcb_engineers)               { |actor, _context| FlipperGroups.hcb_engineer?(actor.actor) }
+Flipper.register(:hq_descendant_users)         { |actor, _context| FlipperGroups.hq_descendant_user?(actor.actor) }
+Flipper.register(:hq_descendant_organizations) { |actor, _context| FlipperGroups.hq_descendant_organization?(actor.actor) }

--- a/spec/initializers/flipper_groups_spec.rb
+++ b/spec/initializers/flipper_groups_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Verifies the groups registered in config/initializers/flipper_groups.rb are
+# wired to FlipperGroups and correctly unwrap the Flipper actor end to end.
+RSpec.describe "flipper_groups initializer" do
+  let(:outsider) { create(:user, email: "outsider@example.com") }
+
+  # A distinct feature per group keeps enable_group state from leaking between
+  # examples.
+  def gate(group, actor)
+    feature = :"group_wiring_#{group}"
+    Flipper.enable_group(feature, group)
+    Flipper.enabled?(feature, actor)
+  end
+
+  it "gates a feature on the :hcb_team group" do
+    melanie = create(:user, email: "melanie@hackclub.com")
+
+    expect(gate(:hcb_team, melanie)).to be(true)
+    expect(gate(:hcb_team, outsider)).to be(false)
+  end
+
+  it "gates a feature on the :hcb_engineers group" do
+    engineer = create(:user, email: "gary@hackclub.com")
+
+    expect(gate(:hcb_engineers, engineer)).to be(true)
+    expect(gate(:hcb_engineers, outsider)).to be(false)
+  end
+
+  it "gates a feature on the :hq_descendant_users group" do
+    admin = create(:user, :make_admin)
+
+    expect(gate(:hq_descendant_users, admin)).to be(true)
+    expect(gate(:hq_descendant_users, outsider)).to be(false)
+  end
+
+  it "gates a feature on the :hq_descendant_organizations group with an Event actor" do
+    hq_org = create(:event)
+    other_org = create(:event)
+    stub_const("FlipperGroups::HQ_ROOT_EVENT_IDS", [hq_org.id])
+
+    expect(gate(:hq_descendant_organizations, hq_org)).to be(true)
+    expect(gate(:hq_descendant_organizations, other_org)).to be(false)
+  end
+end

--- a/spec/initializers/flipper_groups_spec.rb
+++ b/spec/initializers/flipper_groups_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe "flipper_groups initializer" do
     expect(gate(:hcb_engineers, outsider)).to be(false)
   end
 
+  it "gates a feature on the :hackclub_emails group" do
+    staff = create(:user, email: "staff@hackclub.com")
+
+    expect(gate(:hackclub_emails, staff)).to be(true)
+    expect(gate(:hackclub_emails, outsider)).to be(false)
+  end
+
+  it "gates a feature on the :admins_and_auditors group" do
+    auditor = create(:user, access_level: :auditor)
+
+    expect(gate(:admins_and_auditors, auditor)).to be(true)
+    expect(gate(:admins_and_auditors, outsider)).to be(false)
+  end
+
   it "gates a feature on the :hq_descendant_users group" do
     admin = create(:user, :make_admin)
 

--- a/spec/lib/flipper_groups_spec.rb
+++ b/spec/lib/flipper_groups_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FlipperGroups do
+  describe ".hcb_team?" do
+    it "is true for a user anywhere in the org tree" do
+      melanie = create(:user, email: "melanie@hackclub.com")
+
+      expect(described_class.hcb_team?(melanie)).to be(true)
+    end
+
+    it "is true for a member listed by usr_ public id rather than email" do
+      member = create(:user, email: "someone-else@example.com")
+      stub_const("HackClub::OrgChart::TREE", { melanie: [member.public_id] })
+
+      expect(described_class.hcb_team?(member)).to be(true)
+    end
+
+    it "is false for a user not in the org tree" do
+      outsider = create(:user, email: "outsider@example.com")
+
+      expect(described_class.hcb_team?(outsider)).to be(false)
+    end
+
+    it "is false for a non-User actor" do
+      expect(described_class.hcb_team?(create(:event))).to be(false)
+    end
+
+    it "does not match an Event whose id collides with a User id in the set" do
+      event = create(:event)
+      allow(described_class).to receive(:hcb_team_user_ids).and_return(Set[event.id])
+
+      expect(described_class.hcb_team?(event)).to be(false)
+    end
+  end
+
+  describe ".hcb_engineer?" do
+    it "is true for a user in gary's subtree" do
+      manu = create(:user, email: "manu@hackclub.com")
+
+      expect(described_class.hcb_engineer?(manu)).to be(true)
+    end
+
+    it "is true for gary" do
+      gary = create(:user, email: "gary@hackclub.com")
+
+      expect(described_class.hcb_engineer?(gary)).to be(true)
+    end
+
+    it "is false for a team member outside gary's subtree" do
+      sean = create(:user, email: "sean@hackclub.com") # reports to lucy, not gary
+
+      expect(described_class.hcb_engineer?(sean)).to be(false)
+    end
+  end
+
+  describe ".hq_descendant_user?" do
+    let(:hq_root) { create(:event) }
+
+    before { stub_const("#{described_class}::HQ_ROOT_EVENT_IDS", [hq_root.id]) }
+
+    it "is true for an admin even when pretending not to be an admin" do
+      admin = create(:user, :make_admin, pretend_is_not_admin: true)
+
+      expect(described_class.hq_descendant_user?(admin)).to be(true)
+    end
+
+    it "is true for an auditor" do
+      auditor = create(:user, access_level: :auditor)
+
+      expect(described_class.hq_descendant_user?(auditor)).to be(true)
+    end
+
+    it "is true for a manager of an HQ root event" do
+      user = create(:user)
+      create(:organizer_position, event: hq_root, user:, role: :manager)
+
+      expect(described_class.hq_descendant_user?(user)).to be(true)
+    end
+
+    it "is true for a manager of a descendant of an HQ root event" do
+      child = create(:event, parent: hq_root)
+      user = create(:user)
+      create(:organizer_position, event: child, user:, role: :manager)
+
+      expect(described_class.hq_descendant_user?(user)).to be(true)
+    end
+
+    it "is false for a manager of an ancestor of an HQ root event" do
+      grandparent = create(:event)
+      root = create(:event, parent: grandparent)
+      stub_const("#{described_class}::HQ_ROOT_EVENT_IDS", [root.id])
+      user = create(:user)
+      create(:organizer_position, event: grandparent, user:, role: :manager)
+
+      expect(described_class.hq_descendant_user?(user)).to be(false)
+    end
+
+    it "is false for a manager of an unrelated event" do
+      user = create(:user)
+      create(:organizer_position, event: create(:event), user:, role: :manager)
+
+      expect(described_class.hq_descendant_user?(user)).to be(false)
+    end
+
+    it "is false for a non-manager member of an HQ event" do
+      user = create(:user)
+      create(:organizer_position, event: hq_root, user:, role: :member)
+
+      expect(described_class.hq_descendant_user?(user)).to be(false)
+    end
+
+    it "is false for a non-User actor" do
+      expect(described_class.hq_descendant_user?(hq_root)).to be(false)
+    end
+  end
+
+  describe ".hq_descendant_organization?" do
+    let(:hq_root) { create(:event) }
+
+    before { stub_const("#{described_class}::HQ_ROOT_EVENT_IDS", [hq_root.id]) }
+
+    it "is true for an HQ root organization" do
+      expect(described_class.hq_descendant_organization?(hq_root)).to be(true)
+    end
+
+    it "is true for a descendant of an HQ root organization" do
+      child = create(:event, parent: hq_root)
+
+      expect(described_class.hq_descendant_organization?(child)).to be(true)
+    end
+
+    it "is false for an ancestor of an HQ root organization" do
+      grandparent = create(:event)
+      root = create(:event, parent: grandparent)
+      stub_const("#{described_class}::HQ_ROOT_EVENT_IDS", [root.id])
+
+      expect(described_class.hq_descendant_organization?(grandparent)).to be(false)
+    end
+
+    it "is false for an unrelated organization" do
+      expect(described_class.hq_descendant_organization?(create(:event))).to be(false)
+    end
+
+    it "is false for a non-Event actor" do
+      expect(described_class.hq_descendant_organization?(create(:user))).to be(false)
+    end
+  end
+
+  describe "resilience of the cached id sets" do
+    it "reports a missing HQ root event rather than silently dropping it" do
+      present = create(:event)
+      stub_const("#{described_class}::HQ_ROOT_EVENT_IDS", [present.id, 999_999])
+
+      expect(Rails.error).to receive(:report).with(an_instance_of(StandardError))
+
+      expect(described_class.hq_event_ids).to include(present.id)
+    end
+
+    it "reports and does not cache an unexpectedly-empty id set" do
+      allow(HackClub::OrgChart).to receive(:user_ids).and_return([])
+
+      expect(Rails.error).to receive(:report).with(an_instance_of(StandardError))
+
+      expect(described_class.hcb_team_user_ids).to eq(Set.new)
+    end
+  end
+end

--- a/spec/lib/flipper_groups_spec.rb
+++ b/spec/lib/flipper_groups_spec.rb
@@ -55,6 +55,50 @@ RSpec.describe FlipperGroups do
     end
   end
 
+  describe ".hackclub_email?" do
+    it "is true for an @hackclub.com email" do
+      expect(described_class.hackclub_email?(create(:user, email: "person@hackclub.com"))).to be(true)
+    end
+
+    it "is true regardless of case" do
+      expect(described_class.hackclub_email?(create(:user, email: "Person@HackClub.com"))).to be(true)
+    end
+
+    it "is false for a subdomain of hackclub.com" do
+      expect(described_class.hackclub_email?(create(:user, email: "person@events.hackclub.com"))).to be(false)
+    end
+
+    it "is false for a non-hackclub.com email" do
+      expect(described_class.hackclub_email?(create(:user, email: "person@example.com"))).to be(false)
+    end
+
+    it "is false for a non-User actor" do
+      expect(described_class.hackclub_email?(create(:event))).to be(false)
+    end
+  end
+
+  describe ".admin_or_auditor?" do
+    it "is true for an admin" do
+      expect(described_class.admin_or_auditor?(create(:user, :make_admin))).to be(true)
+    end
+
+    it "is true for an auditor" do
+      expect(described_class.admin_or_auditor?(create(:user, access_level: :auditor))).to be(true)
+    end
+
+    it "is false for an admin who is pretending not to be an admin" do
+      expect(described_class.admin_or_auditor?(create(:user, :make_admin, pretend_is_not_admin: true))).to be(false)
+    end
+
+    it "is false for a normal user" do
+      expect(described_class.admin_or_auditor?(create(:user))).to be(false)
+    end
+
+    it "is false for a non-User actor" do
+      expect(described_class.admin_or_auditor?(create(:event))).to be(false)
+    end
+  end
+
   describe ".hq_descendant_user?" do
     let(:hq_root) { create(:event) }
 

--- a/spec/mailers/previews/user/subordinate_summary_preview.rb
+++ b/spec/mailers/previews/user/subordinate_summary_preview.rb
@@ -3,7 +3,7 @@
 class User
   class SubordinateSummaryPreview < ActionMailer::Preview
     def weekly
-      manager, subordinates = User::SubordinateSummaryJob.org_layers.first
+      manager, subordinates = HackClub::OrgChart.layers.first
       User::SubordinateSummaryMailer.weekly(manager:, subordinates:)
     end
 

--- a/spec/models/hack_club/org_chart_spec.rb
+++ b/spec/models/hack_club/org_chart_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HackClub::OrgChart do
+  describe ".keys" do
+    it "returns every key in the tree when no root is given" do
+      keys = described_class.keys
+
+      expect(keys).to include(:melanie, :gary, :lucy, :paul)
+      expect(keys).to include("sierra", "manu", "sarvesh", "usr_MVt1m1")
+    end
+
+    it "returns the root and everyone below it, inclusive" do
+      expect(described_class.keys(:gary)).to match_array(
+        [:gary, "manu", "ruien", "luke", "samuelf", "usr_BetQLy", "usr_Jptm3Z", "usr_73tAe4"]
+      )
+    end
+
+    it "does not include people outside the requested subtree" do
+      expect(described_class.keys(:gary)).not_to include(:melanie, :lucy, "sean")
+    end
+
+    it "returns an empty array for an unknown root" do
+      expect(described_class.keys(:nobody)).to eq([])
+    end
+  end
+
+  describe ".user_ids" do
+    it "resolves tree keys to the ids of existing users, skipping the rest" do
+      gary = create(:user, email: "gary@hackclub.com")
+      manu = create(:user, email: "manu@hackclub.com")
+      outsider = create(:user, email: "someone-else@hackclub.com")
+
+      ids = described_class.user_ids(:gary)
+
+      expect(ids).to include(gary.id, manu.id)
+      expect(ids).not_to include(outsider.id)
+    end
+
+    it "reports an unresolvable key rather than dropping it silently" do
+      gary = create(:user, email: "gary@hackclub.com")
+      stub_const("#{described_class}::TREE", { gary: ["ghost"] })
+
+      expect(Rails.error).to receive(:report).with(
+        an_instance_of(StandardError), context: { key: "ghost" }
+      )
+
+      expect(described_class.user_ids).to contain_exactly(gary.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

We want to gate features on internal Hack Club populations (the whole team, engineers, HQ organizers, staff by email, admins/auditors) without hand-maintaining actor lists per flag. Flipper was also hitting Postgres on every flag check with no caching.

## Describe your changes

- **Flag read caching.** Flag/gate config now reads through `Rails.cache` (shared Redis in prod/staging) with a 12h backstop TTL instead of Postgres on every check. Unknown features now `:warn` instead of silently disabling.
- **Actor groups.** Registers six Flipper groups in `FlipperGroups`. Each predicate guards on actor class (User vs Event) so wrong-type actors and User/Event id collisions fall through to `false`:
  - `hcb_team` / `hcb_engineers` — members of the HQ org chart (engineers = Gary's subtree).
  - `hackclub_emails` — any user with an `@hackclub.com` address (exact domain, case-insensitive; no cached set, checked off the email directly).
  - `admins_and_auditors` — any admin, superadmin, or auditor; honors the pretend-to-be-a-normal-user preference.
  - `hq_descendant_users` / `hq_descendant_organizations` — the HQ root events (183, 9511) and their descendants (not ancestors), and the users who manage them. Admins/auditors always qualify here, ignoring pretend mode.
- **`HackClub::OrgChart`.** The HQ reporting tree is extracted out of `SubordinateSummaryJob` into a single home, now consumed by both the weekly mailer and the Flipper groups.
- **Cache hygiene.** Resolved id sets use a short TTL keyed on a digest of their source, so a deploy that edits the tree or the HQ roots busts the cache. Unexpectedly-empty results are reported and not cached (a transient blip self-heals next request), and unresolvable tree keys are reported rather than dropped silently.

Specs cover the predicates, the end-to-end group wiring, org-chart resolution (including `usr_` public ids and id-collision guards), and the reporting behavior.
