### PR TITLE
[Ledger::Item] Fix declined and reversed status for card charges

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -176,8 +176,6 @@ class Ledger
       case linked_object_type
       when "CardCharge"
         return :released if uncaptured_stripe_authorization?
-
-        return :settled
       when "IncreaseCheck" # Increase checks use the same state for users canceling and ops rejecting
         return :canceled if linked_object.try(:rejected?) || linked_object.try(:increase_stopped?) || linked_object.try(:column_stopped?)
       end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Non-released card charges could only get a status of settled.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Allow them to get declined and reversed statuses.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

