### PR TITLE
[Ledger] Add an index matching the ledger page's default sort

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -28,6 +28,7 @@
 #  index_ledger_items_on_amount_cents     (amount_cents)
 #  index_ledger_items_on_author_id        (author_id)
 #  index_ledger_items_on_datetime         (datetime)
+#  index_ledger_items_on_default_sort     ((\nCASE\n    WHEN ((status)::text = 'pending'::text) THEN 0\n    ELSE 1\nEND), datetime DESC, created_at DESC, id DESC)
 #  index_ledger_items_on_linked_object    (linked_object_type,linked_object_id)
 #  index_ledger_items_on_receipt_missing  (id) WHERE (receipt_required AND (marked_no_or_lost_receipt_at IS NULL) AND (receipt_count = 0))
 #  index_ledger_items_on_short_code       (short_code) UNIQUE

--- a/db/migrate/20260718150000_add_default_sort_index_to_ledger_items.rb
+++ b/db/migrate/20260718150000_add_default_sort_index_to_ledger_items.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddDefaultSortIndexToLedgerItems < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # Matches Ledger::Query#execute's default ORDER BY exactly (including sort
+    # direction per column) so a paginated fetch can walk this index in order
+    # and stop once it has enough rows, instead of sorting every matching row
+    # first.
+    add_index :ledger_items,
+              "(CASE WHEN (status = 'pending') THEN 0 ELSE 1 END), datetime DESC, created_at DESC, id DESC",
+              name: "index_ledger_items_on_default_sort",
+              algorithm: :concurrently
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_16_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_18_150000) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -1618,6 +1618,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_16_120000) do
     t.string "status"
     t.text "system_memo"
     t.datetime "updated_at", null: false
+    t.index "(\nCASE\n    WHEN ((status)::text = 'pending'::text) THEN 0\n    ELSE 1\nEND), datetime DESC, created_at DESC, id DESC", name: "index_ledger_items_on_default_sort"
     t.index ["amount_cents"], name: "index_ledger_items_on_amount_cents"
     t.index ["author_id"], name: "index_ledger_items_on_author_id"
     t.index ["datetime"], name: "index_ledger_items_on_datetime"

--- a/spec/models/ledger/query_spec.rb
+++ b/spec/models/ledger/query_spec.rb
@@ -551,4 +551,30 @@ RSpec.describe Ledger::Query, type: :model do
       expect(result.pluck(:id)).to match_array(ids_of(item_a, item_b, item_c, item_d, item_e, item_g))
     end
   end
+
+  describe "default sort index" do
+    it "has an index that can satisfy the default sort without a separate Sort step" do
+      # A tiny table like this test's fixtures would use a sequential scan
+      # regardless of any index, so disable that (and explicit sorting) to
+      # force Postgres to reveal whether an index-based plan is even
+      # possible. If the default ORDER BY in Ledger::Query#execute ever
+      # changes, this fails until a matching index is added/updated for it -
+      # otherwise every ledger page load pays to sort its entire result set
+      # before returning the first page.
+      ActiveRecord::Base.transaction do
+        connection = ActiveRecord::Base.connection
+        connection.execute("SET LOCAL enable_seqscan = off")
+        connection.execute("SET LOCAL enable_sort = off")
+
+        sql = execute_query({}).page(1).per(25).to_sql
+        plan = connection.execute("EXPLAIN #{sql}").pluck("QUERY PLAN").join("\n")
+
+        expect(plan).not_to match(/\bSort\b/),
+                            "Ledger::Query's default sort has no supporting index (Postgres had to fall back to " \
+                            "sorting even with sequential scans/sorts penalized):\n\n#{plan}"
+
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
 end

--- a/spec/models/ledger/query_spec.rb
+++ b/spec/models/ledger/query_spec.rb
@@ -573,6 +573,16 @@ RSpec.describe Ledger::Query, type: :model do
                             "Ledger::Query's default sort has no supporting index (Postgres had to fall back to " \
                             "sorting even with sequential scans/sorts penalized):\n\n#{plan}"
 
