### PR TITLE
[Ledger::Item] Fix incorrect status for released card charges

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -175,6 +175,8 @@ class Ledger
       case linked_object_type
       when "CardCharge"
         return :released if uncaptured_stripe_authorization?
+
+        return :settled
       when "IncreaseCheck" # Increase checks use the same state for users canceling and ops rejecting
         return :canceled if linked_object.try(:rejected?) || linked_object.try(:increase_stopped?) || linked_object.try(:column_stopped?)
       end

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -408,7 +408,7 @@ class Ledger
     # An approved Stripe authorization that never settled was released without
     # capture, as opposed to being declined outright
     def uncaptured_stripe_authorization?
-      canonical_pending_transactions.any? { |cpt| cpt.raw_pending_stripe_transaction&.stripe_transaction&.dig("approved") }
+      canonical_transactions.none? && canonical_pending_transactions.any? { |cpt| cpt.raw_pending_stripe_transaction&.stripe_transaction&.dig("approved") }
     end
 
     def assign_linked_object!


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were setting the status as released for ledger items that had canonical transactions.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check if there are canonical transactions.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

