### PR TITLE
[Ledger] Throttle and bound anonymous reads of an organization's transactions

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -40,6 +40,8 @@ class CardGrantsController < ApplicationController
 
     @use_card_grant_ledgers = true
     set_ledger_filters
+    return if performed?
+
     @per = params[:per] || 25
     @table_only = true
     @ledger = @event.ledger

--- a/app/controllers/concerns/set_ledger_filters.rb
+++ b/app/controllers/concerns/set_ledger_filters.rb
@@ -3,13 +3,38 @@
 module SetLedgerFilters
   extend ActiveSupport::Concern
 
+  # Params that narrow a ledger. `q` is excluded because the search box renders
+  # outside the filter menu; `subledger` because it picks which ledger to show
+  # rather than filtering one.
+  FILTER_PARAMS = %i[
+    tag user type start end minimum_amount maximum_amount
+    missing_receipts merchant direction category
+  ].freeze
+
   included do
     private
+
+    # Filtering is what makes a transparent organization expensive to read
+    # anonymously: every combination is a separate, uncacheable trip through the
+    # transaction engines. Anonymous readers get the unfiltered page.
+    #
+    # Runs before the filters are resolved, because resolving them is most of the
+    # cost: `Event#merchants` alone loads every transaction for the organization.
+    def reject_disabled_filters
+      @ledger_filters_disabled = !signed_in?
+      return unless @ledger_filters_disabled
+      return if FILTER_PARAMS.none? { |name| params[name].present? }
+
+      render plain: "Invalid parameters. Please try again", status: :bad_request
+    end
 
     def set_ledger_filters
       # The search query name was historically `search`. It has since been renamed
       # to `q`. This following line retains backwards compatibility.
       params[:q] ||= params[:search]
+
+      reject_disabled_filters
+      return if performed?
 
       if params[:tag]
         @tag = Tag.find_by(event_id: @event.id, label: params[:tag])
@@ -48,12 +73,6 @@ module SetLedgerFilters
         merchant = @event.merchants.find { |merchant| merchant[:id] == @merchant }
 
         @merchant_name = merchant.present? ? merchant[:name] : "Merchant #{@merchant}"
-      end
-
-      @ledger_filters_disabled = !signed_in?
-      has_filters = @tag || @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @missing_receipts || @merchant || @direction || @category
-      if @ledger_filters_disabled && has_filters
-        render plain: "Invalid parameters. Please try again", status: :bad_request
       end
     end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1480,6 +1480,9 @@ class EventsController < ApplicationController
     # to `q`. This following line retains backwards compatibility.
     params[:q] ||= params[:search]
 
+    reject_disabled_filters
+    return if performed?
+
     if params[:tag]
       @tag = Tag.find_by(event_id: @event.id, label: params[:tag])
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -224,7 +224,7 @@ class EventsController < ApplicationController
     @pending_transactions = type_results[:pending_transactions]
 
     page = (params[:page] || 1).to_i
-    per_page = (params[:per] || TRANSACTIONS_PER_PAGE).to_i
+    per_page = (params[:per] || TRANSACTIONS_PER_PAGE).to_i.clamp(1, 200)
 
     @transactions = Kaminari.paginate_array(@all_transactions).page(page).per(per_page)
     TransactionGroupingEngine::Transaction::AssociationPreloader.new(transactions: @transactions, event: @event).run!
@@ -1275,7 +1275,7 @@ class EventsController < ApplicationController
 
   def ledger
     authorize @event
-    @per = params[:per] || 25
+    @per = (params[:per] || 25).to_i.clamp(1, 200)
 
     @items = ledger_query.execute(ledgers: @ledgers)
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -175,16 +175,33 @@ class Rack::Attack
     end
   end
 
