### PR TITLE
[Signup] Require the form to be rendered before a signup posts

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -38,7 +38,10 @@ class DonationsController < ApplicationController
     p.fullscreen :self
   end
 
-  invisible_captcha only: [:make_donation], honeypot: :subtitle, on_timestamp_spam: :redirect_to_404
+  # Opted out of the timestamp check: this form has not been checked for
+  # multi-step flows that would consume the session token. See
+  # config/initializers/invisible_captcha.rb.
+  invisible_captcha only: [:make_donation], honeypot: :subtitle, on_timestamp_spam: :redirect_to_404, timestamp_enabled: false
 
   # GET /donations/1
   def show

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -6,6 +6,14 @@ class ExportsController < ApplicationController
   skip_before_action :signed_in_user
   skip_after_action :verify_authorized, only: :collect_email
 
+  # Requesting an export with an `email` param creates a User for it, which
+  # makes this an unauthenticated account creation path like the signup forms.
+  # Scoped to that param so ordinary exports, which create nothing, are
+  # unaffected: the collect_email form is the only thing that renders the token.
+  invisible_captcha only: [:transactions],
+                    honeypot: :remember_me,
+                    if: -> { params[:email].present? }
+
   def transactions
     authorize @event, :show?
 

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -5,7 +5,15 @@ class LoginsController < ApplicationController
   skip_after_action :verify_authorized
   before_action :set_login, except: [:new, :create, :reauthenticate]
   before_action :set_user, except: [:new, :create, :reauthenticate]
-  invisible_captcha only: [:create, :complete], honeypot: :remember_me
+  # `create` is the endpoint that turns an email address into a User, so it
+  # takes the timestamp check: the form has to have been rendered first.
+  invisible_captcha only: [:create], honeypot: :remember_me
+
+  # `complete` opts out. The check consumes the session token, and the WebAuthn
+  # path (logins/new -> create -> choose_login_preference -> security_key ->
+  # POST complete) renders no form in between that would write a new one, so a
+  # security key sign in would be rejected with no way to retry.
+  invisible_captcha only: [:complete], honeypot: :remember_me, timestamp_enabled: false
 
   layout ->{ @login&.for_application? ? "apply" : "login" }
 

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -11,7 +11,10 @@ class MarketingController < ApplicationController
   skip_before_action :redirect_to_onboarding
   skip_after_action :verify_authorized # not Pundit-managed
 
-  invisible_captcha only: [:funder_inquiry], honeypot: :subtitle
+  # Opted out of the timestamp check: this form has not been checked for
+  # multi-step flows that would consume the session token. See
+  # config/initializers/invisible_captcha.rb.
+  invisible_captcha only: [:funder_inquiry], honeypot: :subtitle, timestamp_enabled: false
 
   after_action :allow_indexing, only: [:funders, :funders_faq]
 

--- a/app/controllers/recurring_donations_controller.rb
+++ b/app/controllers/recurring_donations_controller.rb
@@ -10,7 +10,10 @@ class RecurringDonationsController < ApplicationController
   skip_before_action :signed_in_user
   skip_before_action :redirect_to_onboarding
 
-  invisible_captcha only: [:create], honeypot: :subtitle
+  # Opted out of the timestamp check: this form has not been checked for
+  # multi-step flows that would consume the session token. See
+  # config/initializers/invisible_captcha.rb.
+  invisible_captcha only: [:create], honeypot: :subtitle, timestamp_enabled: false
 
   def create
     params[:recurring_donation][:amount] = Monetize.parse(params[:recurring_donation][:amount]).cents

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -10,10 +10,12 @@ module Reimbursement
     skip_before_action :signed_in_user, only: [:show, :start, :create, :finished]
     skip_after_action :verify_authorized, only: [:start, :finished]
 
