### PR TITLE
[Ledger::Item] Route all custom_memo writes through HcbCode#update_custom_memo!

### DIFF
--- a/app/controllers/canonical_pending_transactions_controller.rb
+++ b/app/controllers/canonical_pending_transactions_controller.rb
@@ -38,10 +38,12 @@ class CanonicalPendingTransactionsController < ApplicationController
 
       # `custom_memo` is mirrored onto the transaction's ledger item, which caches
       # its `memo` from that copy. `HcbCode#update_custom_memo!` is the only writer
-      # that keeps both sides in sync. Transactions missing an HCB code still have
-      # nowhere else to write to.
+      # that keeps both sides in sync; fall back to the ledger item, and only write
+      # the column directly when the transaction has neither.
       if (hcb_code = @canonical_pending_transaction.local_hcb_code)
         hcb_code.update_custom_memo!(custom_memo)
+      elsif (ledger_item = @canonical_pending_transaction.ledger_item)
+        ledger_item.update_custom_memo!(custom_memo)
       else
         @canonical_pending_transaction.update!(custom_memo:)
       end

--- a/app/controllers/canonical_pending_transactions_controller.rb
+++ b/app/controllers/canonical_pending_transactions_controller.rb
@@ -27,7 +27,25 @@ class CanonicalPendingTransactionsController < ApplicationController
 
     authorize @canonical_pending_transaction
 
-    @canonical_pending_transaction.update!(canonical_pending_transaction_params)
+    attributes = canonical_pending_transaction_params
+    renamed = attributes.key?(:custom_memo)
+    custom_memo = attributes.delete(:custom_memo).presence
+
+    ActiveRecord::Base.transaction do
+      @canonical_pending_transaction.update!(attributes) unless attributes.empty?
+
+      next unless renamed
+
+      # `custom_memo` is mirrored onto the transaction's ledger item, which caches
+      # its `memo` from that copy. `HcbCode#update_custom_memo!` is the only writer
+      # that keeps both sides in sync. Transactions missing an HCB code still have
+      # nowhere else to write to.
+      if (hcb_code = @canonical_pending_transaction.local_hcb_code)
+        hcb_code.update_custom_memo!(custom_memo)
+      else
+        @canonical_pending_transaction.update!(custom_memo:)
+      end
+    end
 
     unless params[:no_flash]
       flash[:success] = "Updated pending transaction"

--- a/app/controllers/canonical_transactions_controller.rb
+++ b/app/controllers/canonical_transactions_controller.rb
@@ -26,7 +26,21 @@ class CanonicalTransactionsController < ApplicationController
 
     authorize @canonical_transaction
 
-    @canonical_transaction.update!(params.require(:canonical_transaction).permit(:custom_memo))
+    attributes = params.require(:canonical_transaction).permit(:custom_memo)
+
+    if attributes.key?(:custom_memo)
+      custom_memo = attributes[:custom_memo].presence
+
+      # `custom_memo` is mirrored onto the transaction's ledger item, which caches
+      # its `memo` from that copy. `HcbCode#update_custom_memo!` is the only writer
+      # that keeps both sides in sync. Transactions missing an HCB code still have
+      # nowhere else to write to.
+      if (hcb_code = @canonical_transaction.local_hcb_code)
+        hcb_code.update_custom_memo!(custom_memo)
+      else
+        @canonical_transaction.update!(custom_memo:)
+      end
+    end
 
     unless params[:no_flash]
       flash[:success] = "Renamed transaction"

--- a/app/controllers/canonical_transactions_controller.rb
+++ b/app/controllers/canonical_transactions_controller.rb
@@ -33,10 +33,12 @@ class CanonicalTransactionsController < ApplicationController
 
       # `custom_memo` is mirrored onto the transaction's ledger item, which caches
       # its `memo` from that copy. `HcbCode#update_custom_memo!` is the only writer
-      # that keeps both sides in sync. Transactions missing an HCB code still have
-      # nowhere else to write to.
+      # that keeps both sides in sync; fall back to the ledger item, and only write
+      # the column directly when the transaction has neither.
       if (hcb_code = @canonical_transaction.local_hcb_code)
         hcb_code.update_custom_memo!(custom_memo)
+      elsif (ledger_item = @canonical_transaction.ledger_item)
+        ledger_item.update_custom_memo!(custom_memo)
       else
         @canonical_transaction.update!(custom_memo:)
       end

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -793,19 +793,24 @@ class HcbCode < ApplicationRecord
   # *and* on their ledger items, which cache `memo` from their own copy. Writing
   # only one side leaves the other rendering a stale memo, so write them all.
   def update_custom_memo!(memo)
+    cts = canonical_transactions.to_a
+    cpts = canonical_pending_transactions.to_a
     # `hcb_codes.ledger_item_id` is only back-linked when the transaction engine
     # *creates* the item; a transaction that adopted an existing one leaves it
     # null, so resolve through the transactions as well.
-    ledger_item_ids = [ledger_item_id, *canonical_transactions.pluck(:ledger_item_id), *canonical_pending_transactions.pluck(:ledger_item_id)].compact.uniq
+    ledger_item_ids = [ledger_item_id, *cts.map(&:ledger_item_id), *cpts.map(&:ledger_item_id)].compact.uniq
     ledger_items = Ledger::Item.where(id: ledger_item_ids).to_a
 
-    ActiveRecord::Base.transaction do
-      canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-      canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
-      ledger_items.each { |item| item.update!(custom_memo: memo) }
-    end
+    # Every write below cascades into `Ledger::Item#map!` and `#refresh!` for each
+    # record, so don't pay for a rename that wouldn't change anything.
+    return if [*cts, *cpts, *ledger_items].all? { |record| record.custom_memo == memo }
 
