### PR TITLE
[Payout Method] Fix admins configuring payout methods for others

### DIFF
--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -95,7 +95,7 @@ class LegalEntity
 
     def render_error_payout_settings(payout_method)
       @legal_entity = payout_method.legal_entity || legal_entity
-      @user = @legal_entity&.users&.first || current_user
+      @user = legal_entity&.users&.find_by(id: params[:user_id]) || current_user
       @payout_method = payout_method
       @legal_entities = @user.legal_entities
       flash.now[:error] = payout_method.error_messages.to_sentence

--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -112,9 +112,6 @@ class LegalEntity
                         current_user&.personal_legal_entity
     end
 
-    # Admins may manage payout methods for any user (e.g. from a reimbursement
-    # report); everyone else is limited to entities they belong to. Per-action
-    # authorization still applies.
     def manageable_legal_entities
       current_user&.admin? ? LegalEntity.all : current_user&.legal_entities
     end

--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -10,7 +10,6 @@ class LegalEntity
       authorize LegalEntity::PayoutMethod.new(legal_entity:), :create?
 
       service = LegalEntity::PayoutMethodService::Update.new(
-        user: legal_entity_owner,
         legal_entity:,
         details_type: params.dig(:user, :payout_method_type),
         details_attrs: details_params_for(params.dig(:user, :payout_method_type)),
@@ -29,7 +28,6 @@ class LegalEntity
       authorize @payout_method
 
       service = LegalEntity::PayoutMethodService::Update.new(
-        user: legal_entity_owner,
         legal_entity: @payout_method.legal_entity,
         details_type: @payout_method.details_type,
         details_attrs: details_params_for(@payout_method.details_type),
@@ -114,17 +112,9 @@ class LegalEntity
                         current_user&.personal_legal_entity
     end
 
-    # The user whose payout method is being managed. Normally that's whoever is
-    # acting on an entity they belong to (self-service, personal or business).
-    # When an admin manages payouts on someone else's behalf (e.g. from a
-    # reimbursement report) they aren't a member, so fall back to the entity's
-    # user — unambiguous for personal entities, which is the only such case.
-    def legal_entity_owner
-      return current_user if current_user && legal_entity&.users&.include?(current_user)
-
-      legal_entity&.users&.first || current_user
-    end
-
+    # Admins may manage payout methods for any user (e.g. from a reimbursement
+    # report); everyone else is limited to entities they belong to. Per-action
+    # authorization still applies.
     def manageable_legal_entities
       current_user&.admin? ? LegalEntity.all : current_user&.legal_entities
     end

--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -114,7 +114,14 @@ class LegalEntity
                         current_user&.personal_legal_entity
     end
 
+    # The user whose payout method is being managed. Normally that's whoever is
+    # acting on an entity they belong to (self-service, personal or business).
+    # When an admin manages payouts on someone else's behalf (e.g. from a
+    # reimbursement report) they aren't a member, so fall back to the entity's
+    # user — unambiguous for personal entities, which is the only such case.
     def legal_entity_owner
+      return current_user if current_user && legal_entity&.users&.include?(current_user)
+
       legal_entity&.users&.first || current_user
     end
 

--- a/app/controllers/legal_entity/payout_methods_controller.rb
+++ b/app/controllers/legal_entity/payout_methods_controller.rb
@@ -10,7 +10,7 @@ class LegalEntity
       authorize LegalEntity::PayoutMethod.new(legal_entity:), :create?
 
       service = LegalEntity::PayoutMethodService::Update.new(
-        user: current_user,
+        user: legal_entity_owner,
         legal_entity:,
         details_type: params.dig(:user, :payout_method_type),
         details_attrs: details_params_for(params.dig(:user, :payout_method_type)),
@@ -29,7 +29,7 @@ class LegalEntity
       authorize @payout_method
 
       service = LegalEntity::PayoutMethodService::Update.new(
-        user: current_user,
+        user: legal_entity_owner,
         legal_entity: @payout_method.legal_entity,
         details_type: @payout_method.details_type,
         details_attrs: details_params_for(@payout_method.details_type),
@@ -96,10 +96,10 @@ class LegalEntity
     end
 
     def render_error_payout_settings(payout_method)
-      @user = current_user
-      @payout_method = payout_method
-      @legal_entities = current_user.legal_entities
       @legal_entity = payout_method.legal_entity || legal_entity
+      @user = @legal_entity&.users&.first || current_user
+      @payout_method = payout_method
+      @legal_entities = @user.legal_entities
       flash.now[:error] = payout_method.error_messages.to_sentence
 
       # `edit_payout` lives under `users/`, but this controller isn't namespaced
@@ -110,12 +110,20 @@ class LegalEntity
 
     def legal_entity
       @legal_entity ||= @payout_method&.legal_entity ||
-                        current_user&.legal_entities&.find_by(id: params[:legal_entity_id]) ||
+                        manageable_legal_entities&.find_by(id: params[:legal_entity_id]) ||
                         current_user&.personal_legal_entity
     end
 
+    def legal_entity_owner
+      legal_entity&.users&.first || current_user
+    end
+
+    def manageable_legal_entities
+      current_user&.admin? ? LegalEntity.all : current_user&.legal_entities
+    end
+
     def set_payout_method
-      scope = LegalEntity::PayoutMethod.unarchived.where(legal_entity: current_user&.legal_entities)
+      scope = LegalEntity::PayoutMethod.unarchived.where(legal_entity: manageable_legal_entities)
       @payout_method = scope.find_by(id: params[:id])
       return if @payout_method
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -71,7 +71,6 @@ class PaymentsController < ApplicationController
     return if @legal_entity.default_payout_method && details_attrs.values.any? { |value| value.to_s.include?("•") }
 
     LegalEntity::PayoutMethodService::Update.new(
-      user: current_user,
       legal_entity: @legal_entity,
       details_type: type,
       details_attrs:,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -398,7 +398,6 @@ class UsersController < ApplicationController
       payout_ok = true
       if payout_method_type.present?
         payout_update = LegalEntity::PayoutMethodService::Update.new(
-          user: @user,
           legal_entity: @legal_entity,
           details_type: payout_method_type,
           details_attrs: payout_method_details_params

--- a/app/services/legal_entity/payout_method_service/update.rb
+++ b/app/services/legal_entity/payout_method_service/update.rb
@@ -2,22 +2,21 @@
 
 class LegalEntity
   module PayoutMethodService
-    # Builds, validates, and persists the default payout method for a user's
-    # legal entity (their personal legal entity by default, or another legal
-    # entity they belong to). Encapsulates the business rules that previously lived
-    # across User#build_default_payout_method, User#valid_payout_method, and
-    # the UsersController#update transaction.
+    # Builds, validates, and persists a payout method for a given legal entity
+    # (a user's personal legal entity, or another entity they belong to).
+    # Encapsulates the business rules that previously lived across
+    # User#build_default_payout_method, User#valid_payout_method, and the
+    # UsersController#update transaction.
     #
     # On failure, #run returns false and the (unsaved) payout method, exposed
     # via #payout_method, carries the relevant errors.
     class Update
       attr_reader :payout_method
 
-      def initialize(user:, details_type:, details_attrs: {}, legal_entity: nil, make_default: true, replacing: nil)
-        @user = user
+      def initialize(legal_entity:, details_type:, details_attrs: {}, make_default: true, replacing: nil)
+        @legal_entity = legal_entity
         @details_type = details_type
         @details_attrs = details_attrs || {}
-        @legal_entity = legal_entity || user.personal_legal_entity
         @make_default = make_default
         @replacing = replacing
       end
@@ -63,7 +62,9 @@ class LegalEntity
       end
 
       def repoint_failed_and_draft_reports(replaced_method)
-        on_replaced_method = @user.reimbursement_reports.where(legal_entity_payout_method_id: replaced_method&.id)
+        on_replaced_method = Reimbursement::Report
+                             .where(user: @legal_entity.users)
+                             .where(legal_entity_payout_method_id: replaced_method&.id)
 
         failed = on_replaced_method.joins(:payout_holding).where(reimbursement_payout_holdings: { aasm_state: :failed })
         draft = on_replaced_method.where(aasm_state: :draft)

--- a/app/views/users/payout_form/_form.html.erb
+++ b/app/views/users/payout_form/_form.html.erb
@@ -14,6 +14,7 @@
   <% form_opts.merge!(url: payout_method_path(editing), method: :patch) if editing %>
   <% form_opts.merge!(url: payout_methods_path, method: :post) if creating %>
   <%= form_with(**form_opts) do |form| %>
+    <%= hidden_field_tag :user_id, user.id %>
     <% if creating && legal_entity %>
       <%= hidden_field_tag :legal_entity_id, legal_entity.id %>
     <% end %>

--- a/spec/controllers/legal_entity/payout_methods_controller_spec.rb
+++ b/spec/controllers/legal_entity/payout_methods_controller_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe LegalEntity::PayoutMethodsController do
              })
       end.to change { legal_entity.reload.payout_methods.count }.by(1)
     end
+
+    context "when an admin adds a payout method for another user" do
+      let(:admin) { create(:user, :make_admin) }
+
+      before { create_session(admin, verified: true) }
+
+      it "adds the method to the target user's entity, not the admin's" do
+        expect do
+          post(:create, params: {
+                 legal_entity_id: legal_entity.id,
+                 user: {
+                   payout_method_type: "LegalEntity::PayoutMethod::AchTransfer",
+                   payout_method_ach_transfer: { account_number: "12345678", routing_number: "021000021" }
+                 }
+               })
+        end.to change { legal_entity.reload.payout_methods.count }.by(1)
+
+        expect(admin.personal_legal_entity.reload.payout_methods.count).to eq(0)
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/services/legal_entity/payout_method_service/update_spec.rb
+++ b/spec/services/legal_entity/payout_method_service/update_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
     it "creates the chosen method as the user's default when none exists" do
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs
       )
@@ -49,7 +49,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
                          ))
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs
       )
