### PR TITLE
Let admins page the on-call engineer from HCB admin

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -19,6 +19,10 @@ LOCKBOX="A3F1C7D829B65E4FA2D8C9E31F7B04E5D1A6B3C8829F54E7C0D3A5916E2F48BC"
 
 OPENAI_API_KEY="sk..."
 
+# Events API v2 integration key for the PagerDuty service that pages the
+# engineering on-call escalation policy. Leave blank to disable /admin/page_engineers.
+PAGERDUTY__MANUAL_PAGE_ROUTING_KEY=""
+
 STRIPE__TEST__PHYSICAL_BUNDLE_IDS__US_VISA_CREDIT_BLACK="ics..."
 STRIPE__TEST__PHYSICAL_BUNDLE_IDS__US_VISA_CREDIT_WHITE="ics..."
 STRIPE__TEST__PUBLISHABLE_KEY="pk..."

--- a/app/controllers/admin/engineering_pages_controller.rb
+++ b/app/controllers/admin/engineering_pages_controller.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Admin
+  # Break-glass: lets an admin open a PagerDuty incident against the engineering
+  # on-call escalation policy when something urgent is wrong with HCB.
+  class EngineeringPagesController < ApplicationController
+    skip_after_action :verify_authorized # do not force pundit
+
+    # ApplicationController's bare `protect_from_forgery` resolves to
+    # :null_session, which doesn't sign the request out here (Current.session is
+    # already loaded from the cookie by then). Waking a human deserves a real
+    # token check.
+    protect_from_forgery with: :exception
+
+    # NOTE: deliberately *not* the usual `signed_in_admin`, which only requires
+    # `auditor?`. Paging wakes a human up, so it's gated on `admin?`.
+    before_action :signed_in_true_admin
+
+    # /admin is excluded from the global Rack::Attack throttle, so this is the
+    # only ceiling. Set well above what a real incident needs: the first page
+    # always goes through, but a stuck retry loop can't ring the phone forever.
+    rate_limit to: 5, within: 5.minutes, only: :create,
+               by: -> { current_user&.id },
+               with: -> { redirect_to admin_tools_path, flash: { error: "You've paged several times in the last few minutes. Someone has already been notified. Contact an engineer directly if it's urgent." } }
+
+    layout "admin"
+
+    MAX_MESSAGE_LENGTH = 120
+    CONFIRMATION_PHRASE = "PAGE"
+
+    def new
+    end
+
+    def create
+      @message = params[:message].to_s.strip
+
+      return refuse("Tell the on-call engineer what's happening.") if @message.blank?
+
+      if @message.length > MAX_MESSAGE_LENGTH
+        return refuse("Keep it under #{MAX_MESSAGE_LENGTH} characters so it fits in a phone notification.")
+      end
+
+      # Also enforced client-side by the type-to-confirm Stimulus controller,
+      # but that's only a convenience. This is the guard that actually holds.
+      unless params[:confirmation].to_s.strip == CONFIRMATION_PHRASE
+        return refuse("Type #{CONFIRMATION_PHRASE} to confirm you want to wake someone up.")
+      end
+
+      unless PagerDutyService.manual_page_enabled?
+        return refuse("PagerDuty isn't configured in this environment, so nobody was paged.")
+      end
+
+      result = PagerDutyService.trigger(
+        routing_key: PagerDutyService.manual_page_routing_key,
+        summary: page_summary,
+        source: page_source,
+        severity: "critical",
+        client_url: root_url,
+        component: "hcb",
+        group: "manual",
+        klass: "manual_page",
+        custom_details: page_custom_details,
+        links: [{ href: user_url(current_user), text: "#{current_user.name} on HCB" }]
+      )
+
+      # Deliberately "accepted", not "paged". A 202 only proves PagerDuty took
+      # the event. Whether a phone actually rings depends on the escalation
+      # policy, the on-call user's notification rules, and alert grouping, none
+      # of which a write-only routing key lets us read back.
+      redirect_to admin_tools_path, flash: { success: "PagerDuty accepted the page (ref #{result["dedup_key"]}). If nobody reaches out within a few minutes, contact an engineer directly." }
+    rescue Faraday::TimeoutError => e
+      # A read timeout: the request went out but no response came back, so the
+      # event may well have been enqueued and someone may already be dialing.
+      # Saying "nobody was notified" here would send the admin off to wake a
+      # second person for no reason. A failure to connect at all is a different
+      # error (Faraday::ConnectionFailed) and falls through to the branch below,
+      # where "nobody was notified" is accurate.
+      report_failure(e)
+      flash.now[:error] = "PagerDuty didn't respond in time, so we can't confirm the page went out. It may have fired anyway. If nobody reaches out within a few minutes, contact an engineer directly."
+      render :new, status: :bad_gateway
+    rescue => e
+      # Broad on purpose. Every path out of here tells the admin nobody was
+      # paged, which is the truthful and safe answer for any unexpected error.
+      report_failure(e)
+      flash.now[:error] = "PagerDuty didn't accept the page, so nobody was notified. Contact an engineer directly."
+      render :new, status: :bad_gateway
+    end
+
+    private
+
+    def refuse(message)
+      flash.now[:error] = message
+      render :new, status: :unprocessable_content
+    end
+
+    # This is the whole thing the on-call engineer sees on their lock screen, so
+    # the message leads and the attribution trails (push notifications truncate).
+    def page_summary
+      summary = "#{@message} · paged by #{current_user.name}"
+      summary = "[#{Rails.env}] #{summary}" unless Rails.env.production?
+      summary
+    end
+
+    # The configured host rather than request.host, which is attacker-influenced
+    # via the Host header and is what on-call reads to tell staging from prod.
+    def page_source
+      Rails.application.routes.default_url_options[:host].presence || "hcb"
+    end
+
+    def page_custom_details
+      details = {
+        paged_by: current_user.name,
+        paged_by_email: current_user.email,
+        environment: Rails.env,
+        message: @message
+      }
+      # Otherwise on-call calls back the impersonated user, not the real actor.
+      if current_session&.impersonated?
+        details[:impersonated_by] = current_session.impersonated_by&.email
+      end
+      details
+    end
+
+    def report_failure(error)
+      Rails.logger.error("[page_engineers] failed to page on-call: #{error.class}: #{error.message}")
+      Rails.error.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {
+          paged_by_id: current_user&.id,
+          response_status: error.try(:response_status)
+        }
+      )
+    end
+
+    def signed_in_true_admin
+      return if admin_signed_in?
+
+      # Auditors can see the nav item and the admin tools card, so send them
+      # somewhere useful instead of bouncing them to a sign-in screen they're
+      # already past.
+      if signed_in?
+        redirect_to admin_tools_path, flash: { error: "Only admins can page the on-call engineer. Ask an admin, or post in Slack." }
+      else
+        redirect_to auth_users_path(require_reload: true), flash: { error: "You’ll need to sign in as an admin." }
+      end
+    end
+
+  end
+end

