### PR TITLE
Safelist office IPs via a memoized parse

### DIFF
--- a/app/models/hack_club.rb
+++ b/app/models/hack_club.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Facts about Hack Club the organization (as opposed to any single event/org in
+# the app). See also HackClub::OrgChart for the HQ reporting structure.
+module HackClub
+  # Office IP addresses and CIDR ranges, from the OFFICE_IP credential, as IPAddr
+  # objects. Used to safelist office traffic in Rack::Attack, which checks it on
+  # every request, so the parsed result is memoized. The memo is keyed on the raw
+  # credential so it re-parses if the value ever changes rather than going stale.
+  # Malformed entries are skipped (and reported) so a single typo can't take down
+  # every request that checks them.
+  def self.office_ips
+    raw = Credentials.fetch(:OFFICE_IP).to_s
+    # Capture the memo in a local first. The previous version set
+    # @office_ips_source before @office_ips, so a concurrent reader (this runs
+    # in a Rack::Attack safelist on every request, under Puma's thread pool)
+    # could see the matching source key while @office_ips was still nil and
+    # return nil, crashing the safelist block on `nil.any?`. Requiring a
+    # non-nil captured value closes that window.
+    cached = @office_ips
+    return cached if cached && @office_ips_source == raw
+
+    parsed = raw.split(",").filter_map do |entry|
+      office_ip = entry.strip
+      ip = IPAddr.new(office_ip)
+      # Reject a default route ("0.0.0.0/0", "::/0"). It would safelist the
+      # entire internet, and since Rack::Attack safelists take precedence over
+      # blocklists and throttles, that would also silently disable the
+      # webhook-origin blocklists and login brute-force protection.
+      if ip.prefix.zero?
+        Rails.error.report(
+          ArgumentError.new("overly-broad OFFICE_IP entry rejected"),
+          context: { office_ip: }
+        )
+        next
+      end
+
+      ip
+    rescue IPAddr::InvalidAddressError => e
+      Rails.error.report(e, context: { office_ip: })
+      nil
+    end
+
+    # Publish the parsed list before the source key so a racing reader that
+    # observes the matching key also observes the populated list.
+    @office_ips = parsed
+    @office_ips_source = raw
+    parsed
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -18,9 +18,14 @@ class Rack::Attack
     bad_ips&.include?(req.ip)
   end
 
-  # Safelist Hack Club Office(s)
-  Credentials.fetch(:OFFICE_IP)&.split(",")&.map(&:strip)&.each do |office_ip|
-    safelist_ip(office_ip)
+  # Safelist Hack Club Office(s). Resolved in the block rather than at boot (like
+  # the webhook lists below), because referencing the autoloaded HackClub constant
+  # during initialization fails. HackClub.office_ips memoizes the parse, so this
+  # stays cheap despite running per request.
+  safelist("Hack Club offices") do |req|
+    HackClub.office_ips.any? { |office_ip| office_ip.include?(req.ip) }
+  rescue IPAddr::InvalidAddressError
+    false
   end
   safelist_ip("10.0.0.0/16")
 

--- a/spec/models/hack_club_spec.rb
+++ b/spec/models/hack_club_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HackClub do
+  describe ".office_ips" do
+    it "parses the OFFICE_IP credential into IPAddr objects" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("1.2.3.4, 5.6.7.8/24 ")
+
+      expect(described_class.office_ips).to eq([IPAddr.new("1.2.3.4"), IPAddr.new("5.6.7.8/24")])
+    end
+
+    it "reports and skips malformed entries" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("1.2.3.4, not-an-ip")
+
+      expect(Rails.error).to receive(:report).with(
+        an_instance_of(IPAddr::InvalidAddressError), context: { office_ip: "not-an-ip" }
+      )
+
+      expect(described_class.office_ips).to eq([IPAddr.new("1.2.3.4")])
+    end
+
+    it "parses once, reporting a malformed entry only once across repeated calls" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("not-an-ip")
+
+      expect(Rails.error).to receive(:report).once
+
+      3.times { described_class.office_ips }
+    end
+
+    it "returns an empty array when the credential is unset" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return(nil)
+
+      expect(described_class.office_ips).to eq([])
+    end
+
+    it "never returns nil when a concurrent parse has published the source key but not the list" do
+      # Simulate the interleaving where one thread has recorded the source key
+      # but has not yet published the parsed list. A reader in this window must
+      # re-parse rather than return the not-yet-populated nil (which would crash
+      # the Rack::Attack safelist on `nil.any?`).
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("1.2.3.4")
+      described_class.instance_variable_set(:@office_ips_source, "1.2.3.4")
+      described_class.instance_variable_set(:@office_ips, nil)
+
+      expect(described_class.office_ips).to eq([IPAddr.new("1.2.3.4")])
+    end
+
+    it "rejects a default-route entry that would safelist the entire internet" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("0.0.0.0/0")
+      described_class.instance_variable_set(:@office_ips_source, nil)
+
+      office_ips = described_class.office_ips
+
+      expect(office_ips).to eq([])
+      expect(office_ips.any? { |ip| ip.include?("8.8.8.8") }).to be(false)
+    end
+
+    it "rejects an IPv6 default-route entry" do
+      allow(Credentials).to receive(:fetch).with(:OFFICE_IP).and_return("::/0")
+      described_class.instance_variable_set(:@office_ips_source, nil)
+
+      expect(described_class.office_ips).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

The Rack::Attack office-IP safelist parsed `OFFICE_IP` at boot. That breaks once the parse references an autoloaded constant (initializers run before autoloading is ready), and the original parsing had a few sharp edges: a single malformed entry raised on every request, and a default-route entry would have safelisted the entire internet, silently disabling the webhook blocklists and login brute-force throttles.

## Describe your changes

- **Resolve at request time, not boot.** Moves the office safelist into a `safelist` block (like the webhook lists below it) so it no longer parses at initialization. `HackClub.office_ips` memoizes the parsed `IPAddr` list, keyed on the raw credential so it re-parses only if the value changes, keeping the per-request check cheap.
- **Harden parsing.** Malformed entries are reported and skipped so one typo can't crash every request. A default-route entry (`0.0.0.0/0`, `::/0`) is rejected so it can't safelist the whole internet and disable the blocklists/throttles that safelists take precedence over.
- **Thread-safety.** The memo publishes the parsed list before the source key, so a concurrent reader (this runs under Puma's thread pool on every request) can't observe a matching key while the list is still `nil`.

Specs cover parsing, malformed-entry reporting, the once-per-value memo, the empty credential, and both IPv4/IPv6 default-route rejections.
