### PR TITLE
[Ledger] Make styling match old ledger

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -147,6 +147,12 @@ html[data-dark='true'] {
   }
 }
 
+// Grey out the memo for pending transactions. The memo link uses
+// `color: inherit`, so setting the cell's color muted greys it in both themes.
+.transaction__memo--pending {
+  color: map-get($palette, muted);
+}
+
 // Fills the remaining table width and truncates with an ellipsis instead of
 // widening the table (max-width: 0 keeps the content from sizing the cell)
 .transaction__memo--fluid {

--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -105,7 +105,6 @@ html[data-dark='true'] {
       content: '';
       position: absolute;
       inset: -0.25rem 0;
-      
     }
   }
 

--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -98,10 +98,6 @@ html[data-dark='true'] {
     color: inherit;
     text-decoration: none;
 
-    &:hover {
-      text-decoration: underline;
-    }
-
     // Enlarge the vertical touch target without affecting row height: an
     // absolutely-positioned overlay extends the clickable area above and below
     // while staying out of layout flow.
@@ -109,6 +105,7 @@ html[data-dark='true'] {
       content: '';
       position: absolute;
       inset: -0.25rem 0;
+      
     }
   }
 

--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -75,6 +75,10 @@
 }
 
 html[data-dark='true'] {
+  .transaction__memo a {
+    color: inherit;
+  }
+
   .transaction--frc {
     color: $white;
 
@@ -105,7 +109,7 @@ html[data-dark='true'] {
       content: '';
       position: absolute;
       inset: -0.25rem 0;
-      
+
     }
   }
 

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -11,14 +11,15 @@
   <td><%= item.datetime.strftime("%b %e, %Y") %></td>
   <td class="transaction__memo transaction__memo--fluid<%= " transaction__memo--pending" if item.pending? %>">
     <div>
-      <div class="flex-auto flex items-center" style="gap: 1ch; min-width: 0;">
-        <% if item.status.present? && !item.settled? %>
-          <%= badge_for item.status_text, class: item.status_css %>
-        <% end %>
-        <%# the tooltip wraps the memo alone so that it stays centered on it, not on the status badge %>
-        <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="min-width: 0; overflow: hidden; text-overflow: ellipsis;">
-          <%= link_to item.memo, ledger_item_path(item),
-                      data: popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false } %>
+      <div class="flex-auto flex flex-wrap items-center" style="gap: 0.25rem 1ch; min-width: 0;">
+        <div class="flex items-center" style="gap: 1ch; min-width: 0;">
+          <% if item.status.present? && !item.settled? %>
+            <%= badge_for item.status_text, class: item.status_css %>
+          <% end %>
+          <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="min-width: 0; overflow: hidden; text-overflow: ellipsis;">
+            <%= link_to item.memo, ledger_item_path(item),
+                        data: popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false } %>
+          </div>
         </div>
 
         <%= render "ledger/items/tags", item: %>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -9,7 +9,7 @@
     </div>
   </td>
   <td><%= item.datetime.strftime("%b %e, %Y") %></td>
-  <td class="transaction__memo transaction__memo--fluid">
+  <td class="transaction__memo transaction__memo--fluid<%= " transaction__memo--pending" if item.pending? %>">
     <div>
       <div class="flex-auto flex items-center" style="gap: 1ch; min-width: 0;">
         <% if item.status.present? && !item.settled? %>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -11,12 +11,12 @@
   <td><%= item.datetime.strftime("%b %e, %Y") %></td>
   <td class="transaction__memo transaction__memo--fluid<%= " transaction__memo--pending" if item.pending? %>">
     <div>
-      <div class="flex-auto flex flex-wrap items-center" style="gap: 0.25rem 1ch; min-width: 0;">
-        <div class="flex items-center" style="gap: 1ch; min-width: 0;">
+      <div class="flex-auto flex flex-wrap items-center gap-y-1 gap-x-[1ch] min-w-0">
+        <div class="flex items-center gap-[1ch] min-w-0">
           <% if item.status.present? && !item.settled? %>
             <%= badge_for item.status_text, class: item.status_css %>
           <% end %>
-          <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="min-width: 0; overflow: hidden; text-overflow: ellipsis;">
+          <div class="tooltipped tooltipped--s min-w-0 overflow-hidden text-ellipsis" aria-label="<%= item.memo %>">
             <%= link_to item.memo, ledger_item_path(item),
                         data: popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false } %>
           </div>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -11,11 +11,12 @@
   <td><%= item.datetime.strftime("%b %e, %Y") %></td>
   <td class="transaction__memo transaction__memo--fluid">
     <div>
-      <div class="flex-auto">
+      <div class="flex-auto flex items-center" style="gap: 1ch; min-width: 0;">
         <% if item.status.present? && !item.settled? %>
           <%= badge_for item.status_text, class: item.status_css %>
         <% end %>
-        <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="display: inline-block; max-width: 100%; vertical-align: top; overflow: hidden; text-overflow: ellipsis;">
+        <%# the tooltip wraps the memo alone so that it stays centered on it, not on the status badge %>
+        <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="min-width: 0; overflow: hidden; text-overflow: ellipsis;">
           <%= link_to item.memo, ledger_item_path(item),
                       data: popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false } %>
         </div>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -12,10 +12,10 @@
   <td class="transaction__memo transaction__memo--fluid">
     <div>
       <div class="flex-auto">
-        <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="overflow: hidden; text-overflow: ellipsis;">
-          <% if item.status.present? && !item.settled? %>
-            <%= badge_for item.status_text, class: item.status_css %>
-          <% end %>
+        <% if item.status.present? && !item.settled? %>
+          <%= badge_for item.status_text, class: item.status_css %>
+        <% end %>
+        <div class="tooltipped tooltipped--s" aria-label="<%= item.memo %>" style="display: inline-block; max-width: 100%; vertical-align: top; overflow: hidden; text-overflow: ellipsis;">
           <%= link_to item.memo, ledger_item_path(item),
                       data: popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false } %>
         </div>


### PR DESCRIPTION
Improves styling for the new ledger

<img width="666" height="125" alt="image" src="https://github.com/user-attachments/assets/3e32bd8f-8fdf-44bf-978d-08e2d8d7e437" />
<img width="1316" height="398" alt="Screenshot From 2026-07-21 23-41-05" src="https://github.com/user-attachments/assets/2e93a506-caf9-4de6-87ec-a542d7add30c" />

