### PR TITLE
[Contractors] [Payments] Show unauthorized callout for users who don't have permission

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -120,7 +120,22 @@ class StaticPagesController < ApplicationController
           "Cancel an HCB Transfer": :manager,
           "View an HCB Transfer": :reader
         },
+        Payments: {
+          "Send a payment": :manager,
+          "Cancel a payment": :manager,
+          "View a payment": :reader,
+          "View the organization's recipients": :manager,
+          "Add a recipient": :manager,
+          "Edit or archive a recipient": :member,
+          _preface: "For paying people & vendors"
+        },
         _preface: "As a general rule, only managers can create/modify financial transfers"
+      },
+      Contractors: {
+        "View the list of contractors": :reader,
+        "View a contractor's details, rate, and invoices": :reader,
+        "Invite a contractor": :manager,
+        "Approve or reject a contractor's invoice": :manager,
       },
       Cards: {
         "Order a card": :member,

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -126,7 +126,7 @@ class StaticPagesController < ApplicationController
           "View a payment": :reader,
           "View the organization's recipients": :manager,
           "Add a recipient": :manager,
-          "Edit or archive a recipient": :member,
+          "Edit or archive a recipient": :manager,
           _preface: "For paying people & vendors"
         },
         _preface: "As a general rule, only managers can create/modify financial transfers"

--- a/app/policies/payee_policy.rb
+++ b/app/policies/payee_policy.rb
@@ -10,11 +10,11 @@ class PayeePolicy < ApplicationPolicy
   end
 
   def update?
-    member?
+    manager?
   end
 
   def archive?
-    member?
+    manager?
   end
 
   def choose_legal_entity?
@@ -27,8 +27,8 @@ class PayeePolicy < ApplicationPolicy
 
   private
 
-  def member?
-    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :member)
+  def manager?
+    user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
 end

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -16,8 +16,9 @@
   </div>
 </nav>
 
-<% steps = content_for?(:table_of_contents) && !@unauthorized %>
-<% ooo = !@unauthorized %>
+<% can_transfer = @can_transfer != false %>
+<% steps = content_for?(:table_of_contents) && can_transfer %>
+<% ooo = can_transfer %>
 <% sidebar = steps || ooo || content_for?(:sidebar_footer) %>
 
 <div
@@ -45,7 +46,7 @@
   <div class="flex-1 md:pt-3 sm:mb-24">
     <%= render "application/flash", klass: "mb-2" unless sidebar %>
     <%= yield %>
-    <% unless @unauthorized %>
+    <% if can_transfer %>
       <% if controller_path == "payroll/positions" %>
         <p class="muted mt-3 text-center text-sm">
           We'll email the contractor to sign their contract and complete onboarding. Payments can't be sent until that's done.

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -16,6 +16,7 @@
   </div>
 </nav>
 
+<%# if can_transfer is nil, assume we can transfer %>
 <% can_transfer = @can_transfer != false %>
 <% steps = content_for?(:table_of_contents) && can_transfer %>
 <% ooo = can_transfer %>

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -19,8 +19,7 @@
 <%# if @can_transfer is nil, assume we can transfer %>
 <% can_transfer = @can_transfer != false %>
 <% steps = content_for?(:table_of_contents) && can_transfer %>
-<% ooo = can_transfer %>
-<% sidebar = steps || ooo || content_for?(:sidebar_footer) %>
+<% sidebar = steps || can_transfer || content_for?(:sidebar_footer) %>
 
 <div
   class="flex flex-col md:flex-row max-w-5xl lg:px-8 mx-auto w-full <%= steps ? "mt-40" : "mt-28" %> md:mt-20 gap-5"
@@ -40,7 +39,7 @@
         <% if content_for?(:sidebar_footer) %>
           <%= yield :sidebar_footer %>
         <% end %>
-        <%= render "application/ooo_callout", resource: "transfer", financial: true if ooo %>
+        <%= render "application/ooo_callout", resource: "transfer", financial: true if can_transfer %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -16,34 +16,45 @@
   </div>
 </nav>
 
+<% steps = content_for?(:table_of_contents) && !@unauthorized %>
+<% ooo = !@unauthorized %>
+<% sidebar = steps || ooo || content_for?(:sidebar_footer) %>
+
 <div
-  class="flex flex-col md:flex-row max-w-5xl lg:px-8 mx-auto w-full mt-40 md:mt-20 gap-5"
+  class="flex flex-col md:flex-row max-w-5xl lg:px-8 mx-auto w-full <%= steps ? "mt-40" : "mt-28" %> md:mt-20 gap-5"
   data-controller="scroll-seek <%= "check-preview" if @check.present? %>"
   <% if @check.present? %> data-action="scroll@window->check-preview#render"<% end %>>
