### PR TITLE
Upgrade ruby-vips to resolve ActiveStorage warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -805,8 +805,9 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-limiter (2.3.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.1.4)
+    ruby-vips (2.3.0)
       ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     safely_block (0.5.0)


### PR DESCRIPTION
```
libvips's unfuzzed operations are not safe to use with untrusted content, and Active Storage cannot disable them. Disabling them requires libvips 8.13 or later and ruby-vips 2.2.1 or later. Please upgrade libvips and ruby-vips, or remove the ruby-vips gem from your Gemfile.
```