### PR TITLE
Improve card locking wording

### DIFF
--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -70,7 +70,7 @@ module UserService
 
     def notify_unlocked
       CardLockingMailer.cards_unlocked(user: @user).deliver_later
-      send_sms("Your HCB cards work again. Keep uploading receipts within 7 days of the charge. Manage them at #{CardLocking.inbox_url}.")
+      send_sms("Your HCB cards work again. Keep uploading receipts within 7 days of the charge, or your cards will lock again. Manage them at #{CardLocking.inbox_url}.")
     end
 
     def locked_message(now:)

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -70,7 +70,7 @@ module UserService
 
     def notify_unlocked
       CardLockingMailer.cards_unlocked(user: @user).deliver_later
-      send_sms("Your HCB cards work again. Keep uploading receipts within 7 days of the charge, or your cards will lock again. Manage them at #{CardLocking.inbox_url}.")
+      send_sms("Your HCB cards work again. Keep uploading receipts within 7 days of the charge, or your cards will lock again. Manage receipts at #{CardLocking.inbox_url}.")
     end
 
     def locked_message(now:)

--- a/app/views/card_locking_mailer/cards_locked.html.erb
+++ b/app/views/card_locking_mailer/cards_locked.html.erb
@@ -2,7 +2,7 @@
   Your HCB cards are locked because <%= @count %> <%= "receipt".pluralize(@count) %> <%= @count == 1 ? "is" : "are" %> overdue. Upload <%= @count == 1 ? "it" : "them" %> and your cards work again in seconds.
 </p>
 <p>
-  Every charge needs a receipt within 7 days. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.
+  Every charge needs a receipt within 7 days, or your cards will lock again. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.
 </p>
 <p>
   Any subscriptions or recurring charges on this card will also be declined until you upload.

--- a/app/views/card_locking_mailer/cards_locked.html.erb
+++ b/app/views/card_locking_mailer/cards_locked.html.erb
@@ -2,7 +2,7 @@
   Your HCB cards are locked because <%= @count %> <%= "receipt".pluralize(@count) %> <%= @count == 1 ? "is" : "are" %> overdue. Upload <%= @count == 1 ? "it" : "them" %> and your cards work again in seconds.
 </p>
 <p>
-  Every charge needs a receipt within 7 days, or your cards will lock again. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.
+  Every charge needs a receipt within 7 days. Overdue receipts result in your cards being locked. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.
 </p>
 <p>
   Any subscriptions or recurring charges on this card will also be declined until you upload.

--- a/app/views/card_locking_mailer/cards_unlocked.html.erb
+++ b/app/views/card_locking_mailer/cards_unlocked.html.erb
@@ -1,2 +1,2 @@
 <p>Your HCB cards work again.</p>
-<p>Keep uploading every receipt within 7 days of the charge. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.</p>
+<p>Keep uploading every receipt within 7 days of the charge, or your cards will lock again. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.</p>

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,5 +1,5 @@
 <p>
-  You have <%= @count %> <%= "receipt".pluralize(@count) %> we still need. Charges that go more than 7 days without a receipt can lock your cards. Upload these to stay ahead.
+  You have <%= @count %> <%= "receipt".pluralize(@count) %> we still need. Charges that go more than 7 days without a receipt will lock your cards. Upload these to stay ahead.
 </p>
 <p>
   Every charge needs a receipt within 7 days. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -11,7 +11,12 @@
 <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
   <%= render "application/callout", class: "mt-2", type: "info", title: "Card locking", badge: badge_for("Beta", class: "bg-muted") do %>
     <p class="my-0">
-      Upload a receipt within <strong>7 days</strong> of every card charge. Miss it and your cards pause until you upload. Uploading unlocks them in seconds. Your cards are currently <strong class="<%= current_user.cards_locked? ? "error" : "success" %>"><%= current_user.cards_locked? ? "locked" : "active" %></strong>.
+      Upload a receipt within <strong>7 days</strong> of every card charge. Miss it and your cards <strong>will lock</strong> until you upload.
+      <% if current_user.cards_locked? %>
+        Your cards are currently <strong class="error">locked</strong>. Uploading a receipt will unlock them in seconds.
+      <% else %>
+        Your cards are currently <strong class="success">active</strong>.
+      <% end %>
     </p>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Summary of the problem
Users are confused whether cards _will_ or _may_ lock. See #14565 


## Describe your changes
Changes all wording to indicate cards _will_ lock after 7 days of no receipts. Works in conjunction with #14568.

Wording is changed to:
1) Emphasize that cards will lock.
2) Remind users that cards will lock again.