-  <div class="md:w-[375px]">
-    <div class="md:sticky top-28" id="table-of-contents">
-      <div class="flex fixed z-10 w-full backdrop-blur-xl scrollbar-hidden left-0 top-20 md:static border-[rgba(200,200,200,.3)] md:rounded-xl p-2 border-solid border-[1px] border-x-0 md:border-x-[1px] overflow-x-auto">
-        <div class="inline-flex md:flex md:w-full md:flex-col mx-auto md:mx-0 gap-4 md:gap-0 px-5 md:px-0">
-          <%= yield :table_of_contents %>
-        </div>
+  <% if sidebar %>
+    <div class="md:w-[375px]">
+      <div class="md:sticky top-28" id="table-of-contents">
+        <% if steps %>
+          <div class="flex fixed z-10 w-full backdrop-blur-xl scrollbar-hidden left-0 top-20 md:static border-[rgba(200,200,200,.3)] md:rounded-xl p-2 border-solid border-[1px] border-x-0 md:border-x-[1px] overflow-x-auto">
+            <div class="inline-flex md:flex md:w-full md:flex-col mx-auto md:mx-0 gap-4 md:gap-0 px-5 md:px-0">
+              <%= yield :table_of_contents %>
+            </div>
+          </div>
+        <% end %>
+        <%= render "application/flash", klass: "mt-2" %>
+        <% if content_for?(:sidebar_footer) %>
+          <%= yield :sidebar_footer %>
+        <% end %>
+        <%= render "application/ooo_callout", resource: "transfer", financial: true if ooo %>
       </div>
-      <%= render "application/flash", klass: "mt-2" %>
-      <% if content_for?(:sidebar_footer) %>
-        <%= yield :sidebar_footer %>
-      <% end %>
-      <%= render "application/ooo_callout", resource: "transfer", financial: true %>
     </div>
-  </div>
+  <% end %>
   <div class="flex-1 md:pt-3 sm:mb-24">
+    <%= render "application/flash", klass: "mb-2" unless sidebar %>
     <%= yield %>
-    <% if controller_path == "payroll/positions" %>
-      <p class="muted mt-3 text-center text-sm">
-        We'll email the contractor to sign their contract and complete onboarding. Payments can't be sent until that's done.
-      </p>
-    <% else %>
-      <p class="muted mt-3 text-center text-sm <%= "hidden" if controller_name == "payments" && @payee.nil? %>">
-        Your transfer will be reviewed on the next business day <% if @payee && !@payee.managed? %><br><strong>after <%= @payee.display_name %> has submitted their tax information</strong><% end %>
-      </p>
+    <% unless @unauthorized %>
+      <% if controller_path == "payroll/positions" %>
+        <p class="muted mt-3 text-center text-sm">
+          We'll email the contractor to sign their contract and complete onboarding. Payments can't be sent until that's done.
+        </p>
+      <% else %>
+        <p class="muted mt-3 text-center text-sm <%= "hidden" if controller_name == "payments" && @payee.nil? %>">
+          Your transfer will be reviewed on the next business day <% if @payee && !@payee.managed? %><br><strong>after <%= @payee.display_name %> has submitted their tax information</strong><% end %>
+        </p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/transfer.html.erb
+++ b/app/views/layouts/transfer.html.erb
@@ -16,7 +16,7 @@
   </div>
 </nav>
 
-<%# if can_transfer is nil, assume we can transfer %>
+<%# if @can_transfer is nil, assume we can transfer %>
 <% can_transfer = @can_transfer != false %>
 <% steps = content_for?(:table_of_contents) && can_transfer %>
 <% ooo = can_transfer %>

--- a/app/views/payments/_form.html.erb
+++ b/app/views/payments/_form.html.erb
@@ -5,6 +5,7 @@
 <% else %>
 
 <% disabled = !policy(event).create_payment? %>
+<% @unauthorized = disabled %>
 <% manual = payee&.managed? %>
 
 <% existing_payout_method = payee&.legal_entity&.default_payout_method if manual %>
@@ -14,6 +15,7 @@
 <% end %>
 
 <div data-controller="payee-picker payout-toggle manual-payee" data-action="manual-payee:changed->payout-toggle#update">
+  <% unless disabled && payee.nil? %>
   <div data-scroll-seek-target="section">
     <h3 class="mb-2">Recipient</h3>
     <div class="card mb-4 p-0 overflow-hidden">
