### PR TITLE
[Payments] Fix showing other transfer types

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -651,12 +651,12 @@ class EventsController < ApplicationController
     # The search query name was historically `search`. It has since been renamed
     # to `q`. This following line retains backwards compatibility.
     @payments = @event.payments.includes(:payee)
-    @ach_transfers = @event.ach_transfers.where(payment_attempt: nil)
+    @ach_transfers = @event.ach_transfers.where.missing(:payment_attempt)
     @paypal_transfers = @event.paypal_transfers
-    @wires = @event.wires.where(payment_attempt: nil)
-    @wise_transfers = @event.wise_transfers.where(payment_attempt: nil)
+    @wires = @event.wires.where.missing(:payment_attempt)
+    @wise_transfers = @event.wise_transfers.where.missing(:payment_attempt)
     @checks = @event.checks.includes(:lob_address)
-    @increase_checks = @event.increase_checks.where(payment_attempt: nil)
+    @increase_checks = @event.increase_checks.where.missing(:payment_attempt)
     @disbursements = @event.outgoing_disbursements.includes(:destination_event)
 
     @disbursements = @disbursements.not_card_grant_related

--- a/app/views/events/payments.html.erb
+++ b/app/views/events/payments.html.erb
@@ -118,6 +118,10 @@
                   <span class="tooltipped tooltipped--e inline-block" aria-label="Wise transfer">
                     <%= inline_icon "wise" %>
                   </span>
+                <% elsif d.is_a?(Payment) %>
+                  <span class="tooltipped tooltipped--e inline-block" aria-label="Payment">
+                    <%= inline_icon "payment" %>
+                  </span>
                 <% else %>
                   <span class="tooltipped tooltipped--e inline-block" aria-label="HCB transfer">
                     <%= inline_icon "door-leave" %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The new payments page wasn't showing old types of transfers

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change where payment attrempt is nil to where.missing

Also use a proper icon for payments

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

