### PR TITLE
[Ledger] Improve performance with Turbo

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -148,6 +148,10 @@ class EventsController < ApplicationController
     render partial: "events/home/users_chart", locals: { users: @users, timeframe: params[:timeframe], event: @event }
   end
 
+  def stats
+    authorize @event
+  end
+
   def transactions
     maybe_pending_invite = OrganizerPositionInvite.pending.find_by(user: current_user, event: @event)
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -33,6 +33,7 @@ class EventPolicy < ApplicationPolicy
   alias_method :transactions?, :show?
   alias_method :transactions_list?, :transactions?
   alias_method :merchants_filter?, :transactions?
+  alias_method :stats?, :show?
 
   def toggle_hidden?
     user&.admin?

--- a/app/views/events/ledger.html.erb
+++ b/app/views/events/ledger.html.erb
@@ -6,35 +6,30 @@
   <span class="flex-grow">Transactions</span>
 <% end %>
 
-<div class="statset mb-2">
-  <div class="stat">
-    <span class="stat__label">Account balance</span>
-    <%# this event has a fee credit (owes negative fees) %>
-    <% if @event.fee_balance_v2_cents < 0 %>
-      <span class="stat__value stat__value--no-space"><%= render_money_amount @event.balance_v2_cents %></span>
-      <span class="self-end" style="font-size: 10px;">+$<%= render_money_amount @event.fee_balance_v2_cents.abs %>
-        fee credit</span>
-    <% else %>
-    <span class="stat__value stat__value--no-space">
-      <%= render_money_amount(@event.balance_available_v2_cents) %>
-    </span>
-    <% end %>
-  </div>
+<%= turbo_frame_tag "event_stats", src: event_stats_path(@event) do %>
+  <div class="statset mb-2">
+    <div class="stat">
+      <span class="stat__label">Account balance</span>
+      <span class="stat__value stat__value--no-space">
+        —
+      </span>
+    </div>
 
-  <div class="stat stat--small">
-    <span class="stat__label">Total revenue</span>
-    <span class="stat__value stat__value--no-space">
-      <%= render_money_amount(@event.total_raised) %>
-    </span>
-  </div>
+    <div class="stat stat--small">
+      <span class="stat__label">Total revenue</span>
+      <span class="stat__value stat__value--no-space">
+        —
+      </span>
+    </div>
 
-  <div class="stat stat--small">
-    <span class="stat__label">Total expenses</span>
-    <span class="stat__value stat__value--no-space">
-      <%= render_money_amount(@event.total_spent_cents) %>
-    </span>
+    <div class="stat stat--small">
+      <span class="stat__label">Total expenses</span>
+      <span class="stat__value stat__value--no-space">
+        —
+      </span>
+    </div>
   </div>
-</div>
+<% end %>
 
 <%= render "callout", type: "info", title: "You're previewing the new ledger", footer: :questions, class: "mt-0" do %>
   HCB is working on a faster ledger to improve your experience. If you have any feedback, send it our way!

--- a/app/views/events/stats.html.erb
+++ b/app/views/events/stats.html.erb
@@ -1,0 +1,31 @@
+<%= turbo_frame_tag "event_stats" do %>
+  <div class="statset mb-2">
+    <div class="stat">
+      <span class="stat__label">Account balance</span>
+      <%# this event has a fee credit (owes negative fees) %>
+      <% if @event.fee_balance_v2_cents < 0 %>
+        <span class="stat__value stat__value--no-space"><%= render_money_amount @event.balance_v2_cents %></span>
+        <span class="self-end" style="font-size: 10px;">+$<%= render_money_amount @event.fee_balance_v2_cents.abs %>
+          fee credit</span>
+      <% else %>
+      <span class="stat__value stat__value--no-space">
+        <%= render_money_amount(@event.balance_available_v2_cents) %>
+      </span>
+      <% end %>
+    </div>
+
+    <div class="stat stat--small">
+      <span class="stat__label">Total revenue</span>
+      <span class="stat__value stat__value--no-space">
+        <%= render_money_amount(@event.total_raised) %>
+      </span>
+    </div>
+
+    <div class="stat stat--small">
+      <span class="stat__label">Total expenses</span>
+      <span class="stat__value stat__value--no-space">
+        <%= render_money_amount(@event.total_spent_cents) %>
+      </span>
+    </div>
+  </div>
+<% end %>

--- a/app/views/ledgers/_ledger.html.erb
+++ b/app/views/ledgers/_ledger.html.erb
@@ -1,71 +1,73 @@
 <%# locals: (ledger: nil, items:, table_only: true, filter: nil, show_fee: false) %>
 
