### PR TITLE
[Ledger::Item] Redact account-verification amounts

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -77,6 +77,23 @@ class Ledger
 
     scope :missing_receipt, -> { where(receipt_required: true, marked_no_or_lost_receipt_at: nil, receipt_count: 0) }
 
+    # Substring identifiers (case-insensitive) in the memo that indicate an
+    # account-verification micro-deposit. Most use "ACCTVERIFY"; a few companies
+    # use other variants. Mirrors CanonicalTransaction#likely_account_verification_related?.
+    ACCOUNT_VERIFICATION_MEMO_MATCHES = %w[acctverify verify validation sdv-vrfy amts:].freeze
+
+    # Account-verification micro-deposit amounts prove ownership of a linked
+    # external account, so they're redacted from non-organizer (transparency)
+    # viewers, matching the legacy transactions page. These arrive as raw bank
+    # transactions (no linked object) — the Ledger-native equivalent of the
+    # legacy HCB-000- code, avoiding a dependency on the old transaction engine.
+    def likely_account_verification_related?
+      return false unless amount_cents.abs < 100
+      return false unless linked_object_type.nil?
+
+      ACCOUNT_VERIFICATION_MEMO_MATCHES.any? { |s| memo.downcase.include?(s) }
+    end
+
     # This is defined because the Receiptable concern overrides the receipt_required? method defined by ActiveRecord
     def receipt_required?
       self[:receipt_required]

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -16,7 +16,11 @@
   </td>
   <td class="nowrap">
     <span class="flex items-center justify-end">
-      <%= item.amount.format %>
+      <% if !organizer_signed_in? && item.likely_account_verification_related? %>
+        <%= redacted_amount %>
+      <% else %>
+        <%= item.amount.format %>
+      <% end %>
     </span>
   </td>
   <% admin_tool("", "td") do %>

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -394,4 +394,40 @@ RSpec.describe Ledger::Item, type: :model do
       expect(item.custom_memo).to eq("Custom memo")
     end
   end
+
+  describe "account verification detection" do
+    # Pins memo/amount/linked_object_type past the refresh! callbacks (which
+    # recompute them from canonical transactions these items don't have),
+    # mirroring the shared ledger specs. A null linked_object_type marks a raw
+    # bank transaction, which is what account-verification micro-deposits are.
+    def acctverify_item(memo:, amount_cents:, linked_object_type: nil)
+      item = create(:ledger_item)
+      item.update_columns(memo:, amount_cents:, linked_object_type:)
+      item.reload
+    end
+
+    describe "#likely_account_verification_related?" do
+      it "is true for a sub-$1 raw bank transaction whose memo names a verification" do
+        expect(acctverify_item(memo: "ACCTVERIFY deposit", amount_cents: 12)).to be_likely_account_verification_related
+      end
+
+      it "matches the other known memo variants case-insensitively" do
+        ["sdv-vrfy", "AMTS: 0.12", "validation", "verify"].each do |memo|
+          expect(acctverify_item(memo:, amount_cents: -12)).to be_likely_account_verification_related
+        end
+      end
+
+      it "is false when the amount is $1 or more" do
+        expect(acctverify_item(memo: "ACCTVERIFY deposit", amount_cents: 100)).not_to be_likely_account_verification_related
+      end
+
+      it "is false when the transaction has a linked object" do
+        expect(acctverify_item(memo: "ACCTVERIFY deposit", amount_cents: 12, linked_object_type: "Invoice")).not_to be_likely_account_verification_related
+      end
+
+      it "is false when the memo does not name a verification" do
+        expect(acctverify_item(memo: "Coffee", amount_cents: 12)).not_to be_likely_account_verification_related
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Account-verification micro-deposit amounts function as a shared secret proving ownership of a linked external account (Venmo/PayPal/etc.). The legacy transactions page redacts these amounts from non-organizer (transparency) viewers and, when an amount filter is active, drops them from results. The new ledger page (`app/views/ledger/_item.html.erb`) renders `item.amount.format` in the clear, so a public viewer of a transparent organization sees the exact micro-deposit amounts. Both `LedgerPolicy#show` and `EventPolicy#ledger?` grant readers/public access when `new_ledger_2026_06_30` is enabled, so this should be resolved before the flag widens.

## Describe your changes

- Add `Ledger::Item#likely_account_verification_related?`, mirroring `CanonicalTransaction#likely_account_verification_related?` (sub-$1 raw bank transaction whose memo names a verification: `acctverify`/`verify`/`validation`/`sdv-vrfy`/`amts:`).
- Redact the amount cell in `app/views/ledger/_item.html.erb` for `!organizer_signed_in?` viewers, reusing the same `redacted_amount` helper and guard the legacy `_canonical_transaction.html.erb` uses. `organizer_signed_in?(as: :reader)` is true for any reader-or-above, so redaction only triggers for true transparency-mode viewers.

**Ledger-native, no old-engine dependency:** instead of joining to `HcbCode` and matching the legacy `HCB-000-` code string, the check uses a null `linked_object_type` (a raw bank transaction) — the equivalent signal on the new engine, already a column on the row, so no join, no preload, and no N+1.

**Scope:** this is based off `main`, where `#ledger` has no amount/search filters, so the legacy "reject account-verification rows from amount-filtered results" guard has no analog here. That guard belongs with the `Ledger::Query` filter work (#12834), where the filters — and thus the enumeration vector — are introduced.

**Known edge case (documented, intentional):** the match runs against the computed `Ledger::Item#memo`. For these raw micro-deposits `system_memo` is always nil, so `memo` normally falls through to the raw bank text and parity holds. If an organizer set a `custom_memo` on a verification deposit, the match would miss it (legacy matches the raw memo). Detecting that would require reading `canonical_transactions` — the old-engine dependency this intentionally avoids — so it's left as a narrow, documented gap. Note the memo cell itself still shows the raw `ACCTVERIFY AMTS: …` text (as the legacy page does), so full secrecy would also require redacting the memo; out of scope here.

Reviewed by an independent agent pass (fail-safe behavior on nil `@event`, no N+1, genuine specs all confirmed). Model behavior is covered by 5 new specs in `spec/models/ledger/item_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PTygTe5HAC1rB5z5Ao7Hr
