### PR TITLE
Add lost receipts as a filter option

### DIFF
--- a/app/controllers/concerns/set_ledger_filters.rb
+++ b/app/controllers/concerns/set_ledger_filters.rb
@@ -8,7 +8,7 @@ module SetLedgerFilters
   # rather than filtering one.
   FILTER_PARAMS = %i[
     tag user type start end minimum_amount maximum_amount
-    missing_receipts merchant direction category
+    missing_receipts lost_receipts merchant direction category
   ].freeze
 
   included do
@@ -48,6 +48,7 @@ module SetLedgerFilters
       @minimum_amount = params[:minimum_amount].presence ? Money.from_amount(params[:minimum_amount].to_f) : nil
       @maximum_amount = params[:maximum_amount].presence ? Money.from_amount(params[:maximum_amount].to_f) : nil
       @missing_receipts = params[:missing_receipts].present?
+      @lost_receipts = params[:lost_receipts].present?
       @merchant = params[:merchant].presence
       @direction = params[:direction].presence
       @category = TransactionCategory.find_by(slug: params[:category])
@@ -103,6 +104,8 @@ module SetLedgerFilters
         query << { receipt_required: { "$eq": true } }
         query << { marked_no_or_lost_receipt_at: { "$eq": nil } }
       end
+
+      query << { marked_no_or_lost_receipt_at: { "$ne": nil } } if @lost_receipts
 
       query << { datetime: { "$gte": @start_date.to_date } } if @start_date.present?
       # Whole-day inclusive end bound, matching the old transactions page

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -196,6 +196,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
+      lost_receipts: @lost_receipts,
       category: @category,
       merchant: @merchant,
       order_by: @order_by.to_sym,
@@ -1491,6 +1492,7 @@ class EventsController < ApplicationController
     @minimum_amount = params[:minimum_amount].presence ? Money.from_amount(params[:minimum_amount].to_f) : nil
     @maximum_amount = params[:maximum_amount].presence ? Money.from_amount(params[:maximum_amount].to_f) : nil
     @missing_receipts = params[:missing_receipts].present?
+    @lost_receipts = params[:lost_receipts].present?
     @merchant = params[:merchant].presence
     @direction = params[:direction].presence
     @category = TransactionCategory.find_by(slug: params[:category])
@@ -1526,6 +1528,7 @@ class EventsController < ApplicationController
       start_date: @start_date,
       end_date: @end_date,
       missing_receipts: @missing_receipts,
+      lost_receipts: @lost_receipts,
       category: @category,
       merchant: @merchant,
       order_by: @order_by&.to_sym || "date",
@@ -1559,7 +1562,8 @@ class EventsController < ApplicationController
         @direction.nil? &&
         @category.nil? &&
         @merchant.nil? &&
-        !@missing_receipts
+        !@missing_receipts &&
+        !@lost_receipts
     )
 
     @cacheable = !(organizer_signed_in? || has_filters)

--- a/app/services/pending_transaction_engine/pending_transaction/all.rb
+++ b/app/services/pending_transaction_engine/pending_transaction/all.rb
@@ -3,7 +3,7 @@
 module PendingTransactionEngine
   module PendingTransaction
     class All
-      def initialize(event_id:, search: nil, tag_id: nil, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, revenue: false, expenses: false, user: nil, missing_receipts: false, category: nil, merchant: nil, order_by: :date, subledger: false)
+      def initialize(event_id:, search: nil, tag_id: nil, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, revenue: false, expenses: false, user: nil, missing_receipts: false, lost_receipts: false, category: nil, merchant: nil, order_by: :date, subledger: false)
         @event_id = event_id
         @search = search
         @tag_id = tag_id&.to_i
@@ -15,6 +15,7 @@ module PendingTransactionEngine
         @expenses = expenses
         @user = user
         @missing_receipts = missing_receipts
+        @lost_receipts = lost_receipts
         @category = category
         @merchant = merchant
         @order_by = order_by
@@ -74,6 +75,12 @@ module PendingTransactionEngine
                 cpts.joins("LEFT JOIN hcb_codes ON hcb_codes.hcb_code = canonical_pending_transactions.hcb_code")
                     .joins("LEFT JOIN receipts ON receipts.receiptable_id = hcb_codes.id AND receipts.receiptable_type = 'HcbCode'")
                     .where("receipts.id IS NULL AND hcb_codes.marked_no_or_lost_receipt_at is NULL AND canonical_pending_transactions.amount_cents <= 0")
+            end
+
+            if @lost_receipts
+              cpts =
+                cpts.joins("LEFT JOIN hcb_codes ON hcb_codes.hcb_code = canonical_pending_transactions.hcb_code")
+                    .where("hcb_codes.marked_no_or_lost_receipt_at IS NOT NULL")
             end
 
             if @user

--- a/app/services/transaction_grouping_engine/transaction/all.rb
+++ b/app/services/transaction_grouping_engine/transaction/all.rb
@@ -3,7 +3,7 @@
 module TransactionGroupingEngine
   module Transaction
     class All
-      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false, category: nil, merchant: nil, order_by: :date, subledger: false)
+      def initialize(event_id:, search: nil, tag_id: nil, expenses: false, revenue: false, minimum_amount: nil, maximum_amount: nil, start_date: nil, end_date: nil, user: nil, missing_receipts: false, lost_receipts: false, category: nil, merchant: nil, order_by: :date, subledger: false)
         @event_id = event_id
         @search = ActiveRecord::Base.sanitize_sql_like(search || "")
         @tag_id = tag_id&.to_i
