### PR TITLE
[User] Block spam domains + friendlier typo error message

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -45,6 +45,9 @@ class LoginsController < ApplicationController
     cookies.signed["browser_token_#{@login.hashid}"] = { value: @login.browser_token, expires: Login::EXPIRATION.from_now }
 
     continue_login(preference: login_preference || :email)
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:error] = e.record.errors.full_messages.to_sentence
+    return redirect_to auth_users_path
   rescue => e
     flash[:error] = e.message
     return redirect_to auth_users_path

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -151,7 +151,7 @@ module Users
 
       redirect_to choose_login_preference_login_path(@login)
     rescue ActiveRecord::RecordInvalid => e
-      flash[:error] = e.message
+      flash[:error] = e.record.errors.full_messages.to_sentence
 
       render :new, status: :unprocessable_content
     end

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -151,7 +151,7 @@ module Users
 
       redirect_to choose_login_preference_login_path(@login)
     rescue ActiveRecord::RecordInvalid => e
-      flash[:error] = e.record.errors.full_messages.to_sentence
+      flash.now[:error] = e.record.errors.full_messages.to_sentence
 
       render :new, status: :unprocessable_content
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,7 +228,11 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates_email_format_of :email
   normalizes :email, with: ->(email) { email.strip.downcase }
-  validates :email, nondisposable: true, on: :create
+  EMAIL_TYPO_MESSAGE = lambda do |user, _|
+    fix = EmailTypoDomains.suggestion_for(user.email)
+    fix ? "looks like a typo. Did you mean #{user.email.sub(/@.+/, "@#{fix}")}?" : Nondisposable.configuration.error_message
+  end
+  validates :email, nondisposable: { message: EMAIL_TYPO_MESSAGE }, on: :create
 
   validates :phone_number, phone: { allow_blank: true }
 

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -34,6 +34,57 @@ Nondisposable.configure do |config|
     msn.com
     aol.com
     rambler.ua
+    dropoffs.org
+    meikeya.com
+    luckfeed.com
+    kywa.uk
+    tormails.com
+    besteya.com
+    diarshop.com
+    rapplo.com
+    lasttea.com
+    suahi.com
+    gicont.com
+    tempbox.app
+    prvsv.com
+    bagss.store
+    xhseeds.com
+    tempforward.com
+    twothird.org
+    mailbank.org
+    wutcloud.com
+    weebox.org
+    niggawatt.org
+    mailwarrior.info
+    cockbit.org
+    pucann.org
+    holeass.com
+    otona.uk
+    longbiba.org
+    2mails1box.info
+    gaylordmail.com
+    bitdelivery.org
+    tvtmall.com
+    sanszero.com
+    sesedm.com
+    senione.com
+    pngk.uk
+    rancord.com
+    paviri.com
+    rlvpn.site
+    alexx.buzz
+    luca.surf
+    kenji.quest
+    kaim.buzz
+    worldwides.help
+    nina.christmas
+    benn.mom
+    splindor.com
+    tivogo.com
+    bezill.com
+    codoteam.com
+    rightbliss.beauty
+    silesia.life
   ].freeze
 
   # https://www.okta.com/blog/threat-intelligence/opportunistic-sms-pumping-attacks-target-customer-sign-up-pages/
@@ -72,13 +123,31 @@ Nondisposable.configure do |config|
     writemeplz.net
   ].freeze
 
+  # Unambiguous typos of major providers (gmail.com, icloud.com,
+  # hackclub.com, protonmail.com). Nobody can legitimately own these as a
+  # real mailbox, so blocking is zero-cost and helps real users catch their
+  # own typo on signup. Also found in SMS pumping fraud.
+  typo_domains = %w[
+    gmail.con
+    gmail.co
+    gamil.com
+    icloud.con
+    gmil.com
+    hackclub.co
+    gmail.ocm
+    gmail.ckm
+    gmail.cok
+    gmail.xom
+    gmali.com
+    gamail.com
+    gmail.cpom
+    gmail.cokm
+    gmail.fom
+    protonmail.con
+  ].freeze
+
   # Add custom domains you want to be considered as disposable
-  config.additional_domains = hcb_sourced_domains + okta_sourced_domains + [
-    # Project people who mistype gmail.com, but these were also found in SMS pumping fraud
-    "gmail.con",
-    "gmail.co",
-    "gamil.com"
-  ]
+  config.additional_domains = hcb_sourced_domains + okta_sourced_domains + typo_domains
 
   # Exclude domains that are considered disposable but you want to allow anyways
   # config.excluded_domains = ["false-positive-domain.com"]

--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Referenced below during Rails boot, before Zeitwerk's lazy `lib/`
+# autoloading is reliably available, so it's required explicitly.
+require_relative "../../lib/email_typo_domains"
+
 Nondisposable.configure do |config|
   # Customize the error message if needed
   config.error_message = "provider is unsupported. Please try with another email address."
