### PR TITLE
[Tax] Refresh contractors and payments on TIN match success

### DIFF
--- a/app/controllers/legal_entities_controller.rb
+++ b/app/controllers/legal_entities_controller.rb
@@ -113,11 +113,11 @@ class LegalEntitiesController < ApplicationController
         # Re-point each payment at the new payee and then re-run the payability
         # check: these have been waiting in pending_legal_entity, and moving them
         # onto an already-payable entity is exactly the moment they can proceed.
-        # on_legal_entity_assigned no-ops unless the new entity is payable, so a
+        # refresh_legal_entity_state! no-ops unless the new entity is payable, so a
         # not-yet-payable target leaves them pending, as before.
         pending.each do |payment|
           payment.update!(payee: new_payee)
-          payment.on_legal_entity_assigned
+          payment.refresh_legal_entity_state!
         end
       end
 

--- a/app/mailers/payment_mailer.rb
+++ b/app/mailers/payment_mailer.rb
@@ -4,8 +4,7 @@ class PaymentMailer < ApplicationMailer
   before_action :set_payment
 
   def missing_payout_method
-    @initial = params[:initial]
-    mail to: @recipients, subject: params[:initial] ? initial_subject : "[Action Required] Configure a payout method for \"#{@payment.purpose}\" from #{@payment.event.name}"
+    mail to: @recipients, subject: initial_subject
   end
 
   def missing_tax_information

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -62,8 +62,8 @@ class LegalEntity < ApplicationRecord
   end
 
   # Re-check onboarding for any of this entity's contractor positions that are
-  # mid-onboarding. Called when a step that lives on the legal entity (tax form,
-  # payout method) completes.
+  # mid-onboarding and payments that are pending. Called when a step that lives
+  # on the legal entity (tax form, payout method) completes.
   def refresh_pending_contractors_payments!
     payments.each(&:on_legal_entity_payable) if payable?
 

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -65,7 +65,7 @@ class LegalEntity < ApplicationRecord
   # mid-onboarding and payments that are pending. Called when a step that lives
   # on the legal entity (tax form, payout method) completes.
   def refresh_pending_contractors_payments!
-    payments.each(&:on_legal_entity_payable) if payable?
+    payments.pending_legal_entity.each(&:on_legal_entity_payable) if payable?
 
     Payroll::Position.joins(:payee)
                      .where(payees: { legal_entity_id: id }, aasm_state: :onboarding)

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -64,7 +64,9 @@ class LegalEntity < ApplicationRecord
   # Re-check onboarding for any of this entity's contractor positions that are
   # mid-onboarding. Called when a step that lives on the legal entity (tax form,
   # payout method) completes.
-  def refresh_contractor_onboarding!
+  def refresh_pending_contractors_payments!
+    payments.each(&:on_legal_entity_payable) if payable?
+
     Payroll::Position.joins(:payee)
                      .where(payees: { legal_entity_id: id }, aasm_state: :onboarding)
                      .find_each(&:refresh_onboarding_state!)

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -65,7 +65,7 @@ class LegalEntity < ApplicationRecord
   # mid-onboarding and payments that are pending. Called when a step that lives
   # on the legal entity (tax form, payout method) completes.
   def refresh_pending_contractors_payments!
-    payments.pending_legal_entity.each(&:on_legal_entity_payable) if payable?
+    payments.pending_legal_entity.each(&:refresh_legal_entity_state!) if payable?
 
     Payroll::Position.joins(:payee)
                      .where(payees: { legal_entity_id: id }, aasm_state: :onboarding)

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -65,7 +65,7 @@ class LegalEntity < ApplicationRecord
   # mid-onboarding and payments that are pending. Called when a step that lives
   # on the legal entity (tax form, payout method) completes.
   def refresh_pending_contractors_payments!
-    payments.pending_legal_entity.each(&:refresh_legal_entity_state!) if payable?
+    payments.pending_legal_entity.each(&:refresh_legal_entity_state!)
 
     Payroll::Position.joins(:payee)
                      .where(payees: { legal_entity_id: id }, aasm_state: :onboarding)

--- a/app/models/legal_entity/payout_method.rb
+++ b/app/models/legal_entity/payout_method.rb
@@ -54,8 +54,7 @@ class LegalEntity
 
     after_create do
       if default? && other_methods.none?
-        legal_entity.payments.pending_legal_entity.each(&:on_default_payout_method_created)
-        legal_entity.refresh_contractor_onboarding!
+        legal_entity.refresh_pending_contractors_payments!
       end
     end
 

--- a/app/models/payee.rb
+++ b/app/models/payee.rb
@@ -44,7 +44,7 @@ class Payee < ApplicationRecord
 
   after_update do
     if legal_entity_id_previously_changed?(from: nil)