@@ -42,8 +44,6 @@
           </div>
         </div>
 
-      <% elsif disabled %>
-        <p class="muted px-5 py-4 m0">You don't have permission to send payments from this organization.</p>
       <% else %>
 
         <%= render "payments/payee_picker", event: %>
@@ -51,6 +51,7 @@
       <% end %>
     </div>
   </div>
+  <% end %>
 
   <div class="<%= "hidden" unless payee %>">
     <%= form_with(model: payment, url: event_payments_path(event_id: event.slug), local: true) do |form| %>

--- a/app/views/payments/_form.html.erb
+++ b/app/views/payments/_form.html.erb
@@ -5,7 +5,7 @@
 <% else %>
 
 <% disabled = !policy(event).create_payment? %>
-<% @unauthorized = disabled %>
+<% @can_transfer = !disabled %>
 <% manual = payee&.managed? %>
 
 <% existing_payout_method = payee&.legal_entity&.default_payout_method if manual %>

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -13,9 +13,11 @@
   </div>
 <% end %>
 
-<% content_for :sidebar_footer do %>
-  <%= render "events/transfers/modal" %>
-  <%= link_to "Send transfer manually", "#", class: "btn mt2", data: { behavior: "modal_trigger", modal: "send_transfer" } %>
+<% if policy(@event).create_payment? %>
+  <% content_for :sidebar_footer do %>
+    <%= render "events/transfers/modal" %>
+    <%= link_to "Send transfer manually", "#", class: "btn mt2", data: { behavior: "modal_trigger", modal: "send_transfer" } %>
+  <% end %>
 <% end %>
 
 <% if @recent_payments&.any? %>

--- a/app/views/payroll/positions/_form.html.erb
+++ b/app/views/payroll/positions/_form.html.erb
@@ -12,6 +12,10 @@
   <% end %>
 <% end %>
 
+<% if disabled %>
+  <%= render partial: "events/unauthorized_callout", locals: { action: editing ? "edit this contractor" : "invite a contractor" } %>
+<% end %>
+
 <div data-controller="payee-picker manual-payee">
   <% if editing %>
     <div data-scroll-seek-target="section">

--- a/app/views/payroll/positions/_form.html.erb
+++ b/app/views/payroll/positions/_form.html.erb
@@ -2,19 +2,22 @@
 
 <% editing = position&.persisted? %>
 <% disabled = !policy(event).create_transfer? %>
-
-<%= content_for :sidebar_footer do %>
-  <%= render "application/callout", type: "info", title: "About contractor payments", class: "mt-2" do %>
-    <ul class="m-0 pl-8">
-      <li>Contractor agreements require HCB operations review before processing.</li>
-      <li>The contractor will need to sign the contract and complete W-9/W-8BEN tax forms.</li>
-    </ul>
-  <% end %>
-<% end %>
+<% @unauthorized = disabled %>
 
 <% if disabled %>
   <%= render partial: "events/unauthorized_callout", locals: { action: editing ? "edit this contractor" : "invite a contractor" } %>
+<% else %>
+  <%= content_for :sidebar_footer do %>
+    <%= render "application/callout", type: "info", title: "About contractor payments", class: "mt-2" do %>
+      <ul class="m-0 pl-8">
+        <li>Contractor agreements require HCB operations review before processing.</li>
+        <li>The contractor will need to sign the contract and complete W-9/W-8BEN tax forms.</li>
+      </ul>
+    <% end %>
+  <% end %>
 <% end %>
+
+<% unless disabled && payee.nil? %>
 
 <div data-controller="payee-picker manual-payee">
   <% if editing %>
@@ -136,3 +139,5 @@
     </button>
   <% end %>
 </div>
+
+<% end %>

--- a/app/views/payroll/positions/_form.html.erb
+++ b/app/views/payroll/positions/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% editing = position&.persisted? %>
 <% disabled = !policy(event).create_transfer? %>
-<% @unauthorized = disabled %>
+<% @can_transfer = !disabled %>
 
 <% if disabled %>
   <%= render partial: "events/unauthorized_callout", locals: { action: editing ? "edit this contractor" : "invite a contractor" } %>


### PR DESCRIPTION
<img width="1236" height="397" alt="image" src="https://github.com/user-attachments/assets/b3056aaf-ad43-4580-a8b6-dc9defba0bb9" />

It's weird that the form fields are just disabled when users don't have access
It also adds payments/contractors to the `/roles` page