### PR TITLE
Annotate check constraints and group polymorphic columns

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -19,7 +19,7 @@
 :format_rdoc: false
 :format_yard: false
 :frozen: false
-:grouped_polymorphic: false
+:grouped_polymorphic: true
 :hide_default_column_types: 'json,jsonb,hstore'
 :hide_limit_column_types: 'integer,bigint,boolean'
 :ignore_columns: 

--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -45,7 +45,7 @@
 :root_dir:
 - ''
 :routes: false
-:show_check_constraints: false
+:show_check_constraints: true
 :show_complete_foreign_keys: false
 :show_enums: false
 :show_exclusion_constraints: false

--- a/app/models/ahoy/message.rb
+++ b/app/models/ahoy/message.rb
@@ -10,8 +10,8 @@
 #  sent_at   :datetime
 #  subject   :text
 #  to        :string
-#  user_type :string
 #  user_id   :bigint
+#  user_type :string
 #
 # Indexes
 #

--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -65,6 +65,10 @@
 #  fk_rails_...  (ledger_item_id => ledger_items.id)
 #  fk_rails_...  (raw_pending_stripe_transaction_id => raw_pending_stripe_transactions.id)
 #
+# Check Constraints
+#
+#  canonical_pending_transactions_fronted_null  (fronted IS NOT NULL)
+#
 class CanonicalPendingTransaction < ApplicationRecord
   has_paper_trail
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -11,11 +11,11 @@
 #  friendly_memo           :text
 #  hcb_code                :text
 #  memo                    :text             not null
-#  transaction_source_type :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  ledger_item_id          :bigint
 #  transaction_source_id   :bigint
+#  transaction_source_type :string
 #
 # Indexes
 #

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,13 +7,13 @@
 #  id                 :bigint           not null, primary key
 #  action             :integer          default(0), not null
 #  admin_only         :boolean          default(FALSE), not null
-#  commentable_type   :string
 #  content_ciphertext :text
 #  deleted_at         :datetime
 #  has_untracked_edit :boolean          default(FALSE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  commentable_id     :bigint
+#  commentable_type   :string
 #  user_id            :bigint
 #
 # Indexes

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -6,7 +6,6 @@
 #
 #  id                   :bigint           not null, primary key
 #  aasm_state           :string           not null
-#  contractable_type    :string
 #  cosigner_email       :string
 #  deleted_at           :datetime
 #  external_service     :integer
@@ -18,6 +17,7 @@
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  contractable_id      :bigint
+#  contractable_type    :string
 #  document_id          :bigint
 #  external_id          :string
 #  external_template_id :string

--- a/app/models/contract/fiscal_sponsorship.rb
+++ b/app/models/contract/fiscal_sponsorship.rb
@@ -6,7 +6,6 @@
 #
 #  id                   :bigint           not null, primary key
 #  aasm_state           :string           not null
-#  contractable_type    :string
 #  cosigner_email       :string
 #  deleted_at           :datetime
 #  external_service     :integer
@@ -18,6 +17,7 @@
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  contractable_id      :bigint
+#  contractable_type    :string
 #  document_id          :bigint
 #  external_id          :string
 #  external_template_id :string

--- a/app/models/contract/payroll_position.rb
+++ b/app/models/contract/payroll_position.rb
@@ -6,7 +6,6 @@
 #
 #  id                   :bigint           not null, primary key
 #  aasm_state           :string           not null
-#  contractable_type    :string
 #  cosigner_email       :string
 #  deleted_at           :datetime
 #  external_service     :integer
@@ -18,6 +17,7 @@
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  contractable_id      :bigint
+#  contractable_type    :string
 #  document_id          :bigint
 #  external_id          :string
 #  external_template_id :string

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,10 +7,10 @@
 #  id          :bigint           not null, primary key
 #  aasm_state  :string           not null
 #  deleted_at  :datetime
-#  entity_type :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  entity_id   :bigint           not null
+#  entity_type :string           not null
 #  event_id    :bigint           not null
 #  gusto_id    :string
 #

--- a/app/models/employee/payment.rb
+++ b/app/models/employee/payment.rb
@@ -9,7 +9,6 @@
 #  amount_cents   :integer          default(0), not null
 #  approved_at    :datetime
 #  description    :text
-#  payout_type    :string
 #  rejected_at    :datetime
 #  review_message :text
 #  title          :text             not null
@@ -17,6 +16,7 @@
 #  updated_at     :datetime         not null
 #  employee_id    :bigint           not null
 #  payout_id      :bigint