--- a/app/javascript/components/command_bar/actions.js
+++ b/app/javascript/components/command_bar/actions.js
@@ -701,6 +701,16 @@ export const adminActions = (adminUrls, isPretending) => {
       icon: <Icon glyph="member-add" size={16} />,
       perform: navigate('/admin/new_teenagers_leaderboard'),
     },
+    {
+      id: 'admin-page-engineers',
+      section: 'Admin Tools',
+      priority: Priority.HIGH,
+      name: 'Page engineers',
+      keywords:
+        'page engineers oncall on-call pagerduty incident outage emergency help',
+      icon: <Icon glyph="important" size={16} />,
+      perform: navigate('/admin/page_engineers'),
+    },
     // airtable
     {
       id: 'admin-applications-airtable',

--- a/app/javascript/controllers/type_to_confirm_controller.js
+++ b/app/javascript/controllers/type_to_confirm_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Keeps a submit button disabled until the user types an exact phrase.
+//
+// Progressive enhancement only: the button is rendered enabled so the form
+// still works without JS, and the server re-checks the phrase. Never rely on
+// this as the only guard.
+//
+//   <form data-controller="type-to-confirm" data-type-to-confirm-phrase-value="PAGE">
+//     <input data-type-to-confirm-target="input" data-action="input->type-to-confirm#check">
+//     <input type="submit" data-type-to-confirm-target="submit">
+//   </form>
+export default class extends Controller {
+  static targets = ['input', 'submit']
+  static values = { phrase: String }
+
+  connect() {
+    this.check()
+  }
+
+  check() {
+    // Fail open if the markup is incomplete: a missing phrase or input target
+    // should leave the form usable rather than trapping someone behind a
+    // permanently disabled button.
+    if (!this.hasInputTarget || !this.phraseValue) {
+      this.setDisabled(false)
+      return
+    }
+
+    this.setDisabled(this.inputTarget.value.trim() !== this.phraseValue)
+  }
+
+  setDisabled(disabled) {
+    this.submitTargets.forEach(submit => {
+      submit.disabled = disabled
+    })
+  }
+}

--- a/app/models/admin/nav.rb
+++ b/app/models/admin/nav.rb
@@ -428,6 +428,12 @@ module Admin
             path: new_teenagers_leaderboard_admin_index_path,
             count: ->{ 0 }, # I think this would be expensive to calculate
             count_type: :records,
+          ),
+          make_item(
+            name: "Page Engineers",
+            path: admin_page_engineers_path,
+            count: ->{ 0 }, # nothing to count; this is an action, not a queue
+            count_type: :records,
           )
         ]
       )

