### PR TITLE
[Ledger] Replace Event#merchants scan with a Ledger-scoped lookup

### DIFF
--- a/app/controllers/concerns/set_ledger_filters.rb
+++ b/app/controllers/concerns/set_ledger_filters.rb
@@ -37,7 +37,7 @@ module SetLedgerFilters
       @users = User.where(id: author_ids).or(User.where(id: @event.users.select(:id))).with_attached_profile_picture.order(Arel.sql("CONCAT(preferred_name, full_name) ASC"))
 
       if @merchant
-        merchant = @event.merchants.find { |merchant| merchant[:id] == @merchant }
+        merchant = ledger_merchants(@ledgers).find { |merchant| merchant[:id] == @merchant }
 
         @merchant_name = merchant.present? ? merchant[:name] : "Merchant #{@merchant}"
       end
@@ -106,6 +106,64 @@ module SetLedgerFilters
 
       query << { status: { "$in": [nil, "settled", "pending", "reversed"] } } # TODO: add not null validation and remove nil status from here
       Ledger::Query.new({ "$and": query })
+    end
+
+    # Distinct merchants for the given ledgers' CardCharge items, with a
+    # transaction count per merchant. Scoped to Ledger::Item so this only
+    # reflects card charges that are actually mapped onto these ledgers.
+    #
+    # Merchant data lives in a JSONB blob on the underlying raw Stripe
+    # transaction; pulling the whole blob per charge (e.g. via
+    # `card_charge.merchant_data`, which loads full `RawStripeTransaction`/
+    # `RawPendingStripeTransaction` records) is the expensive part at this
+    # volume, not the merchant lookup itself. Extracting just the
+    # `merchant_data` key with the `->` operator keeps the query and the
+    # amount of data pulled back small.
+    def ledger_merchants(ledgers)
+      card_charge_ids = Ledger::Item.where(
+        linked_object_type: "CardCharge",
+        id: Ledger::Mapping.where(ledger: ledgers).select(:ledger_item_id)
+      ).pluck(:linked_object_id)
+      return [] if card_charge_ids.empty?
+
+      merchant_data_by_charge_id = {}
+
+      # A card charge's `merchant_data` prefers its latest settled
+      # RawStripeTransaction, falling back to its RawPendingStripeTransaction
+      # (mirrors CardCharge#merchant_data's `raw_stripe_transactions.last ||
+      # raw_pending_stripe_transaction`).
+      last_settled_transaction_id_by_charge_id = CardChargeRawStripeTransaction
+                                                 .where(card_charge_id: card_charge_ids)
+                                                 .group(:card_charge_id)
+                                                 .maximum(:raw_stripe_transaction_id)
+
+      if last_settled_transaction_id_by_charge_id.present?
+        charge_id_by_transaction_id = last_settled_transaction_id_by_charge_id.invert
+        RawStripeTransaction.where(id: last_settled_transaction_id_by_charge_id.values)
+                            .pluck(:id, Arel.sql("stripe_transaction -> 'merchant_data'"))
+                            .each do |transaction_id, merchant_data|
+          next if merchant_data.blank?
+
+          merchant_data_by_charge_id[charge_id_by_transaction_id[transaction_id]] = merchant_data
+        end
+      end
+
+      pending_only_charge_ids = card_charge_ids - merchant_data_by_charge_id.keys
+      if pending_only_charge_ids.present?
+        CardCharge.where(id: pending_only_charge_ids)
+                  .joins(:raw_pending_stripe_transaction)
+                  .pluck(:id, Arel.sql("raw_pending_stripe_transactions.stripe_transaction -> 'merchant_data'"))
+                  .each do |charge_id, merchant_data|
+          next if merchant_data.blank?
+
+          merchant_data_by_charge_id[charge_id] = merchant_data
+        end
+      end
+
+      merchant_data_by_charge_id.values.group_by { |merchant_data| merchant_data["network_id"] }.map do |network_id, group|
+        yellow_pages_merchant = YellowPages::Merchant.lookup(network_id:)
+        { id: network_id, name: yellow_pages_merchant.name || group.first["name"].titleize, count: group.size }
+      end
     end
 
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1218,18 +1218,7 @@ class EventsController < ApplicationController
     authorize @event
 
     @merchant = params[:merchant]
