### PR TITLE
[Payments] Add link to manual transfer pages for admins

### DIFF
--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -13,6 +13,12 @@
   </div>
 <% end %>
 
+<% content_for :sidebar_footer do %>
+  <% admin_tool("mt-6") do %>
+    <%= link_to "Send transfer manually", "#", class: "btn", data: { behavior: "modal_trigger", modal: "send_transfer" } %>
+  <% end %>
+<% end %>
+
 <% if @recent_payments&.any? %>
   <% content_for :sidebar_footer do %>
     <div class="mt-6">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Admins still need to send manual transfers without the new flow.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add modal for the manual transfer page back to the payments new page

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