--- a/app/services/pager_duty_service.rb
+++ b/app/services/pager_duty_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Sends events to PagerDuty's Events API v2.
+#
+# An event is addressed to a PagerDuty *service* by that service's integration
+# key (the "routing key"), never to a person. PagerDuty turns the event into an
+# incident and notifies whoever the service's escalation policy says is on call,
+# escalating if nobody acknowledges. Routing keys are write-only credentials:
+# they can create incidents but can't read anything back.
+#
+# https://developer.pagerduty.com/docs/send-alert-event
+class PagerDutyService
+  # Raised when PagerDuty answered but did not accept the event, so nobody was
+  # paged. Distinct from Faraday::Error, which means we never got an answer.
+  class EventRejected < StandardError; end
+
+  ENQUEUE_PATH = "/v2/enqueue"
+
+  # PagerDuty truncates longer summaries, and it's the only field that reliably
+  # shows up in a push notification.
+  MAX_SUMMARY_LENGTH = 1024
+
+  SEVERITIES = ["critical", "error", "warning", "info"].freeze
+
+  def self.conn
+    # Short timeouts: callers page synchronously so an admin finds out
+    # immediately whether a human was actually reached.
+    @conn ||= Faraday.new url: "https://events.pagerduty.com", request: { timeout: 5, open_timeout: 3 } do |f|
+      f.request :json
+      f.response :raise_error
+      f.response :json
+    end
+  end
+
+  # Routing key for the service that pages the engineering on-call escalation
+  # policy when an admin manually asks for help.
+  def self.manual_page_routing_key
+    Credentials.fetch(:PAGERDUTY, :MANUAL_PAGE_ROUTING_KEY)
+  end
+
+  def self.manual_page_enabled?
+    manual_page_routing_key.present?
+  end
+
+  def self.trigger(routing_key:, summary:, source:, severity: "critical", client_url: nil, component: nil, group: nil, klass: nil, custom_details: {}, links: [])
+    raise ArgumentError, "unknown severity: #{severity.inspect}" unless SEVERITIES.include?(severity)
+
+    body = {
+      routing_key:,
+      event_action: "trigger",
+      client: "HCB",
+      client_url:,
+      payload: {
+        summary: summary.truncate(MAX_SUMMARY_LENGTH),
+        source:,
+        severity:,
+        timestamp: Time.current.iso8601,
+        component:,
+        group:,
+        class: klass,
+        custom_details:
+      }.compact,
+      links:
+    }.compact
+
+    response = conn.post(ENQUEUE_PATH, body)
+    verify_accepted!(response)
+    response.body
+  rescue => e
+    # AppSignal turns the Rails error reporter's `context:` into tags, which
+    # can't hold nested hashes, so the body gets dropped. Attach it as custom
+    # data (which supports nesting) and keep scalars as filterable tags.
+    Appsignal.add_tags(
+      pager_duty_source: source,
+      response_status: e.try(:response_status)
+    )
+    Appsignal.add_custom_data(
+      pager_duty: {
+        summary:,
+        source:,
+        severity:,
+        response_status: e.try(:response_status),
+        response_body: e.try(:response_body)
+      }
+    )
+    raise
+  end
+
+  # PagerDuty acknowledges an accepted event with 202 and a body of
+  # `{"status": "success", "dedup_key": ...}`. Faraday's `raise_error` only
+  # covers 4xx and 5xx, so without this check a 200 from an intercepting proxy,
+  # a 301 to another host, a 204, or a 202 carrying `{"status": "invalid
+  # event"}` would all read as a successful page and nobody would be woken up.
+  private_class_method def self.verify_accepted!(response)
+    body = response.body
+
+    return if response.status == 202 &&
+              body.is_a?(Hash) &&
+              body["status"] == "success" &&
+              body["dedup_key"].present?
+
+    raise EventRejected, "PagerDuty did not accept the event (HTTP #{response.status}, body: #{body.inspect.truncate(500)})"
+  end
+
+end

