### PR TITLE
[Card Locking] Roll out enforcement to everyone from 08/11

### DIFF
--- a/app/models/concerns/card_locking/charge_behavior.rb
+++ b/app/models/concerns/card_locking/charge_behavior.rb
@@ -108,7 +108,8 @@ module CardLocking
       due_at =
         if enforcement_start_date && settled_at >= enforcement_start_date.beginning_of_day
           CardLocking::Deadline.new(
-            settled_at:, trusted:, last_settled_charge_at:, current_due_at: receipt_due_at, now:
+            settled_at:, trusted:, last_settled_charge_at:, current_due_at: receipt_due_at, now:,
+            resolved: resolved_at.present?
           ).compute
         end
 

--- a/app/services/card_locking.rb
+++ b/app/services/card_locking.rb
@@ -27,27 +27,39 @@ module CardLocking
   # cardholder is in. Bounds candidate discovery and the outstanding pile, and is
   # the single enforcement date the feature collapses to once the staged rollout
   # below finishes (see enforcement_start_date).
+  #
+  # It is a floor across *all* stages, so it must never be advanced to a later
+  # stage's date. Doing so drops every earlier-stage charge out of
+  # HcbCode.card_locking_candidates, which the lock decision, the sweep and the
+  # outstanding pile all read through: the next sweep unlocks cardholders who are
+  # already being enforced and mails them that their cards work again.
   ENFORCEMENT_START_DATE = Date.new(2026, 7, 17)
 
   # Staged rollout of enforcement. A cardholder's charges become lockable on the
-  # date of the first stage flag they carry; a cardholder in no stage is never
+  # earliest stage date they hold a flag for; a cardholder in no stage is never
   # enforced (their charges never get a deadline, so their cards never lock).
+  #
+  # Earliest-wins is what leaves an already-enforced cardholder untouched when a
+  # later stage is switched on for everyone: they end up holding both flags and
+  # keep their original date, so their deadlines and locks do not move. For the
+  # same reason, never repoint an existing stage at a later date, never disable a
+  # stage on an enforced cardholder, and never delete the earliest entry.
   #
   # RIP-OUT: when the rollout is done, delete ENFORCEMENT_STAGES and
   # enforcement_start_date, have callers use ENFORCEMENT_START_DATE directly, and
-  # remove the Flipper flags. To add a stage, add a row (keep earliest first).
-  ENFORCEMENT_STAGES = [
-    [:card_locking_enabled_on_07_17_2026, Date.new(2026, 7, 17)],
-    [:card_locking_enabled_on_07_28_2026, Date.new(2026, 7, 28)],
-  ].freeze
+  # remove the Flipper flags. To add a stage, add an entry (order does not matter).
+  ENFORCEMENT_STAGES = {
+    card_locking_enabled_on_07_17_2026: Date.new(2026, 7, 17),
+    card_locking_enabled_on_07_28_2026: Date.new(2026, 7, 28),
+    card_locking_enabled_on_08_11_2026: Date.new(2026, 8, 11),
+  }.freeze
 
   # The date on or after which this cardholder's charges can lock their cards, or
   # nil if they are not yet in any rollout stage.
   def self.enforcement_start_date(user)
     return nil unless user
 
-    ENFORCEMENT_STAGES.each { |flag, date| return date if Flipper.enabled?(flag, user) }
-    nil
+    ENFORCEMENT_STAGES.filter_map { |flag, date| date if Flipper.enabled?(flag, user) }.min
   end
 
   # The Receipt Bin URL cardholders are sent to upload outstanding receipts.

--- a/app/services/card_locking/deadline.rb
+++ b/app/services/card_locking/deadline.rb
@@ -11,15 +11,27 @@ module CardLocking
   # below `now + DEADLINE_SHORTENING_FLOOR`, so losing trust cannot make a pile of
   # receipts overdue in the same instant.
   class Deadline
-    def initialize(settled_at:, trusted:, last_settled_charge_at:, current_due_at:, now:)
+    def initialize(settled_at:, trusted:, last_settled_charge_at:, current_due_at:, now:, resolved: false)
       @settled_at = settled_at
       @trusted = trusted
       @last_settled_charge_at = last_settled_charge_at
       @current_due_at = current_due_at
       @now = now
