### PR TITLE
[Ledger] Fix memo rendering on table

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -173,6 +173,10 @@ html[data-dark='true'] {
   visibility: visible;
 }
 
+.transaction:not(:hover) .add-tag-badge {
+  width: 1px;
+}
+
 .transaction:hover .suggested_tag,
 .suggested_tag[aria-expanded='true'] {
   max-width: 125px;

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -40,9 +40,6 @@
       <% end %>
     </span>
   </td>
-  <% admin_tool("", "td") do %>
-    <%= item.short_code %>
-  <% end %>
   <td>
     <% if item.author.present? %>
       <div class="flex items-center justify-center tooltipped tooltipped--w" aria-label="<%= item.author.name %>">

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -11,7 +11,7 @@
   <td><%= item.datetime.strftime("%b %e, %Y") %></td>
   <td class="transaction__memo transaction__memo--fluid<%= " transaction__memo--pending" if item.pending? %>">
     <div>
-      <div class="flex-auto flex flex-wrap items-center gap-y-1 gap-x-[1ch] min-w-0">
+      <div class="flex-auto">
         <div class="flex items-center gap-[1ch] min-w-0">
           <% unless item.settled? %>
             <%= badge_for item.status_text, class: item.status_css %>
@@ -26,13 +26,10 @@
       </div>
 
       <%= render "ledger/items/tag_menu", item: %>
-    </div>
-  </td>
-  <td class="nowrap">
-    <span class="flex items-center justify-end">
+
       <%= list_badge_for auditor_signed_in? ? item.comment_count : item.not_admin_only_comment_count, "comment", "post", optional: true %>
       <%= list_badge_for item.receipt_count, "receipt", "payment-docs", optional: item.receipt_optional?, required: item.missing_receipt? %>
-    </span>
+    </div>
   </td>
   <td class="nowrap">
     <span class="flex items-center justify-end">

--- a/app/views/ledger/items/_tag_menu.html.erb
+++ b/app/views/ledger/items/_tag_menu.html.erb
@@ -9,7 +9,7 @@
 <% event = @event || hcb_code&.event %>
 <% if hcb_code.present? && !event&.demo_mode? && event.present? && policy(hcb_code).toggle_tag? %>
   <div class="overflow-visible relative" style="margin-left: 0.5rem;" data-controller="menu">
-    <button class="list-badge add-tag-badge ml0 menu__toggle menu__toggle--arrowless" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
+    <button class="list-badge add-tag-badge !mx-0 menu__toggle menu__toggle--arrowless" data-menu-target="toggle" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">+ Add tag</button>
     <div class="menu__content menu__content--2 menu__content--compact menu__content--left text-sm" data-menu-target="content">
       <% event.tags.each do |tag| %>
         <div class="flex items-center" data-tag="<%= tag.id %>">

--- a/app/views/ledgers/_ledger.html.erb
+++ b/app/views/ledgers/_ledger.html.erb
@@ -50,7 +50,6 @@
             <th><%# icon %></th>
             <th>Date</th>
             <th>Memo</th>
-            <th><%# receipt count %></th>
             <th class="text-right">Amount</th>
             <% admin_tool("", "th") do %>
               Short Code

--- a/app/views/ledgers/_ledger.html.erb
+++ b/app/views/ledgers/_ledger.html.erb
@@ -51,9 +51,6 @@
             <th>Date</th>
             <th>Memo</th>
             <th class="text-right">Amount</th>
-            <% admin_tool("", "th") do %>
-              Short Code
-            <% end %>
             <th><%# user avatar %></th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary of the problem

Memos don't render properly.

<img width="577" height="506" alt="image" src="https://github.com/user-attachments/assets/e33515eb-eed6-4ff3-b08a-3b0904c379e9" />



## Describe your changes

This PR updates the CSS to better line up with our old ledger.

<img width="553" height="439" alt="image" src="https://github.com/user-attachments/assets/0fe9591b-b02b-47ce-9f58-2f45abd0fb9e" />
