### PR TITLE
[Card Locking] Temporarily disable trust assessment

### DIFF
--- a/app/services/user_service/refresh_receipt_deadlines.rb
+++ b/app/services/user_service/refresh_receipt_deadlines.rb
@@ -2,9 +2,8 @@
 
 module UserService
   # Maintains card_charge_settled_at / receipt_due_at on a cardholder's outstanding
-  # charges. Idempotent; safe to run every few minutes. The slide advances as new
-  # charges settle; the shortening floor (inside CardLocking::Deadline) protects
-  # the pile when trust is lost.
+  # charges. Idempotent; safe to run every few minutes. The shortening floor
+  # (inside CardLocking::Deadline) protects the pile when trust is lost.
   class RefreshReceiptDeadlines
     def initialize(user:, now: Time.current)
       @user = user
@@ -14,7 +13,9 @@ module UserService
     def run
       return unless @user.stripe_cardholder
 
-      trusted = @user.receipt_trusted?(now: @now)
+      # Disabled: a cardholder sailing past the promised 7 days cannot tell a
+      # grace period from a bug. Restore with `@user.receipt_trusted?(now: @now)`.
+      trusted = false
       last_settled = @user.last_settled_charge_at
       enforcement_start_date = CardLocking.enforcement_start_date(@user)
 

--- a/spec/services/user_service/refresh_receipt_deadlines_spec.rb
+++ b/spec/services/user_service/refresh_receipt_deadlines_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe UserService::RefreshReceiptDeadlines do
     expect(hcb_code.receipt_due_at).to be_within(2.seconds).of(1.day.ago + 7.days)
   end
 
-  it "slides due dates for a trusted cardholder to their most recent charge" do
+  # Un-skip when grace periods are announced.
+  it "slides due dates for a trusted cardholder to their most recent charge", :card_locking_trust, skip: "Trust is disabled" do
     # Deterministic on-time history: five charges settled 40-44 days ago, each with
     # a receipt uploaded the next day (well inside the 7-day window). They resolve on
     # time, giving a 100% on-time rate, so the cardholder is genuinely trusted.
@@ -47,7 +48,7 @@ RSpec.describe UserService::RefreshReceiptDeadlines do
     expect(old_outstanding.receipt_due_at).to be_within(2.seconds).of(1.day.ago + 7.days)
   end
 
-  it "does not shorten an outstanding charge below 72h when trust is lost" do
+  it "does not shorten an outstanding charge below 72h when trust is lost", :card_locking_trust, skip: "Trust is disabled" do
     hcb_code = create_settled_card_charge(user:, settled_at: 6.days.ago)
     hcb_code.update_columns(card_charge_settled_at: 6.days.ago, receipt_due_at: now + 5.days)
 


### PR DESCRIPTION
## Summary of the problem

Card locking tells cardholders "upload a receipt within 7 days of every card charge, miss it and your cards pause." A *trusted* cardholder (on-time rate at or above 80% over 6 months) instead gets a sliding deadline that can run to 14 days, so their cards stay unlocked well past the 7 days they were promised.

From the cardholder's side there is no way to tell a granted grace period from a broken promise. The deadline we state stops being believable, and HCB looks broken.

The long-term fix is to say it out loud: at the moment a card would have locked, tell a trusted cardholder they've been granted a grace period, and until when. That is a pleasant surprise with no ambiguity. This PR is the short-term step while that gets built.

## Describe your changes

`UserService::RefreshReceiptDeadlines` stops feeding trust into the deadline, so every cardholder gets the flat 7 days. That one line is the whole behavior change: it is the only producer of `trusted: true` in the codebase, since every other caller of `materialize_card_locking!` already uses the untrusted default.

`CardLocking::TrustAssessment` and `User#receipt_trusted?` are untouched and still covered by their specs, so restoring the slide is a one-line revert.

### Transition safety

Cardholders who lose the slide keep **at least 72 hours** (`CardLocking::DEADLINE_SHORTENING_FLOOR`), and they are **not** locked silently:

- At deploy, every shortened deadline lands at or beyond `now + 72h`. Nothing goes overdue in the same instant, and nothing is inside the 48h warning window yet.
- The warning email and SMS fire at roughly **T+24h**, the lock at **T+72h**. The daily dedup key cannot swallow that warning, since no digest can be sent between T and T+24h.
- Cardholders whose deadline is already inside 72h keep it unchanged, and are already inside the warning window.

Expect a warning spike around T+24h and a lock spike around T+72h, since the floor synchronizes previously-trusted cardholders onto roughly the same boundary. Worth having support staffed for it.

### Testing

The two specs covering the slide are **skipped rather than rewritten**, tagged `card_locking_trust`, so they can be un-skipped exactly as they are when grace periods are announced. Run them with `--tag card_locking_trust`.

Parking them loses no coverage of the protection that makes this deploy safe: the 72h shortening floor is covered as a pure unit in `spec/services/card_locking/deadline_spec.rb`, including the exact-at-floor boundary. Rest of the card-locking suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)