+      @resolved = resolved
     end
 
     def compute
+      # A first-ever deadline may not land already overdue. No-op for a normal
+      # charge, whose settled_at + 7d is far past now + 72h; it only bites when a
+      # charge is first materialized long after it settled, which would otherwise
+      # lock a cardholder instantly with no pre-lock warning.
+      #
+      # Outstanding charges only. A resolved charge's deadline is history, read by
+      # receipt_trusted? to decide whether its receipt arrived on time, and moving
+      # it forward would recast a late upload as on-time. Not hypothetical:
+      # BackfillCardLockingTimingTask materializes all history at Time.current, so
+      # clamping there would inflate trust wholesale.
+      return [target, @now + DEADLINE_SHORTENING_FLOOR].max if @current_due_at.nil? && !@resolved
       return target if @current_due_at.nil?
       return @current_due_at if @current_due_at <= @now # already overdue: frozen
 

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -10,11 +10,17 @@ module UserService
 
     def run
       return unless @user.present?
-      return unless Flipper.enabled?(:card_locking_2025_06_09, @user)
       return if @unlock_only && !@user.cards_locked?
 
       now = Time.current
-      should_lock = @user.card_locking_suppressed?(now:) ? false : @user.card_locking_has_overdue_charge?(now:)
+
+      # card_locking_2025_06_09 is the feature kill switch, and it unlocks rather
+      # than freezes: as an early return it would strand already-locked cardholders
+      # with no way to unlock by uploading, so switching the feature off during an
+      # incident would deepen it. Folded into should_lock, disabling the flag
+      # releases them on the next sweep, which reaches every locked cardholder via
+      # User.card_locking_candidates.
+      should_lock = Flipper.enabled?(:card_locking_2025_06_09, @user) && @user.cards_should_lock?(now:)
 
       # Uploading a receipt can only ever unlock. If a charge is still overdue,
       # leave the lock exactly as it is (do NOT unlock with work outstanding), but

--- a/app/tasks/maintenance/grant_card_locking_rollout_grace_task.rb
+++ b/app/tasks/maintenance/grant_card_locking_rollout_grace_task.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # One-off, for the general rollout only. Pushes every already-overdue receipt
+  # deadline out to now + GRACE, so switching enforcement on for everyone warns
+  # cardholders before it locks them instead of locking them on the next sweep.
+  #
+  # It exists because the two rollout flags cover different populations. The stage
+  # flag has been materializing deadlines for a whole group of cardholders, while
+  # card_locking_2025_06_09 (which gates locking AND every notification) was on for
+  # a much smaller set. Cardholders in the gap have had deadlines quietly going
+  # overdue for weeks without a single email or SMS, some of them across dozens of
+  # charges. Opening the master gate would lock all of them at once, with the lock
+  # notice as their first contact with the feature.
+  #
+  # Cardholders whose cards are already locked are skipped: they are already being
+  # enforced and have had the notifications, so granting grace would unlock them,
+  # mail them that their cards work again, and re-lock them GRACE later.
+  #
+  # Run this BEFORE enabling card_locking_2025_06_09 globally. Idempotent in the
+  # sense that a second run only re-grants grace to whoever is still overdue, but
+  # it is meant to run once, immediately before the flag flip.
+  class GrantCardLockingRolloutGraceTask < MaintenanceTasks::Task
+    # Leaves a full WARNING_LEAD_TIME (48h) of warning before the lock lands, so
+    # every affected cardholder gets an email and SMS roughly 24h out.
+    GRACE = CardLocking::DEADLINE_SHORTENING_FLOOR
+
+    def collection
+      HcbCode.card_locking_candidates
+             .receipt_overdue
+             .where(stripe_cardholders: { user_id: User.where(cards_locked: false) })
+             .distinct
+    end
+
+    def process(hcb_code)
+      # The sweep will not claw this back: Deadline#compute's shortening branch
+      # clamps to min(max(target, now + 72h), current_due_at), which holds at the
+      # granted value rather than dropping to the original settled_at + 7 days.
+      hcb_code.update_columns(receipt_due_at: GRACE.from_now)
+    end
+
+  end
+end

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -9,7 +9,7 @@
 </h1>
 
 <% if Flipper.enabled?(:card_locking_2025_06_09, current_user) %>
