### PR TITLE
[Admin] Always show mark no / lost button

### DIFF
--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -111,7 +111,7 @@
       </section>
     <% end %>
 
-    <% if defined?(receiptable) && receiptable&.missing_receipt? %>
+    <% if defined?(receiptable) && (receiptable&.missing_receipt? || (admin_signed_in? && !receiptable&.no_or_lost_receipt?)) %>
       <div class="flex muted justify-end items-center mt1">
         <%= inline_icon "forbidden", size: 20 %>
         <%= link_to receiptable_mark_no_or_lost_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id), method: :post do %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Sometimes missing receipt logic is buggy and admins need to be able to mark a transaction as no or lost for the user. This should eventually be fixed by the new transaction engine.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Always show the mark no / lost button to admins unless the transaction has already been marked.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

