### PR TITLE
[Receipts] Allow marking no/lost receipt from the emailed receipt request link

### DIFF
--- a/app/controllers/receiptables_controller.rb
+++ b/app/controllers/receiptables_controller.rb
@@ -1,18 +1,27 @@
 # frozen_string_literal: true
 
 class ReceiptablesController < ApplicationController
+  # Emailed receipt requests link to a signed upload page that doesn't require
+  # signing in. Marking no/lost receipt from that page shouldn't either.
+  skip_before_action :signed_in_user, only: :mark_no_or_lost
   before_action :set_receiptable
   skip_after_action :verify_authorized # do not force pundit
 
   def mark_no_or_lost
-    authorize @receiptable, policy_class: ReceiptablePolicy
+    authorize @receiptable, policy_class: ReceiptablePolicy unless from_signed_link?
 
     if @receiptable.no_or_lost_receipt!
       flash[:success] = "Marked no/lost receipt on that transaction."
-      redirect_to @receiptable
     else
       flash[:error] = "Failed to mark that transaction as no/lost receipt."
-      redirect_back(fallback_location: @receiptable)
+    end
+
+    if from_signed_link?
+      # Reuse the secret they arrived with, so they land back on the page they
+      # started from and see the "Marked no/lost receipt" banner.
+      redirect_to attach_receipt_hcb_code_path(id: @receiptable.hashid, s: params[:s])
+    else
+      redirect_to @receiptable
     end
   end
 
@@ -27,6 +36,15 @@ class ReceiptablesController < ApplicationController
 
     @klass = RECEIPTABLE_TYPE_MAP[params[:receiptable_type]]
     @receiptable = @klass.find(params[:receiptable_id])
+  end
+
+  # True when the request came from the signed link in a receipt request email,
+  # which grants access without signing in (same secret the upload form uses).
+  def from_signed_link?
+    return @from_signed_link if defined?(@from_signed_link)
+
+    @from_signed_link = @receiptable.is_a?(HcbCode) && params[:s].present? &&
+                        HcbCode.find_signed(params[:s], purpose: :receipt_upload) == @receiptable
   end
 
 end

--- a/app/controllers/receiptables_controller.rb
+++ b/app/controllers/receiptables_controller.rb
@@ -5,23 +5,25 @@ class ReceiptablesController < ApplicationController
   # signing in. Marking no/lost receipt from that page shouldn't either.
   skip_before_action :signed_in_user, only: :mark_no_or_lost
   before_action :set_receiptable
-  skip_after_action :verify_authorized # do not force pundit
 
   def mark_no_or_lost
-    authorize @receiptable, policy_class: ReceiptablePolicy unless from_signed_link?
+    # Always run the policy, even for the signed link, so that Pundit's
+    # `verify_authorized` can stay on: an action that forgets to authorize now
+    # fails loudly rather than silently allowing the request through.
+    begin
+      authorize @receiptable, policy_class: ReceiptablePolicy
+    rescue Pundit::NotAuthorizedError
+      raise unless from_signed_link?
+    end
 
     if @receiptable.no_or_lost_receipt!
       flash[:success] = "Marked no/lost receipt on that transaction."
+      # Signed link visitors can't view the transaction itself, so send them
+      # back where they came from, reusing the secret they arrived with.
+      redirect_to from_signed_link? ? attach_receipt_hcb_code_path(@receiptable, s: params[:s]) : @receiptable
     else
       flash[:error] = "Failed to mark that transaction as no/lost receipt."
-    end
-
-    if from_signed_link?
-      # Reuse the secret they arrived with, so they land back on the page they
-      # started from and see the "Marked no/lost receipt" banner.
-      redirect_to attach_receipt_hcb_code_path(id: @receiptable.hashid, s: params[:s])
-    else
-      redirect_to @receiptable
+      redirect_back(fallback_location: @receiptable)
     end
   end
 

--- a/app/policies/hcb_code_policy.rb
+++ b/app/policies/hcb_code_policy.rb
@@ -49,8 +49,11 @@ class HcbCodePolicy < ApplicationPolicy
     gte_member_in_events?
   end
 
+  # `user` is nil for signed out requests, and a charge whose cardholder can't
+  # be resolved has a nil owner, so without the first clause the two compare
+  # equal and an anonymous request is treated as the purchaser.
   def user_made_purchase?
