### PR TITLE
[CPSM] Create when a CT is assigned to the same LI as the CPT

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -145,6 +145,7 @@ class CanonicalTransaction < ApplicationRecord
   after_commit if: -> { previous_changes.key?("ledger_item_id") } do
     old_ledger_item_id = previous_changes["ledger_item_id"].first
     Ledger::Item.find(old_ledger_item_id).refresh! if old_ledger_item_id.present?
+    settle_cpt!
   end
 
   after_create :write_hcb_code
@@ -496,6 +497,12 @@ class CanonicalTransaction < ApplicationRecord
         update!(ledger_item: li)
         li.map!
       end
+    end
+  end
+
+  def settle_cpt!
+    if ledger_item.present? && ledger_item.canonical_pending_transactions.unsettled.count == 1
+      CanonicalPendingSettledMapping.create!(canonical_pending_transaction_id: ledger_item.canonical_pending_transactions.first, canonical_transaction_id: self.id)
     end
   end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We weren't previously creating settled mappings when CTs were assigned to LIs with CPTs.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Create a CPSM to link the CT to the CPT if there is only one unsettled CPT on the LI.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

