### PR TITLE
[Contracts] Fix layout of payroll contract sign page for HCB

### DIFF
--- a/app/views/contract/parties/show.html.erb
+++ b/app/views/contract/parties/show.html.erb
@@ -5,7 +5,7 @@
 <h2><%= @party.hcb? ? "Sign #{@contract.event_name}'s agreement as HCB Operations" : "Sign your HCB agreement" %></h2>
 
 <div class="grid md:grid-cols-5 gap-5" data-controller="contract" data-contract-advance-path-value="<%= completed_contract_party_path(@party) unless @contract.contractable.is_a?(Event::Application) && @party.hcb? %>">
-  <%= render partial: "contract/parties/docuseal_embed", locals: { party: @party, klass: @contract.is_a?(Contract::FiscalSponsorship) ? "md:col-span-3" : "md:col-span-5" } %>
+  <%= render partial: "contract/parties/docuseal_embed", locals: { party: @party, klass: @contract.is_a?(Contract::FiscalSponsorship) || @party.hcb? ? "md:col-span-3" : "md:col-span-5" } %>
   <div class="md:col-span-2 max-h-[75vh]">
     <% if @party.hcb? %>
       <div class="card">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The actions box was rendering below the contract instead of to the side.