-    ledger_items.each(&:refresh!)
+    ActiveRecord::Base.transaction do
+      cts.each { |ct| ct.update!(custom_memo: memo) }
+      cpts.each { |cpt| cpt.update!(custom_memo: memo) }
+      ledger_items.each { |item| item.update!(custom_memo: memo) }
+      ledger_items.each(&:refresh!)
+    end
   end
 
 end

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -790,10 +790,19 @@ class HcbCode < ApplicationRecord
   end
 
   def update_custom_memo!(memo)
-    if ledger_item.present?
-      ledger_item.update_custom_memo!(memo)
+    # `hcb_codes.ledger_item_id` is only back-linked when the transaction engine
+    # *creates* the item; a transaction that adopted an existing item leaves it
+    # null. Resolving through the transactions as well means a rename still
+    # reaches the ledger item — otherwise it writes the canonical transactions
+    # only and `Ledger::Item#memo` keeps its old value.
+    ledger_item_ids = [ledger_item_id, *canonical_transactions.pluck(:ledger_item_id), *canonical_pending_transactions.pluck(:ledger_item_id)].compact.uniq
+    ledger_items = Ledger::Item.where(id: ledger_item_ids)
+
+    if ledger_items.any?
+      ledger_items.each { |item| item.update_custom_memo!(memo) }
       return
     end
+
     canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
     canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
   end

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -789,22 +789,23 @@ class HcbCode < ApplicationRecord
     update(event_id: event&.id, subledger_id: subledger&.id)
   end
 
+  # `custom_memo` is stored on every canonical (pending) transaction in the group
+  # *and* on their ledger items, which cache `memo` from their own copy. Writing
+  # only one side leaves the other rendering a stale memo, so write them all.
   def update_custom_memo!(memo)
     # `hcb_codes.ledger_item_id` is only back-linked when the transaction engine
-    # *creates* the item; a transaction that adopted an existing item leaves it
-    # null. Resolving through the transactions as well means a rename still
-    # reaches the ledger item — otherwise it writes the canonical transactions
-    # only and `Ledger::Item#memo` keeps its old value.
+    # *creates* the item; a transaction that adopted an existing one leaves it
+    # null, so resolve through the transactions as well.
     ledger_item_ids = [ledger_item_id, *canonical_transactions.pluck(:ledger_item_id), *canonical_pending_transactions.pluck(:ledger_item_id)].compact.uniq
-    ledger_items = Ledger::Item.where(id: ledger_item_ids)
+    ledger_items = Ledger::Item.where(id: ledger_item_ids).to_a
 
-    if ledger_items.any?
-      ledger_items.each { |item| item.update_custom_memo!(memo) }
-      return
+    ActiveRecord::Base.transaction do
+      canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
+      canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
+      ledger_items.each { |item| item.update!(custom_memo: memo) }
     end
 
-    canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-    canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
+    ledger_items.each(&:refresh!)
   end
 
 end

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -336,10 +336,12 @@ class Ledger
     def update_custom_memo!(memo)
       # TODO: remove CT and CPT updates because they are HCB code specific
       ActiveRecord::Base.transaction do
-        if hcb_code.present?
-          hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-          hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
-        end
+        # `canonical_transactions` (keyed by `ledger_item_id`) and
+        # `hcb_code.canonical_transactions` (keyed by the HCB code) can diverge,
+        # and the HCB code is missing entirely when it was never back-linked to
+        # this item. Write the union so neither side keeps a stale memo.
+        (canonical_transactions.to_a | hcb_code&.canonical_transactions.to_a).each { |ct| ct.update!(custom_memo: memo) }
+        (canonical_pending_transactions.to_a | hcb_code&.canonical_pending_transactions.to_a).each { |cpt| cpt.update!(custom_memo: memo) }
         update!(custom_memo: memo)
       end
 

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -335,16 +335,23 @@ class Ledger
 
     def update_custom_memo!(memo)
       # TODO: remove CT and CPT updates because they are HCB code specific
-      ActiveRecord::Base.transaction do
-        # This item's own transactions, keyed by `ledger_item_id`. Renaming a
-        # whole HCB code group goes through HcbCode#update_custom_memo!, which
-        # keys by the HCB code instead — the two sets can diverge.
-        canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-        canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
-        update!(custom_memo: memo)
-      end
+      # This item's own transactions, keyed by `ledger_item_id`. Renaming a whole
+      # HCB code group goes through HcbCode#update_custom_memo!, which keys by the
+      # HCB code instead — the two sets can diverge.
+      cts = canonical_transactions.to_a
+      cpts = canonical_pending_transactions.to_a
 
-      refresh!
+      # Every write below cascades into `map!` and `refresh!` for each record, so
+      # don't pay for a rename that wouldn't change anything.
+      return if custom_memo == memo && [*cts, *cpts].all? { |record| record.custom_memo == memo }
+
+      ActiveRecord::Base.transaction do
+        cts.each { |ct| ct.update!(custom_memo: memo) }
+        cpts.each { |cpt| cpt.update!(custom_memo: memo) }
+        update!(custom_memo: memo)
+
+        refresh!
+      end
     end
 
     def map!

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -336,12 +336,11 @@ class Ledger
     def update_custom_memo!(memo)
       # TODO: remove CT and CPT updates because they are HCB code specific
       ActiveRecord::Base.transaction do
-        # `canonical_transactions` (keyed by `ledger_item_id`) and
-        # `hcb_code.canonical_transactions` (keyed by the HCB code) can diverge,
-        # and the HCB code is missing entirely when it was never back-linked to
-        # this item. Write the union so neither side keeps a stale memo.
-        (canonical_transactions.to_a | hcb_code&.canonical_transactions.to_a).each { |ct| ct.update!(custom_memo: memo) }
-        (canonical_pending_transactions.to_a | hcb_code&.canonical_pending_transactions.to_a).each { |cpt| cpt.update!(custom_memo: memo) }
+        # This item's own transactions, keyed by `ledger_item_id`. Renaming a
+        # whole HCB code group goes through HcbCode#update_custom_memo!, which
+        # keys by the HCB code instead — the two sets can diverge.
+        canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
+        canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
         update!(custom_memo: memo)
       end
 

