### PR TITLE
[CardGrant] Default new grants to expiring after 90 days

### DIFF
--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -311,7 +311,7 @@ class CardGrant < ApplicationRecord
   end
 
   def default_expiration_at
-    (created_at || Time.current) + CardGrantSetting.expiration_preferences[card_grant_setting&.expiration_preference || "1 year"].days
+    (created_at || Time.current) + CardGrantSetting.expiration_preferences[card_grant_setting&.expiration_preference || "90 days"].days
   end
 
   def last_time_change_to(...)

--- a/app/models/card_grant_setting.rb
+++ b/app/models/card_grant_setting.rb
@@ -9,7 +9,7 @@
 #  banned_merchants                  :string
 #  block_suspected_fraud             :boolean          default(TRUE), not null
 #  category_lock                     :string
-#  expiration_preference             :integer          default(365), not null
+#  expiration_preference             :integer          default(90), not null
 #  invite_message                    :string
 #  keyword_lock                      :string
 #  merchant_lock                     :string

--- a/app/tasks/maintenance/backfill_card_grant_setting_expiration_preference_task.rb
+++ b/app/tasks/maintenance/backfill_card_grant_setting_expiration_preference_task.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Moves organizations still on the old 1 year default over to the new 90 day default.
+  # Settings records are created implicitly the first time an organization touches card
+  # grants, so most records sitting at 1 year never reflected a choice by anyone. Records
+  # where someone explicitly picked 1 year are left alone, identified by a PaperTrail
+  # update touching the preference. Card grants that have already been issued keep the
+  # expiration date stored on their own record.
+  class BackfillCardGrantSettingExpirationPreferenceTask < MaintenanceTasks::Task
+    def collection
+      CardGrantSetting.where(expiration_preference: CardGrantSetting.expiration_preferences["1 year"])
+                      .where.not(id: explicitly_chosen)
+    end
+
+    def process(card_grant_setting)
+      card_grant_setting.update!(expiration_preference: "90 days")
+    end
+
+    private
+
+    # A record's create version lists every attribute, so only updates indicate a choice.
+    # `jsonb_exists` is the function form of the `?` operator, which ActiveRecord would
+    # otherwise consume as a bind placeholder.
+    def explicitly_chosen
+      PaperTrail::Version.where(item_type: "CardGrantSetting", event: "update")
+                         .where("jsonb_exists(object_changes, 'expiration_preference')")
+                         .select(:item_id)
+    end
+
+  end
+end

--- a/db/migrate/20260804180803_change_card_grant_setting_expiration_preference_default_to90_days.rb
+++ b/db/migrate/20260804180803_change_card_grant_setting_expiration_preference_default_to90_days.rb
@@ -1,0 +1,5 @@
+class ChangeCardGrantSettingExpirationPreferenceDefaultTo90Days < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :card_grant_settings, :expiration_preference, from: 365, to: 90
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_160241) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_180803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -495,7 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_160241) do
     t.string "category_lock"
     t.datetime "created_at", null: false
     t.bigint "event_id", null: false
-    t.integer "expiration_preference", default: 365, null: false
+    t.integer "expiration_preference", default: 90, null: false
     t.string "invite_message"
     t.string "keyword_lock"
     t.string "merchant_lock"

--- a/spec/models/card_grant_setting_spec.rb
+++ b/spec/models/card_grant_setting_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CardGrantSetting, type: :model do
+  it "expires grants after 90 days by default" do
+    setting = create(:card_grant_setting)
+
+    expect(setting.expiration_preference).to eq("90 days")
+  end
+end

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -3,6 +3,27 @@
 require "rails_helper"
 
 RSpec.describe CardGrant, type: :model do
+  describe "expiration" do
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+    end
+
+    it "expires 90 days after creation under default settings" do
+      card_grant = create(:card_grant)
+
+      expect(card_grant.expiration_at).to eq(90.days.from_now.to_date)
+    end
+
+    it "honours a longer expiration preference on the organization's settings" do
+      event = create(:event)
+      create(:card_grant_setting, event:, expiration_preference: "1 year")
+
+      card_grant = create(:card_grant, event:)
+
+      expect(card_grant.expiration_at).to eq(365.days.from_now.to_date)
+    end
+  end
+
   describe "ledger association" do
     # CardGrant has an after_create :transfer_money callback that triggers
     # DisbursementService::Create, which requires the source event to have

--- a/spec/tasks/maintenance/backfill_card_grant_setting_expiration_preference_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_card_grant_setting_expiration_preference_task_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::BackfillCardGrantSettingExpirationPreferenceTask, versioning: true do
+  describe "#collection" do
+    it "includes a setting left at 1 year" do
+      setting = create(:card_grant_setting, expiration_preference: "1 year")
+
+      expect(described_class.new.collection).to include(setting)
+    end
+
+    it "includes a setting whose other fields were edited" do
+      setting = create(:card_grant_setting, expiration_preference: "1 year")
+      setting.update!(invite_message: "It's pizza time!")
+
+      expect(described_class.new.collection).to include(setting)
+    end
+
+    it "excludes a setting whose expiration preference was explicitly chosen" do
+      setting = create(:card_grant_setting, expiration_preference: "6 months")
+      setting.update!(expiration_preference: "1 year")
+
+      expect(described_class.new.collection).not_to include(setting)
+    end
+
+    it "excludes settings at other expiration preferences" do
+      settings = ["90 days", "6 months", "2 years"].map do |preference|
+        create(:card_grant_setting, expiration_preference: preference)
+      end
+
+      expect(described_class.new.collection).not_to include(*settings)
+    end
+  end
+
+  describe "#process" do
+    it "moves the setting to 90 days" do
+      setting = create(:card_grant_setting, expiration_preference: "1 year")
+
+      described_class.new.process(setting)
+
+      expect(setting.reload.expiration_preference).to eq("90 days")
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

New card grants default to expiring after 1 year. We want 90 days.

Card grant settings records are created implicitly, and blank, the first time an
organization touches card grants, so most records sitting at 1 year never reflected a
choice by anyone. Those should move to 90 days too.

## Describe your changes

Changes the `card_grant_settings.expiration_preference` column default from 365 to 90,
plus the matching `"1 year"` fallback in `CardGrant#default_expiration_at` so the two
defaults can't drift. The available options (90 days / 6 months / 1 year / 2 years) don't
change.

Adds `Maintenance::BackfillCardGrantSettingExpirationPreferenceTask` to move existing
records off the old default. It skips organizations that explicitly chose 1 year,
identified by a PaperTrail `update` version touching `expiration_preference` — a record's
`create` version lists every attribute, so only updates indicate a choice.

Card grants that have already been issued are unaffected: a grant's expiration date is
written to its own record at creation, so nothing live shifts.

One accepted limitation: `expiration_preference` shipped in Aug 2024, but PaperTrail was
only added to `CardGrantSetting` in Sep 2025 (ada9b39f7). An organization that explicitly
chose 1 year inside that window has no version recording it and will be moved to 90 days.
The setting is re-selectable and their existing grants keep their dates.
