### PR TITLE
Normalize payee email

### DIFF
--- a/app/models/payee.rb
+++ b/app/models/payee.rb
@@ -34,6 +34,8 @@ class Payee < ApplicationRecord
   has_many :payments
   has_many :payroll_positions, class_name: "Payroll::Position"
 
+  normalizes :email, with: ->(email) { email.strip.downcase }
+
   validates_uniqueness_of :legal_entity_id, scope: [:event_id], allow_nil: true
 
   validate :managed_legal_entity_constraints


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Payee emails weren't being normalized, which meant that sending an invite to Admin@bank.engineering would have a user sign in as admin@bank.engineering but not be able to access the payment.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Normalize payee email.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