--- a/app/services/canonical_pending_transaction_service/settle.rb
+++ b/app/services/canonical_pending_transaction_service/settle.rb
@@ -14,9 +14,18 @@ module CanonicalPendingTransactionService
           canonical_pending_transaction: @canonical_pending_transaction
         )
 
-        if @canonical_transaction.custom_memo.nil?
-          @canonical_transaction.custom_memo = @canonical_pending_transaction.custom_memo
-          @canonical_transaction.save!
+        # Only copy a memo that exists — routing a nil through
+        # `update_custom_memo!` would clear the memo on every record in the group,
+        # including the ledger item's.
+        if @canonical_transaction.custom_memo.nil? && @canonical_pending_transaction.custom_memo.present?
+          # `custom_memo` is mirrored onto the transaction's ledger item, which
+          # caches its `memo` from that copy. `HcbCode#update_custom_memo!` is the
+          # only writer that keeps both sides in sync.
+          if (hcb_code = @canonical_transaction.local_hcb_code)
+            hcb_code.update_custom_memo!(@canonical_pending_transaction.custom_memo)
+          else
+            @canonical_transaction.update!(custom_memo: @canonical_pending_transaction.custom_memo)
+          end
         end
 
         sync_transaction_category!

--- a/app/services/canonical_pending_transaction_service/settle.rb
+++ b/app/services/canonical_pending_transaction_service/settle.rb
@@ -14,19 +14,7 @@ module CanonicalPendingTransactionService
           canonical_pending_transaction: @canonical_pending_transaction
         )
 
-        # Only copy a memo that exists — routing a nil through
-        # `update_custom_memo!` would clear the memo on every record in the group,
-        # including the ledger item's.
-        if @canonical_transaction.custom_memo.nil? && @canonical_pending_transaction.custom_memo.present?
-          # `custom_memo` is mirrored onto the transaction's ledger item, which
-          # caches its `memo` from that copy. `HcbCode#update_custom_memo!` is the
-          # only writer that keeps both sides in sync.
-          if (hcb_code = @canonical_transaction.local_hcb_code)
-            hcb_code.update_custom_memo!(@canonical_pending_transaction.custom_memo)
-          else
-            @canonical_transaction.update!(custom_memo: @canonical_pending_transaction.custom_memo)
-          end
-        end
+        copy_custom_memo!
 
         sync_transaction_category!
       end
@@ -45,6 +33,34 @@ module CanonicalPendingTransactionService
     end
 
     private
+
+    def copy_custom_memo!
+      memo = @canonical_pending_transaction.custom_memo
+
+      # Only copy a memo that exists — routing a nil through
+      # `update_custom_memo!` would clear the memo on every record in the group,
+      # including the ledger item's.
+      return unless @canonical_transaction.custom_memo.nil? && memo.present?
+
+      # `custom_memo` is mirrored onto the transaction's ledger item, which caches
+      # its `memo` from that copy. `HcbCode#update_custom_memo!` is the only
+      # writer that keeps both sides in sync; fall back to the ledger item, and
+      # only write the column directly when the transaction has neither.
+      if (hcb_code = @canonical_transaction.local_hcb_code)
+        hcb_code.update_custom_memo!(memo)
+      elsif (ledger_item = @canonical_transaction.ledger_item)
+        ledger_item.update_custom_memo!(memo)
+      else
+        @canonical_transaction.update!(custom_memo: memo)
+      end
+
+      # `CanonicalPendingSettledMapping` hands the canonical transaction over to
+      # the pending transaction's ledger item once this transaction commits. When
+      # the two HCB codes differ — several settle paths pair a pending transaction
+      # with a still-ungrouped HCB-000 canonical transaction — that item sits in
+      # another group and the write above never reaches it.
+      @canonical_pending_transaction.ledger_item&.update_custom_memo!(memo)
+    end
 
     def sync_transaction_category!
       return unless @canonical_transaction.category.nil?

--- a/app/services/stripe_card_service/nightly.rb
+++ b/app/services/stripe_card_service/nightly.rb
@@ -21,10 +21,14 @@ module StripeCardService
     #   Check out HcbCode#memo for more info on how this work.
     def rename_canonical_transaction
       stripe_issuing_card_canonical_transactions_to_rename.find_each(batch_size: 100) do |canonical_transaction|
-        # `without_custom_memo` only filters on the canonical transaction, so an
-        # organizer's rename that so far only reached the ledger item would be
-        # overwritten by this default memo.
-        next if canonical_transaction.ledger_item&.custom_memo.present?
+        # Renaming writes the whole HCB code group, while `without_custom_memo`
+        # only filters on this one transaction. Skip the group entirely if anything
+        # in it already carries an organizer's memo — this default would erase it.
+        # `HcbCode#custom_memo` only reads the first transaction, so check them all.
+        hcb_code = canonical_transaction.local_hcb_code
+        next if hcb_code&.canonical_transactions&.with_custom_memo&.exists? ||
+                hcb_code&.canonical_pending_transactions&.with_custom_memo&.exists? ||
+                canonical_transaction.ledger_item&.custom_memo.present?
 
         # `custom_memo` is mirrored onto the transaction's ledger item, which
         # caches its `memo` from that copy. `HcbCode#update_custom_memo!` is the
@@ -33,8 +37,10 @@ module StripeCardService
         #
         # `safely` keeps one unrenameable transaction from aborting the nightly.
         safely do
-          if (hcb_code = canonical_transaction.local_hcb_code)
+          if hcb_code
             hcb_code.update_custom_memo!(CARD_FEE_MEMO)
