### PR TITLE
[Ledger] Always render bank fees as settled

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -166,7 +166,7 @@ class Ledger
     end
 
     def calculate_status
-      return :settled if linked_object_type == "Reimbursement::ExpensePayout"
+      return :settled if linked_object_type.in?(["Reimbursement::ExpensePayout", "BankFee"])
       return :settled if linked_object_type == "Disbursement::Outgoing" && linked_object.counterparty.canonical_pending_transactions.fronted.any?
       return :settled if linked_object_type.in?(["Disbursement::Outgoing", "Disbursement::Incoming"]) && linked_object.approved_at.present? && !linked_object.rejected? && !linked_object.errored?
       return :settled if canonical_pending_transactions.fronted.not_declined.revenue.any? && primary_ledger&.can_front_balance?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We don't want to confuse this week's "fake" transaction with the prior week's that hasn't settled yet.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Return `:settled` if the linked object is a bank fee.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

