### PR TITLE
Redirect transfers page to payments page when enabled

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -741,6 +741,10 @@ class EventsController < ApplicationController
   def transfers
     authorize @event
 
+    if Flipper.enabled?(:payments_contractors_refresh_2026_06_26, @event)
+      redirect_to event_payments_path(@event)
+    end
+
     params[:q] ||= params[:search]
 
     @ach_transfers = @event.ach_transfers

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -743,6 +743,7 @@ class EventsController < ApplicationController
 
     if Flipper.enabled?(:payments_contractors_refresh_2026_06_26, @event)
       redirect_to event_payments_path(@event)
+      return
     end
 
     params[:q] ||= params[:search]

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -150,7 +150,7 @@ module EventsHelper
       tooltip: "Send & transfer money",
       icon: "payment-transfer",
       symbol: :transfers,
-      available_proc: ->(event) { policy(event).transfers? }
+      available_proc: ->(event) { policy(event).transfers? && !Flipper.enabled?(:payments_contractors_refresh_2026_06_26, event) }
     },
     {
       name: "Payments",

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -160,7 +160,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def transfers?
-    !Flipper.enabled?(:payments_contractors_refresh_2026_06_26, record) && show? && record.plan.transfers_enabled?
+    show? && record.plan.transfers_enabled?
   end
 
   def payments?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Existing links still reference transfers

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Moves the flipper check for the transfers page from the policy into the controller and nav, so that we can redirect.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

