### PR TITLE
[User::Session] Stop creating a session on every anonymous request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,6 @@ class ApplicationController < ActionController::Base
   # that you want to be unauthenticated with skip_before_action.
   before_action :signed_in_user
 
-  before_action :ensure_created_session
-
   # Track papertrail edits to specific users
   before_action :set_paper_trail_whodunnit
 

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -32,7 +32,10 @@ class LoginsController < ApplicationController
 
     @user = User.create_with(creation_method: @login.for_application? ? :application_form : :login).find_or_create_by!(email: params[:email])
 
-    current_session.referral_attributions.each do |attribution|
+    # An anonymous visitor only has a session if they arrived via a referral
+    # link (see Referral::LinksController#show). No session means no clicks to
+    # attribute, so there is nothing to transfer.
+    current_session&.referral_attributions&.each do |attribution|
       attribution.update!(user: @user)
     end
 

--- a/app/controllers/referral/links_controller.rb
+++ b/app/controllers/referral/links_controller.rb
@@ -10,6 +10,15 @@ module Referral
       if @link
         authorize @link
 
+        # An anonymous visitor needs a session for the attribution to hang off
+        # of, so it can be bound to a user once they sign up. This is the only
+        # place that creates one; every other reader of an anonymous session
+        # only cares about a session a referral click already created.
+        #
+        # Created only once the link is known to be real, so bogus slugs don't
+        # mint throwaway sessions.
+        ensure_created_session
+
         Rails.error.handle do
           Referral::Attribution.create!(user: current_user, user_session: current_session, program: @link.program, link: @link)
         end

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -122,7 +122,10 @@ module Users
         @user.creation_method = :first_robotics_form
         @user.save!
 
-        current_session.referral_attributions.where(user_id: nil).find_each do |attribution|
+        # An anonymous visitor only has a session if they arrived via a
+        # referral link (see Referral::LinksController#show). No session means
+        # no clicks to attribute, so there is nothing to transfer.
+        current_session&.referral_attributions&.where(user_id: nil)&.find_each do |attribution|
           attribution.update!(user: @user)
         end
 
@@ -138,7 +141,7 @@ module Users
 
       @user = User.find_by!(email: user_params[:email])
 
-      current_session.referral_attributions.where(user_id: nil).find_each do |attribution|
+      current_session&.referral_attributions&.where(user_id: nil)&.find_each do |attribution|
         attribution.update!(user: @user)
       end
 

--- a/app/jobs/user/session/delete_anonymous_sessions_job.rb
+++ b/app/jobs/user/session/delete_anonymous_sessions_job.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class User
+  class Session
+    # Deletes the throwaway sessions minted for visitors who never signed in.
+    #
+    # These came from the global `ensure_created_session` before_action: every
+    # request from a client that didn't retain cookies (crawlers, webhook
+    # senders, API consumers) created a session row plus a matching PaperTrail
+    # version, growing `user_sessions` into the tens of millions of rows.
+    #
+    # `ensure_created_session` has since been narrowed to referral link clicks,
+    # which stops the bulk of these from being created, but a click that never
+    # leads to a signup still leaves one behind. So this runs on a schedule
+    # rather than once, draining the existing backlog along the way.
+    class DeleteAnonymousSessionsJob < ApplicationJob
+      queue_as :low
+
+      BATCH_SIZE = 1_000
+
+      # Bounds the work per run: keeps an invocation short enough that the
+      # schedule can't start a second run on top of a first (nothing else
+      # enforces uniqueness), and spreads out the dead tuples and WAL a bulk
+      # delete generates so autovacuum can keep pace.
+      MAX_PER_RUN = 500_000
+
+      # @return [Integer] the number of sessions deleted
+      def perform(max_per_run: MAX_PER_RUN)
+        deleted = 0
+
+        deletable.in_batches(of: BATCH_SIZE) do |batch|
+          deleted += purge(batch.pluck(:id))
+          break if deleted >= max_per_run
+        end
+
+        deleted
+      end
+
+      private
+
+      # Sessions that never became real ones:
+      #
+      #   - `user_id` is nil, so the session never authenticated. Nothing
+      #     assigns a user to an already-persisted session (signing in mints a
+      #     new one), so this can't be a session that signed in and detached.
+      #   - it has already expired, so no visitor is mid-signup on it.
+      #   - no `Referral::Attribution` points at it. Those carry signup
+      #     attribution, and the FK is ON DELETE NO ACTION, so deleting one
+      #     would raise anyway.
+      def deletable
+        User::Session
+          .where(user_id: nil)
+          .expired
+          .where.not(id: Referral::Attribution.where.not(user_session_id: nil).select(:user_session_id))
+      end
+
+      # Every reference to `user_sessions` was audited before writing this:
+      # incoming foreign keys, `logins.user_session_id` (which has no FK, only
+      # `Login`'s own validations), `governance_request_contexts`, and every
+      # polymorphic `*_type` column. Only two things point at anonymous
+      # sessions, and both go with them:
+      #
+      #   - PaperTrail versions. One per insert, plus an update version for a
+      #     session that went through `SessionsHelper#sign_out`, which uses
+      #     `update` rather than `update_columns`.
+      #   - `user_session.create` activities with a null owner, null recipient
+      #     and no parameters, left by a callback that fired for anonymous
+      #     sessions until bf0e737f4 guarded it.
+      #
+      # Rows are removed with `delete_all` so the PaperTrail callback doesn't
+      # write a fresh version per destroy. The three deletes share a
+      # transaction so a failure on the last one can't leave a session alive
+      # with its audit trail already stripped.
+      #
+      # @return [Integer] the number of sessions deleted
+      def purge(ids)
+        return 0 if ids.empty?
+
+        User::Session.transaction do
+          PaperTrail::Version.where(item_type: "User::Session", item_id: ids).delete_all
+          PublicActivity::Activity.where(trackable_type: "User::Session", trackable_id: ids).delete_all
+          User::Session.where(id: ids).delete_all
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -193,6 +193,11 @@ clear_old_user_sessions:
   class: "User::Session::ClearOldUserSessionsJob"
   queue: low
 