-      payments.pending_legal_entity.each(&:on_legal_entity_assigned)
+      legal_entity.refresh_pending_contractors_payments!
     end
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -88,7 +88,7 @@ class Payment < ApplicationRecord
     if legal_entity&.payable? && legal_entity.default_payout_method.present?
       create_payment_attempt!
     elsif legal_entity&.payable?
-      PaymentMailer.with(payment: self, initial: true).missing_payout_method.deliver_later
+      PaymentMailer.with(payment: self).missing_payout_method.deliver_later
     else
       PaymentMailer.with(payment: self).missing_tax_information.deliver_later
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -110,20 +110,17 @@ class Payment < ApplicationRecord
     MoneyService.convert_to_usd(amount_cents, currency)
   end
 
-  def on_legal_entity_assigned
-    on_legal_entity_payable if legal_entity.payable?
-  end
+  # Idempotent: safe to call any number of times, from any code path that
+  # touches the associated legal entity (tax form completion, payout method
+  # creation, payee reassignment). Only ever creates a payment attempt —
+  # never sends mail, so repeated calls can't spam a recipient with reminders.
+  def refresh_legal_entity_state!
+    return unless pending_legal_entity?
+    return unless legal_entity&.payable?
+    return if legal_entity.default_payout_method.nil?
+    return unless attempts.all?(&:failed?)
 
-  def on_legal_entity_payable
-    if legal_entity.default_payout_method.present?
-      create_payment_attempt!
-    else
-      PaymentMailer.with(payment: self, initial: false).missing_payout_method.deliver_later
-    end
-  end
-
-  def on_default_payout_method_created
-    create_payment_attempt! if legal_entity.payable?
+    create_payment_attempt!
   end
 
   def receipt_required?

--- a/app/models/tax/form.rb
+++ b/app/models/tax/form.rb
@@ -84,6 +84,10 @@ module Tax
       mark_completed! if may_mark_completed?
     end
 
+    after_update if: -> { taxbandits_tin_matching_status_previously_changed?(to: :success) } do
+      legal_entity.refresh_pending_contractors_payments!
+    end
+
     after_update if: -> { tin_hash_previously_changed?(from: nil) } do
       # Locked: a legal entity's TIN can never change once set, and two forms
       # completing concurrently would otherwise both see a nil hash and race.
@@ -115,8 +119,7 @@ module Tax
         after do
           import_taxbandits_data if sent_with_taxbandits?
 
-          legal_entity.payments.each(&:on_legal_entity_payable) if legal_entity.payable?
-          legal_entity.refresh_contractor_onboarding!
+          legal_entity.refresh_pending_contractors_payments!
         end
       end
 

--- a/app/views/payment_mailer/missing_payout_method.html.erb
+++ b/app/views/payment_mailer/missing_payout_method.html.erb
@@ -1,13 +1,6 @@
 <p>Hello <%= @payment.legal_entity.name %>,</p>
 
-<% if @initial %>
-  <%= render partial: "initial_message", locals: { payment: @payment } %>
-<% else %>
-  <p>
-    We're almost ready to send your payment of <%= @payment.amount.format(with_currency: true) %>
-    for <i>"<%= @payment.purpose %>"</i> from <%= @payment.event.name %> through HCB!
-  </p>
-<% end %>
+<%= render partial: "initial_message", locals: { payment: @payment } %>
 
 <p>
   In order to process this payment, please <%= link_to "configure your payout method on HCB", legal_entity_url(@payment.legal_entity) %>.

--- a/spec/mailers/previews/payment_mailer_preview.rb
+++ b/spec/mailers/previews/payment_mailer_preview.rb
@@ -2,7 +2,7 @@
 
 class PaymentMailerPreview < ActionMailer::Preview
   def missing_payout_method
-    PaymentMailer.with(payment: Payment.last, initial: true).missing_payout_method
+    PaymentMailer.with(payment: Payment.last).missing_payout_method
   end
 
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -154,13 +154,6 @@ RSpec.describe Payment, type: :model do
       end
 
       context "without a default payout method" do
-        it "sends the missing_payout_method mailer" do
-          mail = double("mail", deliver_later: true)
-          allow(PaymentMailer).to receive_message_chain(:with, :missing_payout_method).and_return(mail)
-          tax_form.mark_completed!
-          expect(mail).to have_received(:deliver_later)
-        end
-
         it "does not create a payment attempt" do
           expect { tax_form.mark_completed! }.not_to(change { payment.attempts.count })
         end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
If we're waiting on a TIN match success to pay someone, we need to refresh the contractors/payments when that happens.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Refactor the refresh method to refresh both payments and contractors, and call it on tin match success.

This also removes sending the payout method missing email after tax information is submitted - this is because otherwise it would be sent multiple times each time the refresh method was called, and #14296 will add reminder emails that will take its place.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

