### PR TITLE
[CardLockingMailer] Use `attach_receipt_url`

### DIFF
--- a/app/mailers/canonical_pending_transaction_mailer.rb
+++ b/app/mailers/canonical_pending_transaction_mailer.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 class CanonicalPendingTransactionMailer < ApplicationMailer
+  include HcbCodeHelper # for attach_receipt_url
+
   def notify_approved
     @cpt = CanonicalPendingTransaction.find(params[:canonical_pending_transaction_id])
     @user = @cpt.stripe_card.user
 
     return unless @user.email_charge_notifications_enabled?
 
-    @upload_url = Rails.application.routes.url_helpers.attach_receipt_hcb_code_url(
-      id: @cpt.local_hcb_code.hashid,
-      s: @cpt.local_hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload)
-    )
+    @upload_url = attach_receipt_url(@cpt.local_hcb_code)
 
     to = @cpt.stripe_card.user.email_address_with_name
     subject = "#{@cpt.local_hcb_code.receipt_required? ? "Upload a receipt for your transaction" : "New transaction"} at #{@cpt.smart_memo}"
@@ -26,10 +25,7 @@ class CanonicalPendingTransactionMailer < ApplicationMailer
 
     return unless @user.email_charge_notifications_enabled?
 
-    @upload_url = Rails.application.routes.url_helpers.attach_receipt_hcb_code_url(
-      id: @cpt.local_hcb_code.hashid,
-      s: @cpt.local_hcb_code.signed_id(expires_in: 2.weeks, purpose: :receipt_upload)
-    )
+    @upload_url = attach_receipt_url(@cpt.local_hcb_code)
 
     to = @cpt.stripe_card.user.email_address_with_name
     subject = "#{@cpt.smart_memo} settled at #{ApplicationController.helpers.render_money(@ct.amount)}."

--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CardLockingMailer < ApplicationMailer
+  helper :hcb_code # for attach_receipt_url, so recipients can upload receipts without signing in
+
   def cards_locked(user:)
     @user = user
     @hcb_codes = user.card_locking_overdue_charges.to_a

--- a/app/views/card_locking_mailer/_transactions_table.html.erb
+++ b/app/views/card_locking_mailer/_transactions_table.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% hcb_codes.sort_by { |hcb| hcb.card_charge_settled_at || hcb.created_at }.reverse.each do |hcb| %>
       <tr>
-        <td><%= link_to render_money(hcb.amount_cents.abs.to_s), hcb_code_url(hcb) %></td>
+        <td><%= link_to render_money(hcb.amount_cents.abs.to_s), attach_receipt_url(hcb) %></td>
         <td><%= hcb.stripe_merchant["name"] %></td>
         <td><%= time_ago_in_words(hcb.card_charge_settled_at || hcb.created_at) %> ago</td>
         <% if show_org %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Card locking emails didn't use signed URLs for uploading receipts.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use helper that provides signed URLs.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