@@ -15,6 +15,7 @@ module TransactionGroupingEngine
         @end_date = end_date&.to_datetime
         @user = user
         @missing_receipts = missing_receipts
+        @lost_receipts = lost_receipts
         @category = category
         @merchant = merchant
         @order_by = order_by
@@ -154,7 +155,7 @@ module TransactionGroupingEngine
           query_params.merge!({ tag_id: @tag_id })
         end
 
-        if !@tag_id && @missing_receipts
+        if !@tag_id && (@missing_receipts || @lost_receipts)
           joins << <<~SQL
             left join hcb_codes on hcb_codes.hcb_code = q1.hcb_code
           SQL
@@ -166,6 +167,8 @@ module TransactionGroupingEngine
           SQL
           conditions << "receipts.id IS NULL AND hcb_codes.marked_no_or_lost_receipt_at is NULL AND q1.amount_cents <= 0"
         end
+
+        conditions << "hcb_codes.marked_no_or_lost_receipt_at IS NOT NULL" if @lost_receipts
 
         conditions << "q1.amount_cents < 0" if @expenses
         conditions << "q1.amount_cents > 0" if @revenue

--- a/app/views/events/filters/_filter.html.erb
+++ b/app/views/events/filters/_filter.html.erb
@@ -1,4 +1,4 @@
-<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @direction || @category || @merchant %>
+<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @lost_receipts || @direction || @category || @merchant %>
 
 <div class="flex flex-row justify-between items-center width-100 gap-2 mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
@@ -189,6 +189,14 @@
         <div class="badge badge-large bg-muted">
           Missing receipts
           <%= link_to event_transactions_list_path(@event, upsert_query_params(missing_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+            <%= inline_icon "view-close", size: 20 %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if @lost_receipts %>
+        <div class="badge badge-large bg-muted">
+          Lost receipts
+          <%= link_to event_transactions_list_path(@event, upsert_query_params(lost_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>

--- a/app/views/events/filters/_filter_menu.html.erb
+++ b/app/views/events/filters/_filter_menu.html.erb
@@ -143,10 +143,13 @@
         </div>
         <div data-tabs-target="tab" id="receipts">
           <div class="flex items-center">
-            <%= link_to("Missing receipts", event_transactions_list_path(@event, upsert_query_params(missing_receipts: true, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+            <%= link_to("Missing receipts", event_transactions_list_path(@event, upsert_query_params(missing_receipts: true, lost_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          </div>
+          <div class="flex items-center">
+            <%= link_to("Lost receipts", event_transactions_list_path(@event, upsert_query_params(lost_receipts: true, missing_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @lost_receipts}", data: { turbo_prefetch: "false" }) %>
           </div>
           <div>
-            <%= link_to("All transactions", event_transactions_list_path(@event, upsert_query_params(missing_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+            <%= link_to("All transactions", event_transactions_list_path(@event, upsert_query_params(missing_receipts: nil, lost_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts || @lost_receipts}", data: { turbo_prefetch: "false" }) %>
           </div>
         </div>
       </div>

--- a/app/views/ledgers/filters/_filter.html.erb
+++ b/app/views/ledgers/filters/_filter.html.erb
@@ -1,4 +1,4 @@
-<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @direction || @category || @merchant %>
+<% filter_applied = @user || @type || @start_date || @end_date || @minimum_amount || @maximum_amount || @tag || @missing_receipts || @lost_receipts || @direction || @category || @merchant %>
 
 <div class="flex flex-row justify-between items-center width-100 gap-2 mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
@@ -170,6 +170,14 @@
         <div class="badge badge-large bg-muted">
           Missing receipts
           <%= link_to event_ledger_path(@event, upsert_query_params(missing_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
+            <%= inline_icon "view-close", size: 20 %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if @lost_receipts %>
+        <div class="badge badge-large bg-muted">
+          Lost receipts
+          <%= link_to event_ledger_path(@event, upsert_query_params(lost_receipts: nil)), class: "flex items-center", data: { turbo_prefetch: "false" } do %>
             <%= inline_icon "view-close", size: 20 %>
           <% end %>
         </div>

--- a/app/views/ledgers/filters/_filter_menu.html.erb
+++ b/app/views/ledgers/filters/_filter_menu.html.erb
@@ -143,10 +143,13 @@
         </div>
         <div data-tabs-target="tab" id="receipts">
           <div class="flex items-center">
-            <%= link_to("Missing receipts", event_ledger_path(@event, upsert_query_params(missing_receipts: true, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+            <%= link_to("Missing receipts", event_ledger_path(@event, upsert_query_params(missing_receipts: true, lost_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+          </div>
+          <div class="flex items-center">
+            <%= link_to("Lost receipts", event_ledger_path(@event, upsert_query_params(lost_receipts: true, missing_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" if @lost_receipts}", data: { turbo_prefetch: "false" }) %>
           </div>
           <div>
-            <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params(missing_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts}", data: { turbo_prefetch: "false" }) %>
+            <%= link_to("All transactions", event_ledger_path(@event, upsert_query_params(missing_receipts: nil, lost_receipts: nil, page: 1)), class: "flex-auto menu__action #{"menu__action--active" unless @missing_receipts || @lost_receipts}", data: { turbo_prefetch: "false" }) %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary of the problem
It would be nice to easily see how many transactions an org has lost a receipt for.
<img width="463" height="453" alt="image" src="https://github.com/user-attachments/assets/c5e9eba7-ff83-4a96-92a6-78756be8013b" />


## Describe your changes
Adds a button to see transactions an org has lost a receipt for