### PR TITLE
[Tax] Fix TIN verification requirement UI/logic

### DIFF
--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -80,9 +80,10 @@ class LegalEntity < ApplicationRecord
   # completes and turns out to disagree, which is what mismatched_tax_form catches.
   def payable?
     form = latest_completed_tax_form
+    requires_verification = form.form_type == "W9" && tax_identification_number.predicted_to_be_over_threshold?
 
     form.present? && mismatched_tax_form.nil? && entity_type_mismatched_tax_form.nil? &&
-      (form.taxbandits_tin_match_success? || !tax_identification_number.predicted_to_be_over_threshold?) &&
+      (form.taxbandits_tin_match_success? || !requires_verification) &&
       !tin_banned? && !archived?
   end
 

--- a/app/models/legal_entity.rb
+++ b/app/models/legal_entity.rb
@@ -80,7 +80,7 @@ class LegalEntity < ApplicationRecord
   # completes and turns out to disagree, which is what mismatched_tax_form catches.
   def payable?
     form = latest_completed_tax_form
-    requires_verification = form.form_type == "W9" && tax_identification_number.predicted_to_be_over_threshold?
+    requires_verification = form&.form_type == "W9" && tax_identification_number.predicted_to_be_over_threshold?
 
     form.present? && mismatched_tax_form.nil? && entity_type_mismatched_tax_form.nil? &&
       (form.taxbandits_tin_match_success? || !requires_verification) &&

--- a/app/views/legal_entities/show.html.erb
+++ b/app/views/legal_entities/show.html.erb
@@ -134,13 +134,26 @@
       <%= @legal_entity.person? ? "You have" : "#{@legal_entity.name.presence || "Business"} has" %>
       been banned from receiving payments from organizations on HCB.
     </p>
-  <% else %>
+  <% elsif @legal_entity.latest_completed_tax_form.taxbandits_tin_match_failed? %>
     <p>
       Your submission for <%= @legal_entity.person? ? "your" : "#{@legal_entity.name.presence || "Business"}'s" %>
       tax information is invalid.
     </p>
 
     <%= button_to "Start tax form", tax_forms_path, params: { legal_entity_id: @legal_entity.hashid }, class: "btn" %>
+  <% else %>
+    <p>
+      Your submission for <%= @legal_entity.person? ? "your" : "#{@legal_entity.name.presence || "Business"}'s" %>
+      tax information is pending verification.
+    </p>
+
+    <p>
+      While we process your submission, <%= @legal_entity.default_payout_method.present? ? "review your" : "add a" %> 
+      payout method below. Once your submission is verified<%= " and you have added a payout method" unless @legal_entity.default_payout_method.present?%>,
+      you'll be able to receive payments from any organization on HCB.
+    </p>
+
+    <%= render "users/payout_methods_list", user: current_user, legal_entity: @legal_entity %>
   <% end %>
 <% elsif @legal_entity.latest_tax_form.nil? || @legal_entity.latest_tax_form.failed? %>
   <p>

--- a/app/views/legal_entities/show.html.erb
+++ b/app/views/legal_entities/show.html.erb
@@ -148,8 +148,8 @@
     </p>
 
     <p>
-      While we process your submission, <%= @legal_entity.default_payout_method.present? ? "review your" : "add a" %> 
-      payout method below. Once your submission is verified<%= " and you have added a payout method" unless @legal_entity.default_payout_method.present?%>,
+      While we process your submission, <%= @legal_entity.default_payout_method.present? ? "review your" : "add a" %>
+      payout method below. Once your submission is verified<%= " and you have added a payout method" unless @legal_entity.default_payout_method.present? %>,
       you'll be able to receive payments from any organization on HCB.
     </p>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were requiring TIN matching for all tax forms (even though only W9s support it), and when TIN matching was pending, it told the user the form was invalid instead of asking them to wait.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a branch to fix the UI in LE show, and fix the logic in LE payable? to not require it unless it's a W9.

A future PR will add emails for when TIN matching succeeds/fails

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