-    # Opted out of the timestamp check: this form has not been checked for
-    # multi-step flows that would consume the session token. See
-    # config/initializers/invisible_captcha.rb.
-    invisible_captcha only: [:create], honeypot: :subtitle, timestamp_enabled: false
+    # `create` is reachable without a session whenever the organization has
+    # turned on its public reimbursement page, and it creates a User, so it
+    # takes the timestamp check like the other public forms. Safe here because
+    # the public form on `start` is the only thing that posts to it, in one
+    # step, so nothing consumes the session token in between.
+    invisible_captcha only: [:create], honeypot: :subtitle
 
     # POST /reimbursement_reports
     def create

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -10,7 +10,10 @@ module Reimbursement
     skip_before_action :signed_in_user, only: [:show, :start, :create, :finished]
     skip_after_action :verify_authorized, only: [:start, :finished]
 
-    invisible_captcha only: [:create], honeypot: :subtitle
+    # Opted out of the timestamp check: this form has not been checked for
+    # multi-step flows that would consume the session token. See
+    # config/initializers/invisible_captcha.rb.
+    invisible_captcha only: [:create], honeypot: :subtitle, timestamp_enabled: false
 
     # POST /reimbursement_reports
     def create

--- a/app/views/exports/collect_email.html.erb
+++ b/app/views/exports/collect_email.html.erb
@@ -7,6 +7,7 @@
   <%= form_with(model: false, local: true, method: :get, url: transactions_exports_path(event: @event_slug, format: @file_extension)) do |form| %>
     <%= form.text_field :event, style: "display: none", value: @event_slug %>
     <%= form.text_field :email, class: "w-100 fit my2", placeholder: "fiona@hackclub.com", required: true, type: "email" %>
+    <%= invisible_captcha :remember_me %>
     <p>
       <%= form.submit "Submit" %>
     </p>

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -3,8 +3,24 @@
 InvisibleCaptcha.setup do |config|
   # config.honeypots           << ['more', 'fake', 'attribute', 'names']
   config.visual_honeypots    = false
-  # config.timestamp_threshold = 2
-  config.timestamp_enabled   = false
+
+  # The timestamp feature does two things: it rejects submissions when the form
+  # was never rendered (the view helper writes a token into the session), and it
+  # rejects submissions that arrive faster than `timestamp_threshold`.
+  #
+  # Only the first is wanted. It costs a real browser nothing and rejects
+  # scripts that POST straight at an endpoint, whereas the speed check is easy
+  # for a script to defeat by waiting and would reject people whose password
+  # manager autofills the form and who then submit right away. A threshold of 0
+  # keeps the "was the form actually rendered" check and disables the speed
+  # check, since submitting always takes a positive amount of time.
+  #
+  # The view helper consults this global flag rather than any per-action option,
+  # so it has to be enabled here for the token to be written at all. Controllers
+  # that have not been checked for multi-step flows opt out with
+  # `timestamp_enabled: false`; see LoginsController for why that matters.
+  config.timestamp_threshold = 0
+  config.timestamp_enabled   = true
   # config.injectable_styles   = false
   config.spinner_enabled     = false
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe LoginsController do
       email = "test@example.com"
       expect(User.find_by(email:)).to be_nil
 
+      get(:new)
+
       expect { post(:create, params: { email: "test@example.com", login: { purpose: "" } }) }
         .to( change { Login.count }.by(1).and(change { User.count }.by(1)) )
 
@@ -43,6 +45,8 @@ RSpec.describe LoginsController do
 
     it "uses the existing user if the email matches" do
       user = create(:user, email: "test@example.com")
+
+      get(:new)
 
       expect { post(:create, params: { email: user.email, login: { purpose: "" } }) }
         .to(change { Login.count }.by(1).and(change { User.count }.by(0)))