-  <%= render "application/callout", class: "mt-2", type: "info", title: "Card locking", badge: badge_for("Beta", class: "bg-muted") do %>
+  <%= render "application/callout", class: "mt-2", type: "info", title: "Card locking" do %>
     <p class="my-0">
       Upload a receipt within <strong>7 days</strong> of every card charge. Miss it and your cards pause until you upload. Uploading unlocks them in seconds. Your cards are currently <strong class="<%= current_user.cards_locked? ? "error" : "success" %>"><%= current_user.cards_locked? ? "locked" : "active" %></strong>.
     </p>

--- a/spec/models/user/card_locking_trust_spec.rb
+++ b/spec/models/user/card_locking_trust_spec.rb
@@ -9,9 +9,13 @@ RSpec.describe User, type: :model do
 
   before { travel_to(now) }
 
+  # Each charge is materialized as of when it settled, which is what production
+  # does: the settle hook fires a MaterializeChargeJob at settle time. Passing the
+  # current `now` would instead model a charge first materialized days late, which
+  # CardLocking::Deadline deliberately floors so it cannot land already overdue.
   def materialize_all
     HcbCode.where(hcb_code: user.stripe_cards.flat_map { |c| c.local_hcb_codes.pluck(:hcb_code) })
-           .find_each { |hc| hc.materialize_card_locking!(now:) }
+           .find_each { |hc| hc.materialize_card_locking!(now: hc.card_locking_settled_at || now) }
   end
 
   describe "#receipt_trusted?" do

--- a/spec/services/card_locking/deadline_spec.rb
+++ b/spec/services/card_locking/deadline_spec.rb
@@ -89,4 +89,22 @@ RSpec.describe CardLocking::Deadline do
     current_due = settled_at + 7.days
     expect(compute(current_due_at: current_due)).to eq(settled_at + 7.days)
   end
+
+  it "case 16: first deadline whose target is already past → now + 72.hours" do
+    expect(compute(settled_at: now - 30.days)).to eq(now + 72.hours)
+  end
+
+  it "case 17: first deadline inside the floor → now + 72.hours" do
+    expect(compute(settled_at: now - 5.days)).to eq(now + 72.hours)
+  end
+
+  it "case 18: first deadline beyond the floor is untouched by it" do
+    expect(compute(settled_at: now - 1.day)).to eq(now - 1.day + 7.days)
+  end
+
+  # A resolved charge's deadline is read by receipt_trusted? to decide whether the
+  # receipt was on time. Flooring it forward would recast a late upload as on-time.
+  it "case 19: a resolved charge's first deadline is not floored" do
+    expect(compute(settled_at: now - 30.days, resolved: true)).to eq(now - 30.days + 7.days)
+  end
 end

--- a/spec/services/card_locking/enforcement_start_date_spec.rb
+++ b/spec/services/card_locking/enforcement_start_date_spec.rb
@@ -25,10 +25,30 @@ RSpec.describe "CardLocking.enforcement_start_date" do
     expect(CardLocking.enforcement_start_date(user)).to eq(Date.new(2026, 7, 28))
   end
 
+  it "is 2026-08-11 for a cardholder in the general rollout stage" do
+    Flipper.enable(:card_locking_enabled_on_08_11_2026, user)
+
+    expect(CardLocking.enforcement_start_date(user)).to eq(Date.new(2026, 8, 11))
+  end
+
   it "uses the earliest stage the cardholder is in" do
     Flipper.enable(:card_locking_enabled_on_07_17_2026, user)
     Flipper.enable(:card_locking_enabled_on_07_28_2026, user)
 
     expect(CardLocking.enforcement_start_date(user)).to eq(Date.new(2026, 7, 17))
+  end
+
+  # The general rollout switches the 08/11 stage on for everyone, so a pilot
+  # cardholder ends up holding both flags. Earliest-wins is what keeps their
+  # enforcement date, and therefore their existing deadlines and locks, unmoved.
+  it "keeps a pilot cardholder on their original date once the general stage is on" do
+    Flipper.enable(:card_locking_enabled_on_07_17_2026, user)
+    Flipper.enable(:card_locking_enabled_on_08_11_2026, user)
+
+    expect(CardLocking.enforcement_start_date(user)).to eq(Date.new(2026, 7, 17))
+  end
+
+  it "does not let the global floor drift past the earliest stage" do
+    expect(CardLocking::ENFORCEMENT_START_DATE).to eq(CardLocking::ENFORCEMENT_STAGES.values.min)
   end
 end