+#  payout_type    :string
 #  reviewed_by_id :bigint
 #
 # Indexes

--- a/app/models/event/affiliation.rb
+++ b/app/models/event/affiliation.rb
@@ -5,12 +5,12 @@
 # Table name: event_affiliations
 #
 #  id              :bigint           not null, primary key
-#  affiliable_type :string           not null
 #  metadata        :jsonb            not null
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  affiliable_id   :bigint           not null
+#  affiliable_type :string           not null
 #
 # Indexes
 #

--- a/app/models/governance/admin/transfer/approval_attempt.rb
+++ b/app/models/governance/admin/transfer/approval_attempt.rb
@@ -13,12 +13,12 @@
 #  current_limit_window_started_at      :datetime         not null
 #  denial_reason                        :string
 #  result                               :string           not null
-#  transfer_type                        :string           not null
 #  created_at                           :datetime         not null
 #  updated_at                           :datetime         not null
 #  governance_admin_transfer_limit_id   :bigint           not null
 #  governance_request_context_id        :bigint
 #  transfer_id                          :bigint           not null
+#  transfer_type                        :string           not null
 #  user_id                              :bigint           not null
 #
 # Indexes

--- a/app/models/governance/request_context.rb
+++ b/app/models/governance/request_context.rb
@@ -6,7 +6,6 @@
 #
 #  id                          :bigint           not null, primary key
 #  action_name                 :string           not null
-#  authentication_session_type :string           not null
 #  controller_name             :string           not null
 #  http_method                 :string           not null
 #  ip_address                  :inet             not null
@@ -16,6 +15,7 @@
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  authentication_session_id   :bigint           not null
+#  authentication_session_type :string           not null
 #  impersonator_id             :bigint
 #  request_id                  :string           not null
 #  user_id                     :bigint           not null

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -30,6 +30,10 @@
 #
 #  fk_rails_...  (ledger_item_id => ledger_items.id) ON DELETE => nullify
 #
+# Check Constraints
+#
+#  constraint_hcb_codes_on_short_code_to_uppercase  (short_code = upper(short_code))
+#
 class HcbCode < ApplicationRecord
   has_paper_trail
 

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -24,6 +24,10 @@
 #  fk_rails_...  (card_grant_id => card_grants.id)
 #  fk_rails_...  (event_id => events.id)
 #
+# Check Constraints
+#
+#  ledgers_owner_rules  ("primary" IS TRUE AND (event_id IS NOT NULL AND card_grant_id IS NULL OR event_id IS NULL AND card_grant_id IS NOT NULL) OR "primary" IS FALSE AND event_id IS NULL AND card_grant_id IS NULL)
+#
 class Ledger < ApplicationRecord
   self.table_name = "ledgers"
 

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -9,7 +9,6 @@
 #  comment_count                :integer          default(0), not null
 #  custom_memo                  :text
 #  datetime                     :datetime         not null
-#  linked_object_type           :string
 #  marked_no_or_lost_receipt_at :datetime
 #  memo                         :text             not null
 #  not_admin_only_comment_count :integer          default(0), not null
@@ -22,6 +21,7 @@
 #  updated_at                   :datetime         not null
 #  author_id                    :bigint
 #  linked_object_id             :bigint
+#  linked_object_type           :string
 #
 # Indexes
 #

--- a/app/models/legal_entity/payout_method.rb
+++ b/app/models/legal_entity/payout_method.rb
@@ -7,11 +7,11 @@
 #  id              :bigint           not null, primary key
 #  archived        :boolean          default(FALSE), not null
 #  default         :boolean          default(FALSE), not null
-#  details_type    :string           not null
 #  name            :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  details_id      :bigint           not null
