### PR TITLE
Modify Intercom settings to disable for unauthenticated users

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -14,6 +14,8 @@ class LoginsController < ApplicationController
     response.delete_header("X-Robots-Tag")
   end
 
+  before_action { @_intercom_script_tag_helper_called = true }
+
   # view to log in
   def new
     render "users/logout" if current_user

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -39,7 +39,7 @@ IntercomRails.config do |config|
   # == Include for logged out Users
   # If set to true, include the Intercom messenger on all pages, regardless of whether
   # The user model class (set below) is present.
-  config.include_for_logged_out_users = false
+  config.include_for_logged_out_users = true
 
   # == User model class
   # The class which defines your user model

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -39,7 +39,7 @@ IntercomRails.config do |config|
   # == Include for logged out Users
   # If set to true, include the Intercom messenger on all pages, regardless of whether
   # The user model class (set below) is present.
-  config.include_for_logged_out_users = true
+  config.include_for_logged_out_users = false
 
   # == User model class
   # The class which defines your user model


### PR DESCRIPTION
## Summary of the problem

Users are having difficulty navigating between pages on HCB when not signed in. Actions like switching authentication methods or completing a login will get a response from the server, but the user is not able to progress.

Intercom rewrites `history.pushState` but has a buggy implementation resulting in errors on navigation.


## Describe your changes

This PR modifies Intercom's configuration to disable Intercom when the user is not signed in. This works around Intercom's bug hidden inside their `history.pushState` implementation.