-  throttle("/hq/transactions/ip", limit: 25, period: 1.minute) do |req|
-    if req.path.start_with?("/hq/transactions") && req.cookies[:session_token].nil?
-      req.ip
-    end
+  # Reading an organization's transactions runs the transaction engines, which
+  # cost seconds per request, and a transparent organization can be read without
+  # signing in. The page and its Turbo frame are each requested directly, so both
+  # need covering.
+  ledger_path = %r{
+    \A/
+    (?!admin/)                    # `req/ip` above exempts /admin
+    [^/]+/                        # organization slug
+    (transactions_list | transactions | ledger)
+    (\.[^/]*)?                    # `(.:format)` reaches the same action
+    /?\z
+  }x
+
+  # Presence only: the cookie is encrypted, and verifying it would mean a database
+  # lookup ahead of Rails. A forged value falls through to the wider throttle
+  # below, which is why that one exists.
+  #
+  # `Rack::Request#cookies` is string-keyed; a symbol reads as nil every time and
+  # throttles signed-in organizers too.
+  throttle("transparency/ledger/ip", limit: 25, period: 1.minute) do |req|
+    req.ip if req.path.match?(ledger_path) && req.cookies["session_token"].nil?
   end
 
-  throttle("/hq/ledger/ip", limit: 30, period: 1.minute) do |req|
-    if req.path.start_with?("/hq/ledger") && req.cookies[:session_token].nil?
-      req.ip
-    end
+  # Set far above what clicking through pages reaches, so it only catches
+  # automation sending an unverified `session_token`.
+  throttle("ledger/ip", limit: 100, period: 1.minute) do |req|
+    req.ip if req.path.match?(ledger_path)
   end
 
   # Lockout IP addresses that are hammering your donation page.

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -380,4 +380,39 @@ RSpec.describe EventsController do
     end
   end
 
+  describe "#transactions_list" do
+    let(:event) { create(:event, is_public: true) }
+
+    it "serves the unfiltered list to an anonymous reader" do
+      get(:transactions_list, params: { event_id: event.slug })
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "rejects a filter from an anonymous reader before reaching the transaction engines" do
+      expect(TransactionGroupingEngine::Transaction::All).not_to receive(:new)
+      expect(PendingTransactionEngine::PendingTransaction::All).not_to receive(:new)
+
+      get(:transactions_list, params: { event_id: event.slug, direction: "revenue" })
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "rejects every filter param from an anonymous reader" do
+      SetLedgerFilters::FILTER_PARAMS.each do |param|
+        get(:transactions_list, params: { event_id: event.slug, param => "x" })
+
+        expect(response).to have_http_status(:bad_request), "expected #{param} to be rejected"
+      end
+    end
+
+    it "allows a filter from a signed-in organizer" do
+      sign_in_organizer_of(event)
+
+      get(:transactions_list, params: { event_id: event.slug, direction: "revenue" })
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
 end

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Rack::Attack, type: :request do
+  # Rack::Attack is only enabled in production, and the test cache is a
+  # null_store, which would silently never increment a counter.
+  around do |example|
+    enabled = Rack::Attack.enabled
+    store = Rack::Attack.cache.store
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    begin
+      example.run
+    ensure
+      Rack::Attack.enabled = enabled
+      Rack::Attack.cache.store = store
+    end
+  end
+
+  def discriminator(throttle, path, session_token: nil)
+    env = Rack::MockRequest.env_for(path, "REMOTE_ADDR" => "203.0.113.7")
+    env["HTTP_COOKIE"] = "session_token=#{session_token}" if session_token
+    Rack::Attack.throttles.fetch(throttle).block.call(Rack::Attack::Request.new(env))
+  end
+
+  describe "transparency/ledger/ip" do
+    it "throttles anonymous reads of any organization's transactions" do
+      [
+        "/an-organization/transactions",
+        "/an-organization/transactions_list",
+        "/an-organization/ledger",
+        "/some-other-org/transactions_list",
+        # The format suffix reaches the same action at the same cost.
+        "/an-organization/transactions_list.json",
+        "/an-organization/transactions.csv"
+      ].each do |path|
+        expect(discriminator("transparency/ledger/ip", path)).to eq("203.0.113.7"), "expected #{path} to be throttled"
+      end
+    end
+
+    it "ignores requests that carry a session_token cookie" do
+      expect(discriminator("transparency/ledger/ip", "/an-organization/transactions_list", session_token: "abc123")).to be_nil
+    end
+
+    it "ignores paths outside the ledger surface" do
+      [
+        "/an-organization",
+        "/an-organization/team",
+        "/an-organization/transactions_list/extra",
+        "/admin/ledger",
+        "/admin/ledger_items",
+        "/storage/representations/redirect/abc/def"
+      ].each do |path|
+        expect(discriminator("transparency/ledger/ip", path)).to be_nil, "expected #{path} not to be throttled"
+      end
+    end
+
+    it "responds with 429 once an anonymous client passes the limit" do
+      limit = Rack::Attack.throttles.fetch("transparency/ledger/ip").limit
+
+      # Counters bucket by `Time.now.to_i / period`, so a minute boundary
+      # mid-loop would reset the count and lose the throttle.
+      freeze_time do
+        limit.times { get "/an-organization/transactions_list" }
+        expect(response.body).not_to eq("Retry later\n")
+
+        get "/an-organization/transactions_list"
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.body).to eq("Retry later\n")
+      end
+    end
+  end
+
+  describe "ledger/ip" do
+    # A forged `session_token` escapes the throttle above, since the cookie can't
+    # be verified at this layer. This is what stops that meaning unlimited access.
+    it "applies whether or not a session_token cookie is present" do
+      expect(discriminator("ledger/ip", "/an-organization/transactions_list")).to eq("203.0.113.7")
+      expect(discriminator("ledger/ip", "/an-organization/transactions_list", session_token: "forged")).to eq("203.0.113.7")
+    end
+
+    it "responds with 429 to a client sending an unverified session_token" do
+      limit = Rack::Attack.throttles.fetch("ledger/ip").limit
+      forged = { "HTTP_COOKIE" => "session_token=forged" }
+
+      freeze_time do
+        limit.times { get "/an-organization/transactions_list", headers: forged }
+        expect(response.body).not_to eq("Retry later\n")
+
+        get "/an-organization/transactions_list", headers: forged
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Reading an organization's transactions runs the transaction engines, which cost
seconds per request. On a transparent organization those pages are readable
without signing in, so crawlers reach them freely, and sustained crawling is
enough on its own to keep the web workers busy. Everything else queues behind it,
so the whole site gets slower rather than just the ledger.

