### PR TITLE
[Tags] Reject creating a tag onto another organization's transaction

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -15,6 +15,12 @@ class TagsController < ApplicationController
       hcb_code = HcbCode.find(params[:hcb_code_id])
       authorize hcb_code, :toggle_tag?
 
+      # `toggle_tag?` only asks whether the user is a member of *some* event on
+      # this HCB code, so it would let a member of two organizations attach one
+      # organization's tag to the other's transaction. `HcbCodes#toggle_tag`
+      # guards the same gap.
+      raise Pundit::NotAuthorizedError unless hcb_code.events.include?(@event)
+
       suppress(ActiveRecord::RecordNotUnique) do
         hcb_code.tags << tag
       end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagsController do
+  include SessionSupport
+
+  describe "#create" do
+    let(:user) { create(:user) }
+    let(:event) { create(:event) }
+
+    before do
+      create(:organizer_position, user:, event:)
+      create_session(user, verified: true)
+    end
+
+    def hcb_code_belonging_to(event)
+      canonical_transaction = create(:canonical_transaction)
+      create(:canonical_event_mapping, canonical_transaction:, event:)
+      canonical_transaction.local_hcb_code
+    end
+
+    it "creates the tag and attaches it to a transaction in the same organization" do
+      hcb_code = hcb_code_belonging_to(event)
+
+      post(:create, params: { event_id: event.slug, label: "Snacks", color: "muted", emoji: "🍕", hcb_code_id: hcb_code.hashid })
+
+      tag = event.tags.sole
+      expect(tag.label).to eq("Snacks")
+      expect(hcb_code.reload.tags).to include(tag)
+    end
+
+    it "refuses to attach the tag to a transaction from another organization" do
+      other_event = create(:event)
+      create(:organizer_position, user:, event: other_event)
+      hcb_code = hcb_code_belonging_to(other_event)
+
+      post(:create, params: { event_id: event.slug, label: "Snacks", color: "muted", emoji: "🍕", hcb_code_id: hcb_code.hashid })
+
+      expect(hcb_code.reload.tags).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

`TagsController#create` accepts an optional `hcb_code_id` and attaches the newly created tag to that transaction. It authorizes the transaction with `toggle_tag?`, which asks only whether the user is a member of **some** event on that HCB code, not whether it belongs to the organization the tag was created in.

So a user who belongs to two organizations could create a tag in organization A and attach it to organization B's transaction.

`HcbCodes#toggle_tag` already closes exactly this gap:

```ruby
raise Pundit::NotAuthorizedError unless hcb_code.events.include?(tag.event)
```

`create` was missing the equivalent check.

Impact is limited. It requires membership in both organizations, and the ledger filters displayed chips to the current organization, so the stray tag would not usually be visible. It is still an inconsistency between two paths that should agree.

## Describe your changes

Added the same consistency check to `create`, and a spec covering both the allowed and the rejected case. The rejection spec fails without the fix.