--- a/spec/requests/exports_controller_spec.rb
+++ b/spec/requests/exports_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ExportsController", type: :request do
+  # Requesting an export with an `email` param creates a User for it, so it is
+  # an unauthenticated account creation path and carries the same requirement
+  # as the signup forms: the form has to have been rendered first.
+  let(:event) { create(:event, is_public: true) }
+
+  def visit_collect_email_form
+    get collect_email_exports_path(event_slug: event.slug, file_extension: "csv")
+  end
+
+  describe "GET /exports/:event.csv with an email" do
+    # The email branch only runs for exports large enough to be queued, which
+    # is what makes the request create a User rather than stream a file.
+    before do
+      allow_any_instance_of(Export::Event::Transactions::Csv).to receive(:async?).and_return(true)
+    end
+
+    it "creates no user when the client never rendered the form" do
+      email = "scripted-#{SecureRandom.hex(4)}@example.invalid"
+
+      expect {
+        get "/exports/#{event.slug}.csv", params: { email: }
+      }.to change { User.count }.by(0)
+
+      expect(User.find_by(email:)).to be_nil
+    end
+
+    it "queues the export once the form has been rendered" do
+      email = "requester-#{SecureRandom.hex(4)}@example.invalid"
+      visit_collect_email_form
+
+      expect {
+        get "/exports/#{event.slug}.csv", params: { email: }
+      }.to change { User.count }.by(1)
+
+      expect(User.find_by(email:)).to be_present
+    end
+  end
+
+  describe "GET /exports/:event.csv without an email" do
+    it "leaves an ordinary export, which creates no user, unaffected" do
+      get "/exports/#{event.slug}.csv"
+
+      expect(flash[:error]).to be_blank
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/logins_controller_spec.rb
+++ b/spec/requests/logins_controller_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "LoginsController", type: :request do
   let(:program) { Referral::Program.create!(name: "Referral test program", creator:) }
   let(:link)    { program.links.create!(name: "Primary", creator:) }
 
+  # Rendering the login form is what writes invisible_captcha's session token,
+  # so anything posting to /logins has to fetch it first, the way a browser does.
+  def visit_login_form
+    get auth_users_path
+  end
+
   describe "POST /logins" do
     it "binds a prior referral click to the user signing in" do
       get "/referrals/#{link.slug}"
@@ -14,21 +20,61 @@ RSpec.describe "LoginsController", type: :request do
       expect(attribution.user).to be_nil
 
       email = "referred-#{SecureRandom.hex(4)}@example.invalid"
+      visit_login_form
       post "/logins", params: { email:, login: { return_to: "/" } }
 
-      expect(attribution.reload.user).to eq(User.find_by(email:))
+      user = User.find_by(email:)
+      expect(user).to be_present
+      expect(attribution.reload.user).to eq(user)
     end
 
     # `#create` rescues everything and redirects to the auth page, so a nil
     # session would surface as a confusing flash rather than a 500.
     it "completes for a visitor who never clicked a referral link and so has no session" do
       email = "direct-#{SecureRandom.hex(4)}@example.invalid"
+      visit_login_form
 
       expect {
         post "/logins", params: { email:, login: { return_to: "/" } }
       }.to change { Login.count }.by(1)
 
       expect(response).not_to redirect_to(auth_users_path)
+    end
+
+    it "rejects a submission from a client that never rendered the form" do
+      email = "scripted-#{SecureRandom.hex(4)}@example.invalid"
+
+      expect {
+        post "/logins", params: { email:, login: { return_to: "/" } }
+      }.to change { Login.count }.by(0)
+
+      expect(User.find_by(email:)).to be_nil
+    end
+
+    it "accepts a submission sent immediately after the form renders" do
+      email = "autofilled-#{SecureRandom.hex(4)}@example.invalid"
+      visit_login_form
+
+      expect {
+        post "/logins", params: { email:, login: { return_to: "/" } }
+      }.to change { Login.count }.by(1)
+    end
+  end
+
+  describe "POST /logins/:id/complete" do
+    # The security key flow renders no form between `create` and `complete`, so
+    # if `complete` enforced the timestamp there would be no session token left
+    # and a passkey sign in would fail with no way to retry.
+    it "reaches the action for a security key sign in" do
+      user = create(:user, verified: true)
+      visit_login_form
+      post "/logins", params: { email: user.email, login: { return_to: "/" } }
+      login = Login.last
+
+      post "/logins/#{login.hashid}/complete", params: { method: "webauthn", credential: "not-a-real-credential" }
+
+      expect(flash[:error]).to be_present
+      expect(flash[:error]).not_to eq(InvisibleCaptcha.timestamp_error_message)
     end
   end
 end

