### PR TITLE
[Card Locking] Add engineering alert mailer for lock/unlock events

### DIFF
--- a/app/mailers/engineering_alert_mailer.rb
+++ b/app/mailers/engineering_alert_mailer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Internal alerts for HCB engineers, posted to a Slack channel via a
+# Slack-posting email address. One action per alert type, following the
+# same shape as AdminMailer's engineer-facing actions (balance_anomalies,
+# fee_anomalies, ...), but kept separate since these aren't admin-workflow
+# emails.
+#
+# Counts/suppressed are passed in by the caller (captured at the moment of
+# the transition) rather than queried here: this runs inside an async
+# MailDeliveryJob, an arbitrary interval after the transition that triggered
+# it, so querying live state here would describe "now," not the transition
+# being reported on.
+class EngineeringAlertMailer < ApplicationMailer
+  default to: -> { Credentials.fetch(:SLACK_HCB_ENGR_ALERTS_EMAIL) }
+
+  def cards_locked(user:, overdue_count:, suppressed:)
+    @user = user
+    @count = overdue_count
+    @suppressed = suppressed
+    mail subject: "[Card Locking] #{@user.name}'s cards were locked"
+  end
+
+  def cards_unlocked(user:, remaining_overdue_count:, suppressed:)
+    @user = user
+    @remaining_overdue_count = remaining_overdue_count
+    @suppressed = suppressed
+
+    # An unlock with overdue charges still outstanding is only a violated
+    # precondition when it's NOT from admin suppression -- suppression is a
+    # supported action that unlocks without resolving receipts by design
+    # (see UserService::UpdateCardLocking#run and users_controller.rb's
+    # suppress_card_locking). Report it as an anomaly (reported in
+    # production, raised loudly in development/test) only in the genuine
+    # case.
+    if @remaining_overdue_count.positive? && !@suppressed
+      Rails.error.unexpected(
+        # user_id kept out of the message (only in context) so AppSignal
+        # groups every occurrence as one error, not one per user.
+        "[Card Locking] unlocked with #{@remaining_overdue_count} overdue charges remaining",
+        context: { user_id: user.id, remaining_overdue_count: @remaining_overdue_count }
+      )
+    end
+
+    mail subject: "[Card Locking] #{@user.name}'s cards were unlocked"
+  end
+
+end

--- a/app/models/concerns/card_locking/cardholder_behavior.rb
+++ b/app/models/concerns/card_locking/cardholder_behavior.rb
@@ -10,6 +10,14 @@ module CardLocking
   module CardholderBehavior
     extend ActiveSupport::Concern
 
+    included do
+      # Model-level (not service-level) so it catches every writer of
+      # cards_locked, not just UserService::UpdateCardLocking -- an
+      # engineering-alert verification signal is only useful if it can't be
+      # bypassed by a future call site or a console fix.
+      after_update_commit :send_card_locking_engineering_alert, if: :saved_change_to_cards_locked?
+    end
+
     class_methods do
       def card_locking_candidates
         candidate_user_ids = HcbCode.card_locking_candidates.select("DISTINCT stripe_cardholders.user_id")
@@ -109,6 +117,25 @@ module CardLocking
 
     def card_locking_outstanding_count
       card_locking_outstanding_charges.count
+    end
+
+    private
+
+    def send_card_locking_engineering_alert
+      # Captured now (at the transition), not left for the mailer to query
+      # later inside its async job -- the mailer needs to describe this
+      # transition, not whatever state exists whenever the job dequeues.
+      suppressed = card_locking_suppressed?
+
+      if cards_locked?
+        EngineeringAlertMailer.cards_locked(
+          user: self, overdue_count: card_locking_overdue_charges.count, suppressed:
+        ).deliver_later
+      else
+        EngineeringAlertMailer.cards_unlocked(
+          user: self, remaining_overdue_count: card_locking_overdue_charges.count, suppressed:
+        ).deliver_later
+      end
     end
   end
 end

