### PR TITLE
Create `Reimbursement::PayoutHolding#event`

### DIFF
--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -56,7 +56,7 @@ module Reimbursement
     after_create do
       CanonicalPendingTransaction.create!(
         reimbursement_payout_holding: self,
-        event: Event.find(EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING),
+        event:,
         amount_cents:,
         memo: hcb_code,
         date: created_at,
@@ -97,6 +97,10 @@ module Reimbursement
       if Reimbursement::PayoutHolding.where(reimbursement_reports_id:).excluding(self).any?
         errors.add(:base, "A reimbursement report can only have one payout holding.")
       end
+    end
+
+    def event
+      @event ||= Event.find(EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING)
     end
 
     def payout_transfer


### PR DESCRIPTION
## Summary of the problem

`Reimbursement::PayoutHolding` does not have `event` implemented, so `Ledger::Mapper` cannot use `linked_object&.event` as a mapping strategy.


## Describe your changes

This PR implements `Reimbursement::PayoutHolding#event` so it can be referenced in `Ledger::Mapper`.