### PR TITLE
[Ledger::Item] Fix incorrect `settled` status for disbursements

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -169,7 +169,7 @@ class Ledger
       @ct_sum ||= canonical_transactions.sum(:amount_cents)
       return :settled if linked_object_type == "Reimbursement::ExpensePayout"
       return :settled if linked_object_type == "Disbursement::Outgoing" && linked_object.counterparty.canonical_pending_transactions.fronted.any?
-      return :settled if linked_object_type.in?(["Disbursement::Outgoing", "Disbursement::Incoming"]) && linked_object.approved_at.present?
+      return :settled if linked_object_type.in?(["Disbursement::Outgoing", "Disbursement::Incoming"]) && linked_object.approved_at.present? && !linked_object.rejected? && !linked_object.errored?
       return :settled if canonical_transactions.none? && canonical_pending_transactions.fronted.not_declined.revenue.any? && primary_ledger&.can_front_balance?
       return :pending if canonical_pending_transactions.unsettled.exists?
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some rejected disbursements were rendering as settled


## Describe your changes

Change the conditions for `settled` for disbursements