--- a/spec/services/user_service/update_card_locking_spec.rb
+++ b/spec/services/user_service/update_card_locking_spec.rb
@@ -77,9 +77,23 @@ RSpec.describe UserService::UpdateCardLocking, type: :service do
     expect { described_class.new(user:).run }.not_to(change { user.reload.cards_locked? })
   end
 
-  it "is a no-op when the master flag is disabled" do
+  it "does not lock an overdue cardholder when the feature is disabled" do
     Flipper.disable(:card_locking_2025_06_09, user)
     allow(user).to receive(:card_locking_has_overdue_charge?).and_return(true)
     expect { described_class.new(user:).run }.not_to(change { user.reload.cards_locked? })
+  end
+
+  # The kill switch releases locked cardholders rather than freezing them. Were it
+  # an early return, switching the feature off would leave them locked with no way
+  # to unlock by uploading.
+  it "unlocks an already-locked cardholder when the feature is disabled" do
+    user.update!(cards_locked: true)
+    Flipper.disable(:card_locking_2025_06_09, user)
+    allow(user).to receive(:card_locking_has_overdue_charge?).and_return(true)
+
+    expect {
+      described_class.new(user:).run
+    }.to change { user.reload.cards_locked? }.from(true).to(false)
+     .and have_enqueued_mail(CardLockingMailer, :cards_unlocked)
   end
 end

--- a/spec/tasks/maintenance/grant_card_locking_rollout_grace_task_spec.rb
+++ b/spec/tasks/maintenance/grant_card_locking_rollout_grace_task_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::GrantCardLockingRolloutGraceTask, type: :model do
+  include_context "card locking charges"
+
+  let(:now) { Time.zone.parse("2026-10-10 12:00:00") }
+
+  before { travel_to(now) }
+
+  def run_task
+    task = described_class.new
+    task.collection.each { |hcb_code| task.process(hcb_code) }
+  end
+
+  def overdue_charge(settled_at: 20.days.ago)
+    create_settled_card_charge(user:, settled_at:).tap do |charge|
+      charge.update_columns(card_charge_settled_at: settled_at, receipt_due_at: settled_at + 7.days)
+    end
+  end
+
+  it "pushes an overdue deadline out to the grace window" do
+    charge = overdue_charge
+
+    run_task
+
+    expect(charge.reload.receipt_due_at).to be_within(1.second).of(now + described_class::GRACE)
+    expect(user.cards_should_lock?(now:)).to be(false)
+  end
+
+  it "leaves the grace outside the warning window, so the cardholder is warned before locking" do
+    overdue_charge
+
+    run_task
+
+    expect(user.card_locking_has_approaching_charge?(now:)).to be(false)
+    expect(user.card_locking_has_approaching_charge?(now: now + 25.hours)).to be(true)
+    expect(user.cards_should_lock?(now: now + described_class::GRACE + 1.minute)).to be(true)
+  end
+
+  # An already-locked cardholder has had the notifications and is being enforced.
+  # Granting grace would unlock them, mail them that their cards work again, and
+  # re-lock them three days later.
+  it "skips a cardholder whose cards are already locked" do
+    charge = overdue_charge
+    user.update!(cards_locked: true)
+
+    run_task
+
+    expect(charge.reload.receipt_due_at).to be_within(1.second).of(charge.card_charge_settled_at + 7.days)
+  end
+
+  it "leaves a charge that is not yet overdue alone" do
+    settled_at = 1.day.ago
+    charge = create_settled_card_charge(user:, settled_at:)
+    charge.update_columns(card_charge_settled_at: settled_at, receipt_due_at: settled_at + 7.days)
+
+    run_task
+
+    expect(charge.reload.receipt_due_at).to be_within(1.second).of(settled_at + 7.days)
+  end
+
+  # The whole point of the grace is that it survives contact with the sweep.
+  it "is not clawed back by the next deadline refresh" do
+    charge = overdue_charge
+
+    run_task
+    UserService::RefreshReceiptDeadlines.new(user:, now:).run
+
+    expect(charge.reload.receipt_due_at).to be_within(1.second).of(now + described_class::GRACE)
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Card locking has only ever been enforced for a pilot cohort. Rolling it out to everyone needs a new rollout stage, but flipping that switch as things stand causes three separate bad experiences.

