### PR TITLE
[Signup] Scope the rendered-form check per form, and authorize before creating a user

### DIFF
--- a/app/controllers/concerns/form_provenance.rb
+++ b/app/controllers/concerns/form_provenance.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Records, per form, that a client actually rendered it, and requires that
+# before accepting the submission.
+#
+# `invisible_captcha`'s timestamp check already requires that *some* guarded
+# form was rendered, but it stores a single global `invisible_captcha_timestamp`
+# in the session, so a token seeded by the login page is accepted by any other
+# guarded endpoint. That is enough for a client which fetches nothing, and not
+# enough for one that fetches the cheapest page and posts somewhere else.
+#
+# This keys the record on the specific form instead. The token is written
+# server side by the action that renders the form and is never sent to the
+# client, so it cannot be stripped or forged the way a hidden field could.
+# Absence always rejects.
+module FormProvenance
+  extend ActiveSupport::Concern
+
+  SESSION_KEY = "form_provenance"
+
+  class_methods do
+    # Declares that `form` must have been rendered before these actions run.
+    # A macro rather than an `included do` block because callback order is
+    # source order, and this needs to sit after the `invisible_captcha` macro
+    # so the cheaper check runs first.
+    def require_rendered_form(form, **options)
+      before_action(options) { require_rendered_form!(form) }
+    end
+  end
+
+  private
+
+  # Called by the action that renders the form.
+  def record_rendered_form(form)
+    session[SESSION_KEY] = (session[SESSION_KEY] || {}).merge(form.to_s => true)
+  end
+
+  def require_rendered_form!(form)
+    return if consume_rendered_form(form)
+
+    flash[:error] = "Sorry, something went wrong with that form. Please try again."
+    redirect_back fallback_location: root_path
+  end
+
+  # Consumed on use, so one render buys one submission.
+  def consume_rendered_form(form)
+    recorded = session[SESSION_KEY]
+    return false unless recorded.is_a?(Hash) && recorded[form.to_s]
+
+    session[SESSION_KEY] = recorded.except(form.to_s)
+    true
+  end
+end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -2,6 +2,7 @@
 
 class ExportsController < ApplicationController
   include SetEvent
+  include FormProvenance
   before_action :set_event, only: [:transactions, :reimbursements]
   skip_before_action :signed_in_user
   skip_after_action :verify_authorized, only: :collect_email
@@ -13,6 +14,9 @@ class ExportsController < ApplicationController
   invisible_captcha only: [:transactions],
                     honeypot: :remember_me,
                     if: -> { params[:email].present? }
+  require_rendered_form :export_email,
+                        only: [:transactions],
+                        if: -> { params[:email].present? }
 
   def transactions
     authorize @event, :show?
@@ -131,6 +135,8 @@ class ExportsController < ApplicationController
     end
     @event_slug = params[:event_slug]
     @file_extension = params[:file_extension]
+
+    record_rendered_form :export_email
   end
 
   private

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LoginsController < ApplicationController
+  include FormProvenance
+
   skip_before_action :signed_in_user, except: [:reauthenticate]
   skip_after_action :verify_authorized
   before_action :set_login, except: [:new, :create, :reauthenticate]
@@ -8,6 +10,7 @@ class LoginsController < ApplicationController
   # `create` is the endpoint that turns an email address into a User, so it
   # takes the timestamp check: the form has to have been rendered first.
   invisible_captcha only: [:create], honeypot: :remember_me
+  require_rendered_form :login, only: [:create]
 
   # `complete` opts out. The check consumes the session token, and the WebAuthn
   # path (logins/new -> create -> choose_login_preference -> security_key ->
@@ -26,6 +29,8 @@ class LoginsController < ApplicationController
 
   # view to log in
   def new
+    record_rendered_form :login
+
     render "users/logout" if current_user
 
     referral_link_id = Referral::Link.find_by(slug: params[:referral])&.slug if params[:referral].present?

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -3,6 +3,7 @@
 module Reimbursement
   class ReportsController < ApplicationController
     include SetEvent