--- a/app/views/admin/engineering_pages/new.html.erb
+++ b/app/views/admin/engineering_pages/new.html.erb
@@ -1,0 +1,62 @@
+<% title "Page engineers" %>
+
+<div class="card border b--warning mb3">
+  <div class="flex items-center warning">
+    <%= inline_icon "important", size: 32, class: "mr1" %>
+    <p class="bold mt0 mb0">This wakes up a real person.</p>
+  </div>
+  <ul class="mt1 mb2">
+    <li>
+      This opens a critical PagerDuty incident and notifies whoever is on call
+      right now, however they've told PagerDuty to reach them, at whatever hour
+      it happens to be for them.
+    </li>
+    <li>
+      Use this when HCB is broken in a way that can’t wait: money is moving
+      wrong, organizations are blocked, or something is down.
+    </li>
+    <li>
+      For anything that can wait until morning, post in Slack instead.
+    </li>
+  </ul>
+</div>
+
+<% if PagerDutyService.manual_page_enabled? %>
+  <%= form_with(url: admin_page_engineers_path, method: :post, local: true, class: "card",
+                data: { controller: "type-to-confirm", type_to_confirm_phrase_value: Admin::EngineeringPagesController::CONFIRMATION_PHRASE }) do |form| %>
+    <%= form.label :message, "What’s happening?" %>
+    <p class="secondary mt0 mb1">
+      This is the entire thing the on-call engineer sees on their phone. Be
+      specific, and say what’s broken rather than what you were doing.
+    </p>
+    <%= form.text_field :message,
+                        value: @message,
+                        required: true,
+                        autofocus: true,
+                        maxlength: Admin::EngineeringPagesController::MAX_MESSAGE_LENGTH,
+                        placeholder: "Transfers are failing for every org with an error page" %>
+
+    <%= form.label :confirmation, "Type #{Admin::EngineeringPagesController::CONFIRMATION_PHRASE} to confirm", class: "mt2" %>
+    <%= form.text_field :confirmation,
+                        autocomplete: "off",
+                        placeholder: Admin::EngineeringPagesController::CONFIRMATION_PHRASE,
+                        data: { type_to_confirm_target: "input", action: "input->type-to-confirm#check" } %>
+
+    <div class="actions">
+      <%# Rendered enabled on purpose. The Stimulus controller disables it until %>
+      <%# the phrase is typed, but if the JS bundle fails to load (plausible %>
+      <%# during the very outage you'd be paging about) this still submits, and %>
+      <%# the controller re-checks the phrase server-side. %>
+      <%= form.submit "Page the on-call engineer",
+                      class: "bg-error",
+                      data: { type_to_confirm_target: "submit" } %>
+    </div>
+  <% end %>
+<% else %>
+  <div class="card">
+    <p class="mt0 mb0">
+      PagerDuty isn’t configured in this environment, so this page can’t reach
+      anyone. Set <code>PAGERDUTY__MANUAL_PAGE_ROUTING_KEY</code> to enable it.
+    </p>
+  </div>
+<% end %>

--- a/app/views/static_pages/admin_tools.html.erb
+++ b/app/views/static_pages/admin_tools.html.erb
@@ -92,6 +92,8 @@
         <%= card_to "Pending ledger", pending_ledger_admin_index_path, badge: CanonicalPendingTransaction.unsettled.count %>
         <%= card_to "Account numbers", account_numbers_admin_index_path, badge: Column::AccountNumber.count, subtle_badge: true %>
         <%= card_to "Recurring donations", recurring_donations_admin_index_path, badge: RecurringDonation.active.count %>
+        <%# Admin-only: auditors can reach this page but not the paging action. %>
+        <%= card_to "Page engineers", admin_page_engineers_path if admin_signed_in? %>
       </ul>
       <details>
         <summary>Old cards</summary>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,6 +345,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: redirect("/admin/events")
+    get "page_engineers", to: "engineering_pages#new", as: :page_engineers
+    post "page_engineers", to: "engineering_pages#create"
     namespace :ledger_audits do
       resources :tasks, only: [:index, :show, :create] do
         post :reviewed

