### PR TITLE
[contracts] allows reissue of contracts

### DIFF
--- a/app/controllers/organizer_position_invites_controller.rb
+++ b/app/controllers/organizer_position_invites_controller.rb
@@ -121,6 +121,26 @@ class OrganizerPositionInvitesController < ApplicationController
     redirect_to event_team_path @invite.event
   end
 
+  def resend_to_cosigner
+    authorize @invite
+
+    new_cosigner_email = params[:cosigner_email]&.strip
+    contract = @invite.contract
+
+    if new_cosigner_email == @invite.user.email
+      flash[:error] = "You cannot use your own email as the cosigner's email"
+    elsif new_cosigner_email == contract.party(:cosigner)&.email
+      contract.party(:cosigner).notify
+      flash[:success] = "Resent agreement to cosigner"
+    else
+      contract.mark_voided!(reissuing: true)
+      @invite.send_contract(cosigner_email: new_cosigner_email, include_videos: contract.include_videos, reissue_of: contract)
+      flash[:success] = "Resent agreement to cosigner"
+    end
+
+    redirect_back_or_to organizer_position_invite_path(@invite)
+  end
+
   private
 
   def set_opi

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -245,6 +245,12 @@ class Contract < ApplicationRecord
     reissue_of_id.present?
   end
 
+  def owned_by?(user)
+    return false if user.nil?
+
+    parties.where(role: [:signee, :organizer]).exists?(user:)
+  end
+
   def inline_documents?
     prefills&.dig("documents").present?
   end

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -317,8 +317,8 @@ class Event
 
     def check_cosigner_update
       if contract.present? && cosigner_email_previously_changed?
-        contract.mark_voided!
-        send_contract
+        contract.mark_voided!(reissuing: true)
+        send_contract(reissue_of: contract)
       end
     end
 

--- a/app/policies/contract/party_policy.rb
+++ b/app/policies/contract/party_policy.rb
@@ -13,7 +13,12 @@ class Contract
     end
 
     def resend?
-      user&.admin?
+      return user&.admin? if record.hcb?
+
+      # Self-service: the contract's own signee/organizer can resend to any
+      # non-HCB party on their own contract without changing anything. To
+      # restrict this back to admins only, drop the `|| ...` clause below.
+      user&.admin? || record.contract.owned_by?(user)
     end
 
     alias_method :completed?, :show?

--- a/app/policies/organizer_position_invite_policy.rb
+++ b/app/policies/organizer_position_invite_policy.rb
@@ -45,6 +45,12 @@ class OrganizerPositionInvitePolicy < ApplicationPolicy
     user&.admin?
   end
 
+  def resend_to_cosigner?
+    return false if record.contract&.party(:cosigner).nil?
+
+    record.contract.party(:cosigner).pending? && (record.user == user || user&.admin?)
+  end
+
   private
 
   def admin_or_manager?

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -39,5 +39,30 @@
       <% disabled = @invite.contract.present? && !@invite.contract.signed? %>
       <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
     <% end %>
+
+    <% if @invite.contract&.party(:cosigner)&.pending? && policy(@invite).resend_to_cosigner? %>
+      <button class="btn bg-muted" data-behavior="modal_trigger" data-modal="cosigner_agreement">Manage cosigner's agreement</button>
+    <% end %>
   </div>
 </main>
+
+<% if @invite.contract&.party(:cosigner)&.pending? && policy(@invite).resend_to_cosigner? %>
+  <section data-behavior="modal" role="dialog" id="cosigner_agreement" class="modal modal--scroll">
+    <%= modal_header "Manage cosigner's agreement" %>
+    <p>
+      The fiscal sponsorship agreement has been sent to <span class="font-bold"><%= @invite.contract.party(:cosigner).email %></span> for them to sign.
+      You can change your cosigner's email here, or resend it to the same address.
+      <% if @invite.contract.party(:signee).signed? %>
+        <span class="font-bold">If you change the email, you'll need to sign the agreement again.</span>
+      <% end %>
+    </p>
+
+    <%= form_with url: resend_to_cosigner_organizer_position_invite_path(@invite), method: :post do |form| %>
+      <%= label_tag :cosigner_email do %>
+        Cosigner email <span class="text-primary">*</span>
+      <% end %>
+      <%= email_field_tag :cosigner_email, @invite.contract.party(:cosigner).email, required: true, placeholder: "orpheus@hackclub.com" %>
+      <%= form.submit "Resend cosigner's agreement", class: "btn mt-2" %>
+    <% end %>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,6 +392,7 @@ Rails.application.routes.draw do
     member do
       post "change_position_role"
       post "send_contract"
