### PR TITLE
Update payout method settings tab copy to include payments

### DIFF
--- a/app/views/users/_settings_dropdown.html.erb
+++ b/app/views/users/_settings_dropdown.html.erb
@@ -18,7 +18,7 @@
                   use_my_path ? settings_address_path : address_user_path(local_assigns[:user] || current_user),
                   selected: local_assigns[:selected] == :settings_billing_address && local_assigns[:open] %>
   <% end %>
-  <%= dock_item "Reimbursement payouts",
+  <%= dock_item "Payouts",
                 use_my_path ? settings_payouts_path : payouts_user_path(local_assigns[:user] || current_user),
                 selected: local_assigns[:selected] == :settings_reimbursement_payouts && local_assigns[:open] %>
   <%= dock_item "Security",

--- a/app/views/users/edit_payout.html.erb
+++ b/app/views/users/edit_payout.html.erb
@@ -7,7 +7,7 @@
     <section>
       <% unless @legal_entity != @user.personal_legal_entity %>
         <p class="muted mt0 mb2">
-          When a <%= link_to "reimbursement report of yours", my_reimbursements_path, data: { turbo_frame: "_top" } %> is approved, HCB will use the information below to reimburse you. Without this information, you won't be able to submit reimbursement reports. You can update these settings at any time.
+          When a <%= link_to "reimbursement report of yours", my_reimbursements_path, data: { turbo_frame: "_top" } %> is approved or an <%= !@user.payments_received.exists? ? link_to("organization sends you a payment", my_pay_path, data: { turbo_frame: "_top" }) : "organization sends you a payment" %>, HCB will use your preferred payout method to pay you. Without a payout method, you won't be able to submit reimbursement reports, and you won't be able to accept payments from organizations on HCB. You can update these settings at any time.
           <% if @user.reimbursement_reports.pending.any? %>
             <p>
               Changes made here will apply to all non-reimbursed reports of yours, including your <%= pluralize(@user.reimbursement_reports.pending.count, "pending report") %>.


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The payout settings tab is currently named and has copy specific to reimbursements and a single payout method, even though it is now also used for payments and can have multiple payout methods.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Update the tab name and copy to include payments.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