--- a/spec/requests/admin/engineering_pages_spec.rb
+++ b/spec/requests/admin/engineering_pages_spec.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Paging engineers from admin", type: :request do
+  let(:enqueue_url) { "https://events.pagerduty.com/v2/enqueue" }
+  let(:routing_key) { "R0UT1NGK3Y" }
+  let(:valid_params) { { message: "Transfers are failing for every org", confirmation: "PAGE" } }
+
+  def sign_in(user)
+    session = create(:user_session, user:, verified: true, expiration_at: 1.hour.from_now)
+    allow_any_instance_of(SessionsHelper).to receive(:find_current_session).and_return(session)
+  end
+
+  def stub_pager_duty(status: 202, body: nil, content_type: "application/json")
+    body ||= { status: "success", dedup_key: "abc123" }.to_json
+    stub_request(:post, enqueue_url).to_return(status:, body:, headers: { "Content-Type" => content_type })
+  end
+
+  before do
+    allow(PagerDutyService).to receive(:manual_page_routing_key).and_return(routing_key)
+    stub_pager_duty
+  end
+
+  describe "authorization" do
+    it "turns away a signed-out visitor without paging anyone" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(response).to redirect_to(/\/users\/auth/)
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "turns away a regular user without paging anyone" do
+      sign_in(create(:user))
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "turns away an auditor without paging anyone" do
+      sign_in(create(:user, :make_auditor))
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "sends an auditor somewhere useful instead of a sign-in screen they're already past" do
+      sign_in(create(:user, :make_auditor))
+
+      get admin_page_engineers_path
+
+      expect(response).to redirect_to(admin_tools_path)
+      expect(flash[:error]).to include("Only admins can page")
+    end
+
+    it "blocks an auditor from the form itself" do
+      sign_in(create(:user, :make_auditor))
+
+      get admin_page_engineers_path
+
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "lets an admin reach the form" do
+      sign_in(create(:user, :make_admin))
+
+      get admin_page_engineers_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Type PAGE to confirm")
+    end
+  end
+
+  describe "paging" do
+    let(:admin) { create(:user, :make_admin, full_name: "Jane Admin") }
+
+    before { sign_in(admin) }
+
+    it "opens a critical incident with the message and who sent it" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(response).to redirect_to(admin_tools_path)
+      expect(flash[:success]).to include("PagerDuty accepted the page")
+      expect(a_request(:post, enqueue_url).with { |req|
+        body = JSON.parse(req.body)
+        payload = body["payload"]
+        body["routing_key"] == routing_key &&
+          body["event_action"] == "trigger" &&
+          payload["severity"] == "critical" &&
+          payload["summary"].include?("Transfers are failing for every org") &&
+          payload["summary"].include?("Jane Admin") &&
+          payload["custom_details"]["paged_by_email"] == admin.email
+      }).to have_been_made.once
+    end
+
+    it "sets the routing fields PagerDuty event rules key off" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url).with { |req|
+        payload = JSON.parse(req.body)["payload"]
+        payload["component"] == "hcb" &&
+          payload["group"] == "manual" &&
+          payload["class"] == "manual_page" &&
+          JSON.parse(req.body)["client"] == "HCB"
+      }).to have_been_made
+    end
+
+    it "surfaces the PagerDuty reference so the admin can follow up" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(flash[:success]).to include("abc123")
+    end
+
+    it "leads the summary with the message so it survives notification truncation" do
+      captured = nil
+      stub_request(:post, enqueue_url).to_return do |request|
+        captured = JSON.parse(request.body)
+        { status: 202, body: { status: "success", dedup_key: "abc123" }.to_json, headers: { "Content-Type" => "application/json" } }
+      end
+
+      post admin_page_engineers_path, params: valid_params
+
+      summary = captured.dig("payload", "summary")
+      expect(summary).to include("Transfers are failing for every org")
+      expect(summary).to include("Jane Admin")
+      expect(summary.index("Transfers are failing")).to be < summary.index("Jane Admin")
+    end
+
+    it "marks the environment when it isn't production, so staging can't look like an outage" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url).with { |req|
+        JSON.parse(req.body)["payload"]["summary"].start_with?("[test]")
+      }).to have_been_made
+    end
+
+    it "links back to the person who paged" do
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url).with { |req|
+        link = JSON.parse(req.body)["links"].first
+        link["href"] == Rails.application.routes.url_helpers.user_url(admin, host: "www.example.com") &&
+          link["text"].include?("Jane Admin")
+      }).to have_been_made
+    end
+
+    it "accepts a message exactly at the length limit" do
+      post admin_page_engineers_path, params: valid_params.merge(message: "a" * Admin::EngineeringPagesController::MAX_MESSAGE_LENGTH)
+
+      expect(a_request(:post, enqueue_url)).to have_been_made
+    end
+  end
+
+  describe "attributing an impersonated page" do
+    it "records the real actor so on-call doesn't call back the impersonated user" do
+      real_admin = create(:user, :make_admin, full_name: "Real Admin")
+      target = create(:user, :make_admin, full_name: "Target Admin")
+      session = create(:user_session, user: target, impersonated_by: real_admin, verified: true, expiration_at: 1.hour.from_now)
+      allow_any_instance_of(SessionsHelper).to receive(:find_current_session).and_return(session)
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(a_request(:post, enqueue_url).with { |req|
+        JSON.parse(req.body)["payload"]["custom_details"]["impersonated_by"] == real_admin.email
+      }).to have_been_made
+    end
+  end
+
+  describe "refusing to page" do
+    before { sign_in(create(:user, :make_admin)) }
+
+    it "rejects a blank message" do
+      post admin_page_engineers_path, params: valid_params.merge(message: "   ")
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(flash[:error]).to include("what's happening")
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "rejects a message too long to fit in a phone notification" do
+      post admin_page_engineers_path, params: valid_params.merge(message: "a" * 200)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(flash[:error]).to include("characters")
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "keeps the typed message on the form so it isn't lost" do
+      post admin_page_engineers_path, params: valid_params.merge(message: "a" * 200)
+
+      expect(response.body).to include("a" * 200)
+    end
+
+    it "refuses without the typed confirmation, even though the check is also client-side" do
+      post admin_page_engineers_path, params: { message: "everything is down" }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "refuses a confirmation with the wrong casing" do
+      post admin_page_engineers_path, params: valid_params.merge(confirmation: "page")
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "refuses when PagerDuty isn't configured" do
+      allow(PagerDutyService).to receive(:manual_page_routing_key).and_return(nil)
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(flash[:error]).to include("isn't configured")
+      expect(a_request(:post, enqueue_url)).not_to have_been_made
+    end
+
+    it "hides the form entirely when PagerDuty isn't configured" do
+      allow(PagerDutyService).to receive(:manual_page_routing_key).and_return(nil)
+
+      get admin_page_engineers_path
+
+      expect(response.body).not_to include("Type PAGE to confirm")
+      expect(response.body).to include("isn’t configured in this environment")
+    end
+  end
+
+  # The one invariant that matters: an admin must never be told a human was
+  # reached when they weren't.
+  describe "never reporting a false success" do
+    before { sign_in(create(:user, :make_admin)) }
+
+    {
+      "PagerDuty returns a server error"               => { status: 500, body: "{}" },
+      "PagerDuty rate limits us"                       => { status: 429, body: "{}" },
+      "an intercepting proxy answers 200"              => { status: 200, body: "<html>proxy</html>", content_type: "text/html" },
+      "the response is an empty 204"                   => { status: 204, body: "" },
+      "a 301 redirect is never followed"               => { status: 301, body: "" },
+      "PagerDuty accepts but reports an invalid event" => { status: 202, body: { status: "invalid event", errors: ["Routing key not found"] }.to_json },
+    }.each do |description, response_attrs|
+      it "reports failure when #{description}" do
+        stub_pager_duty(**response_attrs)
+
+        post admin_page_engineers_path, params: valid_params
+
+        expect(flash[:success]).to be_nil
+        expect(response).to have_http_status(:bad_gateway)
+        expect(response.body).to include("Contact an engineer directly")
+      end
+    end
+
+    it "reports failure when the connection is refused" do
+      stub_request(:post, enqueue_url).to_raise(Errno::ECONNREFUSED)
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(flash[:success]).to be_nil
+      expect(response).to have_http_status(:bad_gateway)
+    end
+
+    # Never connected, so the event definitively did not reach PagerDuty.
+    # faraday-net_http maps Net::OpenTimeout to Faraday::ConnectionFailed.
+    it "states plainly that nobody was paged when the connection never opened" do
+      stub_request(:post, enqueue_url).to_timeout
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(flash[:success]).to be_nil
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response.body).to include("nobody was notified")
+    end
+
+    # The request went out but no response came back, so PagerDuty may well
+    # have enqueued it. Claiming nobody was paged would send the admin off to
+    # wake a second person for nothing.
+    it "says the outcome is unknown when the response times out" do
+      stub_request(:post, enqueue_url).to_raise(Faraday::TimeoutError)
+
+      post admin_page_engineers_path, params: valid_params
+
+      expect(flash[:success]).to be_nil
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response.body).to include("may have fired anyway")
+      expect(response.body).not_to include("nobody was notified")
+    end
+  end
+end

