### PR TITLE
[Jobs] Stagger the jobs that all fire at 07:00 UTC

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -157,11 +157,11 @@ detect_logical_transaction_anomalies:
   class: "Admin::DetectLogicalTransactionAnomaliesJob"
 
 detect_balance_anomalies:
-  cron: "0 7 * * *" # run every 1 day
+  cron: "12 7 * * *" # run every 1 day
   class: "Admin::DetectBalanceAnomaliesJob"
 
 detect_fee_anomalies:
-  cron: "0 7 * * *" # run every 1 day
+  cron: "48 7 * * *" # run every 1 day
   class: "Admin::DetectFeeAnomaliesJob"
 
 ledger_audit_weekly_job:
@@ -169,7 +169,7 @@ ledger_audit_weekly_job:
   class: "Admin::LedgerAudit::GenerateJob"
 
 send_admin_reminders_job:
-  cron: "0 7 * * *" # run at 7am UTC each morning
+  cron: "24 7 * * *" # run at 7am UTC each morning
   class: "SendAdminRemindersJob"
 
 gauge_online_user_count_job:
@@ -181,11 +181,11 @@ user_subordinate_summary_job:
   class: "User::SubordinateSummaryJob"
 
 user_sync_to_loops_job:
-  cron: "0 7 * * *" # run every 1 day
+  cron: "33 7 * * *" # run every 1 day
   class: "User::SyncToLoopsJob"
 
 update_teenager_column_job:
-  cron: "0 7 * * *" # run every 1 day
+  cron: "41 7 * * *" # run every 1 day
   class: "User::UpdateTeenagerColumnJob"
 
 clear_old_user_sessions:


### PR DESCRIPTION
> [!NOTE]
> **This PR was written by [Claude Code](https://claude.com/claude-code).** Gary directed the investigation and reviewed the changes, but the diagnosis and code below were produced by Claude.

## Summary of the problem

Found while investigating Postgres host load. Six scheduled jobs shared the exact same `0 7 * * *` slot:

- `stripe_card_nightly_job`
- `detect_balance_anomalies`
- `detect_fee_anomalies`
- `send_admin_reminders_job`
- `user_sync_to_loops_job`
- `update_teenager_column_job`

They were all enqueued in the same instant every morning. Two of them are whole-fleet sweeps — `Admin::DetectBalanceAnomaliesJob` walks every `Ledger` and `Admin::DetectFeeAnomaliesJob` walks every `Event`, each computing both the old and the new balance for every one — and both are among the longest-running jobs in the app.

In AppSignal, this hour consistently carries the heaviest concentration of Postgres temporary-file writes of any hour in the day, and the disk-usage gauge on the Postgres host shows its largest short excursions inside it.

## Describe your changes

Spread five of the six across the hour, leaving gaps rather than clustering them:

| job | was | now |
|---|---|---|
| `stripe_card_nightly_job` | `0 7` | `0 7` (unchanged) |
| `detect_balance_anomalies` | `0 7` | `12 7` |
| `send_admin_reminders_job` | `0 7` | `24 7` |
| `user_sync_to_loops_job` | `0 7` | `33 7` |
| `update_teenager_column_job` | `0 7` | `41 7` |
| `detect_fee_anomalies` | `0 7` | `48 7` |

`stripe_card_nightly_job` keeps `0 7` deliberately — its inline comment records that it runs "after import", so it has an ordering relationship with the job before it and moving it could reorder something real. Everything else is independent.

The two heavy fleet sweeps are placed furthest apart (`12` and `48`) so they can't overlap even if one runs long.

This doesn't make any individual job cheaper. It stops six of them contending for the same database connections and the same disk at the same moment, which is the part that's cheap to fix.

## Not addressed here

There are other same-slot clusters (`0 0 * * *` has nine jobs, `0 0 1 * *` has five). Those are mostly light, and midnight isn't showing the same pressure, so I've left them rather than widen the diff. Worth a follow-up if the pattern shows up at those hours too.

The underlying cost of the two anomaly sweeps — both are O(all organizations) with a per-organization balance computation on each side — is a separate and larger change.