### PR TITLE
Store merchant info on CardCharge

### DIFF
--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -114,11 +114,8 @@ class CardCharge < ApplicationRecord
   end
 
   def set_merchant_data
-    self.merchant_network_id ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "network_id") ||
-                                 raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "network_id") }.compact.first
-
-    self.merchant_category ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "category") ||
-                               raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "category") }.compact.first
+    self.merchant_network_id ||= merchant_data&.[]("network_id")
+    self.merchant_category ||= merchant_data&.[]("category")
   end
 
 end

--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -36,6 +36,8 @@ class CardCharge < ApplicationRecord
       )
   }
 
+  before_create :set_merchant_data
+
   def stripe_card
     (raw_stripe_transactions.last || raw_pending_stripe_transaction)&.stripe_card
   end
@@ -107,6 +109,14 @@ class CardCharge < ApplicationRecord
     raw_stripe_transaction.association(:card_charge).reset
 
     charge
+  end
+
+  def set_merchant_data
+    self.merchant_network_id ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "network_id") ||
+                                raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "network_id") }.compact.first
+
+    self.merchant_category ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "category") ||
+                              raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "category") }.compact.first
   end
 
 end

--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -5,8 +5,10 @@
 # Table name: card_charges
 #
 #  id                                :bigint           not null, primary key
+#  merchant_category                 :string
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
+#  merchant_network_id               :string
 #  raw_pending_stripe_transaction_id :bigint
 #
 # Indexes

--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -113,10 +113,10 @@ class CardCharge < ApplicationRecord
 
   def set_merchant_data
     self.merchant_network_id ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "network_id") ||
-                                raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "network_id") }.compact.first
+                                 raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "network_id") }.compact.first
 
     self.merchant_category ||= raw_pending_stripe_transaction&.stripe_transaction&.dig("merchant_data", "category") ||
-                              raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "category") }.compact.first
+                               raw_stripe_transactions.map { |rst| rst.stripe_transaction&.dig("merchant_data", "category") }.compact.first
   end
 
 end

--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -89,7 +89,14 @@ class CardCharge < ApplicationRecord
 
       existing
     else
-      create!(raw_pending_stripe_transaction:)
+      charge = create!(raw_pending_stripe_transaction:)
+
+      # set_merchant_data reads raw_stripe_transactions in a before_create hook,
+      # which caches the (empty) collection on this instance. Reset it so the
+      # charge picks up transactions that settle onto it later.
+      charge.association(:raw_stripe_transactions).reset
+
+      charge
     end
   end
 

--- a/db/migrate/20260720210532_add_merchant_network_id_and_merchant_category_to_card_charge.rb
+++ b/db/migrate/20260720210532_add_merchant_network_id_and_merchant_category_to_card_charge.rb
@@ -1,0 +1,6 @@
+class AddMerchantNetworkIdAndMerchantCategoryToCardCharge < ActiveRecord::Migration[8.0]
+  def change
+    add_column :card_charges, :merchant_network_id, :string
+    add_column :card_charges, :merchant_category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_16_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_20_210532) do
+  create_schema "fivetran_metadata"
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database
@@ -461,6 +462,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_16_120000) do
 
   create_table "card_charges", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "merchant_category"
+    t.string "merchant_network_id"
     t.bigint "raw_pending_stripe_transaction_id"
     t.datetime "updated_at", null: false
     t.index ["raw_pending_stripe_transaction_id"], name: "index_card_charges_on_raw_pending_stripe_transaction_id", unique: true


### PR DESCRIPTION
## Summary of the problem

Right now, the only way to query or render merchant information for a CardCharge is by looking up a RawPendingStripeTransactions or the RawStripeTransactions.


## Describe your changes

Store merchant info on CardCharge before_create.