-<% if !table_only && ledger.present? %>
-  <section class="details mb-4">
-    <div>
-      <strong>Type</strong>
-      <span><%= ledger.primary? ? "Primary Ledger" : "Non-Primary Ledger" %></span>
-    </div>
-
-    <% if ledger.event %>
+<%= turbo_frame_tag dom_id(ledger) do %>
+  <% if !table_only && ledger.present? %>
+    <section class="details mb-4">
       <div>
-        <strong>Event</strong>
-        <span><%= link_to ledger.event.name, event_path(ledger.event) %></span>
+        <strong>Type</strong>
+        <span><%= ledger.primary? ? "Primary Ledger" : "Non-Primary Ledger" %></span>
       </div>
-    <% end %>
 
-    <% if ledger.card_grant %>
+      <% if ledger.event %>
+        <div>
+          <strong>Event</strong>
+          <span><%= link_to ledger.event.name, event_path(ledger.event) %></span>
+        </div>
+      <% end %>
+
+      <% if ledger.card_grant %>
+        <div>
+          <strong>Card Grant</strong>
+          <span><%= link_to ledger.card_grant.name, card_grant_path(ledger.card_grant) %></span>
+        </div>
+      <% end %>
+
       <div>
-        <strong>Card Grant</strong>
-        <span><%= link_to ledger.card_grant.name, card_grant_path(ledger.card_grant) %></span>
+        <strong>Balance</strong>
+        <span><%= ledger.balance.format %></span>
       </div>
-    <% end %>
+    </section>
 
-    <div>
-      <strong>Balance</strong>
-      <span><%= ledger.balance.format %></span>
+    <h2>Ledger Items</h2>
+
+    <div class="flex items-center mb2 flex-col sm:flex-row">
+      <div class="flex-grow">
+        <%= page_entries_info items, entry_name: "item" %>
+      </div>
+      <%= paginate items %>
     </div>
-  </section>
+  <% end %>
 
-  <h2>Ledger Items</h2>
+  <% if defined?(filter) %>
+    <%= filter %>
+  <% end %>
 
-  <div class="flex items-center mb2 flex-col sm:flex-row">
-    <div class="flex-grow">
-      <%= page_entries_info items, entry_name: "item" %>
+  <% if items.any? %>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th><%# icon %></th>
+            <th>Date</th>
+            <th>Memo</th>
+            <th><%# receipt count %></th>
+            <th class="text-right">Amount</th>
+            <% admin_tool("", "th") do %>
+              Short Code
+            <% end %>
+            <th><%# user avatar %></th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "ledgers/pending_fee_transaction", locals: { ledger: } if show_fee && ledger.present? %>
+          <%= render partial: "ledger/item", collection: items, as: :item %>
+        </tbody>
+      </table>
     </div>
+
     <%= paginate items %>
-  </div>
-<% end %>
-
-<% if defined?(filter) %>
-  <%= filter %>
-<% end %>
-
-<% if items.any? %>
-  <div class="table-container">
-    <table>
-      <thead>
-        <tr>
-          <th><%# icon %></th>
-          <th>Date</th>
-          <th>Memo</th>
-          <th><%# receipt count %></th>
-          <th class="text-right">Amount</th>
-          <% admin_tool("", "th") do %>
-            Short Code
-          <% end %>
-          <th><%# user avatar %></th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: "ledgers/pending_fee_transaction", locals: { ledger: } if show_fee && ledger.present? %>
-        <%= render partial: "ledger/item", collection: items, as: :item %>
-      </tbody>
-    </table>
-  </div>
-
-  <%= paginate items %>
-<% else %>
-  <%= blankslate "This ledger has no items yet" %>
+  <% else %>
+    <%= blankslate "This ledger has no items yet" %>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -991,6 +991,7 @@ Rails.application.routes.draw do
     get "transactions"
     get "transactions_list"
     get "ledger"
+    get "stats"
     get "merchants_filter"
     put "toggle_hidden"
     post "claim_point_of_contact"


### PR DESCRIPTION
## Summary of the problem

The recent addition of the balance, total raised, and total spent statistics is slowing down the new ledger. Eventually we will completely switch them over to use the new ledger, which will make them a lot faster, but in the meantime we need to come up with another solution.


## Describe your changes

This PR converts the statistics that are still computed from the old transaction engine into an async Turbo frame. To prevent them from refreshing every time the user navigates to a different page, I've also moved the ledger into a regular Turbo frame (not async).