### PR TITLE
Sync .annotaterb.yml with annotaterb 4.24.0 options

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,6 +1,7 @@
 ---
 :active_admin: false
 :additional_file_patterns: []
+:auto_annotate_routes_after_migrate: false
 :classified_sort: true
 :classes_default_to_s: []
 :command: 
@@ -18,10 +19,13 @@
 :format_rdoc: false
 :format_yard: false
 :frozen: false
+:grouped_polymorphic: false
 :hide_default_column_types: 'json,jsonb,hstore'
 :hide_limit_column_types: 'integer,bigint,boolean'
 :ignore_columns: 
+:ignore_database_name: false
 :ignore_model_sub_dir: false
+:ignore_multi_database_name: false
 :ignore_routes: 
 :ignore_unknown_models: false
 :include_version: false
@@ -36,14 +40,20 @@
 :position_in_routes: before
 :position_in_serializer: before
 :position_in_test: before
+:position_of_column_comment: :with_name
 :require: []
 :root_dir:
 - ''
 :routes: false
 :show_check_constraints: false
 :show_complete_foreign_keys: false
+:show_enums: false
+:show_exclusion_constraints: false
 :show_foreign_keys: true
 :show_indexes: true
+:show_indexes_comments: false
+:show_indexes_include: false
+:show_unique_constraints: false
 :simple_indexes: false
 :skip_on_db_migrate: false
 :sort: false


### PR DESCRIPTION
## Summary of the problem

`.annotaterb.yml` was generated by an older version of the gem and had drifted from the option set annotaterb ships today. Ten configuration keys added between 4.16.0 and 4.24.0 were absent from the file.

Nothing was broken by this. annotaterb falls back to `DEFAULT_OPTIONS` for any key missing from the config, so behavior was already correct. But the file no longer showed the full set of knobs available, which makes it harder to see what can be tuned. Follow-up to #12873, which bumped the gem.

## Describe your changes

Ran `rails g annotate_rb:update_config`, which appends the missing keys:

- `auto_annotate_routes_after_migrate`
- `grouped_polymorphic`
- `ignore_database_name`
- `ignore_multi_database_name`
- `position_of_column_comment`
- `show_enums`
- `show_exclusion_constraints`
- `show_indexes_comments`
- `show_indexes_include`
- `show_unique_constraints`

The generator appends to the end of the file. Since this file is otherwise alphabetical, I sorted the new keys into position instead. The diff is 10 insertions and 0 deletions, so no existing line moved.

Each key is set to the gem's own default, making this a no-op for annotation output. Confirmed by running `annotaterb models --frozen` after the change: "Model files unchanged".

Two keys in `DEFAULT_OPTIONS` are deliberately not written by the generator, so their absence is expected: `format_bare` is marked `# Unused` in the gem, and `show_virtual_columns` is not in `ALL_OPTION_KEYS`.