### PR TITLE
[HcbCode] Add `stripe_service_fee` to `linked_object`

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -618,7 +618,7 @@ class HcbCode < ApplicationRecord
       check_deposit || outgoing_disbursement ||
       incoming_disbursement || bank_fee ||
       fee_revenue || reimbursement_expense_payout ||
-      reimbursement_payout_holding
+      reimbursement_payout_holding || stripe_service_fee
   end
 
   # The `:receipt_required` scope determines the type of


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Linked object didn't check for stripe service fees.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check for stripe service fees.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

