### PR TITLE
[User] Block email domains behind a wave of spam signups

### DIFF
--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -9,6 +9,7 @@ Nondisposable.configure do |config|
   config.error_message = "provider is unsupported. Please try with another email address."
 
   # Sourced from https://hcb.hackclub.com/blazer/queries/1116-user-group-domain-by-usage
+  # and https://hcb.hackclub.com/blazer/queries/1268-user-spam-email-domains-that-need-to-be-banned
   #
   # NOTE: aol.com, and msn.com are semi-common email providers, but
   # have very few legitimate users. I'm choosing to block them because the pros
@@ -89,6 +90,37 @@ Nondisposable.configure do |config|
     codoteam.com
     rightbliss.beauty
     silesia.life
+    gwshare.com
+    jobraux.com
+    bejum.com
+    bora4d.com
+    siponly.com
+    myfmcast.com
+    tainela.com
+    svndemo.com
+    mfeva.com
+    gocoiny.com
+    wqeather.com
+    kierko.com
+    mfoos.com
+    webkugel.com
+    kingcq.com
+    cxmail.cfd
+    apdtax.com
+    jomeil.com
+    muskarm.com
+    googxs.com
+    workpolo.com
+    hotkev.com
+    nixaur.com
+    redtion.com
+    tempimail.org
+    gettempmail.net
+    hidepost.net
+    alerous.com
+    toolzim.com
+    kedaiqq.com
+    f5.si
   ].freeze
 
   # https://www.okta.com/blog/threat-intelligence/opportunistic-sms-pumping-attacks-target-customer-sign-up-pages/

--- a/lib/email_typo_domains.rb
+++ b/lib/email_typo_domains.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
-# Single source of truth for the "unambiguous typo of a major provider"
-# domains blocked in config/initializers/nondisposable.rb. Grouped by the
-# real domain so a new typo is one line to add; TYPO_TO_REAL is derived
+# Single source of truth for the "unambiguous typo of, or alias for, a major
+# provider" domains blocked in config/initializers/nondisposable.rb. Grouped by
+# the real domain so a new typo is one line to add; TYPO_TO_REAL is derived
 # once at load for O(1) lookup from User's validation message.
+#
+# googlemail.com is the alias case: it's a real Google domain that delivers to
+# the same mailbox as gmail.com, so signing up with it mints a second account
+# for an inbox we already have. Suggesting the gmail.com form costs those users
+# nothing, since it reaches the same place.
 module EmailTypoDomains
   REAL_TO_TYPOS = {
     "gmail.com"      => %w[
       gmail.con gmail.co gamil.com gmail.ocm gmail.ckm gmail.cok gmail.xom
       gmali.com gamail.com gmail.cpom gmail.cokm gmail.fom gmil.com
+      gmail.cm gmail.om gmai.com gnail.com
+      googlemail.com
     ],
     "icloud.com"     => %w[icloud.con],
-    "hackclub.com"   => %w[hackclub.co],
+    "hackclub.com"   => %w[hackclub.co hackclub.con],
+    "outlook.com"    => %w[outlook.con],
     "protonmail.com" => %w[protonmail.con],
   }.freeze
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe User, type: :model do
       expect(user).to_not be_valid
       expect(user.errors[:email]).to eq(["provider is unsupported. Please try with another email address."])
     end
+
+    it "suggests gmail.com for googlemail.com, which aliases the same mailbox" do
+      user = build(:user, email: "someone@googlemail.com")
+
+      expect(user).to_not be_valid
+      expect(user.errors[:email]).to eq(["looks like a typo. Did you mean someone@gmail.com?"])
+    end
+
+    it "only blocks disposable domains on create, leaving existing accounts usable" do
+      user = create(:user, email: "someone@gmail.com")
+      user.update_column(:email, "someone@googlemail.com")
+
+      expect(user.reload).to be_valid
+    end
+
+    it "allows major providers and school domains" do
+      %w[gmail.com hackclub.com outlook.com icloud.com student.hbuhsd.edu].each do |domain|
+        user = build(:user, email: "someone@#{domain}")
+
+        expect(user).to be_valid, "expected #{domain} to be allowed"
+      end
+    end
   end
 
   context "birthday validations" do


### PR DESCRIPTION
These domains are newly registered, share a common generated-address pattern, and have no product usage beyond signing up. The same pattern matched the domains blocked in #14408, so the actor appears to be rotating domains as we block them.