+#  details_type    :string           not null
 #  legal_entity_id :bigint           not null
 #
 # Indexes

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/spending_by_category.rb
+++ b/app/models/metric/event/spending_by_category.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/spending_by_date.rb
+++ b/app/models/metric/event/spending_by_date.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/spending_by_location.rb
+++ b/app/models/metric/event/spending_by_location.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/spending_by_merchant.rb
+++ b/app/models/metric/event/spending_by_merchant.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/spending_by_user.rb
+++ b/app/models/metric/event/spending_by_user.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/total_raised.rb
+++ b/app/models/metric/event/total_raised.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/total_spent.rb
+++ b/app/models/metric/event/total_spent.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/event/words.rb
+++ b/app/models/metric/event/words.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/merchant_count.rb
+++ b/app/models/metric/hcb/merchant_count.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/new_events.rb
+++ b/app/models/metric/hcb/new_events.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/new_users.rb
+++ b/app/models/metric/hcb/new_users.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/spending_by_category.rb
+++ b/app/models/metric/hcb/spending_by_category.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/spending_by_date.rb
+++ b/app/models/metric/hcb/spending_by_date.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/spending_by_location.rb
+++ b/app/models/metric/hcb/spending_by_location.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/spending_by_merchant.rb
+++ b/app/models/metric/hcb/spending_by_merchant.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/spending_by_user.rb
+++ b/app/models/metric/hcb/spending_by_user.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/stats.rb
+++ b/app/models/metric/hcb/stats.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/total_events.rb
+++ b/app/models/metric/hcb/total_events.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/total_raised.rb
+++ b/app/models/metric/hcb/total_raised.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/total_spent.rb
+++ b/app/models/metric/hcb/total_spent.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/hcb/total_users.rb
+++ b/app/models/metric/hcb/total_users.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/card_grant_amount.rb
+++ b/app/models/metric/user/card_grant_amount.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/card_grant_count.rb
+++ b/app/models/metric/user/card_grant_count.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/lost_receipt_count.rb
+++ b/app/models/metric/user/lost_receipt_count.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/most_interacted_with.rb
+++ b/app/models/metric/user/most_interacted_with.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/platinum_card.rb
+++ b/app/models/metric/user/platinum_card.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/reimbursement_amount.rb
+++ b/app/models/metric/user/reimbursement_amount.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/reimbursement_count.rb
+++ b/app/models/metric/user/reimbursement_count.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/spending_by_category.rb
+++ b/app/models/metric/user/spending_by_category.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/spending_by_date.rb
+++ b/app/models/metric/user/spending_by_date.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/spending_by_location.rb
+++ b/app/models/metric/user/spending_by_location.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/spending_by_merchant.rb
+++ b/app/models/metric/user/spending_by_merchant.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/time_to_receipt.rb
+++ b/app/models/metric/user/time_to_receipt.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/total_spent.rb
+++ b/app/models/metric/user/total_spent.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/wise_transfer_amount.rb
+++ b/app/models/metric/user/wise_transfer_amount.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/wise_transfer_count.rb
+++ b/app/models/metric/user/wise_transfer_count.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/metric/user/words.rb
+++ b/app/models/metric/user/words.rb
@@ -11,12 +11,12 @@
 #  failed_at     :datetime
 #  metric        :jsonb
 #  processing_at :datetime
-#  subject_type  :string
 #  type          :string           not null
 #  year          :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  subject_id    :bigint
+#  subject_type  :string
 #
 # Indexes
 #

--- a/app/models/payment/attempt.rb
+++ b/app/models/payment/attempt.rb
@@ -8,13 +8,13 @@
 #  aasm_state       :string           not null
 #  deleted_at       :datetime
 #  failed_at        :datetime
-#  payout_type      :string
 #  sent_at          :datetime
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  payment_id       :bigint           not null
 #  payout_id        :bigint
 #  payout_method_id :bigint           not null
+#  payout_type      :string
 #
 # Indexes
 #

--- a/app/models/raw_increase_transaction.rb
+++ b/app/models/raw_increase_transaction.rb
@@ -8,12 +8,12 @@
 #  amount_cents            :integer
 #  date_posted             :date
 #  description             :text
-#  increase_route_type     :text
 #  increase_transaction    :jsonb
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  increase_account_id     :text
 #  increase_route_id       :text
+#  increase_route_type     :text
 #  increase_transaction_id :text
 #
 # Indexes

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -14,7 +14,6 @@
 #  extracted_merchant_zip_code     :string
 #  extracted_subtotal_amount_cents :integer
 #  extracted_total_amount_cents    :integer
-#  receiptable_type                :string
 #  suggested_memo                  :string
 #  textual_content_bidx            :string
 #  textual_content_ciphertext      :text
@@ -23,6 +22,7 @@
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  receiptable_id                  :bigint
+#  receiptable_type                :string
 #  user_id                         :bigint
 #
 # Indexes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,10 @@
 #
 #  index_tags_on_event_id  (event_id)
 #
+# Check Constraints
+#
+#  tags_emoji_null  (emoji IS NOT NULL)
+#
 class Tag < ApplicationRecord
   include ActionView::Helpers::TextHelper # for `pluralize`
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,15 +5,15 @@
 # Table name: tasks
 #
 #  id            :bigint           not null, primary key