-    record.stripe_card? && record.stripe_cardholder&.user == user
+    user.present? && record.stripe_card? && record.stripe_cardholder&.user == user
   end
 
   alias receiptable_upload? user_made_purchase?

--- a/app/policies/reimbursement/expense_policy.rb
+++ b/app/policies/reimbursement/expense_policy.rb
@@ -26,8 +26,9 @@ module Reimbursement
       (admin? || (manager? && !creator?)) && record.report.submitted?
     end
 
+    # Guards the same nil == nil comparison as HcbCodePolicy#user_made_purchase?.
     def user_made_expense?
-      record&.report&.user == user
+      user.present? && record&.report&.user == user
     end
 
     alias receiptable_upload? user_made_expense?

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -114,7 +114,7 @@
     <% if defined?(receiptable) && (receiptable&.missing_receipt? || (admin_signed_in? && !receiptable&.no_or_lost_receipt?)) %>
       <div class="flex muted justify-end items-center mt1">
         <%= inline_icon "forbidden", size: 20 %>
-        <%= link_to receiptable_mark_no_or_lost_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id), method: :post do %>
+        <%= link_to receiptable_mark_no_or_lost_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id, s: local_assigns[:secret]), method: :post do %>
           <small class="mt0 mb0">
             No/lost receipt?
           </small>

--- a/spec/controllers/receiptables_controller_spec.rb
+++ b/spec/controllers/receiptables_controller_spec.rb
@@ -3,6 +3,42 @@
 require "rails_helper"
 
 RSpec.describe ReceiptablesController do
+  include SessionSupport
+
+  describe "#mark_no_or_lost" do
+    let(:cpt) { create(:canonical_pending_transaction) }
+    let(:hcb_code) { cpt.local_hcb_code }
+    let(:base_params) { { receiptable_type: "HcbCode", receiptable_id: hcb_code.id } }
+
+    it "marks the transaction using the secret from a receipt request email, without signing in" do
+      secret = hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload)
+
+      post(:mark_no_or_lost, params: base_params.merge(s: secret), as: :html)
+
+      expect(hcb_code.reload).to be_no_or_lost_receipt
+      expect(flash[:success]).to eq("Marked no/lost receipt on that transaction.")
+      expect(URI.parse(response.location).path)
+        .to eq(attach_receipt_hcb_code_path(id: hcb_code.hashid))
+    end
+
+    it "refuses a signed out user without a valid secret" do
+      post(:mark_no_or_lost, params: base_params.merge(s: "not-a-real-secret"), as: :html)
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "marks the transaction and returns to it when signed in" do
+      user = create(:user, :make_admin)
+      create_session(user, verified: true)
+
+      post(:mark_no_or_lost, params: base_params, as: :html)
+
+      expect(hcb_code.reload).to be_no_or_lost_receipt
+      expect(response).to redirect_to(hcb_code_path(hcb_code))
+    end
+  end
+
   context "models including Receiptable" do
     it "are explicitly registered" do
       Rails.application.eager_load!

--- a/spec/controllers/receiptables_controller_spec.rb
+++ b/spec/controllers/receiptables_controller_spec.rb
@@ -6,19 +6,53 @@ RSpec.describe ReceiptablesController do
   include SessionSupport
 
   describe "#mark_no_or_lost" do
+    let(:event) { create(:event) }
     let(:cpt) { create(:canonical_pending_transaction) }
     let(:hcb_code) { cpt.local_hcb_code }
     let(:base_params) { { receiptable_type: "HcbCode", receiptable_id: hcb_code.id } }
+    let(:secret) { hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload) }
+
+    before { create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:) }
 
     it "marks the transaction using the secret from a receipt request email, without signing in" do
-      secret = hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload)
-
       post(:mark_no_or_lost, params: base_params.merge(s: secret), as: :html)
 
       expect(hcb_code.reload).to be_no_or_lost_receipt
       expect(flash[:success]).to eq("Marked no/lost receipt on that transaction.")