--- a/spec/requests/reimbursement/reports_controller_spec.rb
+++ b/spec/requests/reimbursement/reports_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reimbursement::ReportsController", type: :request do
+  # Submitting the public reimbursement form creates a User without a session,
+  # so it carries the same requirement as the signup forms: the form has to
+  # have been rendered first.
+  let(:event) { create(:event, public_reimbursement_page_enabled: true) }
+
+  def visit_public_form
+    get reimbursement_start_reimbursement_report_path(event_name: event.slug)
+  end
+
+  def submit(email:)
+    post reimbursement_reports_path, params: {
+      reimbursement_report: { event_id: event.id, email:, report_name: "Probe report" }
+    }
+  end
+
+  describe "POST /reimbursement/reports" do
+    it "creates no user when the client never rendered the form" do
+      email = "scripted-#{SecureRandom.hex(4)}@example.invalid"
+
+      expect { submit(email:) }.to change { User.count }.by(0)
+
+      expect(User.find_by(email:)).to be_nil
+    end
+
+    it "creates the report's user once the form has been rendered" do
+      email = "claimant-#{SecureRandom.hex(4)}@example.invalid"
+      visit_public_form
+
+      expect { submit(email:) }.to change { User.count }.by(1)
+
+      expect(User.find_by(email:)).to be_present
+    end
+  end
+end

--- a/spec/requests/users/first_controller_spec.rb
+++ b/spec/requests/users/first_controller_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe "Users::FirstController", type: :request do
     }
   end
 
+  # Rendering the signup form is what writes invisible_captcha's session token,
+  # so anything posting to /first has to fetch it first, the way a browser does.
+  def visit_signup_form
+    get welcome_first_index_path
+  end
+
   describe "POST /first" do
     it "responds with a redirect when the supplied email already belongs to an existing user" do
       existing = create(:user, verified: true)
@@ -29,6 +35,7 @@ RSpec.describe "Users::FirstController", type: :request do
       params[:user][:email] = existing.email.upcase
 
       expect {
+        visit_signup_form
         post "/first", params: params
       }.not_to(change { User.count })
 
@@ -41,11 +48,13 @@ RSpec.describe "Users::FirstController", type: :request do
 
       taken = valid_form.deep_dup
       taken[:user][:email] = existing.email
+      visit_signup_form
       post "/first", params: taken
       taken_status = response.status
 
       fresh = valid_form.deep_dup
       fresh[:user][:email] = "brand-new-#{SecureRandom.hex(4)}@example.invalid"
+      visit_signup_form
       post "/first", params: fresh
       fresh_status = response.status
 
@@ -72,6 +81,7 @@ RSpec.describe "Users::FirstController", type: :request do
         expect(attribution.user_id).to be_nil
         expect(attribution.user_session_id).to be_present
 
+        visit_signup_form
         post "/first", params: valid_form
 
         new_user = User.find_by!(email: valid_form[:user][:email])
@@ -83,6 +93,7 @@ RSpec.describe "Users::FirstController", type: :request do
         get "/referrals/#{other_link.slug}"
         expect(Referral::Attribution.where(link: [link, other_link]).pluck(:user_id)).to all(be_nil)
 
+        visit_signup_form
         post "/first", params: valid_form
 
         new_user = User.find_by!(email: valid_form[:user][:email])
@@ -98,6 +109,7 @@ RSpec.describe "Users::FirstController", type: :request do
 
         params = valid_form.deep_dup
         params[:user][:email] = existing.email
