### PR TITLE
Allow removing a primary ledger mapping

### DIFF
--- a/app/models/ledger/mapping.rb
+++ b/app/models/ledger/mapping.rb
@@ -58,7 +58,6 @@ class Ledger
       raise ArgumentError, "mapped_by must be present" if mapped_by.nil?
 
       mapped_by = nil if mapped_by == Ledger::Mapper::SYSTEM
-      
       if mapped_by.present? && ledger.nil?
         Ledger::Mapping.find_by(ledger_item:, on_primary_ledger: true)&.destroy! and return
       end

--- a/app/models/ledger/mapping.rb
+++ b/app/models/ledger/mapping.rb
@@ -58,6 +58,10 @@ class Ledger
       raise ArgumentError, "mapped_by must be present" if mapped_by.nil?
 
       mapped_by = nil if mapped_by == Ledger::Mapper::SYSTEM
+      
+      if mapped_by.present? && ledger.nil?
+        Ledger::Mapping.find_by(ledger_item:, on_primary_ledger: true)&.destroy! and return
+      end
 
       Ledger::Mapping.find_or_initialize_by(ledger_item:, on_primary_ledger: true).tap do |mapping|
         mapping.ledger = ledger


### PR DESCRIPTION
## Summary of the problem

Currently, when admins unmap a CT, it does not also automatically unmap the ledger item.


## Describe your changes

This PR fixes manual unmapping.