### PR TITLE
[Schema] Upgrade to 8.1 & remove create_schema "google_sheets" 

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,8 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.1].define(version: 2026_07_20_210532) do
-  create_schema "google_sheets"
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_20_210532) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_210532) do
   create_schema "google_sheets"
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
## Summary of the problem

`create_schema "google_sheets"` is not managed by the Rails app and shouldn't be in `db/schema.rb`


## Describe your changes

db/schema.rb` has been carrying `create_schema "google_sheets"`, a schema that isn't created or managed by our migrations (nothing in `app/`, `lib/`, `config/`, or `db/migrate/` references it). It only exists on databases where the external sync has run, so the line appeared or disappeared depending on which database the person running `db:migrate` was attached to.

Which schemas get dumped is controlled by `ActiveRecord.dump_schemas`, which defaults to `:schema_search_path`. Before Rails 8.1, though, the `:ruby` dumper ignored that setting and emitted `create_schema` for every non-`public` schema it found. Rails 8.1 fixed it:

> Make schema dumper to account for `ActiveRecord.dump_schemas` when dumping in
> `:ruby` format.
>
> *fatkodima* ([activerecord CHANGELOG](https://github.com/rails/rails/blob/v8.1.3/activerecord/CHANGELOG.md#L375))

We upgraded in https://github.com/hackclub/hcb/pull/14365, but nothing has re-dumped the schema since, so the stale line is still there. With our search path set to `public`, the dumper no longer emits it, verified locally against a database that does have the `google_sheets` schema present. No config change is needed, and the line won't come back.