### PR TITLE
Fix plan check on suborg creation form

### DIFF
--- a/app/views/suborganizations/_form.html.erb
+++ b/app/views/suborganizations/_form.html.erb
@@ -31,7 +31,7 @@
     <%= form.email_field :email, placeholder: "Running this project yourself? Use #{current_user.email}", value: params[:email] %>
   </div>
 
-  <% unless event.plan.is_a?(Event::Plan::HackClubAffiliate) %>
+  <% unless event.config.subevent_plan.constantize <= Event::Plan::HackClubAffiliate %>
     <div class="field">
       <%= form.label :cosigner_email, "Co-signer email", class: "bold" %>
       <%= form.email_field :cosigner_email, placeholder: "Include this if the organizer is under 18", value: params[:cosigner_email] %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It was checking event plan instead of the suborg plan

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change check for cosigner email to look at suborg plan instead of event plan

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