-
-    merchants_hash = {}
-
-    @event.merchants.each do |merchant|
-      if merchants_hash.key?(merchant[:id])
-        merchants_hash[merchant[:id]][:count] = merchants_hash[merchant[:id]][:count] + 1
-      else
-        merchants_hash[merchant[:id]] = { name: merchant[:name], count: 1 }
-      end
-    end
-
-    @merchants = merchants_hash.map { |id, merchant| { id:, name: merchant[:name], count: merchant[:count] } }.sort_by { |merchant| merchant[:count] }.reverse!.first(30)
+    @merchants = ledger_merchants([@event.ledger]).sort_by { |merchant| merchant[:count] }.reverse!.first(30)
   end
 
   def request_call

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -129,6 +129,75 @@ RSpec.describe EventsController do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "resolves @merchant_name from a card charge's pending transaction" do
+      # Creating a RawPendingStripeTransaction auto-creates its CardCharge
+      # (RawPendingStripeTransaction#link_card_charge!), so use that rather
+      # than creating a second CardCharge for the same transaction.
+      raw_pending = create(:raw_pending_stripe_transaction, stripe_transaction: { "merchant_data" => { "name" => "merchant 1", "network_id" => "555000111" } })
+      item = create(:ledger_item, linked_object: raw_pending.card_charge)
+      Ledger::Mapping.create!(ledger: event.ledger, ledger_item: item, on_primary_ledger: true)
+
+      get(:ledger, params: { event_id: event.slug, merchant: "555000111" })
+
+      expect(response).to have_http_status(:ok)
+      expect(controller.instance_variable_get(:@merchant_name)).to eq("Merchant 1")
+    end
+
+    it "falls back to a generic name when the merchant isn't found on this ledger" do
+      get(:ledger, params: { event_id: event.slug, merchant: "000000000" })
+
+      expect(controller.instance_variable_get(:@merchant_name)).to eq("Merchant 000000000")
+    end
+  end
+
+  describe "#merchants_filter" do
+    let(:admin) { create(:user, :make_admin) }
+    let(:event) { create(:event) }
+
+    before { create_session(admin, verified: true) }
+
+    def create_card_charge_item(ledger, network_id:, name:, settled: false)
+      raw_pending = create(:raw_pending_stripe_transaction, stripe_transaction: { "merchant_data" => { "name" => name, "network_id" => network_id } })
+      card_charge = raw_pending.card_charge
+      if settled
+        # Creating a RawStripeTransaction with a matching stripe_authorization_id
+        # auto-links it to the existing card charge (RawStripeTransaction#link_card_charge!).
+        # Uses the factory's own card/cardholder defaults (Ledger::Item#refresh!
+        # resolves the item's author through them) and only overrides merchant_data.
+        rst = create(:raw_stripe_transaction, stripe_authorization_id: raw_pending.stripe_transaction_id)
+        rst.update_columns(stripe_transaction: rst.stripe_transaction.merge("merchant_data" => { "name" => name, "network_id" => network_id }))
+      end
+      item = create(:ledger_item, linked_object: card_charge)
+      Ledger::Mapping.create!(ledger:, ledger_item: item, on_primary_ledger: true)
+      item
+    end
+
+    it "lists distinct merchants with a count, from both settled and pending card charges" do
+      create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
+      create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
+      create_card_charge_item(event.ledger, network_id: "222", name: "bookstore", settled: false)
+
+      get(:merchants_filter, params: { event_id: event.slug })
+
+      merchants = controller.instance_variable_get(:@merchants)
+      expect(merchants).to match_array([
+                                         { id: "111", name: "Bakery", count: 2 },
+                                         { id: "222", name: "Bookstore", count: 1 },
+                                       ])
+    end
+
+    it "does not include another event's ledger in the merchant list" do
+      create_card_charge_item(event.ledger, network_id: "111", name: "bakery")
+
+      other_event = create(:event)
+      create_card_charge_item(other_event.ledger, network_id: "999", name: "other org's merchant")
+
+      get(:merchants_filter, params: { event_id: event.slug })
+
+      merchants = controller.instance_variable_get(:@merchants)
+      expect(merchants.map { |m| m[:id] }).to contain_exactly("111")
+    end
   end
 
   describe "#payments" do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe EventsController do
   end
 
   describe "#ledger" do
+    render_views
+
     let(:admin) { create(:user, :make_admin) }
     let(:event) { create(:event) }
 
@@ -130,7 +132,7 @@ RSpec.describe EventsController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "resolves @merchant_name from a card charge's pending transaction" do
+    it "shows the merchant name in the active-filter badge, resolved from a card charge's pending transaction" do
       # Creating a RawPendingStripeTransaction auto-creates its CardCharge
       # (RawPendingStripeTransaction#link_card_charge!), so use that rather
       # than creating a second CardCharge for the same transaction.
@@ -141,17 +143,19 @@ RSpec.describe EventsController do
       get(:ledger, params: { event_id: event.slug, merchant: "555000111" })
 
       expect(response).to have_http_status(:ok)
-      expect(controller.instance_variable_get(:@merchant_name)).to eq("Merchant 1")
+      expect(response.body).to include("Merchant 1")
     end
 
-    it "falls back to a generic name when the merchant isn't found on this ledger" do
+    it "falls back to a generic badge label when the merchant isn't found on this ledger" do
       get(:ledger, params: { event_id: event.slug, merchant: "000000000" })
 
-      expect(controller.instance_variable_get(:@merchant_name)).to eq("Merchant 000000000")
+      expect(response.body).to include("Merchant 000000000")
     end
   end
 
   describe "#merchants_filter" do
+    render_views
+
     let(:admin) { create(:user, :make_admin) }
     let(:event) { create(:event) }
 
@@ -173,14 +177,26 @@ RSpec.describe EventsController do
       item
     end
 
