### PR TITLE
Reload `@ledger_item` prior to mapping

### DIFF
--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -6,6 +6,7 @@ class Ledger
 
     def initialize(ledger_item:)
       @ledger_item = ledger_item
+      @ledger_item.reload
     end
 
     def run

--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -6,7 +6,7 @@ class Ledger
 
     def initialize(ledger_item:)
       @ledger_item = ledger_item
-      @ledger_item.reload
+      # @ledger_item.reload
     end
 
     def run

--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -6,7 +6,7 @@ class Ledger
 
     def initialize(ledger_item:)
       @ledger_item = ledger_item
-      # @ledger_item.reload
+      @ledger_item.reload
     end
 
     def run

--- a/app/services/pending_transaction_engine/friendly_memo_service/generate.rb
+++ b/app/services/pending_transaction_engine/friendly_memo_service/generate.rb
@@ -30,11 +30,11 @@ module PendingTransactionEngine
       end
 
       def invoice?
-        @invoice ||= raw_pending_invoice_transaction.present?
+        @invoice ||= raw_pending_invoice_transaction&.invoice.present?
       end
 
       def donation?
-        @donation ||= raw_pending_donation_transaction.present?
+        @donation ||= raw_pending_donation_transaction&.donation.present?
       end
 
       def raw_pending_outgoing_check_transaction


### PR DESCRIPTION
## Summary of the problem

`@ledger_item` is not properly loading its association with CTs and CPTs resulting in the ledger item going unmapped


## Describe your changes

Prior to evaluating the mapping logic, reload `@ledger_item` to ensure associations are up to date.