### PR TITLE
[Wise] Fix status colors

### DIFF
--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -178,11 +178,11 @@ class WiseTransfer < ApplicationRecord
 
   def status_color
     if pending?
-      :warning
+      :muted
     elsif approved?
       :blue
     elsif sent?
-      :purple
+      :blue
     elsif rejected? || failed?
       :error
     elsif deposited?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Wise had different status colors than the other transfer types.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Pending is now muted and sent is now blue.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