+      post "resend_to_cosigner"
     end
   end
 

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -103,4 +103,74 @@ RSpec.describe OrganizerPositionInvitesController do
       expect(contract.party(:signee)&.external_id).to eq("STUBBED")
     end
   end
+
+  describe "#resend_to_cosigner" do
+    let(:event) { create(:event) }
+    let(:invite) { create(:organizer_position_invite, event:) }
+
+    before do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+
+      stub_request(:post, "https://api.docuseal.co/submissions")
+        .to_return(
+          status: 201,
+          body: [{ submission_id: "STUBBED" }].to_json,
+          headers: { content_type: "application/json" }
+        )
+      stub_request(:get, "https://api.docuseal.co/submissions/STUBBED")
+        .to_return(
+          status: 200,
+          body: { submitters: [{ role: "HCB", slug: "STUBBED" }, { role: "Contract Signee", slug: "STUBBED" }, { role: "Cosigner", slug: "STUBBED" }] }.to_json,
+          headers: { content_type: "application/json" }
+        )
+
+      invite.send_contract(cosigner_email: "old-cosigner@hackclub.com", include_videos: false)
+    end
+
+    it "resends to the same email without voiding the contract" do
+      create_session(invite.user, verified: true)
+      original_contract = invite.contract
+
+      post :resend_to_cosigner, params: { id: invite.to_param, cosigner_email: "old-cosigner@hackclub.com" }
+
+      expect(flash[:success]).to eq("Resent agreement to cosigner")
+      expect(original_contract.reload).to be_sent
+      expect(invite.reload.contract).to eq(original_contract)
+    end
+
+    it "voids and reissues the contract when the cosigner email changes" do
+      create_session(invite.user, verified: true)
+      original_contract = invite.contract
+
+      post :resend_to_cosigner, params: { id: invite.to_param, cosigner_email: "new-cosigner@hackclub.com" }
+
+      expect(flash[:success]).to eq("Resent agreement to cosigner")
+      expect(original_contract.reload).to be_voided
+
+      new_contract = invite.reload.contract
+      expect(new_contract).not_to eq(original_contract)
+      expect(new_contract.reissue_of).to eq(original_contract)
+      expect(new_contract.party(:cosigner).email).to eq("new-cosigner@hackclub.com")
+    end
+
+    it "rejects the invitee's own email as the cosigner email" do
+      create_session(invite.user, verified: true)
+
+      post :resend_to_cosigner, params: { id: invite.to_param, cosigner_email: invite.user.email }
+
+      expect(flash[:error]).to eq("You cannot use your own email as the cosigner's email")
+      expect(invite.reload.contract).to be_sent
+    end
+
+    it "denies an unrelated, non-admin user" do
+      other_user = create(:user)
+      create_session(other_user, verified: true)
+      original_contract = invite.contract
+
+      post :resend_to_cosigner, params: { id: invite.to_param, cosigner_email: "new-cosigner@hackclub.com" }
+
+      expect(flash[:error]).to eq("You are not authorized to perform this action.")
+      expect(original_contract.reload).to be_sent
+    end
+  end
 end

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -124,6 +124,8 @@ RSpec.describe OrganizerPositionInvitesController do
           body: { submitters: [{ role: "HCB", slug: "STUBBED" }, { role: "Contract Signee", slug: "STUBBED" }, { role: "Cosigner", slug: "STUBBED" }] }.to_json,
           headers: { content_type: "application/json" }
         )
+      stub_request(:delete, "https://api.docuseal.co/submissions/STUBBED")
+        .to_return(status: 200, body: "", headers: { content_type: "application/json" })
 
       invite.send_contract(cosigner_email: "old-cosigner@hackclub.com", include_videos: false)
     end