+          elsif (ledger_item = canonical_transaction.ledger_item)
+            ledger_item.update_custom_memo!(CARD_FEE_MEMO)
           else
             canonical_transaction.update!(custom_memo: CARD_FEE_MEMO)
           end

--- a/app/services/stripe_card_service/nightly.rb
+++ b/app/services/stripe_card_service/nightly.rb
@@ -33,7 +33,11 @@ module StripeCardService
         #
         # `safely` keeps one unrenameable transaction from aborting the nightly.
         safely do
-          canonical_transaction.local_hcb_code.update_custom_memo!(CARD_FEE_MEMO)
+          if (hcb_code = canonical_transaction.local_hcb_code)
+            hcb_code.update_custom_memo!(CARD_FEE_MEMO)
+          else
+            canonical_transaction.update!(custom_memo: CARD_FEE_MEMO)
+          end
         end
       end
     end

--- a/app/services/stripe_card_service/nightly.rb
+++ b/app/services/stripe_card_service/nightly.rb
@@ -2,6 +2,8 @@
 
 module StripeCardService
   class Nightly
+    CARD_FEE_MEMO = "💳 New user card fee"
+
     def run
       rename_canonical_transaction
     end
@@ -18,7 +20,22 @@ module StripeCardService
     #
     #   Check out HcbCode#memo for more info on how this work.
     def rename_canonical_transaction
-      stripe_issuing_card_canonical_transactions_to_rename.update_all(custom_memo: "💳 New user card fee")
+      stripe_issuing_card_canonical_transactions_to_rename.find_each(batch_size: 100) do |canonical_transaction|
+        # `without_custom_memo` only filters on the canonical transaction, so an
+        # organizer's rename that so far only reached the ledger item would be
+        # overwritten by this default memo.
+        next if canonical_transaction.ledger_item&.custom_memo.present?
+
+        # `custom_memo` is mirrored onto the transaction's ledger item, which
+        # caches its `memo` from that copy. `HcbCode#update_custom_memo!` is the
+        # only writer that keeps both sides in sync — an `update_all` here would
+        # skip every callback and leave the ledger showing the raw bank memo.
+        #
+        # `safely` keeps one unrenameable transaction from aborting the nightly.
+        safely do
+          canonical_transaction.local_hcb_code.update_custom_memo!(CARD_FEE_MEMO)
+        end
+      end
     end
 
     def stripe_issuing_card_canonical_transactions_to_rename

--- a/app/views/canonical_pending_transactions/edit.html.erb
+++ b/app/views/canonical_pending_transactions/edit.html.erb
@@ -18,7 +18,9 @@
 <%= form_with(model: @canonical_pending_transaction) do |form| %>
   <div class="field">
     <%= form.label :custom_memo, "Custom Memo" %>
-    <%= form.text_field :custom_memo, list: "custom-memos", placeholder: @canonical_pending_transaction.smart_memo, autofocus: true %>
+    <%# Renaming writes the whole HCB code group, so show the group's memo — this
+        transaction's own column may never have been written. %>
+    <%= form.text_field :custom_memo, value: @canonical_pending_transaction.local_hcb_code&.custom_memo || @canonical_pending_transaction.custom_memo, list: "custom-memos", placeholder: @canonical_pending_transaction.smart_memo, autofocus: true %>
     <datalist id='custom-memos'>
       <%= @suggested_memos.each do |s_memo| %>
         <option><%= s_memo %></option>

--- a/app/views/canonical_transactions/edit.html.erb
+++ b/app/views/canonical_transactions/edit.html.erb
@@ -20,7 +20,9 @@
     <%= form.label :custom_memo do %>
       <strong>Custom memo</strong>
     <% end %>
-    <%= form.text_field :custom_memo, list: "custom-memos", placeholder: @canonical_transaction.smart_memo, autofocus: true, class: "fit" %>
+    <%# Renaming writes the whole HCB code group, so show the group's memo — this
+        transaction's own column may never have been written. %>
+    <%= form.text_field :custom_memo, value: @canonical_transaction.local_hcb_code&.custom_memo || @canonical_transaction.custom_memo, list: "custom-memos", placeholder: @canonical_transaction.smart_memo, autofocus: true, class: "fit" %>
     <datalist id='custom-memos'>
       <%= @suggested_memos.each do |s_memo| %>
         <option><%= s_memo %></option>

--- a/spec/controllers/canonical_pending_transactions_controller_spec.rb
+++ b/spec/controllers/canonical_pending_transactions_controller_spec.rb
@@ -6,6 +6,46 @@ RSpec.describe CanonicalPendingTransactionsController do
   include SessionSupport
   render_views
 
+  describe "#update" do
+    # `custom_memo` lives on the pending transaction *and* on its ledger item,
+    # which caches `memo` from its own copy. Renaming has to write both, or the
+    # ledger keeps showing the old memo.
+    it "renames the ledger item alongside the pending transaction" do
+      user = create(:user, :make_admin)
+      cpt = create(:canonical_pending_transaction)
+      create_session(user, verified: true)
+
+      patch(:update, params: { id: cpt.id, canonical_pending_transaction: { custom_memo: "A shiver of Blåhaj" } }, as: :html)
+
+      expect(cpt.reload.custom_memo).to eq("A shiver of Blåhaj")
+      expect(cpt.ledger_item.reload.custom_memo).to eq("A shiver of Blåhaj")
+      expect(cpt.ledger_item.memo).to eq("A shiver of Blåhaj")
+    end
+
+    it "clears the memo on both records when submitted blank" do
+      user = create(:user, :make_admin)
+      cpt = create(:canonical_pending_transaction)
+      create_session(user, verified: true)
+      cpt.local_hcb_code.update_custom_memo!("A shiver of Blåhaj")
+
+      patch(:update, params: { id: cpt.id, canonical_pending_transaction: { custom_memo: "" } }, as: :html)
+
+      expect(cpt.reload.custom_memo).to be_nil
+      expect(cpt.ledger_item.reload.custom_memo).to be_nil
+    end
+
+    it "still updates the admin-only attributes" do
+      user = create(:user, :make_admin)
+      cpt = create(:canonical_pending_transaction, fronted: false)
+      create_session(user, verified: true)
+
+      patch(:update, params: { id: cpt.id, canonical_pending_transaction: { custom_memo: "Fronted transaction", fronted: true } }, as: :html)
+
+      expect(cpt.reload.fronted).to be(true)
+      expect(cpt.custom_memo).to eq("Fronted transaction")
+    end
+  end
+
   describe "#set_category" do
     it "sets the transaction category" do
       user = create(:user, :make_admin)

