### PR TITLE
Replace query_count gem with Rails built-in query counting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,8 +162,6 @@ group :development, :test do
   gem "pry-rails", require: ENV["EXCLUDE_PRY"] != "true"
 end
 
-gem "query_count"
-
 gem "rack-mini-profiler", "~> 3.3"
 gem "stackprof" # used by `rack-mini-profiler` to provide flamegraphs
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,9 +658,6 @@ GEM
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
-    query_count (1.1.1)
-      activerecord (>= 4.2)
-      railties (>= 4.2)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -1055,7 +1052,6 @@ DEPENDENCIES
   public_activity (>= 3.0.2)
   puma (~> 6.6)
   pundit
-  query_count
   rack-attack
   rack-cors
   rack-mini-profiler (~> 3.3)

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -7,8 +7,8 @@
   </p>
 
   <% if !Rails.env.production? || auditor_signed_in? %>
-    <% @sql_count = QueryCount::Counter.counter %>
-    <% @sql_cached_count = QueryCount::Counter.counter_cache %>
+    <% @sql_cached_count = ActiveRecord::RuntimeRegistry.cached_queries_count %>
+    <% @sql_count = ActiveRecord::RuntimeRegistry.queries_count - @sql_cached_count %>
     <p class="text-center text-xs">
       Loaded using <%= @sql_count %> unique
       SQL <%= "query".pluralize @sql_count %> (+ <%= @sql_cached_count %>

--- a/app/views/application/_logo.html.erb
+++ b/app/views/application/_logo.html.erb
@@ -68,8 +68,8 @@
           <br>
         <% end %>
         <% unless Rails.env.production? %>
-          <% @sql_count = QueryCount::Counter.counter %>
-          <% @sql_cached_count = QueryCount::Counter.counter_cache %>
+          <% @sql_cached_count = ActiveRecord::RuntimeRegistry.cached_queries_count %>
+          <% @sql_count = ActiveRecord::RuntimeRegistry.queries_count - @sql_cached_count %>
           Used <%= @sql_count %> unique SQL <%= "query".pluralize @sql_count %> (+<%= @sql_cached_count %> cached).
           <br>
           Running on Rails <%= Rails::VERSION::STRING %> with Ruby <%= RUBY_VERSION %>.


### PR DESCRIPTION
## Summary of the problem

The `query_count` gem (v1.1.1) has been unmaintained since 2022, and its own README notes that Rails' built-in query counting supersedes it. HCB only uses it for the dev/auditor SQL query readout in the footer and dev menu popover, not as a test tool. On Rails 8 the gem is redundant.

## Describe your changes

- Replaced `QueryCount::Counter.counter` / `.counter_cache` with Rails 8's built-in `ActiveRecord::RuntimeRegistry.queries_count` / `.cached_queries_count` in `_footer.html.erb` and `_logo.html.erb`.
- Removed the gem from the `Gemfile` and `Gemfile.lock`.

Rails' `queries_count` includes cached queries, whereas the gem's `counter` counted only non-cached ones, so the "unique" value is derived as `queries_count - cached_queries_count` to preserve the existing display. The counters share the same per-request lifecycle Rails already uses for its request log line (reset at the start of each action, read live during view render), so the readout behaves as before.

One small, intentional difference: Rails excludes `BEGIN`/`COMMIT` from the count (the gem counted them), so write-heavy pages will show a slightly lower, more accurate query count.

No other references to the gem exist in the codebase. The `hcb_code_query_count` spec helper is built on `ActiveSupport::Notifications` and never used the gem, so it is unaffected.