### PR TITLE
Allow admins to edit wire currency & amount

### DIFF
--- a/app/models/wire.rb
+++ b/app/models/wire.rb
@@ -96,6 +96,12 @@ class Wire < ApplicationRecord
     )
   end
 
+  after_update do
+    if (saved_change_to_amount_cents? || saved_change_to_currency?) && canonical_pending_transaction&.unsettled?
+      canonical_pending_transaction.update!(amount_cents: -1 * MoneyService.convert_to_usd(amount_cents, currency))
+    end
+  end
+
   validates_presence_of :memo, :payment_for, :recipient_name, :recipient_email
   validates_email_format_of :recipient_email, if: :recipient_email_changed?
   normalizes :recipient_email, with: ->(recipient_email) { recipient_email.strip.downcase }

--- a/app/views/wires/edit.html.erb
+++ b/app/views/wires/edit.html.erb
@@ -48,6 +48,16 @@
     <span class="muted">This is to help HCB keep record of our transactions.</span>
   </div>
 
+  <div class="field">
+    <%= form.label :amount, "Currency & amount" %>
+    <div class="flex items-center gap-2">
+      <div style="width: 72px">
+        <%= form.select :currency, Wire::AVAILABLE_CURRENCIES, {}, { required: true, disabled: } %>
+      </div>
+      <%= form.number_field :amount, placeholder: "500.00", step: 0.01, required: true, disabled:, data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" } %>
+    </div>
+  </div>
+
   <%= render partial: "wires/account_details", locals: { form:, disabled:, required: true } %>
 
   <%= render partial: "wires/country_specific_details", locals: { form:, disabled:, required: true } %>

--- a/spec/controllers/wires_controller_spec.rb
+++ b/spec/controllers/wires_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe WiresController do
         params: {
           id: wire.id,
           wire: {
-            currency: "EUR",
+            currency: "CAD",
             amount: "600",
           }
         }
@@ -155,9 +155,9 @@ RSpec.describe WiresController do
       expect(response).to redirect_to(wire_process_admin_path(wire))
 
       wire.reload
-      expect(wire.currency).to eq("EUR")
+      expect(wire.currency).to eq("CAD")
       expect(wire.amount_cents).to eq(600_00)
-      expect(wire.canonical_pending_transaction.reload.amount_cents).to eq(-MoneyService.convert_to_usd(600_00, "EUR"))
+      expect(wire.canonical_pending_transaction.reload.amount_cents).to eq(-MoneyService.convert_to_usd(600_00, "CAD"))
     end
 
     it "is not allowed for non-admins" do

--- a/spec/controllers/wires_controller_spec.rb
+++ b/spec/controllers/wires_controller_spec.rb
@@ -5,26 +5,26 @@ require "rails_helper"
 RSpec.describe WiresController do
   include SessionSupport
 
+  def wire_params
+    {
+      memo: "Test Wire",
+      amount: "500",
+      payment_for: "Snacks",
+      recipient_name: "Orpheus",
+      recipient_email: "orpheus@example.com",
+      account_number: "123456789",
+      bic_code: "NOSCCATT",
+      recipient_country: "CA",
+      currency: "USD",
+      address_line1: "1 Main Street",
+      address_city: "Ottawa",
+      address_postal_code: "K1A 0A6",
+      address_state: "Ontario",
+    }
+  end
+
   describe "create" do
     render_views
-
-    def wire_params
-      {
-        memo: "Test Wire",
-        amount: "500",
-        payment_for: "Snacks",
-        recipient_name: "Orpheus",
-        recipient_email: "orpheus@example.com",
-        account_number: "123456789",
-        bic_code: "NOSCCATT",
-        recipient_country: "CA",
-        currency: "USD",
-        address_line1: "1 Main Street",
-        address_city: "Ottawa",
-        address_postal_code: "K1A 0A6",
-        address_state: "Ontario",
-      }
-    end
 
     it "creates a new wire" do
       user = create(:user)
@@ -116,6 +116,65 @@ RSpec.describe WiresController do
       expect(response).to redirect_to(hcb_code_path(wire.local_hcb_code))
       expect(wire.memo).to eq("Test Wire")
       expect(wire.amount_cents).to eq(500_01)
+    end
+  end
+
+  describe "update" do
+    def create_wire
+      user = create(:user)
+      event = create(:event, :with_positive_balance)
+      create(:organizer_position, user:, event:)
+
+      stub_request(:get, "https://api.column.com/institutions/NOSCCATT")
+        .to_return_json(
+          status: 200,
+          body: { country_code: "CA" }
+        )
+
+      event.wires.create!(user:, **wire_params)
+    end
+
+    it "allows admins to edit the currency and amount" do
+      wire = create_wire
+      expect(wire.canonical_pending_transaction.amount_cents).to eq(-500_00)
+
+      admin = create(:user, :make_admin)
+      create_session(admin, verified: true)
+
+      patch(
+        :update,
+        params: {
+          id: wire.id,
+          wire: {
+            currency: "EUR",
+            amount: "600",
+          }
+        }
+      )
+
+      expect(response).to redirect_to(wire_process_admin_path(wire))
+
+      wire.reload
+      expect(wire.currency).to eq("EUR")
+      expect(wire.amount_cents).to eq(600_00)
+      expect(wire.canonical_pending_transaction.reload.amount_cents).to eq(-MoneyService.convert_to_usd(600_00, "EUR"))
+    end
+
+    it "is not allowed for non-admins" do
+      wire = create_wire
+
+      create_session(wire.user, verified: true)
+
+      patch(
+        :update,
+        params: {
+          id: wire.id,
+          wire: { amount: "600" }
+        }
+      )
+
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+      expect(wire.reload.amount_cents).to eq(500_00)
     end
   end
 end


### PR DESCRIPTION
Adds currency and amount fields to the admin-only "Edit Wire" page so ops can correct wires without rejecting and resubmitting (#14279). Editing amount or currency resyncs the wire's unsettled canonical pending transaction with a fresh USD conversion, mirroring WiseTransfer's after_update behavior.

## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->



## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