--- a/spec/controllers/organizer_position_invites_controller_spec.rb
+++ b/spec/controllers/organizer_position_invites_controller_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe OrganizerPositionInvitesController do
 
     before do
       allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+      allow(ApplicationsTable).to receive(:all).and_return([])
 
       stub_request(:post, "https://api.docuseal.co/submissions")
         .to_return(

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -19,4 +19,32 @@ RSpec.describe Contract, type: :model do
     end
 
   end
+
+  describe "#owned_by?" do
+    let(:payee) { create(:payee) }
+    let(:position) { create(:payroll_position, payee:) }
+    let(:organizer) { create(:user) }
+    let(:other_user) { create(:user) }
+
+    let!(:contract) do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+
+      Contract::PayrollPosition.create!(contractable: position, include_videos: false).tap do |c|
+        c.parties.create!(user: organizer, role: :organizer)
+        c.parties.create!(external_email: payee.email, role: :contractor)
+      end
+    end
+
+    it "is true for the contract's signee/organizer party" do
+      expect(contract.owned_by?(organizer)).to eq(true)
+    end
+
+    it "is false for an unrelated user" do
+      expect(contract.owned_by?(other_user)).to eq(false)
+    end
+
+    it "is false for nil" do
+      expect(contract.owned_by?(nil)).to eq(false)
+    end
+  end
 end

--- a/spec/policies/contract/party_policy_spec.rb
+++ b/spec/policies/contract/party_policy_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contract::PartyPolicy, type: :policy do
+  let(:payee) { create(:payee) }
+  let(:position) { create(:payroll_position, payee:) }
+  let(:organizer) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:admin) { create(:user, :make_admin) }
+
+  let!(:contract) do
+    allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+
+    Contract::PayrollPosition.create!(contractable: position, include_videos: false).tap do |c|
+      c.parties.create!(user: organizer, role: :organizer)
+      c.parties.create!(external_email: payee.email, role: :contractor)
+    end
+  end
+
+  describe "#resend?" do
+    it "allows the contract's own signee/organizer party to resend to another non-HCB party" do
+      expect(described_class.new(organizer, contract.party(:contractor)).resend?).to eq(true)
+    end
+
+    it "denies an unrelated user" do
+      expect(described_class.new(other_user, contract.party(:contractor)).resend?).to eq(false)
+    end
+
+    it "denies a signed-out user" do
+      expect(described_class.new(nil, contract.party(:contractor)).resend?).to eq(false)
+    end
+
+    it "always allows an admin" do
+      expect(described_class.new(admin, contract.party(:contractor)).resend?).to eq(true)
+    end
+
+    it "keeps the HCB party admin-only, even for the contract's own organizer" do
+      expect(described_class.new(organizer, contract.party(:hcb)).resend?).to eq(false)
+      expect(described_class.new(admin, contract.party(:hcb)).resend?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
current implementation does not allow anybody to rescind/resend forms with incorrect information, and only allows admins to void current contract

## Describe your changes
- `Contract#owned_by?` (new) + `Contract::PartyPolicy#resend?` (broadened): the contract's own signee/organizer can now re-send an unchanged invite to another non-HCB party on their own contract, not just admins. The HCB party stays admin-only, and the self-service clause is a single line to drop if it ever needs to be restricted back to admins only.
- Fixed `Event::Application#check_cosigner_update` to void with `reissuing: true` and link the new contract via `reissue_of`, matching the reissue chain used everywhere else (`ContractsController#reissue`, `Payroll::Position`), instead of leaving orphaned, unlinked voided contracts.
- Added `OrganizerPositionInvite#resend_to_cosigner` (policy + controller action + route + UI modal on the invite's own show page), mirroring `Event::Application`'s existing action — it previously had no self-service cosigner-fix path, only an admin-only `send_contract`.

`external_service: manual` contracts need no special-casing: per `dev-docs/guides/contracts.md` they're created directly via console already in the `signed` state, so they never have anything pending to resend as the existing void/archive guards already no-op safely for them.

Added specs (`spec/policies/contract/party_policy_spec.rb`, and additions to `spec/models/contract_spec.rb` and `spec/controllers/organizer_position_invites_controller_spec.rb`) modeled on existing patterns in the repo.

Closes #14545.

