### PR TITLE
Link to scheduling link from application activated email

### DIFF
--- a/app/views/event/application_mailer/activated.html.erb
+++ b/app/views/event/application_mailer/activated.html.erb
@@ -29,7 +29,7 @@
 <p>The signed fiscal sponsorship contract is available for you to <%= link_to "download here", document_download_url(@application.contract.document) %>.</p>
 
 <p>
-  If you would like, you can <%= link_to "schedule an onboarding call", event_url(@application.event, request_call: "true") %> with a member of our team,
+  If you would like, you can <%= link_to "schedule an onboarding call", @application.event.onboarding_scheduling_link.presence || event_url(@application.event, request_call: "true") %> with a member of our team,
   or you can contact us at <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %> if you have any questions.
 </p>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Even if the PoC had a scheduling link configured, we were linking them to the modal to send a email to hcb@ instead of directly to the scheduling link.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
If present, link to the scheduling link in application activated email

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