Four things made that cheaper to do than it should have been:

- The throttles covering these pages were scoped to a single organization's slug,
  and matched only the page, not the Turbo frame that does the work.
- They tested `req.cookies[:session_token]`. `Rack::Request#cookies` is
  string-keyed, so that read as `nil` on every request and the throttles meant
  for anonymous readers were throttling signed-in organizers as well.
- `transactions` and `transactions_list` paths allow transparency mode and left
  the filter space open to anyone, and each combination is a separate, uncacheable
  trip through the engines.
- `?per=` was read straight from params with no ceiling.

## Describe your changes

**Throttling.** One throttle for anonymous readers, keyed per IP, now covering
`transactions`, `transactions_list` and `ledger` on every slug rather than one.
The `(.:format)` variants are matched too, since `transactions_list.json` reaches
the same action at the same cost and would otherwise walk straight past. `/admin`
stays exempt, consistent with `req/ip`. A second throttle applies regardless of
the cookie, because a `session_token` is encrypted and can't be verified at this
layer, so a forged one would otherwise escape the first.

**Filtering.** The guard that already existed for the newer ledger moves into a
shared method and now runs on the classic pages too. It also runs *before* the
filters are resolved rather than after, because resolving them is most of the
cost of the request: `Event#merchants` alone loads every canonical and pending
transaction for the organization, so a request we were about to refuse had
already paid for itself. Search stays available, since `q` renders outside the
filter menu, as does `subledger`, which picks which ledger to show rather than
filtering one. The transactions filter partial already consulted
`@ledger_filters_disabled` to hide the menu; nothing on this path ever set it.

**Pagination.** `?per=` is clamped to the largest count the filter menus offer.

Also guards `CardGrantsController#transaction_index` with `performed?`, since it
calls `set_ledger_filters` mid-action rather than as a `before_action` and would
otherwise double render when the guard refuses.

### Verification

`/ledger` behaviour was compared with and without these changes across every
authenticated case and is identical. The only anonymous difference is a status
change, from 404 to 400, when a filter names a tag or user that doesn't exist:
those used to resolve to `nil` and read as "no filter at all". Anonymous readers
can't read `/ledger` either way.

New specs cover the throttle discriminators, the format-suffix case, the cookie
condition, and the filter refusal for every filter param.

### Not covered here

Rate limiting raises the cost of crawling; it doesn't stop a client that rotates
addresses. The durable fix is making these pages cheap enough not to care, which
is partly what the companion branch does.