-    it "lists distinct merchants with a count, from both settled and pending card charges" do
+    it "lists distinct merchants from both settled and pending card charges, most-transacted first" do
       create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
       create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
       create_card_charge_item(event.ledger, network_id: "222", name: "bookstore", settled: false)
 
       get(:merchants_filter, params: { event_id: event.slug })
 
-      merchants = controller.instance_variable_get(:@merchants)
+      expect(response.body).to include("Bakery")
+      expect(response.body).to include("Bookstore")
+      # Bakery has 2 matching card charges vs. Bookstore's 1, so it renders first.
+      expect(response.body.index("Bakery")).to be < response.body.index("Bookstore")
+    end
+
+    it "counts each merchant's card charges" do
+      create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
+      create_card_charge_item(event.ledger, network_id: "111", name: "bakery", settled: true)
+      create_card_charge_item(event.ledger, network_id: "222", name: "bookstore", settled: false)
+
+      merchants = controller.send(:ledger_merchants, [event.ledger])
+
       expect(merchants).to match_array([
                                          { id: "111", name: "Bakery", count: 2 },
                                          { id: "222", name: "Bookstore", count: 1 },
@@ -195,8 +211,8 @@ RSpec.describe EventsController do
 
       get(:merchants_filter, params: { event_id: event.slug })
 
-      merchants = controller.instance_variable_get(:@merchants)
-      expect(merchants.map { |m| m[:id] }).to contain_exactly("111")
+      expect(response.body).to include("Bakery")
+      expect(response.body).not_to match(/other org/i)
     end
   end
 


### PR DESCRIPTION
> [!NOTE]
> **This PR was written by [Claude Code](https://claude.com/claude-code).** Gary directed the investigation and reviewed the changes, but the diagnosis, code, and benchmarks below were produced by Claude.

## Summary of the problem

The Ledger page's merchant filter — both the `@merchant_name` label (`set_ledger_filters.rb`) and the `merchants_filter` dropdown action — called `Event#merchants`, which:
- loads every `CanonicalTransaction` and `CanonicalPendingTransaction` the event has ever had, with no date bound or limit,
- N+1s each one's `raw_stripe_transaction`/`raw_pending_stripe_transaction`,
- calls `YellowPages::Merchant.lookup` once per transaction rather than deduping first.

Per Gary's rule for this system — rendering the Ledger should only touch `Ledger`, `Ledger::Item`, `Ledger::Mapping`, and `linked_object` — this also reached directly into the old transaction-engine tables, which the Ledger page shouldn't need to know about at all.

## Describe your changes

Replaced with a new `ledger_merchants(ledgers)` helper that:
1. Starts from `Ledger::Item` scoped to the given ledgers, filtered to `linked_object_type: "CardCharge"` — so it only ever reflects what's actually on this Ledger, via `linked_object` (a `CardCharge`), never the raw transaction engine directly.
2. Extracts just the `merchant_data` key from the underlying JSONB blob using Postgres's `->` operator, instead of loading full `RawStripeTransaction`/`RawPendingStripeTransaction` records. `merchant_data` is a small part of a multi-KB JSONB payload (~2.6KB average per row); loading the whole blob per charge just to read one key turned out to be most of the remaining cost after fixing the N+1.
3. Falls back from a charge's latest settled transaction to its pending one, mirroring `CardCharge#merchant_data`'s own `raw_stripe_transactions.last || raw_pending_stripe_transaction` logic.

The legacy (non-Ledger) Transactions page still calls `Event#merchants` directly for its own filter menu and is untouched — that page isn't bound by the Ledger-only-access rule.

## Benchmarks

Medians, before → after, across a few orgs (public IDs shown for the rest):

| Org | Before | After | Speedup |
|---|---|---|---|
| Hack Club HQ | 33,598ms | 88ms | 382x |
| HCB Operations | 11,393ms | 32ms | 353x |
| `org_lbu5qR` | 16,259ms | 46ms | 353x |
| `org_XDunKA` | 9,340ms | 40ms | 236x |
| `org_MNOuwZ` | 7,179ms | 24ms | 303x |
| `org_a7Xunb` | 5,930ms | 26ms | 228x |

## A disclosed behavior difference

The new method returns slightly fewer distinct merchants than the old one on long-running orgs — e.g. 2,187 vs 2,959 on Hack Club HQ. This is because it's scoped to `CardCharge`-linked `Ledger::Item`s that actually exist; some very old `canonical_transactions` predate the Ledger migration and were never backfilled with a corresponding `Ledger::Item`. Since the merchant filter isn't wired up to actually filter query results yet (`# TODO: add filtering for merchant` in `ledger_query`), this list is display-only today, and I think matching what's actually navigable on the Ledger page is more correct than the old event-wide scan, not less — but flagging it explicitly since the numbers differ.

## Tests

`spec/controllers/events_controller_spec.rb` covers both call sites through their actual rendered response (`render_views` + asserting on `response.body`, not internal controller state): the merchant name resolving into the active-filter badge, the generic fallback when a merchant isn't found, distinct merchants rendering most-transacted-first, and a direct assertion on `ledger_merchants`' return value for the exact per-merchant counts. The one I'd flag as most important given the scoping change: that another org's ledger doesn't leak into the merchant list.


