### PR TITLE
[Contractors] Move contractors up in event nav and remove payments beta badge

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -149,17 +149,7 @@ module EventsHelper
       tooltip: "Send & transfer money",
       icon: "payment-transfer",
       symbol: :payments,
-      beta: true,
       available_proc: ->(event) { policy(event).payments? }
-    },
-    {
-      name: "Reimbursements",
-      path_proc: ->(event_id) { event_reimbursements_path(event_id:) },
-      async_badge_proc: ->(event) { event_reimbursements_pending_review_icon_path(event) },
-      tooltip: "Reimburse team members & volunteers",
-      icon: "reimbursement",
-      symbol: :reimbursements,
-      available_proc: ->(event) { policy(event).reimbursements? }
     },
     {
       name: "Contractors",
@@ -169,6 +159,15 @@ module EventsHelper
       symbol: :contractors,
       beta: true,
       available_proc: ->(event) { policy(event).contractors? }
+    },
+    {
+      name: "Reimbursements",
+      path_proc: ->(event_id) { event_reimbursements_path(event_id:) },
+      async_badge_proc: ->(event) { event_reimbursements_pending_review_icon_path(event) },
+      tooltip: "Reimburse team members & volunteers",
+      icon: "reimbursement",
+      symbol: :reimbursements,
+      available_proc: ->(event) { policy(event).reimbursements? }
     },
     {
       section: "",


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
It makes more sense for contractors to be next to payments, and payments shouldn't be marked as beta as it's replacing transfers.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