--- a/spec/controllers/canonical_pending_transactions_controller_spec.rb
+++ b/spec/controllers/canonical_pending_transactions_controller_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe CanonicalPendingTransactionsController do
       expect(cpt.ledger_item.reload.custom_memo).to be_nil
     end
 
+    # The rename form prefills from the group's memo, so a pending transaction
+    # whose own column was never written (renamed before the group write existed)
+    # must not submit a blank field and erase the settled transaction's memo.
+    it "does not clear a memo that only the settled transaction carries" do
+      user = create(:user, :make_admin)
+      cpt = create(:canonical_pending_transaction, amount_cents: -1000)
+      ct = create(:canonical_transaction)
+      ct.update_column(:hcb_code, cpt.hcb_code)
+      ct.update_column(:custom_memo, "Organizer's careful memo")
+      create_session(user, verified: true)
+
+      get(:edit, params: { id: cpt.id })
+
+      expect(response.body).to include("Organizer&#39;s careful memo")
+    end
+
     it "still updates the admin-only attributes" do
       user = create(:user, :make_admin)
       cpt = create(:canonical_pending_transaction, fronted: false)

--- a/spec/controllers/canonical_transactions_controller_spec.rb
+++ b/spec/controllers/canonical_transactions_controller_spec.rb
@@ -6,6 +6,35 @@ RSpec.describe CanonicalTransactionsController do
   include SessionSupport
   render_views
 