+delete_anonymous_user_sessions:
+  cron: "20 * * * *" # run every 1 hour
+  class: "User::Session::DeleteAnonymousSessionsJob"
+  queue: low
+
 card_grant_expiration_job:
   cron: "0 0 * * *" # run every 1 day
   class: "CardGrant::ExpirationJob"

--- a/spec/jobs/user/session/delete_anonymous_sessions_job_spec.rb
+++ b/spec/jobs/user/session/delete_anonymous_sessions_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User::Session::DeleteAnonymousSessionsJob do
+  def anonymous_session(expiration_at: 1.day.ago)
+    create(:user_session, user: nil, expiration_at:)
+  end
+
+  it "deletes an expired anonymous session" do
+    session = anonymous_session
+
+    expect { described_class.perform_now }.to change { User::Session.exists?(session.id) }.from(true).to(false)
+  end
+
+  it "deletes the session's PaperTrail versions", versioning: true do
+    session = anonymous_session
+    versions = PaperTrail::Version.where(item_type: "User::Session", item_id: session.id)
+    expect(versions).to exist
+
+    described_class.perform_now
+
+    expect(versions.reload).not_to exist
+  end
+
+  it "deletes the ownerless activities left by the pre-bf0e737f4 callback" do
+    session = anonymous_session
+    PublicActivity::Activity.create!(trackable: session, key: "user_session.create")
+
+    described_class.perform_now
+
+    expect(PublicActivity::Activity.where(trackable_type: "User::Session", trackable_id: session.id)).not_to exist
+  end
+
+  it "keeps a session that has authenticated" do
+    session = create(:user_session, user: create(:user), expiration_at: 1.day.ago)
+
+    described_class.perform_now
+
+    expect(User::Session.exists?(session.id)).to be true
+  end
+
+  it "keeps an unexpired anonymous session so a visitor mid-signup isn't logged out" do
+    session = anonymous_session(expiration_at: 1.day.from_now)
+
+    described_class.perform_now
+
+    expect(User::Session.exists?(session.id)).to be true
+  end
+
+  it "keeps an anonymous session that carries a referral attribution" do
+    session = anonymous_session
+    creator = create(:user)
+    program = Referral::Program.create!(name: "Test Program", creator:)
+    link = Referral::Link.create!(program:, creator:, name: "Test Link")
+    Referral::Attribution.create!(user_session: session, program:, link:)
+
+    described_class.perform_now
+
+    expect(User::Session.exists?(session.id)).to be true
+  end
+
+  it "stops once the per-run limit is reached so a single run does bounded work" do
+    Array.new(3) { anonymous_session }
+
+    stub_const("#{described_class}::BATCH_SIZE", 1)
+    deleted = described_class.new.perform(max_per_run: 2)
+
+    expect(deleted).to eq(2)
+    expect(User::Session.where(user_id: nil).count).to eq(1)
+  end
+end

--- a/spec/requests/logins_controller_spec.rb
+++ b/spec/requests/logins_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "LoginsController", type: :request do
+  let(:creator) { create(:user, verified: true) }
+  let(:program) { Referral::Program.create!(name: "Referral test program", creator:) }
+  let(:link)    { program.links.create!(name: "Primary", creator:) }
+
+  describe "POST /logins" do
+    it "binds a prior referral click to the user signing in" do
+      get "/referrals/#{link.slug}"
+      attribution = Referral::Attribution.last
+      expect(attribution.user).to be_nil
+
+      email = "referred-#{SecureRandom.hex(4)}@example.invalid"
+      post "/logins", params: { email:, login: { return_to: "/" } }
+
+      expect(attribution.reload.user).to eq(User.find_by(email:))
+    end
+
+    # `#create` rescues everything and redirects to the auth page, so a nil
+    # session would surface as a confusing flash rather than a 500.
+    it "completes for a visitor who never clicked a referral link and so has no session" do
+      email = "direct-#{SecureRandom.hex(4)}@example.invalid"
+
+      expect {
+        post "/logins", params: { email:, login: { return_to: "/" } }
+      }.to change { Login.count }.by(1)
+
+      expect(response).not_to redirect_to(auth_users_path)
+    end
+  end
+end