--- a/app/views/engineering_alert_mailer/cards_locked.html.erb
+++ b/app/views/engineering_alert_mailer/cards_locked.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= link_to(admin_user_url(@user)) do %>
+    <%= @user.name %> (<%= @user.email %>)
+  <% end %> just had their cards locked for <%= @count %> overdue <%= "receipt".pluralize(@count) %>.
+</p>
+<% if @suppressed %>
+  <p><strong>Note:</strong> this user's card locking is currently suppressed by an admin.</p>
+<% end %>

--- a/app/views/engineering_alert_mailer/cards_unlocked.html.erb
+++ b/app/views/engineering_alert_mailer/cards_unlocked.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <%= link_to(admin_user_url(@user)) do %>
+    <%= @user.name %> (<%= @user.email %>)
+  <% end %> just had their cards unlocked.
+</p>
+<% if @suppressed %>
+  <p>Card locking is currently suppressed by an admin for this user. This unlock may be from suppression rather than receipts being resolved.</p>
+<% end %>
+<% if @remaining_overdue_count.positive? %>
+  <p><strong>Warning:</strong> <%= @remaining_overdue_count %> overdue <%= "receipt".pluralize(@remaining_overdue_count) %> still remain despite this unlock. This may indicate a bug.</p>
+<% end %>

--- a/spec/mailers/engineering_alert_mailer_spec.rb
+++ b/spec/mailers/engineering_alert_mailer_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EngineeringAlertMailer, type: :mailer do
+  let(:user) { create(:user) }
+
+  before do
+    allow(Credentials).to receive(:fetch).with(:SLACK_HCB_ENGR_ALERTS_EMAIL).and_return("engr-alerts@example.com")
+  end
+
+  describe "#cards_locked" do
+    it "names the user, overdue count, and admin link" do
+      mail = described_class.cards_locked(user:, overdue_count: 2, suppressed: false)
+
+      expect(mail.to).to eq(["engr-alerts@example.com"])
+      expect(mail.subject).to eq("[Card Locking] #{user.name}'s cards were locked")
+      expect(mail.body.encoded).to include(user.email)
+      expect(mail.body.encoded).to include(admin_user_url(user))
+      expect(mail.body.encoded).not_to include("suppressed")
+    end
+
+    it "flags when the user's card locking is currently suppressed" do
+      mail = described_class.cards_locked(user:, overdue_count: 2, suppressed: true)
+
+      expect(mail.body.encoded).to include("suppressed")
+    end
+  end
+
+  describe "#cards_unlocked" do
+    it "names the user and admin link" do
+      mail = described_class.cards_unlocked(user:, remaining_overdue_count: 0, suppressed: false)
+
+      expect(mail.to).to eq(["engr-alerts@example.com"])
+      expect(mail.subject).to eq("[Card Locking] #{user.name}'s cards were unlocked")
+      expect(mail.body.encoded).to include(user.email)
+      expect(mail.body.encoded).to include(admin_user_url(user))
+    end
+
+    it "flags when the user's card locking is currently suppressed" do
+      mail = described_class.cards_unlocked(user:, remaining_overdue_count: 0, suppressed: true)
+
+      expect(mail.body.encoded).to include("suppressed")
+    end
+
+    it "does not report an anomaly when suppressed, even with overdue charges remaining" do
+      # Admin suppression is a supported action that unlocks without
+      # resolving receipts by design -- not a violated precondition.
+      expect(Rails.error).not_to receive(:unexpected)
+
+      described_class.cards_unlocked(user:, remaining_overdue_count: 1, suppressed: true).message
+    end
+
+    it "does not report an anomaly when no overdue charges remain" do
+      expect(Rails.error).not_to receive(:unexpected)
+
+      described_class.cards_unlocked(user:, remaining_overdue_count: 0, suppressed: false).message
+    end
+
+    # Rails.error.unexpected raises (wrapped) instead of just reporting
+    # whenever Rails.error.debug_mode is true -- true by default in
+    # development/test (config.consider_all_requests_local), false in
+    # production. So a genuine (non-suppressed) violation fails loudly here...
+    it "raises a violated-precondition error for a genuine (non-suppressed) unlock with overdue charges remaining" do
+      # .message forces the lazy MessageDelivery proxy to actually run the
+      # mailer action body; a bare method call alone never executes it.
+      expect { described_class.cards_unlocked(user:, remaining_overdue_count: 1, suppressed: false).message }
+        .to raise_error(ActiveSupport::ErrorReporter::UnexpectedError, /unlocked with 1 overdue/)
+    end
+
+    # ...but only reports (and still sends the alert) in production, where
+    # Rails.error.debug_mode is false and mail delivery must not be disrupted.
+    it "reports without raising and still sends the alert in production" do
+      # unexpected checks the real @debug_mode ivar directly, so stubbing the
+      # reader method has no effect -- must actually flip and restore it.
+      original_debug_mode = Rails.error.debug_mode
+      Rails.error.debug_mode = false
+      begin
+        expect(Rails.error).to receive(:unexpected).with(
+          a_string_including("unlocked with 1 overdue"), context: { user_id: user.id, remaining_overdue_count: 1 }
+        ).and_call_original
+
+        mail = described_class.cards_unlocked(user:, remaining_overdue_count: 1, suppressed: false)
+
+        expect(mail.body.encoded).to include("still remain")
+      ensure
+        Rails.error.debug_mode = original_debug_mode
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/engineering_alert_mailer_preview.rb
+++ b/spec/mailers/previews/engineering_alert_mailer_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class EngineeringAlertMailerPreview < ActionMailer::Preview
+  def cards_locked
+    user = User.first
+    EngineeringAlertMailer.cards_locked(user:, overdue_count: 2, suppressed: false)
+  end
+
+  def cards_unlocked
+    user = User.first
+    EngineeringAlertMailer.cards_unlocked(user:, remaining_overdue_count: 0, suppressed: false)
+  end
+
+end