+  describe "#set_custom_memo" do
+    # `custom_memo` lives on the canonical transaction *and* on its ledger item,
+    # which caches `memo` from its own copy. Renaming has to write both, or the
+    # ledger keeps showing the old memo.
+    it "renames the ledger item alongside the canonical transaction" do
+      user = create(:user, :make_admin)
+      ct = create(:canonical_transaction)
+      create_session(user, verified: true)
+
+      post(:set_custom_memo, params: { id: ct.id, canonical_transaction: { custom_memo: "Snacks at Shelburne Market" } }, as: :html)
+
+      expect(ct.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(ct.ledger_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(ct.ledger_item.memo).to eq("Snacks at Shelburne Market")
+    end
+
+    it "clears the memo on both records when submitted blank" do
+      user = create(:user, :make_admin)
+      ct = create(:canonical_transaction)
+      create_session(user, verified: true)
+      ct.local_hcb_code.update_custom_memo!("Snacks at Shelburne Market")
+
+      post(:set_custom_memo, params: { id: ct.id, canonical_transaction: { custom_memo: "" } }, as: :html)
+
+      expect(ct.reload.custom_memo).to be_nil
+      expect(ct.ledger_item.reload.custom_memo).to be_nil
+    end
+  end
+
   describe "#set_category" do
     it "sets the transaction category" do
       user = create(:user, :make_admin)

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -373,4 +373,37 @@ RSpec.describe HcbCode, type: :model do
       end
     end
   end
+
+  describe "#update_custom_memo!" do
+    # `custom_memo` is stored on every canonical (pending) transaction in the
+    # group *and* on their ledger items, which cache `memo` from their own copy.
+    it "writes every canonical transaction in the group and their ledger items" do
+      first = create(:canonical_transaction)
+      second = create(:canonical_transaction)
+      second.update_column(:hcb_code, first.hcb_code)
+
+      first.local_hcb_code.update_custom_memo!("Snacks at Shelburne Market")
+
+      expect(first.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(second.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(first.ledger_item.reload.memo).to eq("Snacks at Shelburne Market")
+      expect(second.ledger_item.reload.memo).to eq("Snacks at Shelburne Market")
+    end
+
+    # `hcb_codes.ledger_item_id` is only back-linked when the transaction engine
+    # creates the item, so it can be null while the transactions still point at
+    # one. The rename has to find the item through them.
+    it "reaches the ledger item when the HCB code is not back-linked to it" do
+      canonical_transaction = create(:canonical_transaction)
+      ledger_item = canonical_transaction.reload.ledger_item
+      hcb_code = canonical_transaction.local_hcb_code
+      hcb_code.update_columns(ledger_item_id: nil)
+
+      hcb_code.reload.update_custom_memo!("Snacks at Shelburne Market")
+
+      expect(canonical_transaction.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(ledger_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(ledger_item.memo).to eq("Snacks at Shelburne Market")
+    end
+  end
 end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -386,8 +386,10 @@ RSpec.describe HcbCode, type: :model do
 
       expect(first.reload.custom_memo).to eq("Snacks at Shelburne Market")
       expect(second.reload.custom_memo).to eq("Snacks at Shelburne Market")
-      expect(first.ledger_item.reload.memo).to eq("Snacks at Shelburne Market")
-      expect(second.ledger_item.reload.memo).to eq("Snacks at Shelburne Market")
+      # Assert `custom_memo`, not `memo` — `fallback_memo` reads the canonical
+      # transaction's memo, so `memo` looks right even when the item is desynced.
+      expect(first.ledger_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(second.ledger_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
     end
 
     # A transaction whose ledger item was never assigned (the assignment runs in

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -390,6 +390,25 @@ RSpec.describe HcbCode, type: :model do
       expect(second.ledger_item.reload.memo).to eq("Snacks at Shelburne Market")
     end
 
+    # A transaction whose ledger item was never assigned (the assignment runs in
+    # an `after_create_commit` wrapped in `safely`) must still be renamed — it is
+    # the only copy of the memo it has.
+    it "writes transactions that have no ledger item alongside those that do" do
+      with_item = create(:canonical_transaction)
+      without_item = create(:canonical_transaction)
+      without_item.update_column(:hcb_code, with_item.hcb_code)
+      without_item.update_column(:ledger_item_id, nil)
+      # Neither the HCB code nor this transaction can reach the ledger item, so
+      # only `with_item` leads to it.
+      with_item.local_hcb_code.update_columns(ledger_item_id: nil)
+
+      with_item.local_hcb_code.reload.update_custom_memo!("Snacks at Shelburne Market")
+
+      expect(with_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(without_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+      expect(with_item.ledger_item.reload.custom_memo).to eq("Snacks at Shelburne Market")
+    end
+
     # `hcb_codes.ledger_item_id` is only back-linked when the transaction engine
     # creates the item, so it can be null while the transactions still point at
     # one. The rename has to find the item through them.

--- a/spec/services/canonical_pending_transaction_service/settle_spec.rb
+++ b/spec/services/canonical_pending_transaction_service/settle_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
     end
   end
 
+  # Several settle paths pair a pending transaction with a still-ungrouped
+  # HCB-000 canonical transaction (see PendingEventMappingEngine::Settle::Donation
+  # and AdminController#set_wire, which regroup the CT *after* settling), so the
+  # two HCB codes routinely differ. The canonical transaction is handed over to
+  # the pending transaction's ledger item, which lives in the other group.
+  context "when the two HCB codes differ" do
+    let(:canonical_pending_transaction) { create(:canonical_pending_transaction, custom_memo: "Plushie order") }
+    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil) }
+
+    it "should carry the custom_memo onto the ledger item the transaction is handed to" do
+      expect(canonical_transaction.hcb_code).not_to eq(canonical_pending_transaction.hcb_code)
+      destination = canonical_pending_transaction.reload.ledger_item
+
+      service.run!
+
+      expect(canonical_transaction.reload.custom_memo).to eq("Plushie order")
+      expect(canonical_transaction.ledger_item).to eq(destination)
+      expect(destination.reload.custom_memo).to eq("Plushie order")
+    end
+  end
+
   # Settling hands the canonical transaction over to the pending transaction's
   # ledger item (see CanonicalPendingSettledMapping), so that item is the one
   # the memo has to survive on.
@@ -78,14 +99,17 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
     # Settling must never write a nil memo through HcbCode#update_custom_memo!,
     # which would clear the memo on every record in the group — including the
     # ledger item's copy, which is the value the ledger renders.
+    # The canonical transaction's own column is left nil so the pre-existing
+    # `custom_memo.nil?` guard does not short-circuit — only the ledger item
+    # carries the memo, which is the state a legacy rename leaves behind.
     it "should not clear a memo the organizer already set" do
-      canonical_transaction.local_hcb_code.update_custom_memo!("Renamed by an organizer")
       ledger_item = canonical_transaction.reload.ledger_item
+      ledger_item.update_columns(custom_memo: "Renamed by an organizer", memo: "Renamed by an organizer")
 
       service.run!
 
-      expect(canonical_transaction.reload.custom_memo).to eq("Renamed by an organizer")
       expect(ledger_item.reload.custom_memo).to eq("Renamed by an organizer")
+      expect(ledger_item.memo).to eq("Renamed by an organizer")
     end
   end
 

--- a/spec/services/canonical_pending_transaction_service/settle_spec.rb
+++ b/spec/services/canonical_pending_transaction_service/settle_spec.rb
@@ -35,6 +35,45 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
 
         expect(canonical_transaction.reload.custom_memo).to eq(canonical_pending_transaction.custom_memo)
       end
+
+    end
+  end
+
+  # Settling hands the canonical transaction over to the pending transaction's
+  # ledger item (see CanonicalPendingSettledMapping), so that item is the one
+  # the memo has to survive on.
+  context "when the pending transaction was renamed through its HCB code" do
+    let(:canonical_pending_transaction) { create(:canonical_pending_transaction, custom_memo: nil) }
+    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil) }
+
+    it "should carry the custom_memo onto the ledger item the settled transaction joins" do
+      canonical_pending_transaction.local_hcb_code.update_custom_memo!("I am a custom memo")
+      canonical_pending_transaction.reload
+
+      service.run!
+
+      canonical_transaction.reload
+      expect(canonical_transaction.custom_memo).to eq("I am a custom memo")
+      expect(canonical_transaction.ledger_item.reload.custom_memo).to eq("I am a custom memo")
+      expect(canonical_transaction.ledger_item.memo).to eq("I am a custom memo")
+    end
+  end
+
+  context "when canonical_pending_transaction has no custom_memo" do
+    let(:canonical_pending_transaction) { create(:canonical_pending_transaction, custom_memo: nil) }
+    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil) }
+
+    # Settling must never write a nil memo through HcbCode#update_custom_memo!,
+    # which would clear the memo on every record in the group — including the
+    # ledger item's copy, which is the value the ledger renders.
+    it "should not clear a memo the organizer already set" do
+      canonical_transaction.local_hcb_code.update_custom_memo!("Renamed by an organizer")
+      ledger_item = canonical_transaction.reload.ledger_item
+
+      service.run!
+
+      expect(canonical_transaction.reload.custom_memo).to eq("Renamed by an organizer")
+      expect(ledger_item.reload.custom_memo).to eq("Renamed by an organizer")
     end
 
     context "when canonical_transaction has a custom_memo" do

--- a/spec/services/canonical_pending_transaction_service/settle_spec.rb
+++ b/spec/services/canonical_pending_transaction_service/settle_spec.rb
@@ -35,7 +35,19 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
 
         expect(canonical_transaction.reload.custom_memo).to eq(canonical_pending_transaction.custom_memo)
       end
+    end
 
+    context "when canonical_transaction has a custom_memo" do
+      let(:canonical_transaction) { create(:canonical_transaction, custom_memo: "I am a different custom memo") }
+
+      it "should keep the canonical_transaction's custom_memo" do
+        initial_custom_memo = canonical_transaction.custom_memo
+
+        service.run!
+
+        expect(canonical_transaction.reload.custom_memo).to eq(initial_custom_memo)
+        expect(canonical_transaction.custom_memo).to_not eq(canonical_pending_transaction.custom_memo)
+      end
     end
   end
 
@@ -74,19 +86,6 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
 
       expect(canonical_transaction.reload.custom_memo).to eq("Renamed by an organizer")
       expect(ledger_item.reload.custom_memo).to eq("Renamed by an organizer")
-    end
-
-    context "when canonical_transaction has a custom_memo" do
-      let(:canonical_transaction) { create(:canonical_transaction, custom_memo: "I am a different custom memo") }
-
-      it "should keep the canonical_transaction's custom_memo" do
-        initial_custom_memo = canonical_transaction.custom_memo
-
-        service.run!
-
-        expect(canonical_transaction.reload.custom_memo).to eq(initial_custom_memo)
-        expect(canonical_transaction.custom_memo).to_not eq(canonical_pending_transaction.custom_memo)
-      end
     end
   end
 

--- a/spec/services/canonical_pending_transaction_service/settle_spec.rb
+++ b/spec/services/canonical_pending_transaction_service/settle_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
   let(:canonical_pending_transaction) { create(:canonical_pending_transaction) }
   let(:canonical_transaction) { create(:canonical_transaction) }
 
+  # Both tables number their `HCB-000-<id>` codes off their own sequence, so a
+  # canonical transaction and a pending transaction collide whenever the two
+  # sequences line up — which they do on a fresh database. A memo carrying an
+  # `HCB-<short code>` groups the transaction under that code instead, keeping the
+  # two records in genuinely separate groups no matter what the sequences hold.
+  let(:settled_hcb_code) { HcbCode.create!(hcb_code: "HCB-000-settled") }
+
   let(:service) {
     CanonicalPendingTransactionService::Settle.new(
       canonical_transaction:,
@@ -58,7 +65,7 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
   # the pending transaction's ledger item, which lives in the other group.
   context "when the two HCB codes differ" do
     let(:canonical_pending_transaction) { create(:canonical_pending_transaction, custom_memo: "Plushie order") }
-    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil) }
+    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil, memo: "PLUSHIE STORE HCB-#{settled_hcb_code.short_code}") }
 
     it "should carry the custom_memo onto the ledger item the transaction is handed to" do
       expect(canonical_transaction.hcb_code).not_to eq(canonical_pending_transaction.hcb_code)
@@ -77,7 +84,7 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
   # the memo has to survive on.
   context "when the pending transaction was renamed through its HCB code" do
     let(:canonical_pending_transaction) { create(:canonical_pending_transaction, custom_memo: nil) }
-    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil) }
+    let(:canonical_transaction) { create(:canonical_transaction, custom_memo: nil, memo: "PLUSHIE STORE HCB-#{settled_hcb_code.short_code}") }
 
     it "should carry the custom_memo onto the ledger item the settled transaction joins" do
       canonical_pending_transaction.local_hcb_code.update_custom_memo!("I am a custom memo")

