### PR TITLE
Add bin/ci with gitignore for bun.lock due to a bug in cssbundling-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@
 /node_modules
 /yarn-error.log
 
+# This project uses yarn; cssbundling-rails 1.4.2/1.4.3 treats yarn.lock as a
+# bun lockfile, so it runs `bun install` and generates bun.lock on machines
+# that have bun installed. Fixed upstream, should be gone in the release after
+# 1.4.3: https://github.com/rails/cssbundling-rails/pull/172
+/bun.lock
+/bun.lockb
+
 /public/assets
 .byebug_history
 

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../config/boot"
+require "active_support/continuous_integration"
+
+CI = ActiveSupport::ContinuousIntegration
+require_relative "../config/ci"

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Run using bin/ci
+
+CI.run do
+  step "Setup", "bin/setup --skip-server"
+
+  step "Style: Ruby", "bin/rubocop"
+
+  step "Security: Importmap vulnerability audit", "bin/importmap audit"
+  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+  step "Tests: Rails", "bin/rails test"
+  step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+
+  # Optional: Run system tests
+  # step "Tests: System", "bin/rails test:system"
+
+  # Optional: set a green GitHub commit status to unblock PR merge.
+  # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.
+  # if success?
+  #   step "Signoff: All systems go. Ready for merge and deploy.", "gh signoff"
+  # else
+  #   failure "Signoff: CI failed. Do not merge or deploy.", "Fix the issues and try again."
+  # end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Rails 8.1 introduces some setup for running CI locally. `bin/ci` and `config/ci.rb` are from the update generator. However, running these on a machine with bun installed uses bun incorrectly due to a bug that was fixed in https://github.com/rails/cssbundling-rails/pull/172

Since we probably won't switch to using local CI soon, this PR is just for reference