+    include FormProvenance
     include Admin::TransferApprovable
 
     before_action :set_report_user_and_event, except: [:create, :quick_expense, :start, :finished]
@@ -16,10 +17,19 @@ module Reimbursement
     # the public form on `start` is the only thing that posts to it, in one
     # step, so nothing consumes the session token in between.
     invisible_captcha only: [:create], honeypot: :subtitle
+    require_rendered_form :reimbursement_report, only: [:create]
 
     # POST /reimbursement_reports
     def create
       @event = Event.find(report_params[:event_id])
+
+      # Authorize before creating the user, not after. ReportPolicy#create?
+      # reads only the event and the signed in user, never the report's own
+      # user, so it can run against an empty report. Creating the user first
+      # meant a denied request still left a User row behind, for any event id,
+      # whether or not the organization had a public reimbursement page.
+      authorize @event.reimbursement_reports.build, :create?
+
       user = User.create_with(creation_method: :reimbursement_report).find_or_create_by!(email: report_params[:email])
       @report = @event.reimbursement_reports.build(report_params.except(:email, :receipt_id, :value).merge(user:, inviter: organizer_signed_in? ? current_user : nil, currency: user.default_payout_method&.currency || "USD"))
 
@@ -114,6 +124,8 @@ module Reimbursement
       unless @event.public_reimbursement_page_available?
         return not_found
       end
+
+      record_rendered_form :reimbursement_report
     end
 
     def update_currency

--- a/app/controllers/users/first_controller.rb
+++ b/app/controllers/users/first_controller.rb
@@ -3,10 +3,12 @@
 module Users
   class FirstController < ApplicationController
     include UsersHelper
+    include FormProvenance
 
     skip_after_action :verify_authorized
     skip_before_action :signed_in_user
     invisible_captcha only: [:create], honeypot: :remember_me
+    require_rendered_form :first_signup, only: [:create]
 
     def index
       return redirect_to welcome_first_index_path unless signed_in?(allow_unverified: true) && current_user(allow_unverified: true).affiliations.any?
@@ -83,6 +85,8 @@ module Users
 
     def new
       return redirect_to first_index_path if signed_in?(allow_unverified: true) && current_user(allow_unverified: true).affiliations.any?
+
+      record_rendered_form :first_signup
 
       @referral_link_slug = Referral::Link.find_by(slug: params[:referral])&.slug if params[:referral].present?
       @user_referral = params[:referred_by] if params[:referred_by].present?