@@ -62,7 +62,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
     it "fails without persisting when the type is not a supported payout method" do
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "User::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs
       )
@@ -79,7 +79,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       allow(User).to receive(:new).and_call_original
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "User",
         details_attrs: valid_ach_attrs
       )
@@ -91,7 +91,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
 
     it "surfaces detail validation errors without persisting" do
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: { account_number: "12345678", routing_number: "nope" }
       )
@@ -107,7 +107,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(report.legal_entity_payout_method).to be_present
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::WiseTransfer",
         details_attrs: valid_wise_attrs
       )
@@ -126,7 +126,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
                                               }])
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         replacing: old_pm
@@ -163,7 +163,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       end
 
       described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         replacing: replaced_default
@@ -181,7 +181,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       old_pm = report.legal_entity_payout_method
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         replacing: old_pm
@@ -212,7 +212,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       on_other.update_columns(legal_entity_payout_method_id: other_method.id)
 
       described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         replacing: replaced_default
@@ -230,7 +230,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       old_pm = report.legal_entity_payout_method
 
       described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs
       ).run
@@ -249,7 +249,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       old = seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
 
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: { account_number: "99999999", routing_number: "021000021" },
         make_default: old.default?,
@@ -273,7 +273,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       old = seed_default(LegalEntity::PayoutMethod::AchTransfer.new(valid_ach_attrs))
 
       described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         make_default: old.default?,
@@ -290,7 +290,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
       expect(report.legal_entity_payout_method).to eq(old)
 
       described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: valid_ach_attrs,
         make_default: old.default?,
@@ -305,7 +305,7 @@ RSpec.describe LegalEntity::PayoutMethodService::Update do
   describe "#run!" do
     it "raises ActiveRecord::RecordInvalid when the update is invalid" do
       service = described_class.new(
-        user:,
+        legal_entity: user.personal_legal_entity,
         details_type: "LegalEntity::PayoutMethod::AchTransfer",
         details_attrs: { account_number: "12345678", routing_number: "nope" }
       )


### PR DESCRIPTION
## Summary of the problem
We automatically assume in LegalEntityUpdateService that we're changing the current user's not the legal entity owner. 


## Describe your changes
Uses legal entity directly instead of user


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