--- a/spec/requests/referral/links_controller_spec.rb
+++ b/spec/requests/referral/links_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Referral::LinksController", type: :request do
+  let(:creator) { create(:user, verified: true) }
+  let(:program) { Referral::Program.create!(name: "Referral test program", creator:) }
+  let(:link)    { program.links.create!(name: "Primary", creator:) }
+
+  describe "GET /referrals/:slug" do
+    it "creates a session for an anonymous visitor so the attribution can bind on signup" do
+      expect { get "/referrals/#{link.slug}" }.to change { User::Session.count }.by(1)
+
+      expect(Referral::Attribution.last.user_session).to eq(User::Session.last)
+    end
+
+    it "does not create a session for an unrecognized slug" do
+      expect { get "/referrals/not-a-real-slug" }.not_to(change { User::Session.count })
+    end
+  end
+
+  it "does not create a session for an ordinary anonymous request" do
+    expect { get funders_path }.not_to(change { User::Session.count })
+  end
+end

--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -116,6 +116,9 @@ RSpec.describe "Users::FirstController", type: :request do
 
   describe "DELETE /first/sign_out" do
     it "clears the session_token cookie" do
+      post "/first", params: valid_form
+      expect(cookies["session_token"]).to be_present, "expected signup to establish a session to sign out of"
+
       delete "/first/sign_out"
 
       set_cookie_header = response.headers["Set-Cookie"].to_s


### PR DESCRIPTION
## Summary of the problem

`ensure_created_session` has been a global `before_action` on `ApplicationController` since 436cc6dc0 (Apr 27). It runs on every request reaching a controller that skips `signed_in_user`: the public API, stats, marketing pages, Discord webhooks, donation flows, error pages. Any client that doesn't retain cookies (crawlers, webhook senders, API consumers) mints a fresh `User::Session` on every single request, each with a matching PaperTrail version.

Anonymous rows went from none to dominating the table, starting the week of that commit:

| Month | New sessions with `user_id IS NULL` |
| --- | --- |
| Jan to Mar 2026 | 0 |
| Apr 2026 | 307k |
| May 2026 | 5.35M |
| Jun 2026 | 5.66M |
| Jul 2026 (18d) | 7.62M |

`user_sessions` is now into the tens of millions of rows at 5.8 GB, plus `User::Session` versions accounting for 59% of the 19 GB `versions` table, and the disk is close to full. Of those anonymous rows, none have an associated `Login` and only 0.02% ever received a referral attribution.

## Describe your changes

**Stop creating them.** The only feature needing a session for an anonymous visitor is referral attribution, so `ensure_created_session` moves to `Referral::LinksController#show`, called after the link is known to be real so bogus slugs don't mint throwaway sessions.

That makes `current_session` nil again for anonymous visitors, which is what the rest of the app already assumes (it was nil for all anonymous traffic before Apr 27, and nearly every reader already uses `&.`). The remaining non-nil-safe readers are all behind `signed_in_user`. The two sites that transfer referral attributions were written after the global before_action landed, so they assumed non-nil; they now handle nil, where nil means no referral click happened and therefore nothing to transfer.

**Clean up the backlog.** `User::Session::DeleteAnonymousSessionsJob` runs hourly and deletes anonymous sessions that are expired (so nobody mid-signup is logged out) and carry no referral attribution. Work is capped per run so the schedule can't stack runs on itself and so the dead tuples and WAL from a bulk delete stay within reach of autovacuum.

Every reference to `user_sessions` in the schema was audited before writing the delete: the FK graph, `logins.user_session_id`, `governance_request_contexts`, and every polymorphic `*_type` column. Only two things point at these rows, and both are removed alongside them:

- PaperTrail versions, one per insert.
- Ownerless `user_session.create` activities (null owner, null recipient, no parameters) left by the callback fixed in bf0e737f4.

Deletes use `delete_all` so PaperTrail doesn't write a fresh version per destroy.

### Verification

- New job spec covers each deletion criterion and each class of row that must survive.
- Full controller and request suites pass (281 examples), including the referral attribution end to end tests that prove the narrowed before_action still attributes correctly.
- Dry run of the job inside a transaction, then rolled back: 5,000 sessions and 5,006 versions deleted with no FK violations. The 6 extra versions are sign-outs, since `SessionsHelper#sign_out` uses `.update` rather than `update_columns`.

One spec changed: the FIRST sign-out test asserted against a `session_token` cookie that `ensure_created_session` minted on that same request (Rails' `CookieJar#delete` no-ops when the cookie isn't in the jar), so it was passing on a cookie it had just created. It now signs up first so there is a real session to clear.

### Note for deploy

Deleting rows will not shrink the files on disk. Reclaiming space needs a `VACUUM FULL` or `pg_repack` afterwards, best done on `user_sessions` first (~71 MB of scratch space to free ~5.7 GB) and then `versions` (~8 GB scratch to free ~11 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
