### PR TITLE
[Old Ledger] Fix missing rename tooltip

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -113,6 +113,7 @@ html[data-dark='true'] {
       content: '';
       position: absolute;
       inset: -0.25rem 0;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
The old ledger used to show a tooltip for renaming and underline on hover. At some point this functionality broke.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
<img width="2428" height="232" alt="Screenshot From 2026-07-31 19-13-34" src="https://github.com/user-attachments/assets/d4130069-f4f3-405c-99fa-b8592bef78aa" />



<!-- If there are any visual changes, please attach images, videos, or gifs. -->

