### PR TITLE
[Reimbursements] Properly handle failed check payouts

### DIFF
--- a/app/mailers/reimbursement_mailer.rb
+++ b/app/mailers/reimbursement_mailer.rb
@@ -60,6 +60,14 @@ class ReimbursementMailer < ApplicationMailer
     mail subject: "[Reimbursements] PayPal transfer for #{@report.name} failed to send", to: @report.user.email_address_with_name
   end
 
+  def check_failed
+    @payout_holding = params[:reimbursement_payout_holding]
+    @report = @payout_holding.report
+    @reason = params[:reason]
+
+    mail subject: "[Reimbursements] Mailed check for #{@report.name} failed to send", to: @report.user.email_address_with_name
+  end
+
   def expenses_approved
     @report = params[:report]
     @expenses = params[:expenses]

--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -63,7 +63,12 @@ module Reimbursement
                   payout_holding.mark_sent!
                 rescue Faraday::Error => e
                   check.mark_rejected!
+                  payout_holding.mark_failed!
                   message = e.response_body&.dig("message") || e.message
+                  ReimbursementMailer.with(
+                    reimbursement_payout_holding: payout_holding,
+                    reason: message
+                  ).check_failed.deliver_later
                   Rails.error.unexpected "[reimbursements / check issuing] #{message}. report ID: #{payout_holding.report.id}"
                 end
               end

--- a/app/views/reimbursement_mailer/check_failed.html.erb
+++ b/app/views/reimbursement_mailer/check_failed.html.erb
@@ -1,0 +1,5 @@
+We're writing to let you know your payout for "<%= link_to @report.name, @report %>" failed to send. Here's the explanation given by our bank:
+
+<pre><%= @reason %></pre>
+
+Please update your payout details <%= link_to "here", settings_payouts_url %>; afterwards, we'll reattempt the transfer.

--- a/app/views/reimbursement_mailer/check_failed.html.erb
+++ b/app/views/reimbursement_mailer/check_failed.html.erb
@@ -2,4 +2,4 @@ We're writing to let you know your payout for "<%= link_to @report.name, @report
 
 <pre><%= @reason %></pre>
 
-Please update your payout details <%= link_to "here", settings_payouts_url %>; afterwards, we'll reattempt the transfer.
+Please update your payout details <%= link_to "here", settings_payouts_url %>; afterwards, we'll reattempt the payout.


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We never marked the payout holding as failed when handling a failed check payout, and never sent an email.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Mark the payout holding as failed so that it doesn't try again, and send an email to the user about the error.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

