### PR TITLE
[Admin] Fix orphaned ledger item check never matching

### DIFF
--- a/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
+++ b/app/jobs/admin/detect_logical_transaction_anomalies_job.rb
@@ -5,6 +5,8 @@ module Admin
     queue_as :low
 
     def perform(event_id: 183)
+      event = Event.find(event_id)
+
       hcb_codes = []
       HcbCode.where(event_id:).on_main_ledger.find_each do |hcb_code|
         if !(hcb_code.ledger_item.nil? && hcb_code.no_transactions?) && (hcb_code.ledger_item.nil? || hcb_code.smart_amount_cents != hcb_code.ledger_item.amount_cents)
@@ -12,14 +14,35 @@ module Admin
         end
       end
 
-      ledger_items = []
-      Ledger::Item.where.not(id: HcbCode.where(event_id:).select(:ledger_item_id)).find_each do |ledger_item|
-        ledger_items << ledger_item.id
-      end
+      ledger_items = orphaned_ledger_item_ids(event)
 
       if hcb_codes.any? || ledger_items.any?
-        AdminMailer.logical_transaction_anomalies(event: Event.find(event_id), hcb_codes: HcbCode.where(id: hcb_codes), ledger_items: Ledger::Item.where(id: ledger_items)).deliver_now
+        AdminMailer.logical_transaction_anomalies(event:, hcb_codes: HcbCode.where(id: hcb_codes), ledger_items: Ledger::Item.where(id: ledger_items)).deliver_now
       end
+    end
+
+    private
+
+    # Items on the event's ledger that no HCB code of that event points at.
+    #
+    # Expressed as a LEFT JOIN anti-join rather than `where.not(id: <subquery>)`:
+    # that form compiles to `NOT IN`, and because `hcb_codes.ledger_item_id` is
+    # nullable, a single NULL anywhere in the subquery makes the whole predicate
+    # UNKNOWN and the query returns nothing at all. `IS DISTINCT FROM` also keeps
+    # a NULL `event_id` on the joined row counting as a mismatch rather than
+    # dropping it.
+    #
+    # The join is also scoped to the event's own ledger. Comparing every item in
+    # the table against one event's HCB codes would report every other event's
+    # items as anomalies.
+    def orphaned_ledger_item_ids(event)
+      ledger = event.ledger
+      return [] if ledger.nil?
+
+      ledger.items
+            .left_joins(:hcb_code)
+            .where("hcb_codes.id IS NULL OR hcb_codes.event_id IS DISTINCT FROM ?", event.id)
+            .pluck(Ledger::Item.arel_table[:id])
     end
 
   end

--- a/spec/jobs/admin/detect_logical_transaction_anomalies_job_spec.rb
+++ b/spec/jobs/admin/detect_logical_transaction_anomalies_job_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::DetectLogicalTransactionAnomaliesJob do
+  describe "#perform" do
+    let(:event) { create(:event) }
+    let(:other_event) { create(:event) }
+    let(:delivery) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+    def map_to_event_ledger(item)
+      Ledger::Mapping.create!(ledger: event.ledger, ledger_item: item, on_primary_ledger: true)
+    end
+
+    # HcbCode's after_create callback derives event_id from the code's transactions and
+    # writes nil when there are none, so these columns have to be set past the callback.
+    def create_hcb_code(event_id:, ledger_item_id:)
+      create(:hcb_code).tap do |hcb_code|
+        hcb_code.update_columns(event_id:, ledger_item_id:)
+      end
+    end
+
+    def reported_ledger_items
+      captured = nil
+      allow(AdminMailer).to receive(:logical_transaction_anomalies) do |**kwargs|
+        captured = kwargs[:ledger_items].to_a
+        delivery
+      end
+
+      described_class.perform_now(event_id: event.id)
+
+      captured || []
+    end
+
+    it "reports an item on the event's ledger that no HCB code points at" do
+      orphan = create(:ledger_item)
+      map_to_event_ledger(orphan)
+
+      expect(reported_ledger_items).to include(orphan)
+    end
+
+    it "reports orphans even when the event has an HCB code with no ledger item" do
+      orphan = create(:ledger_item)
+      map_to_event_ledger(orphan)
+      create_hcb_code(event_id: event.id, ledger_item_id: nil)
+
+      expect(reported_ledger_items).to include(orphan)
+    end
+
+    it "does not report an item that an HCB code of the event points at" do
+      linked = create(:ledger_item)
+      map_to_event_ledger(linked)
+      create_hcb_code(event_id: event.id, ledger_item_id: linked.id)
+
+      expect(reported_ledger_items).not_to include(linked)
+    end
+
+    it "reports an item whose HCB code belongs to a different event" do
+      crossed = create(:ledger_item)
+      map_to_event_ledger(crossed)
+      create_hcb_code(event_id: other_event.id, ledger_item_id: crossed.id)
+
+      expect(reported_ledger_items).to include(crossed)
+    end
+
+    it "ignores items that are not on the event's ledger" do
+      elsewhere = create(:ledger_item)
+      Ledger::Mapping.create!(ledger: other_event.ledger, ledger_item: elsewhere, on_primary_ledger: true)
+
+      expect(reported_ledger_items).not_to include(elsewhere)
+    end
+  end
+end