--- a/spec/services/pager_duty_service_spec.rb
+++ b/spec/services/pager_duty_service_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PagerDutyService do
+  let(:enqueue_url) { "https://events.pagerduty.com/v2/enqueue" }
+
+  def accepted_body
+    { status: "success", message: "Event processed", dedup_key: "abc123" }.to_json
+  end
+
+  def stub_pager_duty(status: 202, body: accepted_body, content_type: "application/json")
+    stub_request(:post, enqueue_url).to_return(
+      status:, body:, headers: { "Content-Type" => content_type }
+    )
+  end
+
+  describe ".manual_page_routing_key" do
+    it "reads the PAGERDUTY__MANUAL_PAGE_ROUTING_KEY environment variable" do
+      # Guards the credential key itself: a typo in either segment would
+      # disable paging in production with no other signal, because
+      # Credentials.fetch returns nil rather than raising.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("PAGERDUTY__MANUAL_PAGE_ROUTING_KEY").and_return("from-env")
+
+      expect(described_class.manual_page_routing_key).to eq("from-env")
+    end
+  end
+
+  describe ".manual_page_enabled?" do
+    it "is false when the routing key is unset" do
+      allow(described_class).to receive(:manual_page_routing_key).and_return(nil)
+
+      expect(described_class.manual_page_enabled?).to be false
+    end
+
+    it "is true when the routing key is present" do
+      allow(described_class).to receive(:manual_page_routing_key).and_return("R0UT1NGK3Y")
+
+      expect(described_class.manual_page_enabled?).to be true
+    end
+  end
+
+  describe ".trigger" do
+    it "posts a trigger event to the Events API" do
+      stub_pager_duty
+
+      response = described_class.trigger(
+        routing_key: "R0UT1NGK3Y",
+        summary: "Everything is on fire",
+        source: "hcb.hackclub.com",
+        custom_details: { paged_by: "Jane" }
+      )
+
+      expect(response["dedup_key"]).to eq("abc123")
+      expect(a_request(:post, enqueue_url).with { |req|
+        body = JSON.parse(req.body)
+        body["routing_key"] == "R0UT1NGK3Y" &&
+          body["event_action"] == "trigger" &&
+          body["payload"]["summary"] == "Everything is on fire" &&
+          body["payload"]["severity"] == "critical" &&
+          body["payload"]["source"] == "hcb.hackclub.com" &&
+          body["payload"]["custom_details"] == { "paged_by" => "Jane" }
+      }).to have_been_requested
+    end
+
+    it "omits a dedup_key so PagerDuty won't collapse a second page into the first" do
+      stub_pager_duty
+
+      described_class.trigger(routing_key: "key", summary: "hi", source: "hcb")
+
+      expect(a_request(:post, enqueue_url).with { |req| !JSON.parse(req.body).key?("dedup_key") }).to have_been_requested
+    end
+
+    it "truncates a long summary while keeping the start of the message" do
+      stub_pager_duty
+
+      described_class.trigger(routing_key: "key", summary: "start #{"a" * 2000}", source: "hcb")
+
+      expect(a_request(:post, enqueue_url).with { |req|
+        summary = JSON.parse(req.body)["payload"]["summary"]
+        summary.length <= described_class::MAX_SUMMARY_LENGTH && summary.start_with?("start ")
+      }).to have_been_requested
+    end
+
+    it "rejects a severity PagerDuty doesn't understand" do
+      expect {
+        described_class.trigger(routing_key: "key", summary: "hi", source: "hcb", severity: "catastrophic")
+      }.to raise_error(ArgumentError, /unknown severity/)
+    end
+
+    describe "responses that must not be mistaken for a successful page" do
+      # Faraday's raise_error middleware only covers 4xx and 5xx, so each of
+      # these would otherwise return normally and read as "someone was paged".
+      {
+        "a 200 from an intercepting proxy"       => { status: 200, body: "<html>proxy</html>", content_type: "text/html" },
+        "an empty 204"                           => { status: 204, body: "" },
+        "a 301 redirect that was never followed" => { status: 301, body: "" },
+        "a 202 carrying an error body"           => { status: 202, body: { status: "invalid event", errors: ["Routing key not found"] }.to_json },
+        "a 202 with no dedup_key"                => { status: 202, body: { status: "success" }.to_json },
+      }.each do |description, response|
+        it "raises on #{description}" do
+          stub_pager_duty(**response)
+
+          expect {
+            described_class.trigger(routing_key: "key", summary: "hi", source: "hcb")
+          }.to raise_error(PagerDutyService::EventRejected)
+        end
+      end
+    end
+
+    it "raises when PagerDuty rejects the event outright" do
+      stub_pager_duty(status: 400, body: "{}")
+
+      expect {
+        described_class.trigger(routing_key: "key", summary: "hi", source: "hcb")
+      }.to raise_error(Faraday::BadRequestError)
+    end
+
+    it "raises when PagerDuty rate limits us" do
+      stub_pager_duty(status: 429, body: "{}")
+
+      expect {
+        described_class.trigger(routing_key: "key", summary: "hi", source: "hcb")
+      }.to raise_error(Faraday::Error)
+    end
+
+    it "attaches the response body to AppSignal as custom data, which tags can't hold" do
+      stub_pager_duty(status: 400, body: { errors: ["Event object is invalid"] }.to_json)
+      allow(Appsignal).to receive(:add_tags)
+      expect(Appsignal).to receive(:add_custom_data).with(
+        hash_including(pager_duty: hash_including(response_status: 400))
+      )
+
+      expect {
+        described_class.trigger(routing_key: "key", summary: "hi", source: "hcb")
+      }.to raise_error(Faraday::BadRequestError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

When an admin hits something urgent (money moving wrong, a flow blocking organizations, an outage), there's no way to reach an engineer from inside HCB. The current path is posting in Slack and hoping someone's awake: no escalation, no guarantee anyone sees it, and no answer to "who is actually on call right now."

## Describe your changes

Adds `/admin/page_engineers`, a break-glass action that opens a critical PagerDuty incident against the engineering on-call escalation policy.

**Why the escalation policy, not a specific engineer.** PagerDuty's Events API v2 addresses a *service* by its integration key, and the service's escalation policy decides who gets notified. That's the right target here: the admin firing this has no idea who's awake or travelling, and a policy auto-escalates when the first responder doesn't acknowledge, whereas a hand-picked person who doesn't answer is a dead end. Rotation stays managed in PagerDuty instead of synced into our database. The routing key is also write-only, so leaking it can only create pages, not read incidents or schedules. Targeting a person would have required a full REST API token and a much larger blast radius.

**Failing loudly.** PagerDuty acknowledges an accepted event with `202` and a body of `{"status": "success", "dedup_key": ...}`. Faraday's `raise_error` middleware only covers 4xx and 5xx, so the response is verified explicitly. Without that check, a `200` from an intercepting proxy, an unfollowed `301`, an empty `204`, or a `202` carrying `{"status": "invalid event"}` would all read as a successful page. Telling someone a human is coming when nobody was notified is the worst failure this tool can have, so each of those is covered by a spec.

The event fires synchronously rather than from a background job. That's a deliberate departure from how we call other outbound APIs: the admin needs to know within seconds whether to fall back to phoning someone, and a job that silently retries is the wrong failure mode for a pager. A read timeout is reported as an *unknown* outcome (the event may have been enqueued) while a failure to connect is reported as a definite non-delivery.

**Guardrails.** Gated on `admin?` rather than the usual `signed_in_admin`, which only requires `auditor?`. Typing `PAGE` is enforced server-side with the Stimulus controller as progressive enhancement, so a JS failure during an outage can't brick the tool. `/admin` is excluded from the global Rack::Attack throttle, so a per-user `rate_limit` is the only ceiling. Impersonated sessions record the real actor, so on-call doesn't call back the wrong person.

Reachable three ways, since it needs to be findable in seconds but is rarely used: a card on the admin tools grid (which also renders on the admin home dashboard), a command bar entry, and an item in the admin nav.

### Setup required before this does anything

1. Create a PagerDuty service on the engineering escalation policy, urgency high.
2. Add an Events API v2 integration and store its key as `PAGERDUTY__MANUAL_PAGE_ROUTING_KEY`.
3. Optionally install PagerDuty's Slack app so incidents mirror into a channel. Nothing here talks to Slack directly.

Until the key is set the form renders a disabled "not configured" state, so this is inert on merge.

### Testing

50 examples covering authorization (including that auditors are turned away), the payload contract, every response shape that must not be mistaken for success, and both timeout semantics.

Worth doing one real end-to-end page during working hours with the on-call engineer expecting it, to confirm the push notification reads well on its own before relying on this.
