### PR TITLE
[Ledger] Restrict Ledger::ItemsController#show to HCB engineers

### DIFF
--- a/app/controllers/ledger/items_controller.rb
+++ b/app/controllers/ledger/items_controller.rb
@@ -5,9 +5,9 @@ class Ledger
     def show
       @item = Ledger::Item.find_by_hashid!(params[:id])
 
-      # Non-auditors see the user-facing HCB code page rather than the raw
+      # Non-engineers see the user-facing HCB code page rather than the raw
       # ledger item. hcb_codes#show performs its own authorization.
-      unless auditor_signed_in?
+      unless FlipperGroups.hcb_engineer?(current_user)
         skip_authorization
         return redirect_to hcb_code_path(@item.hcb_code)
       end


### PR DESCRIPTION
## Summary of the problem
This page is not ready for usage - it's tripping up some auditors/admins (e.g. Mel/Leo; and potentially other admins, like Zach).

## Describe your changes
Narrowed access to the raw ledger item page (`Ledger::ItemsController#show`) down to just HCB engineers until it's ready to be used more broadly. Everyone else is redirected to the user-facing HCB code page, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)