### PR TITLE
[Event] Only force transparency for Argosy sub-organizations

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -65,7 +65,7 @@ class EventMailer < ApplicationMailer
   end
 
   def transparency_mode_enabled
-    @can_disable_transparency = @event.eligible_for_disabling_transparency?
+    @can_disable_transparency = !@event.forced_transparency?
     mail to: @emails, subject: "#{@event.name} has enabled transparency mode"
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -876,8 +876,12 @@ class Event < ApplicationRecord
     !plan.is_a?(Event::Plan::SalaryAccount)
   end
 
-  def eligible_for_disabling_transparency?
-    !parent&.is_public?
+  def forced_transparency?
+    # `plan` is built by a later `before_validation` callback, so it can still
+    # be nil the first time this runs on a new record.
+    return false unless plan&.forces_transparency?
+
+    parent&.is_public? || false
   end
 
   def eligible_for_indexing?
@@ -1027,7 +1031,7 @@ class Event < ApplicationRecord
       self.is_indexable = false
     end
 
-    unless eligible_for_disabling_transparency?
+    if forced_transparency?
       self.is_public = true
     end
 

--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -59,6 +59,12 @@ class Event
       {}
     end
 
+    # Organizations on plans that force transparency can't opt out of it while
+    # their parent organization is transparent.
+    def forces_transparency?
+      false
+    end
+
     def was_backfilled?
       created_at < Date.new(2024, 8, 24)
     end

--- a/app/models/event/plan/argosy_2025.rb
+++ b/app/models/event/plan/argosy_2025.rb
@@ -39,6 +39,10 @@ class Event
         { is_public: true }
       end
 
+      def forces_transparency?
+        true
+      end
+
       def contract_skip_prefills
         {
           "Contract Signee" => ["The Project"]

--- a/app/models/event/plan/argosy_2026.rb
+++ b/app/models/event/plan/argosy_2026.rb
@@ -39,6 +39,10 @@ class Event
         { is_public: true }
       end
 
+      def forces_transparency?
+        true
+      end
+
       def contract_skip_prefills
         {
           "Contract Signee" => ["The Project"]

--- a/spec/models/event/plan_spec.rb
+++ b/spec/models/event/plan_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Event::Plan, type: :model do
+  describe "#forces_transparency?" do
+    it "is false by default" do
+      expect(Event::Plan::Standard.new.forces_transparency?).to eq(false)
+    end
+
+    it "is true for the 2025 and 2026 Argosy plans" do
+      expect(Event::Plan::Argosy2025.new.forces_transparency?).to eq(true)
+      expect(Event::Plan::Argosy2026.new.forces_transparency?).to eq(true)
+    end
+
+    it "is true for plans inheriting from an Argosy plan" do
+      expect(Event::Plan::ArgosyFtcSim2025.new.forces_transparency?).to eq(true)
+    end
+
+    it "is false for the 2024 Argosy plan" do
+      expect(Event::Plan::Argosy2024.new.forces_transparency?).to eq(false)
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -93,6 +93,58 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#forced_transparency?" do
+    let(:public_parent) { create(:event, is_public: true) }
+    let(:private_parent) { create(:event, is_public: false) }
+
+    it "is true for an Argosy event under a transparent parent" do
+      event = create(:event, parent: public_parent, plan_type: Event::Plan::Argosy2025)
+
+      expect(event.forced_transparency?).to eq(true)
+    end
+
+    it "is false for an Argosy event under a non-transparent parent" do
+      event = create(:event, parent: private_parent, plan_type: Event::Plan::Argosy2026)
+
+      expect(event.forced_transparency?).to eq(false)
+    end
+
+    it "is false for an Argosy event with no parent" do
+      event = create(:event, plan_type: Event::Plan::Argosy2026)
+
+      expect(event.forced_transparency?).to eq(false)
+    end
+
+    it "is false for a non-Argosy event under a transparent parent" do
+      event = create(:event, parent: public_parent, plan_type: Event::Plan::FeeWaived)
+
+      expect(event.forced_transparency?).to eq(false)
+    end
+  end
+
+  describe "transparency enforcement" do
+    it "forces transparency on an Argosy event under a transparent parent" do
+      parent = create(:event, is_public: true)
+      event = create(:event, parent:, is_public: false, plan_type: Event::Plan::Argosy2025)
+
+      expect(event.is_public).to eq(true)
+    end
+
+    it "leaves a non-Argosy event under a transparent parent alone" do
+      parent = create(:event, is_public: true)
+      event = create(:event, parent:, is_public: false)
+
+      expect(event.is_public).to eq(false)
+    end
+
+    it "removes transparency from an event that is ineligible for it" do
+      event = create(:event, is_public: true, plan_type: Event::Plan::SalaryAccount)
+
+      expect(event.is_public).to eq(false)
+      expect(event.is_indexable).to eq(false)
+    end
+  end
+
   describe "#ancestor_ids" do
     it "returns ids ordered from self to root" do
       root = create(:event)


### PR DESCRIPTION
## Summary of the problem

Any organization whose parent organization was transparent had transparency mode forced on and could not turn it off. That rule should only apply to Argosy grantees, not to every sub-organization.

## Describe your changes

Narrows the forcing rule to organizations on the 2025 and 2026 Argosy plans, via a new `Event::Plan#forces_transparency?` predicate. It returns `false` on the base plan and `true` on `Argosy2025` / `Argosy2026`, so the rule lives with the plan rather than as a type check in `Event`. `ArgosyFtcSim2025` inherits from `Argosy2025`, so it is covered too.

`Event#eligible_for_disabling_transparency?` becomes `Event#forced_transparency?`, which reads better at both call sites. The transparency mode mailer uses its inverse to decide whether to tell managers they can turn transparency off.

Note that `plan` can still be nil the first time `forced_transparency?` runs on a new record: the fallback plan is built by a `before_validation` callback registered after the transparency one, hence the nil guard.

Specs cover the plan predicate (including inheritance) and the enforcement behavior on the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)