-#  assignee_type :string           not null
 #  complete      :boolean          default(FALSE)
 #  completed_at  :datetime
-#  taskable_type :string           not null
 #  type          :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  assignee_id   :bigint           not null
+#  assignee_type :string           not null
 #  taskable_id   :bigint           not null
+#  taskable_type :string           not null
 #
 # Indexes
 #

--- a/app/models/task/receiptable/upload.rb
+++ b/app/models/task/receiptable/upload.rb
@@ -5,15 +5,15 @@
 # Table name: tasks
 #
 #  id            :bigint           not null, primary key
-#  assignee_type :string           not null
 #  complete      :boolean          default(FALSE)
 #  completed_at  :datetime
-#  taskable_type :string           not null
 #  type          :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  assignee_id   :bigint           not null
+#  assignee_type :string           not null
 #  taskable_id   :bigint           not null
+#  taskable_type :string           not null
 #
 # Indexes
 #

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -8,10 +8,10 @@
 #  active        :boolean          default(TRUE)
 #  name          :string
 #  step          :integer          default(0)
-#  tourable_type :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  tourable_id   :bigint           not null
+#  tourable_type :string           not null
 #
 # Indexes
 #

--- a/app/models/transaction_category_mapping.rb
+++ b/app/models/transaction_category_mapping.rb
@@ -6,10 +6,10 @@
 #
 #  id                      :bigint           not null, primary key
 #  assignment_strategy     :text             not null
-#  categorizable_type      :text             not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  categorizable_id        :bigint           not null
+#  categorizable_type      :text             not null
 #  transaction_category_id :bigint           not null
 #
 # Indexes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,6 @@
 #  locked_at                     :datetime
 #  monthly_donation_summary      :boolean          default(TRUE)
 #  monthly_follower_summary      :boolean          default(TRUE)
-#  payout_method_type            :string
 #  phone_number                  :text
 #  phone_number_verified         :boolean          default(FALSE)
 #  preferred_name                :string
@@ -38,6 +37,7 @@
 #  updated_at                    :datetime         not null
 #  discord_id                    :string
 #  payout_method_id              :bigint
+#  payout_method_type            :string
 #  webauthn_id                   :string
 #
 # Indexes

--- a/app/models/w9.rb
+++ b/app/models/w9.rb
@@ -5,12 +5,12 @@
 # Table name: w9s
 #
 #  id             :bigint           not null, primary key
-#  entity_type    :string           not null
 #  signed_at      :datetime         not null
 #  url            :string           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  entity_id      :bigint           not null
+#  entity_type    :string           not null
 #  uploaded_by_id :bigint
 #
 # Indexes


### PR DESCRIPTION
## Summary of the problem

Two annotaterb options that are useful against our schema were left off. Both were surveyed against the real schema rather than enabled speculatively:

- **Check constraints.** We have 4 in `db/schema.rb`, none of which are visible from the model files. `ledgers_owner_rules` encodes a real invariant about which owner columns may be set together, and someone editing `Ledger` has no way to see it without opening the schema dump.
- **Polymorphic columns.** We have 33 polymorphic pairs. Sorting `*_type` alphabetically separates it from its `*_id`, so `commentable_type` and `commentable_id` end up in different parts of the annotation.

The other new options from #14445 (`show_enums`, `show_unique_constraints`, `show_exclusion_constraints`, `show_indexes_comments`, `show_indexes_include`) match zero objects in our schema, so they stay off.

> Stacked on #14445. Review that one first. This PR targets `sync-annotaterb-config`, so the diff here is only the incremental change; GitHub will retarget it to `main` once the base merges.

## Describe your changes

Two commits, one per option, so the small and large diffs stay separable.

**`show_check_constraints: true`** adds 16 lines across 4 models (`canonical_pending_transaction`, `hcb_code`, `ledger`, `tag`):

```ruby
# Check Constraints
#
#  tags_emoji_null  (emoji IS NOT NULL)
```

**`grouped_polymorphic: true`** moves each `*_type` next to its matching `*_id`, touching 60 files with 62 insertions and 62 deletions. This is reordering only. I verified per-file that the sorted set of added lines equals the sorted set of removed lines, so no annotation content is added or lost.

Verified with `annotaterb models --frozen` ("Model files unchanged") and `rubocop` across the 64 changed files (no offenses).