--- a/spec/services/stripe_card_service/nightly_spec.rb
+++ b/spec/services/stripe_card_service/nightly_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StripeCardService::Nightly, type: :service do
+  describe "#run" do
+    let!(:canonical_transaction) { create(:canonical_transaction, memo: "HCKCLB Issued card fee") }
+
+    it "renames the canonical transaction" do
+      described_class.new.run
+
+      expect(canonical_transaction.reload.custom_memo).to eq("💳 New user card fee")
+    end
+
+    # `custom_memo` lives on the canonical transaction *and* on its ledger item,
+    # which caches `memo` from its own copy. Renaming has to write both, or the
+    # ledger keeps showing the raw bank memo.
+    it "renames the canonical transaction's ledger item" do
+      described_class.new.run
+
+      ledger_item = canonical_transaction.reload.ledger_item
+      expect(ledger_item.reload.custom_memo).to eq("💳 New user card fee")
+      expect(ledger_item.memo).to eq("💳 New user card fee")
+    end
+
+    it "leaves an already renamed transaction alone" do
+      canonical_transaction.local_hcb_code.update_custom_memo!("Renamed by an organizer")
+
+      described_class.new.run
+
+      expect(canonical_transaction.reload.custom_memo).to eq("Renamed by an organizer")
+      expect(canonical_transaction.ledger_item.reload.custom_memo).to eq("Renamed by an organizer")
+    end
+  end
+end

--- a/spec/services/stripe_card_service/nightly_spec.rb
+++ b/spec/services/stripe_card_service/nightly_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe StripeCardService::Nightly, type: :service do
       expect(ledger_item.memo).to eq("💳 New user card fee")
     end
 
+    # Renaming goes through the whole HCB code group, so a fee transaction that
+    # shares a group with an organizer-renamed transaction must be left alone
+    # rather than stamping the default memo over it.
+    it "leaves a group alone when a sibling transaction carries an organizer's memo" do
+      sibling = create(:canonical_transaction)
+      sibling.update_column(:hcb_code, canonical_transaction.hcb_code)
+      # Renamed before this group write existed, so the fee transaction next to it
+      # is still `without_custom_memo` and the nightly still picks it up.
+      sibling.update_column(:custom_memo, "Organizer's name for this")
+
+      described_class.new.run
+
+      expect(sibling.reload.custom_memo).to eq("Organizer's name for this")
+    end
+
     it "leaves an already renamed transaction alone" do
       canonical_transaction.local_hcb_code.update_custom_memo!("Renamed by an organizer")
 