+        visit_signup_form
         post "/first", params: params
 
         expect(attribution.reload.user_id).to eq(existing.id)
@@ -108,7 +120,10 @@ RSpec.describe "Users::FirstController", type: :request do
       params = valid_form.deep_dup
       params[:user][:email] = "no-referral-#{SecureRandom.hex(4)}@example.invalid"
 
-      expect { post "/first", params: params }.to change { User.count }.by(1)
+      expect {
+        visit_signup_form
+        post "/first", params: params
+      }.to change { User.count }.by(1)
       expect(response.status).to eq(302)
     end
 
@@ -116,6 +131,7 @@ RSpec.describe "Users::FirstController", type: :request do
 
   describe "DELETE /first/sign_out" do
     it "clears the session_token cookie" do
+      visit_signup_form
       post "/first", params: valid_form
       expect(cookies["session_token"]).to be_present, "expected signup to establish a session to sign out of"
 


### PR DESCRIPTION
## Summary of the problem

Four endpoints create a `User` without any session, and every one of them accepted a bare request from a client that never fetched the form:

| Path | Notes |
|---|---|
| `POST /logins` | The login form doubles as registration. 100% of the recent signup wave came through here. |
| `POST /first` | The other public signup form. |
| `POST /reimbursement/reports` | Exempt from `signed_in_user`; `ReportPolicy#create?` admits an anonymous submitter whenever the organization has enabled its public reimbursement page. |
| `GET /exports/:event.csv?email=` | Calls `User.find_or_create_by`. Reachable for any transparent organization, and being a GET it carries no CSRF token. |

The honeypot doesn't help: leaving a hidden field blank is exactly what a real browser does, so a script that fills only the visible fields passes it.

## Describe your changes

Turns on `invisible_captcha`'s timestamp feature. The view helper writes a token into the session when the form renders and the before_action checks for it on submit, so a client that posts straight at an endpoint is rejected. Applied to all four paths above.

Three things made this more than a config flip.

**The view helper consults the global flag,** not per-action options, so the token is only written when the feature is enabled globally. Enabling it globally also switches the check on for the donation, recurring donation, and funder inquiry forms. Those haven't been checked for multi-step flows, so they opt out explicitly and keep their current behaviour; enabling them is a follow-up.

**The check consumes the session token,** and the security key flow renders no form between `create` and `complete`:

```
logins/new -> POST create (consumes token) -> choose_login_preference -> security_key -> POST complete
```

Enforcing it on `complete` rejected passkey sign-ins with *"Sorry, that was too quick! Please resubmit."* and no way to retry, since nothing on that path writes a new token. `complete` opts out, and there's a regression test that fails without the opt-out.

**Threshold is 0, not the gem's default of 4 seconds.** The feature bundles two checks: "was the form rendered" and "was it submitted faster than N seconds". Only the first is wanted. The speed check is easy for a script to defeat by waiting, and it would reject anyone whose password manager autofills the form and who then submits right away. A threshold of 0 keeps the provenance check and disables the speed check, since submitting always takes a positive amount of time.

On exports, the check is scoped with `if:` to requests carrying an `email` param, so ordinary exports (which create no user) are untouched.

## Testing

New and updated request specs cover, per path, that a client which never rendered the form creates no `User`, and that a normal browser flow still works. Each was verified to **fail without its guard** rather than pass vacuously:

- passkey spec fails with `complete` enforced
- exports spec fails with the guard removed (an unauthenticated GET creates a `User`)
- reimbursement spec fails with the opt-out restored

Specs that previously posted without rendering the form first now fetch it, the way a browser does. `spec/requests/`, `spec/controllers/logins_controller_spec.rb`, marketing, reimbursement, donation, and rack_attack specs all pass (128 examples).

## Scope

This is one layer, not a complete answer. It stops clients that skip the form fetch; a script that fetches the form first still gets through. A challenge on the signup path is being designed separately.
