### PR TITLE
[RawPendingStripeServiceFeeTransaction] Make CPT and RPSSFT negative

### DIFF
--- a/app/services/stripe_service_fee_service/create_canonical_pending_transaction.rb
+++ b/app/services/stripe_service_fee_service/create_canonical_pending_transaction.rb
@@ -15,7 +15,7 @@ module StripeServiceFeeService
       ActiveRecord::Base.transaction do
         rpssft = stripe_service_fee.create_raw_pending_stripe_service_fee_transaction!(
           date_posted: stripe_service_fee.created_at.to_date,
-          amount_cents: stripe_service_fee.amount_cents
+          amount_cents: -stripe_service_fee.amount_cents
         )
 
         canonical_pending_transaction = CanonicalPendingTransaction.create!(

--- a/spec/services/stripe_service_fee_service/create_canonical_pending_transaction_spec.rb
+++ b/spec/services/stripe_service_fee_service/create_canonical_pending_transaction_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StripeServiceFeeService::CreateCanonicalPendingTransaction, type:
       rpssft = stripe_service_fee.reload.raw_pending_stripe_service_fee_transaction
 
       expect(rpssft).to be_present
-      expect(rpssft.amount_cents).to eq(stripe_service_fee.amount_cents)
+      expect(rpssft.amount_cents).to eq(-stripe_service_fee.amount_cents)
       expect(rpssft.date_posted).to eq(stripe_service_fee.created_at.to_date)
     end
 
@@ -33,7 +33,7 @@ RSpec.describe StripeServiceFeeService::CreateCanonicalPendingTransaction, type:
       canonical_pending_transaction = run
 
       expect(canonical_pending_transaction).to be_present
-      expect(canonical_pending_transaction.amount_cents).to eq(stripe_service_fee.amount_cents)
+      expect(canonical_pending_transaction.amount_cents).to eq(-stripe_service_fee.amount_cents)
       expect(canonical_pending_transaction.raw_pending_stripe_service_fee_transaction)
         .to eq(stripe_service_fee.reload.raw_pending_stripe_service_fee_transaction)
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were incorrectly creating positive CPTs.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Make the RPSSFT and the CPT use negative `amount_cents`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