### PR DESCRIPTION
## Summary of the problem

`custom_memo` is stored in three places: `canonical_transactions`, `canonical_pending_transactions`, and `ledger_items`. `Ledger::Item#memo` — the memo the ledger renders and searches — is a cached column computed in `Ledger::Item#refresh!` from the **ledger item's own** copy:

```ruby
self.memo = self.custom_memo.presence || self.system_memo.presence || fallback_memo
```

`HcbCode#update_custom_memo!` is the only writer that keeps all three in sync, but five paths wrote the canonical transactions directly and left `ledger_items.custom_memo` NULL:

| Path | |
| --- | --- |
| `CanonicalTransactionsController#set_custom_memo` | organizer rename form |
| `CanonicalPendingTransactionsController#update` | organizer rename form |
| `CanonicalPendingTransactionService::Settle` | pending → settled memo copy |
| `StripeCardService::Nightly` | `update_all`, skips every callback |
| `HcbCode#update_custom_memo!` itself | fallback when `hcb_codes.ledger_item_id` is NULL |

The first two are reachable from the ✏️ icons in `hcb_codes/_transaction_history`, `hcb_codes/_pending_transaction_history` and `transactions/show`.

A direct write does still fire `ledger_item.refresh!`, but `refresh!` reads the ledger item's own (still-NULL) `custom_memo`, so:

- **linked-object transactions** (donations, ACH transfers, card charges…) have a `system_memo`, so the rename is silently discarded — and `refresh!` cannot recover it;
- **raw bank transactions** have no `system_memo` and fall through to `fallback_memo` → `ct.smart_memo`, which is why calling `refresh!` looks like a fix for those. `ledger_items.custom_memo` stays NULL even then.

Since `pg_search_scope :search_memo` runs against `ledger_items.memo`, renamed transactions were also unfindable by their new name in the ledger.

The fifth path is why the others can't simply be re-pointed: `hcb_codes.ledger_item_id` is only back-linked when the transaction engine *creates* the item, so it is NULL for any transaction that adopted an existing one — and `update_custom_memo!` then fell back to writing the canonical transactions only.

## Describe your changes

Every `custom_memo` write on `CanonicalTransaction`/`CanonicalPendingTransaction` now goes through `HcbCode#update_custom_memo!`.

- **`HcbCode#update_custom_memo!`** resolves ledger items through its transactions as well as its own `ledger_item_id`, then writes the canonical transactions, the pending transactions and every resolved ledger item — no early return, so a transaction with no ledger item is still renamed. It short-circuits when nothing would change, since each write cascades into `Ledger::Item#map!` and `#refresh!` per record.
- **`Ledger::Item#update_custom_memo!`** owns just its own transactions (keyed by `ledger_item_id`); group renames are `HcbCode`'s job.
- **Both rename controllers** route through the HCB code, falling back to the ledger item and only writing the column directly when the transaction has neither. The pending-transaction controller keeps `fronted`/`fee_waived` as a normal update, and both only touch the memo when the param is submitted, so an absent field no longer clears it.
- **`Settle`** copies through the HCB code, and only when the pending transaction actually has a memo — routing a `nil` through `update_custom_memo!` would clear the memo on every record in the group. It also writes the pending transaction's ledger item: `CanonicalPendingSettledMapping` hands the canonical transaction over to that item after the transaction commits, and several settle paths (`Settle::Donation`, `AdminController#set_wire`) pair a pending transaction with a still-ungrouped `HCB-000` canonical transaction, so the two HCB codes differ and the destination item would keep its old memo.
- **`StripeCardService::Nightly`** replaces `update_all` (which fired no callbacks at all) with a batched per-transaction rename, skipping any group where a transaction already carries an organizer's memo — the group write would otherwise stamp the default over it.
- **Both rename forms** prefill from the HCB code's memo rather than the record's own column, which is empty for transactions renamed before the group write existed. Submitting that blank field would have cleared the whole group.

### Behaviour change worth a look

Renaming from the per-transaction ✏️ now renames the whole HCB code group instead of the single canonical transaction, matching what the HCB code page and the v4 API already did. Two consequences:

- Per-transaction memos within one group can no longer differ, and the surrounding copy ("Rename transaction") is now about the group.
- `HCB-900-<year>_<week>` groups every fee reimbursement for a week onto one HCB code and one ledger item, **across organizations** — so a group rename there is cross-org, and the write is wider than the single-event policy these two endpoints authorize against. `HcbCodesController#update` already had this reach; these endpoints didn't. Flagging rather than changing authorization in a bugfix — happy to split that out either way.

### Remediation

Already-desynced rows are not repaired here. `Maintenance::BackfillLedgerItemCustomMemosTask` keys off `ledger_item.hcb_code&.custom_memo`, which is NULL for exactly the un-back-linked population above, so it needs to resolve the memo through the item's own transactions before it is re-run.

### Test plan

`bundle exec rspec spec/models spec/services spec/controllers spec/jobs spec/mailboxes` — 1691 examples, the only failures being 4 that need the `wkhtmltopdf` binary and 2 that need Redis, neither available locally and neither memo-related. `rubocop` and `erb_lint` clean.

New specs cover each path (rename and clear) and pin the regressions worth guarding: settling must not clear a memo an organizer already set and must reach the item the transaction is handed to; the nightly must not stamp over a group that already has a memo; a rename must reach the ledger item when the HCB code is not back-linked; and a transaction with no ledger item must still be renamed alongside one that has it. Assertions are on `custom_memo` rather than `memo`, since `fallback_memo` reads the canonical transaction and masks a desynced item.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126DFcNZ5ZECDEij5J4zu2p)_