**The two rollout flags cover different populations.** `card_locking_enabled_on_07_17_2026` decides whether a charge gets a `receipt_due_at`. `card_locking_2025_06_09` decides whether cards actually lock *and* whether any notification is sent. They are not on for the same people, so there are cardholders whose deadlines have been quietly going overdue for weeks without a single email or SMS. Opening the master gate would lock all of them on the next sweep, with the lock notice as their first ever contact with the feature.

**A first-ever deadline can land in the past.** `CardLocking::Deadline` returned `settled_at + 7 days` unclamped when a charge had no deadline yet. Any charge first materialized well after it settled (a backdated import, a charge that becomes receipt-required later, a rollout date set behind the deploy) therefore locks a cardholder instantly, with no pre-lock warning.

**The kill switch does not switch the feature off.** `card_locking_2025_06_09` was an early return in `UpdateCardLocking`, so it only suppressed *new* locks. Already-locked cardholders stayed locked with no way to unlock by uploading. Turning the feature off during an incident would have made that incident worse.

Also: stages resolved by list position, so enforcement dates depended on the constant staying hand-sorted.

## Describe your changes

**Adds the `card_locking_enabled_on_08_11_2026` stage** and resolves stages by earliest date instead of list position. Earliest-wins is what leaves the existing cohort untouched when the new stage goes on for everyone: they end up holding both flags and keep their original date, so their deadlines and locks do not move. `ENFORCEMENT_START_DATE` stays put and is now documented as a floor across *all* stages, because advancing it drops earlier-stage charges out of `card_locking_candidates` and silently unlocks people who are actively being enforced.

**Makes the kill switch real.** The flag moves from an early return into `should_lock`, so disabling it releases locked cardholders on the next sweep rather than freezing them. `User.card_locking_candidates` already includes every locked cardholder, so the sweep reaches them. This also removes a suppression check that duplicated `cards_should_lock?`.

**Floors a first-ever deadline at `now + 72h`.** A no-op for normal charges, whose `settled_at + 7 days` is far beyond that. Outstanding charges only — a resolved charge's deadline is history that `receipt_trusted?` reads to decide whether the receipt arrived on time, and moving it forward would recast a late upload as on-time. That guard matters more than it looks: `BackfillCardLockingTimingTask` materializes all history at `Time.current`, so without it, re-running that task would inflate trust across the board.

**Adds `Maintenance::GrantCardLockingRolloutGraceTask`** for the cohort the floor cannot help, since their deadlines already exist and are already past. It pushes already-overdue deadlines out to `now + 72h`, which sits outside the 48h `WARNING_LEAD_TIME`, so everyone affected gets an email and SMS roughly 24h before their cards lock. Cardholders who are *already* locked are skipped: they have had the notifications, and granting them grace would unlock them, mail them that their cards work again, then re-lock them three days later. The granted deadline survives the next sweep, since `Deadline#compute`'s shortening branch clamps to `min(max(target, now + 72h), current_due_at)`.

Also drops the "Beta" badge from the Receipt Bin callout.

### Rollout order

1. Deploy — inert on its own, no flag changes
2. Run `Maintenance::GrantCardLockingRolloutGraceTask`
3. Enable `card_locking_2025_06_09` **globally**
4. Enable `card_locking_enabled_on_08_11_2026` **globally**

Master flag before stage flag. `RefreshReceiptDeadlines` is gated by neither, so enabling the stage first accrues deadlines with no warnings, and the later master flip mass-locks.

### Follow-ups

This PR deliberately keeps the existing flags to stay small. Stacked PRs will collapse them to a single `card_locking` kill switch and delete `ENFORCEMENT_STAGES` / `enforcement_start_date`. Note for whoever does that: after this rollout both stage flags are permanently load-bearing, and deleting `card_locking_enabled_on_07_17_2026` would mass-unlock the pilot cohort.
