### PR TITLE
[PayoutHolding] Prevent reversing with non-failed wire or wise

### DIFF
--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -113,6 +113,8 @@ module Reimbursement
       raise ArgumentError, "ACH must have been rejected / failed" unless ach_transfer.nil? || ach_transfer.failed? || ach_transfer.rejected?
       raise ArgumentError, "PayPal transfer must have been rejected" unless paypal_transfer.nil? || paypal_transfer.rejected?
       raise ArgumentError, "a check must have been rejected / stopped" unless increase_check.nil? || increase_check.column_rejected? || increase_check.column_stopped?
+      raise ArgumentError, "a wire must have been rejected / failed" unless wire.nil? || wire.rejected? || wire.failed?
+      raise ArgumentError, "a wise transfer must have been rejected / failed" unless wise_transfer.nil? || wise_transfer.rejected? || wise_transfer.failed?
       raise ArgumentError, "must have settled expense payouts" unless expense_payouts.all? { |ep| ep.settled? }
 
       ActiveRecord::Base.transaction do

--- a/app/models/reimbursement/payout_holding.rb
+++ b/app/models/reimbursement/payout_holding.rb
@@ -114,7 +114,7 @@ module Reimbursement
       raise ArgumentError, "PayPal transfer must have been rejected" unless paypal_transfer.nil? || paypal_transfer.rejected?
       raise ArgumentError, "a check must have been rejected / stopped" unless increase_check.nil? || increase_check.column_rejected? || increase_check.column_stopped?
       raise ArgumentError, "a wire must have been rejected / failed" unless wire.nil? || wire.rejected? || wire.failed?
-      raise ArgumentError, "a wise transfer must have been rejected / failed" unless wise_transfer.nil? || wise_transfer.rejected? || wise_transfer.failed?
+      raise ArgumentError, "a Wise transfer must have been rejected / failed" unless wise_transfer.nil? || wise_transfer.rejected? || wise_transfer.failed?
       raise ArgumentError, "must have settled expense payouts" unless expense_payouts.all? { |ep| ep.settled? }
 
       ActiveRecord::Base.transaction do


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were not preventing reversing payout holdings with successful / in progress wire or wise transfers.
closes #14559

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Prevent reversing payout holdings when the attached wire or wise has not failed or been rejected.
https://hcb.hackclub.com/blazer/queries/1301-payout-holdings-with-no-transfer-attached
https://hcb.hackclub.com/blazer/queries/1307-reversed-payout-holding-with-non-failed-or-reversed-wise
https://hcb.hackclub.com/blazer/queries/1308-reversed-payout-holding-with-non-failed-or-reversed-wire

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

