### PR TITLE
[Ledger Mapper] Check `linked_object_v2`

### DIFF
--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -50,6 +50,10 @@ class Ledger
           return event
         end
 
+        if (event = ct.try(:linked_object_v2))
+          return event
+        end
+
         # Fallback, see if any linked objects have an event.
         if (event = ct.linked_object.try(:event))
           return event

--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -50,7 +50,7 @@ class Ledger
           return event
         end
 
-        if (event = ct.try(:linked_object_v2))
+        if (event = ct.linked_object_v2.try(:event))
           return event
         end
 


### PR DESCRIPTION
## Summary of the problem

`linked_object_v2` is being ignored resulting in RawStripeTransaction CTs not being mapped properly


## Describe your changes

Use `linked_object_v2`