### PR TITLE
[CanonicalPendingTransaction] Filter `unsettled` with subqueries, and preload the pending transaction engine

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -128,11 +128,15 @@ class CanonicalPendingTransaction < ApplicationRecord
   scope :reimbursement_payout_holding, -> { where.not(reimbursement_payout_holding_id: nil) }
   scope :unmapped, -> { includes(:canonical_pending_event_mapping).where(canonical_pending_event_mappings: { canonical_pending_transaction_id: nil }) }
   scope :mapped, -> { includes(:canonical_pending_event_mapping).where.not(canonical_pending_event_mappings: { canonical_pending_transaction_id: nil }) }
+  # Filtered with subqueries rather than joins. `where(association: ...)` resolves
+  # through Rails' table aliasing, so an `includes` anywhere else in the query can
+  # reach the same table by another path, take the alias, and silently rebind
+  # these conditions to a different row. Both foreign keys are NOT NULL, so `NOT
+  # IN` is safe here.
   scope :unsettled, -> {
-    includes(:canonical_pending_settled_mappings)
-      .where(canonical_pending_settled_mappings: { canonical_pending_transaction_id: nil })
-      .includes(:canonical_pending_declined_mapping)
-      .where(canonical_pending_declined_mapping: { canonical_pending_transaction_id: nil })
+    preload(:canonical_pending_settled_mappings, :canonical_pending_declined_mapping)
+      .where.not(id: CanonicalPendingSettledMapping.select(:canonical_pending_transaction_id))
+      .where.not(id: CanonicalPendingDeclinedMapping.select(:canonical_pending_transaction_id))
   }
   scope :missing_hcb_code, -> { where(hcb_code: nil) }
   scope :missing_or_unknown_hcb_code, -> { where("hcb_code is null or hcb_code ilike 'HCB-000%'") }

--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -42,12 +42,26 @@ module PendingTransactionEngine
           begin
             included_local_hcb_code_associations = [:receipts, :comments, :canonical_transactions, { canonical_pending_transactions: [:canonical_pending_declined_mapping] }]
             included_local_hcb_code_associations << :tags
-            cpts = CanonicalPendingTransaction.includes([:raw_pending_stripe_transaction,
-                                                         order_by_mapped_at ? :canonical_pending_event_mapping : nil,
-                                                         { local_hcb_code: included_local_hcb_code_associations }])
+            # `includes` here becomes a single LEFT OUTER JOIN across eleven tables,
+            # which multiplies rows out through the has_many associations. `preload`
+            # fetches them in separate queries instead.
+            cpts = CanonicalPendingTransaction.preload([:raw_pending_stripe_transaction,
+                                                        order_by_mapped_at ? :canonical_pending_event_mapping : nil,
+                                                        { local_hcb_code: included_local_hcb_code_associations }])
                                               .unsettled
-                                              .where(id: canonical_pending_event_mappings.pluck(:canonical_pending_transaction_id))
-                                              .order("#{order_by_mapped_at ? "canonical_pending_event_mappings.created_at" : "canonical_pending_transactions.date"} desc, canonical_pending_transactions.id desc")
+                                              .where(id: canonical_pending_event_mappings.select(:canonical_pending_transaction_id))
+
+            cpts =
+              if order_by_mapped_at
+                # Ordering by the mapping needs it joined. There's a unique index on
+                # canonical_pending_transaction_id, so this can't duplicate rows.
+                cpts.joins(:canonical_pending_event_mapping)
+                    .order("canonical_pending_event_mappings.created_at desc, canonical_pending_transactions.id desc")
+              else
+                # Ordering by a raw string re-references the included tables and puts
+                # the join back, so name the columns.
+                cpts.order(date: :desc, id: :desc)
+              end
 
             if @user || @merchant
               cpts = cpts.joins("LEFT JOIN raw_pending_stripe_transactions on raw_pending_stripe_transactions.id = canonical_pending_transactions.raw_pending_stripe_transaction_id")


