### PR TITLE
[CardCharge] Use merchant columns for icon method

### DIFF
--- a/app/models/card_charge.rb
+++ b/app/models/card_charge.rb
@@ -57,13 +57,12 @@ class CardCharge < ApplicationRecord
   end
 
   def icon
-    merchant = YellowPages::Merchant.lookup(network_id: merchant_data["network_id"])
-    category = merchant_data["category"]
-    categorised_category = BreakdownEngine::Categorizer.new(category).run
+    merchant = YellowPages::Merchant.lookup(network_id: merchant_network_id)
+    categorised_category = BreakdownEngine::Categorizer.new(merchant_category).run
 
     if merchant.icon.present?
       merchant
-    elsif %w[passenger_railways railroads commuter_transport_and_ferries].include?(category)
+    elsif %w[passenger_railways railroads commuter_transport_and_ferries].include?(merchant_category)
       "train"
     elsif categorised_category == "Food"
       "food"


### PR DESCRIPTION
## Summary of the problem

CardCharge now has the merchant data that we need, so we no longer need to look up the RawStripeTransaction(s) or RawPendingStripeTransaction.


## Describe your changes

This PR changes `CardCharge#icon` to use first-party CardCharge data instead of looking up the raw / raw pending transaction types.