+        # The absence of a Sort node above only means "no supporting index"
+        # given an ORDER BY is actually present. On its own it can't tell
+        # "correctly ordered by an index" apart from "not ordered at all" -
+        # if execute()'s .order(...) were ever dropped, there'd be no Sort
+        # node either, and the check above would pass despite the real
+        # regression (unordered, unindexed results). Assert the index is
+        # actually the thing satisfying the order to close that gap.
+        expect(plan).to match(/Index( Only)? Scan using index_ledger_items_on_default_sort/),
+                        "Expected the default-sort index to back the query's ORDER BY:\n\n#{plan}"
+
         raise ActiveRecord::Rollback
       end
     end


### PR DESCRIPTION
> [!NOTE]
> **This PR was written by [Claude Code](https://claude.com/claude-code).** Gary directed the investigation and reviewed the changes, but the diagnosis, code, and benchmarks below were produced by Claude.

## Summary of the problem

`Ledger::Query#execute`'s default sort order — pending items first, then `datetime`/`created_at`/`id` descending — had no supporting index. That means even loading page 1 of a ledger with **no filters active at all** required Postgres to sort every single matching row before returning the first 25. This cost scales with total ledger size on every page view, not just deep pagination pages.

## Describe your changes

Added a functional index over the exact same `CASE` expression and sort directions the query already uses:

```ruby
add_index :ledger_items,
          "(CASE WHEN (status = 'pending') THEN 0 ELSE 1 END), datetime DESC, created_at DESC, id DESC",
          name: "index_ledger_items_on_default_sort"
```

Confirmed via `EXPLAIN` this changes the plan from `Sort` + `Parallel Hash Join` over the whole matching set to a `Nested Loop` driven by an `Index Scan` that's already in sorted order — so Postgres can stop as soon as it has 25 rows instead of sorting everything first.

## Benchmarks

Page-1 fetch, no filters, medians before → after:

| Org | Before | After |
|---|---|---|
| Hack Club HQ | 71.2ms | 20.4ms |
| HCB Operations | 80.5ms | 24.1ms |
| HCB Reimbursement Clearinghouse | 65.8ms | 12.4ms |
| `org_lbu5qR` | 58.5ms | 11.5ms |

70-81% faster across the board. The full spec suite for this area (`query_spec`, `item_spec`, events/card_grants/ledgers controller specs — 99 examples) passes unchanged, since this only changes the query plan, not the result set or its order.

## Regression test

Added a test asserting that `Ledger::Query`'s default sort order has a matching index — so if the `ORDER BY` in `execute()` ever changes without a corresponding index update, this fails instead of silently reintroducing the full-sort cost this PR fixes. It disables sequential scans and explicit sorting (`SET LOCAL enable_seqscan/enable_sort = off`) before checking `EXPLAIN`, which forces Postgres to reveal whether an index-based plan exists at all, rather than just picking whatever's cheapest for the spec's small fixture set (a tiny table would use a sequential scan regardless of any index, which would make a plain `EXPLAIN` check unreliable).

The test asserts two things: that the plan has no `Sort` node, and that it's actually `index_ledger_items_on_default_sort` doing the work. Both matter — asserting only the absence of a `Sort` node would also pass if the `ORDER BY` were ever removed from `execute()` entirely (nothing to sort → no `Sort` node → false green), which is exactly the regression this test exists to catch. Verified both assertions fail with a clear message (showing the actual plan) under the relevant regression, and pass against the current code.

## Not addressed here

The separate `COUNT(*)` Kaminari runs for pagination totals doesn't benefit from a sort-order index — counting doesn't care about order — and remains ~100-150ms on the largest ledger. `EXPLAIN` shows it choosing to sequentially scan all of `ledger_items` before joining down to one ledger's items, because the `status` filter alone isn't very selective (matches the large majority of rows). Fixing that would mean restructuring the query to drive from `ledger_mappings` first rather than adding an index, which is a bigger change — flagging it rather than chasing it in this PR.




