### PR TITLE
[Ledger::Mapper] Don't skip non-column CTs

### DIFF
--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -38,10 +38,12 @@ class Ledger
     # Also covers ACH transfers, wires, etc. which are sent using this number.
     def event_from_canonical_transactions
       @ledger_item.canonical_transactions.each do |ct|
-        column_account_number = Column::AccountNumber.find_by(
-          column_id: ct.raw_column_transaction.column_transaction["account_number_id"]
-        )
-        return column_account_number.event if column_account_number
+        if ct.raw_column_transaction.present?
+          column_account_number = Column::AccountNumber.find_by(
+            column_id: ct.raw_column_transaction.column_transaction["account_number_id"]
+          )
+          return column_account_number.event if column_account_number
+        end
 
         # Map transactions on Stripe cards.
         if ct.raw_stripe_transaction.present? && (event = ct.raw_stripe_transaction.likely_event)

--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -38,8 +38,6 @@ class Ledger
     # Also covers ACH transfers, wires, etc. which are sent using this number.
     def event_from_canonical_transactions
       @ledger_item.canonical_transactions.each do |ct|
-        next unless ct.raw_column_transaction
-
         column_account_number = Column::AccountNumber.find_by(
           column_id: ct.raw_column_transaction.column_transaction["account_number_id"]
         )

--- a/spec/models/card_locking_settle_hooks_spec.rb
+++ b/spec/models/card_locking_settle_hooks_spec.rb
@@ -8,15 +8,14 @@ RSpec.describe "card-locking settle hooks" do
   before { travel_to(Time.zone.parse("2026-10-10 12:00:00")) }
 
   it "enqueues the materialize job when the old-engine mapping settles a card charge" do
+    # Both engines fire for a settled Stripe charge (the CanonicalEventMapping
+    # hook plus the auto-created Ledger::Mapping's commit hooks); the job is
+    # idempotent, so the exact count is an implementation detail.
     expect { create_settled_card_charge(user:, settled_at: 1.day.ago) }
-      .to have_enqueued_job(CardLocking::MaterializeChargeJob)
+      .to have_enqueued_job(CardLocking::MaterializeChargeJob).at_least(:once)
   end
 
   it "enqueues the materialize job when a new-engine primary mapping settles a card charge" do
-    # The shared factory's raw_stripe_transaction only produces a
-    # CanonicalTransaction, not a CanonicalPendingTransaction, so
-    # Ledger::Mapper never auto-creates a primary Ledger::Mapping for it.
-    # Build the ledger item and map it directly to exercise the new-engine hook.
     stripe_cardholder = create(:stripe_cardholder, user:)
     stripe_card = create(:stripe_card, :with_stripe_id, stripe_cardholder:, event:)
     raw_stripe_transaction = create(
@@ -29,15 +28,23 @@ RSpec.describe "card-locking settle hooks" do
     raw_stripe_transaction.update!(
       stripe_transaction: raw_stripe_transaction.stripe_transaction.merge("cardholder" => stripe_cardholder.stripe_id)
     )
-    canonical_transaction = create(
-      :canonical_transaction, amount_cents: -10_00, memo: "Test Merchant", date: 1.day.ago.to_date,
-      created_at: 1.day.ago, updated_at: 1.day.ago, transaction_source: raw_stripe_transaction
-    )
-    ledger_item = canonical_transaction.reload.ledger_item
-    primary_ledger = Ledger.find_or_create_by!(primary: true, event:)
 
-    expect { Ledger::Mapping.create!(ledger: primary_ledger, ledger_item:, on_primary_ledger: true) }
-      .to have_enqueued_job(CardLocking::MaterializeChargeJob)
+    # Creating the canonical transaction lets Ledger::Mapper resolve the event
+    # through the Stripe card and auto-create the primary Ledger::Mapping,
+    # whose commit hook enqueues the job. No CanonicalEventMapping exists here,
+    # so the old-engine hook can't be the source.
+    canonical_transaction = nil
+    expect do
+      canonical_transaction = create(
+        :canonical_transaction, amount_cents: -10_00, memo: "Test Merchant", date: 1.day.ago.to_date,
+        created_at: 1.day.ago, updated_at: 1.day.ago, transaction_source: raw_stripe_transaction
+      )
+    end.to have_enqueued_job(CardLocking::MaterializeChargeJob).at_least(:once)
+
+    primary_mapping = canonical_transaction.reload.ledger_item.primary_mapping
+    expect(primary_mapping).to be_present
+    expect(primary_mapping.ledger.event).to eq(event)
+    expect(primary_mapping.mapped_by).to be_nil
   end
 
   it "does not enqueue the materialize job for a non-card, positive-amount mapping" do


### PR DESCRIPTION
## Summary of the problem

Our logic for Stripe transactions... lives _after_ we skip all Stripe transactions.

<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/ee4ddae6-1985-40eb-8299-2e274f6a678a" />



## Describe your changes

Remove the line that skips all non-Column CTs.