-      expect(URI.parse(response.location).path)
-        .to eq(attach_receipt_hcb_code_path(id: hcb_code.hashid))
+      expect(response).to redirect_to(attach_receipt_hcb_code_path(hcb_code, s: secret))
+    end
+
+    it "refuses a secret issued for a different transaction" do
+      other_hcb_code = create(:canonical_pending_transaction).local_hcb_code
+      other_secret = other_hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload)
+
+      post(:mark_no_or_lost, params: base_params.merge(s: other_secret), as: :html)
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(other_hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "refuses a secret issued for a different purpose" do
+      status_secret = hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_status)
+
+      post(:mark_no_or_lost, params: base_params.merge(s: status_secret), as: :html)
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "refuses an expired secret" do
+      # Mint the secret now, so that travelling past its two week expiry is what
+      # invalidates it.
+      params_with_secret = base_params.merge(s: secret)
+
+      travel_to 3.weeks.from_now do
+        post(:mark_no_or_lost, params: params_with_secret, as: :html)
+      end
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
     end
 
     it "refuses a signed out user without a valid secret" do
@@ -28,14 +62,24 @@ RSpec.describe ReceiptablesController do
       expect(flash[:error]).to eq("You are not authorized to perform this action.")
     end
 
-    it "marks the transaction and returns to it when signed in" do
-      user = create(:user, :make_admin)
+    it "marks the transaction and returns to it when signed in as an organizer" do
+      user = create(:user)
+      create(:organizer_position, user:, event:)
       create_session(user, verified: true)
 
       post(:mark_no_or_lost, params: base_params, as: :html)
 
       expect(hcb_code.reload).to be_no_or_lost_receipt
       expect(response).to redirect_to(hcb_code_path(hcb_code))
+    end
+
+    it "refuses a signed in user who isn't on the organization" do
+      create_session(create(:user), verified: true)
+
+      post(:mark_no_or_lost, params: base_params, as: :html)
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
     end
   end
 

--- a/spec/controllers/receiptables_controller_spec.rb
+++ b/spec/controllers/receiptables_controller_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe ReceiptablesController do
       expect(flash[:error]).to eq("You are not authorized to perform this action.")
     end
 
+    it "refuses a signed out user on a charge whose cardholder doesn't resolve" do
+      allow(HcbCode).to receive(:find).and_return(hcb_code)
+      allow(hcb_code).to receive_messages(stripe_card?: true, stripe_cardholder: nil)
+
+      post(:mark_no_or_lost, params: base_params, as: :html)
+
+      expect(hcb_code.reload).not_to be_no_or_lost_receipt
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+    end
+
     it "refuses a signed out user without a valid secret" do
       post(:mark_no_or_lost, params: base_params.merge(s: "not-a-real-secret"), as: :html)
 

--- a/spec/policies/hcb_code_policy_spec.rb
+++ b/spec/policies/hcb_code_policy_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HcbCodePolicy, type: :policy do
+  describe "#user_made_purchase?" do
+    let(:hcb_code) { create(:canonical_pending_transaction).local_hcb_code }
+
+    context "when the charge's cardholder can't be resolved" do
+      before do
+        allow(hcb_code).to receive_messages(stripe_card?: true, stripe_cardholder: nil)
+      end
+
+      it "does not treat a signed out visitor as the purchaser" do
+        expect(described_class.new(nil, hcb_code).user_made_purchase?).to be(false)
+      end
+
+      it "does not authorize a signed out visitor to attach a receipt" do
+        expect(described_class.new(nil, hcb_code).attach_receipt?).to be_falsey
+      end
+
+      it "does not authorize a signed out visitor through ReceiptablePolicy" do
+        expect(ReceiptablePolicy.new(nil, hcb_code).mark_no_or_lost?).to be_falsey
+      end
+
+      it "does not treat an unrelated signed in user as the purchaser" do
+        expect(described_class.new(create(:user), hcb_code).user_made_purchase?).to be(false)
+      end
+    end
+
+    it "treats the cardholder's own user as the purchaser" do
+      cardholder = create(:stripe_cardholder)
+      allow(hcb_code).to receive_messages(stripe_card?: true, stripe_cardholder: cardholder)
+
+      expect(described_class.new(cardholder.user, hcb_code).user_made_purchase?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
The no/lost receipt button does not directly work from the emailed receipt request link. It redirects user to sign in, and then sends them to the home page due to #14514 


## Describe your changes
Allows the no/lost receipt button to work from the emailed receipt request link.

