### PR TITLE
[Schema] Fix CPSM unique migration

### DIFF
--- a/db/migrate/20260804120000_add_unique_indexes_to_canonical_pending_settled_mappings.rb
+++ b/db/migrate/20260804120000_add_unique_indexes_to_canonical_pending_settled_mappings.rb
@@ -9,11 +9,5 @@ class AddUniqueIndexesToCanonicalPendingSettledMappings < ActiveRecord::Migratio
     add_index :canonical_pending_settled_mappings, :canonical_pending_transaction_id,
               unique: true, algorithm: :concurrently,
               name: "index_cpsm_on_cpt_id"
-
-    remove_index :canonical_pending_settled_mappings, :canonical_transaction_id
-
-    add_index :canonical_pending_settled_mappings, :canonical_transaction_id,
-              unique: true, algorithm: :concurrently,
-              name: "index_cpsm_on_ct_id"
   end
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This migration failed and partially ran.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
1. run `ActiveRecord::Base.connection.execute("INSERT INTO schema_migrations (version) VALUES ('20260804120000')")` in the production console
2. merge this PR
3. make a PR to revert the part of the migration that did run
4. delete both migrations and the history of them running in production


concern: does production rollback phantom migrations?


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

