### PR TITLE
Update Gpt-4o into GPT-5.6-luna

### DIFF
--- a/app/controllers/extraction_controller.rb
+++ b/app/controllers/extraction_controller.rb
@@ -41,7 +41,7 @@ class ExtractionController < ApplicationController
     end
 
     response = conn.post("/v1/chat/completions", {
-                           model: "gpt-4o",
+                           model: "gpt-5.6-luna",
                            messages: [
                              {
                                role: "system",

--- a/app/services/hcb_code_service/generate/suggested_tags.rb
+++ b/app/services/hcb_code_service/generate/suggested_tags.rb
@@ -39,7 +39,7 @@ module HcbCodeService
         end
 
         response = conn.post("/v1/chat/completions", {
-                               model:"gpt-5.6-luna",
+                               model: "gpt-5.6-luna",
                                messages: [
                                  {
                                    role: "system",

--- a/app/services/hcb_code_service/generate/suggested_tags.rb
+++ b/app/services/hcb_code_service/generate/suggested_tags.rb
@@ -39,7 +39,7 @@ module HcbCodeService
         end
 
         response = conn.post("/v1/chat/completions", {
-                               model: "gpt-4o",
+                               model:"gpt-5.6-luna",
                                messages: [
                                  {
                                    role: "system",

--- a/app/services/receipt_service/extract.rb
+++ b/app/services/receipt_service/extract.rb
@@ -44,7 +44,7 @@ module ReceiptService
       end
 
       response = conn.post("/v1/chat/completions", {
-                             model: "gpt-4o",
+                             model: "gpt-5.6-luna",
                              messages: [
                                {
                                  role: "system",


### PR DESCRIPTION
## Summary of the problem
gpt-5.6-luna is cheaper and more modern also [slack thread](https://hackclub.enterprise.slack.com/archives/CN523HLKW/p1783901820803889?thread_ts=1783901820.803889&cid=CN523HLKW)



## Describe your changes
Change the model in the ai prompts to use gpt-5.6-luna


