### PR TITLE
[Donation] Stop recent donors from erroring

### DIFF
--- a/app/views/donations/start_donation.html.erb
+++ b/app/views/donations/start_donation.html.erb
@@ -48,7 +48,7 @@
 <% if params[:tier_id].blank? && (@event.show_top_donors || @event.show_recent_donors) %>
   <div class="mt-5 mb-10 grid <%= @event.show_top_donors && @event.show_recent_donors ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1" %> gap-2">
     <%= render "donations/top_donors", top_donors: @top_donors if @event.show_top_donors %>
-    <%= render "donations/recent_donors", recent_donors: @recent_donors if @event.show_recent_donors %>
+    <%= render "donations/recent_donors", recent_donors: @recent_donors if @recent_donors&.any? %>
   </div>
 <% end %>
 


### PR DESCRIPTION
## Summary of the problem

Hot fix to get the recent donors section from erroring under certain cases.

I believe this is happening because we `render start_donation` for other controller actions which means that `@recent_donors` doesn't get set.


## Describe your changes

This is a hot fix to prevent the page from erroring, but need a more thorough fix to ensure the feature works as intended.