@@ -123,31 +127,14 @@ Nondisposable.configure do |config|
     writemeplz.net
   ].freeze
 
-  # Unambiguous typos of major providers (gmail.com, icloud.com,
-  # hackclub.com, protonmail.com). Nobody can legitimately own these as a
-  # real mailbox, so blocking is zero-cost and helps real users catch their
-  # own typo on signup. Also found in SMS pumping fraud.
-  typo_domains = %w[
-    gmail.con
-    gmail.co
-    gamil.com
-    icloud.con
-    gmil.com
-    hackclub.co
-    gmail.ocm
-    gmail.ckm
-    gmail.cok
-    gmail.xom
-    gmali.com
-    gamail.com
-    gmail.cpom
-    gmail.cokm
-    gmail.fom
-    protonmail.con
-  ].freeze
+  # Unambiguous typos of major providers, defined in lib/email_typo_domains.rb
+  # (also used by User to suggest the real domain on signup). Nobody can
+  # legitimately own these as a real mailbox, so blocking is zero-cost and
+  # helps real users catch their own typo on signup. Also found in SMS
+  # pumping fraud.
 
   # Add custom domains you want to be considered as disposable
-  config.additional_domains = hcb_sourced_domains + okta_sourced_domains + typo_domains
+  config.additional_domains = hcb_sourced_domains + okta_sourced_domains + EmailTypoDomains::ALL
 
   # Exclude domains that are considered disposable but you want to allow anyways
   # config.excluded_domains = ["false-positive-domain.com"]

--- a/lib/email_typo_domains.rb
+++ b/lib/email_typo_domains.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Single source of truth for the "unambiguous typo of a major provider"
+# domains blocked in config/initializers/nondisposable.rb. Grouped by the
+# real domain so a new typo is one line to add; TYPO_TO_REAL is derived
+# once at load for O(1) lookup from User's validation message.
+module EmailTypoDomains
+  REAL_TO_TYPOS = {
+    "gmail.com"      => %w[
+      gmail.con gmail.co gamil.com gmail.ocm gmail.ckm gmail.cok gmail.xom
+      gmali.com gamail.com gmail.cpom gmail.cokm gmail.fom gmil.com
+    ],
+    "icloud.com"     => %w[icloud.con],
+    "hackclub.com"   => %w[hackclub.co],
+    "protonmail.com" => %w[protonmail.con],
+  }.freeze
+
+  TYPO_TO_REAL = REAL_TO_TYPOS.each_with_object({}) { |(real, typos), h| typos.each { |typo| h[typo] = real } }.freeze
+
+  ALL = TYPO_TO_REAL.keys.freeze
+
+  def self.suggestion_for(email)
+    TYPO_TO_REAL[email.to_s.split("@").last]
+  end
+end

--- a/lib/email_typo_domains.rb
+++ b/lib/email_typo_domains.rb
@@ -20,6 +20,6 @@ module EmailTypoDomains
   ALL = TYPO_TO_REAL.keys.freeze
 
   def self.suggestion_for(email)
-    TYPO_TO_REAL[email.to_s.split("@").last]
+    TYPO_TO_REAL[email.to_s.split("@").last&.strip&.downcase]
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe User, type: :model do
     expect(user).to be_admin
   end
 
+  describe "nondisposable email validation" do
+    it "suggests the real domain for a known typo domain" do
+      user = build(:user, email: "someone@gmail.con")
+
+      expect(user).to_not be_valid
+      expect(user.errors[:email]).to eq(["looks like a typo. Did you mean someone@gmail.com?"])
+    end
+
+    it "uses the generic message for a non-typo disposable domain" do
+      user = build(:user, email: "someone@tormails.com")
+
+      expect(user).to_not be_valid
+      expect(user.errors[:email]).to eq(["provider is unsupported. Please try with another email address."])
+    end
+  end
+
   context "birthday validations" do
     it "fails validation when birthday is removed" do
       user = create(:user, full_name: "Caleb Denio")


### PR DESCRIPTION
## Summary of the problem
A recent surge in fake signups used disposable/throwaway email domains not yet covered by our blocklist. A historical scan found several older, unaddressed spam bursts too. Separately, typo'd domains (e.g. `gmail.con`) showed the same generic "provider is unsupported" error as actual spam domains.

## Describe your changes
- Adds domains to `config/initializers/nondisposable.rb` identified via a full-history analysis of accounts with zero real product engagement (no organizer positions, invites, or completed logins/sessions) despite meaningful signup volume.
- Adds a friendlier, specific error message ("did you mean gmail.com?") for known typo domains, instead of the generic disposable-email message. The typo list now lives in `lib/email_typo_domains.rb` as a single source of truth shared by the blocklist and the suggestion message.
- Fixes a pre-existing bug where signup validation errors were flashed with an internal-sounding `"Validation failed: "` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)