### PR TITLE
[Ledger::Item] Use `transferred_at` for disbursements in `calculate_status`

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -168,7 +168,7 @@ class Ledger
     def calculate_status
       return :settled if linked_object_type == "Reimbursement::ExpensePayout"
       return :settled if linked_object_type == "Disbursement::Outgoing" && linked_object.counterparty.canonical_pending_transactions.fronted.any?
-      return :settled if linked_object_type.in?(["Disbursement::Outgoing", "Disbursement::Incoming"]) && linked_object.approved_at.present? && !linked_object.rejected? && !linked_object.errored?
+      return :settled if linked_object_type.in?(["Disbursement::Outgoing", "Disbursement::Incoming"]) && linked_object.transferred_at.present? && !linked_object.rejected? && !linked_object.errored?
       return :settled if canonical_pending_transactions.fronted.not_declined.revenue.any? && primary_ledger&.can_front_balance?
       return :pending if canonical_pending_transactions.unsettled.exists?
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some old disbursements don't have `approved_at` set so it is better to check the `transferred_at` method which also accounts for `in_transit_at`.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use `transferred_at` instead of `approved_at` when calculating the status for disbursements.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