--- a/spec/requests/form_provenance_spec.rb
+++ b/spec/requests/form_provenance_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# `invisible_captcha` stores one global timestamp in the session, so a token
+# seeded by any guarded form is accepted by every other guarded endpoint. These
+# cover the per-form record that closes that.
+RSpec.describe "form provenance", type: :request do
+  describe "reimbursement reports" do
+    let(:event) { create(:event, public_reimbursement_page_enabled: true) }
+
+    def submit(email:, event_id: event.id)
+      post reimbursement_reports_path, params: {
+        reimbursement_report: { event_id:, email:, report_name: "Probe report" }
+      }
+    end
+
+    it "rejects a token seeded by a different form" do
+      email = "cross-path-#{SecureRandom.hex(4)}@example.invalid"
+      get auth_users_path # the login form, not the reimbursement one
+
+      expect { submit(email:) }.to change { User.count }.by(0)
+
+      expect(User.find_by(email:)).to be_nil
+    end
+
+    it "accepts the form's own token" do
+      email = "claimant-#{SecureRandom.hex(4)}@example.invalid"
+      get reimbursement_start_reimbursement_report_path(event_name: event.slug)
+
+      expect { submit(email:) }.to change { User.count }.by(1)
+    end
+
+    it "spends the record, so one render buys one submission" do
+      get reimbursement_start_reimbursement_report_path(event_name: event.slug)
+      submit(email: "first-#{SecureRandom.hex(4)}@example.invalid")
+
+      second = "replay-#{SecureRandom.hex(4)}@example.invalid"
+      expect { submit(email: second) }.to change { User.count }.by(0)
+    end
+
+    it "creates no user for an organization without a public reimbursement page" do
+      closed = create(:event, public_reimbursement_page_enabled: false)
+      email = "denied-#{SecureRandom.hex(4)}@example.invalid"
+      get reimbursement_start_reimbursement_report_path(event_name: event.slug)
+
+      expect { submit(email:, event_id: closed.id) }.to change { User.count }.by(0)
+
+      expect(User.find_by(email:)).to be_nil
+    end
+  end
+
+  describe "logins" do
+    it "rejects a token seeded by a different form" do
+      email = "cross-path-#{SecureRandom.hex(4)}@example.invalid"
+      event = create(:event, public_reimbursement_page_enabled: true)
+      get reimbursement_start_reimbursement_report_path(event_name: event.slug)
+
+      expect {
+        post "/logins", params: { email:, login: { return_to: "/" } }
+      }.to change { User.count }.by(0)
+    end
+
+    it "accepts the login form's own token" do
+      email = "signup-#{SecureRandom.hex(4)}@example.invalid"
+      get auth_users_path
+
+      expect {
+        post "/logins", params: { email:, login: { return_to: "/" } }
+      }.to change { User.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
> Stacks on #14487. Base is `signup-form-provenance-check`, so review that one first.

## Summary of the problem

Two holes, both reachable without a session, both found while designing the signup challenge.

**1. The rendered-form check is not scoped to a form.** `invisible_captcha` stores a single global `invisible_captcha_timestamp` in the session, and any guarded controller consumes it. So a token seeded by whichever form is cheapest to fetch is accepted anywhere else. Demonstrated: `GET /users/auth` (the login form) then `POST /reimbursement/reports` passes. That makes #14487 "fetch some form once" rather than "fetch this form".

**2. `Reimbursement::ReportsController#create` created the `User` before `authorize`.** A denied request still left the row behind, for **any** `event_id`, whether or not the organization had a public reimbursement page. Verified:

```
NON-PUBLIC ORG -> RESPONSE: 302, USER CREATED: true
```

Combined, those two made reimbursement a cheaper account factory than the endpoint being hardened: two requests per account, bounded only by the generic `req/ip` throttle of 1000 per 5 minutes rather than `logins/ip`'s 5 per 20 seconds.

## Describe your changes

**`FormProvenance` concern.** Records, per form, that a client actually rendered it. The record is written server side by the action that renders the form and is never sent to the client, so unlike a hidden field it cannot be stripped or forged, and absence always rejects. It is consumed on use, so one render buys one submission. Applied to all four pairs:

| Renders | Guards |
|---|---|
| `logins#new` | `logins#create` |
| `users/first#new` | `users/first#create` |
| `reimbursement/reports#start` | `reimbursement/reports#create` |
| `exports#collect_email` | `exports#transactions` (email branch only) |

Exposed as a class macro rather than an `included do` block, because callback order is source order and it needs to sit after the `invisible_captcha` macro so the cheaper check runs first.

**Authorize before creating the user.** `ReportPolicy#create?` reads only the event and the signed-in user, never the report's own user, so the check moves ahead of `find_or_create_by!` with no change in meaning. The later `authorize @report` is left in place.

## Testing

`spec/requests/form_provenance_spec.rb` covers, on both reimbursement and logins: a token seeded by a *different* form is rejected, the form's own token is accepted, the record is spent so a replay fails, and a non-public organization creates no user. 317 request and controller examples pass.

## Follow-up

The per-form record subsumes the gem's global timestamp. Once this lands, `config.timestamp_enabled` and the per-controller `timestamp_enabled: false` opt-outs from #14487 could be simplified away, which would also remove the passkey opt-out.