### PR TITLE
Remove undefined receipt method from HcbCodesController action callbacks

### DIFF
--- a/app/controllers/hcb_codes_controller.rb
+++ b/app/controllers/hcb_codes_controller.rb
@@ -3,8 +3,8 @@
 class HcbCodesController < ApplicationController
   include TagsHelper
 
-  skip_before_action :signed_in_user, only: [:receipt, :attach_receipt, :receipt_status, :show]
-  skip_after_action :verify_authorized, only: [:receipt, :receipt_status]
+  skip_before_action :signed_in_user, only: [:attach_receipt, :receipt_status, :show]
+  skip_after_action :verify_authorized, only: [:receipt_status]
 
   def show
     @hcb_code = HcbCode.find_by(hcb_code: params[:id]) || HcbCode.find(params[:id])


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We recently turned on the config to raise errors if there's a undefined action in a controller callback - turns out HcbCodesController has one.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove the undefined action from the callbacks.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

