### PR TITLE
[Contractors] Prevent 404s

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -23,9 +23,14 @@ class PaymentsController < ApplicationController
   def create
     authorize @event, policy_class: PaymentPolicy
 
-    @payee = @event.payees.not_archived.find_by_hashid!(payment_params[:payee_id])
-    @legal_entity = @payee.legal_entity
+    @payee = @event.payees.not_archived.find_by_hashid(payment_params[:payee_id])
+    @legal_entity = @payee&.legal_entity
     @payment = Payment.new(payment_params.except(:payee_id, :file).merge(creator: current_user, payee: @payee, currency: "USD"))
+
+    if @payee.nil?
+      flash.now[:error] = "Please choose a recipient for this payment."
+      return render :new, layout: "transfer", status: :unprocessable_content
+    end
 
     if payment_params[:file].blank?
       flash.now[:error] = "Please attach a receipt or invoice for this payment."

--- a/app/controllers/payroll/positions_controller.rb
+++ b/app/controllers/payroll/positions_controller.rb
@@ -39,8 +39,9 @@ module Payroll
     def create
       authorize @event, policy_class: Payroll::PositionPolicy
 
-      @payee = @event.payees.not_archived.find_by_hashid!(position_params[:payee_id])
-      @position = @payee.payroll_positions.build(
+      @payee = @event.payees.not_archived.find_by_hashid(position_params[:payee_id])
+      @position = Payroll::Position.new(
+        payee: @payee,
         title: position_params[:title],
         rate_cents: Monetize.parse(position_params[:rate]).cents,
         rate_unit: position_params[:rate_unit].presence || "hour",
@@ -48,6 +49,12 @@ module Payroll
         end_date: position_params[:ends_on],
         description: position_params[:purpose]
       )
+
+      if @payee.nil?
+        flash.now[:error] = "Please choose a recipient for this contract."
+        return render :new, layout: "transfer", status: :unprocessable_content
+      end
+
       if (attachment = Array(position_params[:file]).compact_blank.first)
         @position.file.attach(attachment)
       end

--- a/app/views/payroll/positions/_form.html.erb
+++ b/app/views/payroll/positions/_form.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <% form_url = editing ? event_payroll_position_path(event_id: event.slug, id: position.id) : event_payroll_positions_path(event_id: event.slug) %>
-  <%= form_with(url: form_url, method: editing ? :patch : :post, scope: :contractor, local: true) do |form| %>
+  <%= form_with(url: form_url, method: editing ? :patch : :post, scope: :contractor, local: true, class: ("hidden" unless payee)) do |form| %>
     <%= form.hidden_field :payee_id, value: payee&.hashid %>
     <%= hidden_field_tag "manual", (payee&.managed? || false).to_s, data: { "manual-payee-target": "manualField" } %>
 

--- a/app/views/payroll/positions/new.html.erb
+++ b/app/views/payroll/positions/new.html.erb
@@ -8,4 +8,4 @@
   <%= render "events/transfers/step_item", number: 3, label: "Sign & invite", seek: false, current: false %>
 <% end %>
 
-<%= render "payroll/positions/form", event: @event, payee: @payee %>
+<%= render "payroll/positions/form", event: @event, payee: @payee, position: @position %>


### PR DESCRIPTION
Fixes a bug where you could get stuck on an unsubmittable contractor form. The form now only shows once a recipient is picked, bad submissions re-render with a clear error instead of a 404, and failed submissions keep what you typed (except the PDF attachment).