### PR DESCRIPTION
## Summary of the problem

`CanonicalPendingTransaction.unsettled` filters with
`where(association: { ... })`, which resolves through Rails' table aliasing. The
condition binds to whichever join claimed the alias, so an `includes` anywhere
else in the same query that reaches the same table by a different path takes that
alias and the scope silently starts filtering on a different row.

That isn't hypothetical. Since #6255 in May 2024, which preloaded
`:canonical_pending_declined_mapping` through `local_hcb_code` to fix an N+1, the
declined half of the scope has been binding to a *sibling* transaction sharing
the same `hcb_code` rather than to the transaction itself. It has effectively
meant "skip this only if every transaction sharing its `hcb_code` is declined".

You can see it in the generated SQL, which joins the table twice:

```sql
-- alias "canonical_pending_declined_mapping"   <- the one the WHERE binds to
  ON ...canonical_pending_transaction_id = "canonical_pending_transactions_hcb_codes"."id"   -- a sibling

-- alias "canonical_pending_declined_mappings_canonical_pending_transacti"
  ON ...canonical_pending_transaction_id = "canonical_pending_transactions"."id"             -- the row itself
```

The scope is correct on its own. It only breaks in combination, which is what
makes it worth removing rather than patching around: the failure is invisible at
the definition site and arrives via an unrelated performance change elsewhere.

Separately, the same query resolves its whole `includes` tree as one LEFT OUTER
JOIN across eleven tables, multiplying rows out through the has_many
associations. It is the slowest query in the app and was reaching the request
timeout, holding a worker for the full duration.

## Describe your changes

**Scope.** Filter with subqueries instead of joins. Subqueries can't be rebound
by an alias. Both foreign keys are `NOT NULL`, so `NOT IN` is safe. The `preload`
replaces what the old `includes` gave callers incidentally: both associations
arrive loaded, so the per-row `settled?` and `declined?` calls in the transaction
partials don't become an N+1. It costs nothing for the aggregate callers, since
preloading only runs when records are materialised, whereas the old `includes`
forced both LEFT JOINs into every `sum`, `count` and `exists?`.

**Engine.** `includes` becomes `preload`, the date ordering names its columns
(a raw string re-references the included tables and puts the join straight back),
and the id filter becomes a subquery. All three are required together: the
subquery *without* `preload` measured roughly 5x slower than before, because the
literal id list is currently what lets Postgres filter by primary key ahead of
the join. Ordering by the mapping genuinely needs it joined, so that branch joins
it explicitly; there's a unique index on
`canonical_pending_event_mappings.canonical_pending_transaction_id`, so the join
can't duplicate rows.

Roughly 4x faster on the organizations with the most pending transactions.
Organizations with very few are marginally slower, trading one join for a handful
of round trips.

### Behaviour

No observable change today, verified from both directions.

Three records in total can trigger the collision — the complete population, not a
sample. They are `CanonicalPendingTransaction` ids **423172**, **423183** and
**608019**. Each has a `CanonicalPendingDeclinedMapping`, and each has no
`HcbCode` row matching its `hcb_code`, so the sibling join yields `NULL` and the
"not declined" test passes vacuously. That missing `HcbCode` row is the defining
property, so these can't be looked up through the usual `/hcb/:id` page.

All three are fronted on organizations that can front balance, so `not_fronted`
already excludes them from the one query where the collision occurs. Every other
caller of `unsettled` — the balance sums, counts and `exists?` checks — builds a
query with only a single join to that table and so never had the collision at
all.

Records and their order are unchanged: compared across the organizations with the
most pending transactions, for both orderings, and for the aggregate callers on
the affected organizations plus controls. The existing suite passes.

### Worth a second opinion

The three rows above are the ones this changes in principle. I'd sanity-check
that population outside my local dataset before merging, since the shape
(a declined transaction whose `hcb_code` has no `hcb_codes` row) is what
generalises, not the count.