--- a/spec/models/concerns/card_locking/cardholder_behavior_spec.rb
+++ b/spec/models/concerns/card_locking/cardholder_behavior_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CardLocking::CardholderBehavior do
+  let(:user) { create(:user) }
+
+  describe "engineering alert on cards_locked transitions" do
+    it "alerts engineering when cards become locked" do
+      expect { user.update!(cards_locked: true) }
+        .to have_enqueued_mail(EngineeringAlertMailer, :cards_locked).once
+    end
+
+    it "alerts engineering when cards become unlocked" do
+      user.update!(cards_locked: true)
+
+      expect { user.update!(cards_locked: false) }
+        .to have_enqueued_mail(EngineeringAlertMailer, :cards_unlocked).once
+    end
+
+    it "does not alert on a save that leaves cards_locked unchanged" do
+      expect { user.update!(card_locking_suppressed_until: 1.hour.from_now) }
+        .not_to have_enqueued_mail(EngineeringAlertMailer)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
Card locking shipped ~2 weeks ago. To verify it's behaving correctly in production, HCB engineers want an alert whenever any user's cards get locked or unlocked.

## Describe your changes
- New `EngineeringAlertMailer` with `cards_locked`/`cards_unlocked` actions, sent to a Slack-posting address via `Credentials.fetch(:SLACK_HCB_ENGR_ALERTS_EMAIL)` (unset today; add the real value in Doppler separately). Content is intentionally minimal (name, email, admin link, counts — no merchant/amount detail).
- Hooked in via a `User` model `after_update_commit` callback (`CardLocking::CardholderBehavior`, keyed on `saved_change_to_cards_locked?`) rather than inside `UserService::UpdateCardLocking`, so it fires on any writer of `cards_locked`, not just that one service.
- Counts/suppression state are captured at the moment of the transition and passed into the mailer, rather than queried live inside the async delivery job, so the alert describes the transition it's reporting on.
- When an unlock leaves overdue charges outstanding and the user is **not** currently suppressed by an admin (suppression is a supported action that unlocks without resolving receipts by design), it's reported via `Rails.error.unexpected` as a violated precondition — reported to AppSignal in production, raised loudly in development/test.

**Note for reviewers:** there's no `Rails.env.production?` gate on delivery — the only thing preventing this from firing outside production is `SLACK_HCB_ENGR_ALERTS_EMAIL` staying unset there. That mirrors how `AdminMailer`/`OrganizerPositionDeletionRequestMailer` already handle `SLACK_NOTIFICATIONS_EMAIL` in this codebase, but worth confirming the Doppler value doesn't get shared into a staging config before this ships.