### PR TITLE
[Tax] Pass Referer header when getting Taxbandits access token

### DIFF
--- a/app/services/taxbandits_service.rb
+++ b/app/services/taxbandits_service.rb
@@ -76,6 +76,7 @@ class TaxbanditsService
         conn.response :json
         conn.response :raise_error
         conn.headers["Authentication"] = signature
+        conn.headers["Referer"] = Credentials.fetch(:TAXBANDITS, :DOMAIN_ID)
         conn.adapter Faraday.default_adapter
       end.get("/v2/tbsauth")
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We're passing this header for normal Taxbandits requests, but forgot to for getting the access token.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Pass the header in the access token request

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

