### PR TITLE
[Contractors] Copy an approved invoice onto its payment

### DIFF
--- a/app/models/payroll/invoice.rb
+++ b/app/models/payroll/invoice.rb
@@ -58,6 +58,7 @@ module Payroll
       event :mark_approved do
         after do |reviewed_by|
           update!(reviewed_by:)
+          copy_receipts_to_payment!
         end
         transitions from: :submitted, to: :approved
       end
@@ -79,6 +80,19 @@ module Payroll
     end
 
     private
+
+    # The document the contractor uploaded is the receipt for the payment their
+    # invoice triggers, so hand it over on approval. Payment::Attempt makes the
+    # same hand-off from payment to transfer, but only at the moment it creates
+    # the transfer — when the payee was ready to be paid straight away that
+    # already happened, so catch the transfer's HCB code up here too.
+    def copy_receipts_to_payment!
+      return if payment.nil?
+
+      [payment, payment.payout&.local_hcb_code].compact.each do |receiptable|
+        Receipt.reupload(old_receiptable: self, new_receiptable: receiptable)
+      end
+    end
 
     def notify_managers
       Payroll::InvoiceMailer.with(invoice: self).submitted.deliver_later


### PR DESCRIPTION
## Summary of the problem
After approving an invoice for a contractor, users had to attach the invoice again to the payment that was made. Requested [here](https://hackclub.slack.com/archives/GBXBFEED9/p1785961160356909).

## Describe your changes
Automates the process so when you approve an invoice for a contractor, the payment that was made has the invoice automatically.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

