### PR TITLE
[PayoutHoldingService] Fix transfers not being assigned on error

### DIFF
--- a/app/services/reimbursement/payout_holding_service/nightly.rb
+++ b/app/services/reimbursement/payout_holding_service/nightly.rb
@@ -30,6 +30,8 @@ module Reimbursement
                   wire.send_wire!
                 rescue
                   wire.mark_rejected!
+                  payout_holding.wire = wire
+                  payout_holding.save!
                   payout_holding.mark_failed!
                   reason = "There was an error creating the wire transfer."
                   reason = wire.errors.full_messages.join(", ") if wire.errors.any?
@@ -63,6 +65,8 @@ module Reimbursement
                   payout_holding.mark_sent!
                 rescue Faraday::Error => e
                   check.mark_rejected!
+                  payout_holding.increase_check = check
+                  payout_holding.save!
                   payout_holding.mark_failed!
                   message = e.response_body&.dig("message") || e.message
                   ReimbursementMailer.with(
@@ -89,6 +93,8 @@ module Reimbursement
                   ach_transfer.approve!(User.system_user)
                 rescue
                   ach_transfer.mark_rejected!(User.system_user)
+                  payout_holding.ach_transfer = ach_transfer
+                  payout_holding.save!
                   payout_holding.mark_failed!
                   ReimbursementMailer.with(
                     reimbursement_payout_holding: payout_holding,


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
When a transfer errors in sending, we do not save it to the payout holding.
https://hcb.hackclub.com/blazer/queries/1301-payout-holdings-with-no-transfer-attached


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Save the transfer to the payout holding.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