### PR DESCRIPTION
> [!NOTE]
> **This PR was written by [Claude Code](https://claude.com/claude-code).** Gary directed the investigation and reviewed the changes, but the diagnosis and code below were produced by Claude.

## Summary of the problem

Found while investigating Postgres host load. `Admin::DetectLogicalTransactionAnomaliesJob` runs hourly and has two checks; the second one has never been able to report anything.

It looked for ledger items that no HCB code points at with:

```ruby
Ledger::Item.where.not(id: HcbCode.where(event_id:).select(:ledger_item_id))
```

`where.not(id: <subquery>)` compiles to `NOT IN`. `hcb_codes.ledger_item_id` is nullable, and in SQL `x NOT IN (1, 2, NULL)` is UNKNOWN rather than true for every `x` — so as soon as one HCB code on the event has no ledger item, the predicate matches **no rows at all**. The check silently returned an empty set instead of the anomalies it exists to surface.

Filtering the NULLs out on its own would swing it to the opposite failure. The query compared *every* `Ledger::Item` in the table against a *single* event's HCB codes, so with the NULLs gone it would report essentially every other event's items as anomalies for this one — and then enumerate them with `find_each` and email the result.

So the NULL bug was masking a scope bug, and fixing either one alone is wrong.

## Describe your changes

Both are fixed together:

- **Scope to the event's own ledger.** The check now starts from `event.ledger.items` instead of `Ledger::Item.all`, which is what "items on this event's ledger with no HCB code" meant in the first place.
- **Express it as a LEFT JOIN anti-join** rather than `NOT IN`. This is NULL-safe by construction, and it uses the existing index on `hcb_codes.ledger_item_id` instead of materialising a subquery. `IS DISTINCT FROM` keeps a joined row with a NULL `event_id` counting as a mismatch rather than being dropped.

Also hoisted the `Event.find` that the mailer call was doing separately, and returns early when the event has no ledger.

## Tests

Added `spec/jobs/admin/detect_logical_transaction_anomalies_job_spec.rb` covering the orphan case, the NULL case that broke it, the linked case that should stay quiet, an item whose HCB code belongs to a different event, and an item on another event's ledger.

Verified the specs discriminate: **2 of 5 fail against the pre-fix job and all 5 pass with the fix.** Rubocop is clean.

One thing worth knowing for anyone writing similar specs: `HcbCode`'s `after_create :write_event_and_subledger_id` derives `event_id` from the code's transactions and writes `nil` when there aren't any, so the spec sets those columns past the callback.

## Note on rollout

This check has been dormant, so the first run after merge may surface a real backlog of anomalies rather than the empty result the job has been sending. Worth watching the first mail before assuming a regression.