### PR TITLE
[Tags] Let members manage tags from the settings tab

### DIFF
--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (event:) %>
 
-<% disabled = !policy(event).update? %>
+<% disabled = !TagPolicy.new(current_user, event).create? %>
 
 <%= turbo_frame_tag :tags_settings do %>
   <h3 class="mb1" id="cards_heading">Create a new tag</h3>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -186,6 +186,26 @@ RSpec.describe EventsController do
     end
   end
 
+  describe "#edit" do
+    render_views
+
+    # Creating, editing and deleting tags are member-level server side, so the
+    # settings tab shouldn't present them as manager-only.
+    it "lets a member manage tags from the settings tab" do
+      member = create(:user)
+      event = create(:event)
+      create(:organizer_position, user: member, event:, role: :member)
+      event.tags.create!(label: "Snacks", color: "muted", emoji: "🍕")
+      create_session(member, verified: true)
+
+      get(:edit, params: { id: event.slug, tab: "tags" })
+      page = Nokogiri::HTML5(response.body)
+
+      expect(page.css("#tags_settings input[name='label'][disabled]")).to be_empty
+      expect(page.css("#tags_settings a[disabled]")).to be_empty
+    end
+  end
+
   describe "#payments" do
     render_views
 


### PR DESCRIPTION
## Summary of the problem

Tag management is member-level everywhere except the settings tab.

`TagPolicy` allows any member to create, update and destroy tags, and the transaction and ledger menus have always offered those actions to members. `events/settings/_tags` gated all three on `policy(event).update?`, which is manager-or-admin. The settings tab therefore implied tags were a manager-only setting while every other surface, and the server, disagreed.

Two things made this worse than a cosmetic mismatch:

- The edit and delete controls were never actually restricted. `pop_icon_to` forwards to `link_to`, and `disabled` is not a valid attribute on an anchor, so the gate only greyed them out. A member could still use them and the server accepted it.
- The create form's fields were genuinely disabled. A member could open Settings then Tags, see the whole page, and find that nothing worked.

Members can reach the page: `EventPolicy#edit?` is `auditor_or_member?`.

## Describe your changes

Gates the tab on `TagPolicy` instead, so the page matches the server and the other tag surfaces. Added a spec covering a member seeing usable controls; it fails without the change.

No policy or controller behaviour changes, so nobody gains an ability they did not already have.
