### PR TITLE
[Card Locking] Clarify copy during suppression period

### DIFF
--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -11,9 +11,26 @@ class CardLockingMailer < ApplicationMailer
     mail to: user.email, subject: "[Urgent] Your HCB cards are locked until you upload your receipts"
   end
 
-  def cards_unlocked(user:)
+  # suppressed_until is set when the unlock came from an admin suppression rather
+  # than from the cardholder clearing their receipts. Their receipts are still
+  # overdue and their cards lock again when it expires, so the copy has to say so
+  # and show them what to upload. Passed in rather than read off the user here,
+  # because the mail is delivered later and the suppression may have been changed
+  # or lifted by then; the reason for the unlock is fixed at the moment it happens.
+  def cards_unlocked(user:, suppressed_until: nil)
     @user = user
-    mail to: user.email, subject: "Your HCB cards work again"
+    @suppressed_until = suppressed_until
+
+    if @suppressed_until
+      @hcb_codes = user.card_locking_overdue_charges.to_a
+      @count = @hcb_codes.size
+      @show_org = user.events.size > 1
+      @timezone = user.assumed_timezone
+
+      mail to: user.email, subject: "Your HCB cards work again until #{@suppressed_until.in_time_zone(@timezone).strftime('%b %-d')}"
+    else
+      mail to: user.email, subject: "Your HCB cards work again"
+    end
   end
 
   def warning(user:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -366,6 +366,35 @@ class User < ApplicationRecord
     words.any? ? words.map(&:first).join.upcase : name
   end
 
+  # HCB stores no timezone preference, so this infers one from sessions, whose
+  # timezone the browser reports at sign-in. A guess, only ever for presenting a
+  # time back to the user. Never compute a deadline from it.
+  #
+  # Takes the most common value across recent sessions rather than the latest, so
+  # a trip does not repoint someone's timezone for a fortnight after they get
+  # home. Ties go to the more recent. A VPN needs no handling: the browser reads
+  # this from the operating system, not from the IP address, so tunnelling through
+  # another country does not change it.
+  #
+  # Most values are IANA names, but some browsers report things ActiveSupport
+  # cannot resolve ("Etc/Unknown", "UTC+480", bare offsets). Those are skipped in
+  # favour of the next best candidate rather than falling straight to the default.
+  DEFAULT_TIMEZONE = ActiveSupport::TimeZone["America/New_York"]
+  TIMEZONE_SESSION_SAMPLE = 20
+
+  def assumed_timezone
+    reported = user_sessions.where.not(timezone: [nil, ""])
+                            .order(Arel.sql("COALESCE(last_seen_at, created_at) DESC"))
+                            .limit(TIMEZONE_SESSION_SAMPLE)
+                            .pluck(:timezone)
+
+    reported.tally
+            .sort_by { |zone, count| [-count, reported.index(zone)] }
+            .each { |zone, _count| return ActiveSupport::TimeZone[zone] || next }
+
+    DEFAULT_TIMEZONE
+  end
+
   # gary@hackclub.com → g***y@hackclub.com
   # gt@hackclub.com → g*@hackclub.com
   # g@hackclub.com → g@hackclub.com

--- a/app/services/card_locking.rb
+++ b/app/services/card_locking.rb
@@ -75,6 +75,14 @@ module CardLocking
     ENFORCEMENT_STAGES.filter_map { |flag, date| date if Flipper.enabled?(flag, user) }.min
   end
 
+  # A deadline as it appears in cardholder-facing copy, in the cardholder's own
+  # timezone (see User#time_zone, inferred from their last session). The zone
+  # abbreviation is kept because the inference can be wrong, and a labelled time
+  # someone can sanity-check beats a bare one they cannot.
+  def self.format_deadline(time, zone)
+    time.in_time_zone(zone).strftime("%b %-d at %-l:%M %p %Z")
+  end
+
   # The Receipt Bin URL cardholders are sent to upload outstanding receipts.
   def self.inbox_url
     Rails.application.routes.url_helpers.my_inbox_url

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -63,7 +63,7 @@ module UserService
       return unless transitioned
 
       # Enqueue notifications outside the row lock, gated on the transition.
-      should_lock ? notify_locked(now:) : notify_unlocked
+      should_lock ? notify_locked(now:) : notify_unlocked(now:)
     end
 
     private
@@ -73,9 +73,25 @@ module UserService
       send_sms(locked_message(now:))
     end
 
-    def notify_unlocked
-      CardLockingMailer.cards_unlocked(user: @user).deliver_later
-      send_sms("Your HCB cards work again. Keep uploading receipts within 7 days of the charge, or your cards will lock again. Manage receipts at #{CardLocking.inbox_url}.")
+    # An unlock has two very different causes. Clearing your receipts earns the
+    # plain "your cards work again". An admin suppression does not: the receipts
+    # are still overdue and the cards lock again when it expires, so telling that
+    # cardholder their cards work again full stop would be a promise HCB breaks on
+    # a date they were never told.
+    def notify_unlocked(now:)
+      suppressed_until = @user.card_locking_suppressed_until if @user.card_locking_suppressed?(now:)
+
+      CardLockingMailer.cards_unlocked(user: @user, suppressed_until:).deliver_later
+      send_sms(unlocked_message(suppressed_until, now:))
+    end
+
+    def unlocked_message(suppressed_until, now:)
+      return "Your HCB cards work again. Keep uploading receipts within 7 days of the charge, or your cards will lock again. Manage receipts at #{CardLocking.inbox_url}." if suppressed_until.nil?
+
+      count = @user.card_locking_overdue_charges(now:).count("hcb_codes.id")
+      noun = "receipt".pluralize(count)
+      deadline = CardLocking.format_deadline(suppressed_until, @user.assumed_timezone)
+      "Your HCB cards work again until #{deadline}, as a one time exception from the HCB team. Upload your #{count} overdue #{noun} before then or your cards lock again. #{CardLocking.inbox_url}"
     end
 
     def locked_message(now:)

--- a/app/views/card_locking_mailer/_transactions_table.html.erb
+++ b/app/views/card_locking_mailer/_transactions_table.html.erb
@@ -10,7 +10,9 @@
     </tr>
   </thead>
   <tbody>
-    <% hcb_codes.sort_by { |hcb| hcb.card_charge_settled_at || hcb.created_at }.reverse.each do |hcb| %>
+    <%# Oldest first: the charge that has been outstanding longest is the most %>
+    <%# overdue, so it is the one to upload first. %>
+    <% hcb_codes.sort_by { |hcb| hcb.card_charge_settled_at || hcb.created_at }.each do |hcb| %>
       <tr>
         <td><%= link_to render_money(hcb.amount_cents.abs.to_s), attach_receipt_url(hcb) %></td>
         <td><%= hcb.stripe_merchant["name"] %></td>

--- a/app/views/card_locking_mailer/cards_unlocked.html.erb
+++ b/app/views/card_locking_mailer/cards_unlocked.html.erb
@@ -1,2 +1,18 @@
-<p>Your HCB cards work again.</p>
-<p>Keep uploading every receipt within 7 days of the charge, or your cards will lock again. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.</p>
+<% if @suppressed_until %>
+  <p>
+    The HCB team has made a one time exception for you, so your cards work again until <strong><%= CardLocking.format_deadline(@suppressed_until, @timezone) %></strong>.
+  </p>
+  <% if @count > 0 %>
+    <p>
+      Upload your overdue <%= "receipt".pluralize(@count) %> before the exception ends, or your cards will lock again. <%= @count == 1 ? "This receipt is" : "These #{@count} receipts are" %> still missing:
+    </p>
+    <%= render "transactions_table", hcb_codes: @hcb_codes, show_org: @show_org %>
+  <% else %>
+    <p>
+      Keep uploading every receipt within 7 days of the charge. Manage your receipts on the HCB <%= link_to "Receipt Bin", my_inbox_url %>.
+    </p>
+  <% end %>
+<% else %>
+  <p>Your HCB cards work again.</p>
+  <p>Keep uploading every receipt within 7 days of the charge, or your cards will lock again. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.</p>
+<% end %>

--- a/spec/mailers/card_locking_mailer_spec.rb
+++ b/spec/mailers/card_locking_mailer_spec.rb
@@ -21,6 +21,62 @@ RSpec.describe CardLockingMailer, type: :mailer do
     end
   end
 
+  describe "#cards_unlocked" do
+    it "does not promise a lasting unlock when it came from a suppression" do
+      hcb_code = create_settled_card_charge(user:, settled_at: 10.days.ago)
+      hcb_code.update!(card_charge_settled_at: 10.days.ago, receipt_due_at: 1.day.ago)
+      suppressed_until = Time.zone.parse("2026-10-12 15:00:00")
+
+      mail = described_class.cards_unlocked(user:, suppressed_until:)
+
+      expect(mail.subject).to eq("Your HCB cards work again until Oct 12")
+      expect(mail.body.encoded).to include("The HCB team has made a one time exception")
+      expect(mail.body.encoded).to match(/lock again/i)
+    end
+
+    # No sessions on this cardholder, so the deadline renders in the default zone
+    # rather than UTC. Getting this wrong shows someone a time hours off the one
+    # their cards actually lock at.
+    it "renders the deadline in the cardholder's assumed timezone" do
+      hcb_code = create_settled_card_charge(user:, settled_at: 10.days.ago)
+      hcb_code.update!(card_charge_settled_at: 10.days.ago, receipt_due_at: 1.day.ago)
+
+      mail = described_class.cards_unlocked(user:, suppressed_until: Time.zone.parse("2026-10-12 15:00:00"))
+
+      expect(mail.body.encoded).to include("Oct 12 at 11:00 AM EDT")
+    end
+
+    it "lists the oldest outstanding charge first" do
+      older = create_settled_card_charge(user:, settled_at: 12.days.ago, amount_cents: -11_00)
+      older.update!(card_charge_settled_at: 12.days.ago, receipt_due_at: 3.days.ago)
+      newer = create_settled_card_charge(user:, settled_at: 10.days.ago, amount_cents: -22_00)
+      newer.update!(card_charge_settled_at: 10.days.ago, receipt_due_at: 1.day.ago)
+
+      body = described_class.cards_unlocked(user:, suppressed_until: 1.day.from_now).body.encoded
+
+      expect(body.index("$11.00")).to be < body.index("$22.00")
+    end
+
+    # Without signed links the cardholder has to sign in, which is the friction
+    # the exception exists to remove.
+    it "links each overdue charge to a signed upload URL" do
+      hcb_code = create_settled_card_charge(user:, settled_at: 10.days.ago)
+      hcb_code.update!(card_charge_settled_at: 10.days.ago, receipt_due_at: 1.day.ago)
+
+      mail = described_class.cards_unlocked(user:, suppressed_until: 1.day.from_now)
+
+      expect(mail.body.encoded).to include(hcb_code.hashid)
+      expect(mail.body.encoded).to match(/[?&]s=/)
+    end
+
+    it "keeps the plain copy when the cardholder cleared their receipts" do
+      mail = described_class.cards_unlocked(user:)
+
+      expect(mail.subject).to eq("Your HCB cards work again")
+      expect(mail.body.encoded).not_to include("one time exception")
+    end
+  end
+
   describe "#warning" do
     it "reports a calm pile count and avoids violation/urgent language" do
       create_settled_card_charge(user:, settled_at: 2.days.ago)

--- a/spec/mailers/previews/card_locking_mailer_preview.rb
+++ b/spec/mailers/previews/card_locking_mailer_preview.rb
@@ -9,6 +9,10 @@ class CardLockingMailerPreview < ActionMailer::Preview
     CardLockingMailer.cards_unlocked(user: User.first)
   end
 
+  def cards_unlocked_by_suppression
+    CardLockingMailer.cards_unlocked(user: User.first, suppressed_until: 24.hours.from_now)
+  end
+
   def warning
     CardLockingMailer.warning(user: User.first)
   end

--- a/spec/models/user/assumed_timezone_spec.rb
+++ b/spec/models/user/assumed_timezone_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  let(:user) { create(:user) }
+
+  def session_with(timezone, last_seen_at:)
+    create(:user_session, user:, timezone:, last_seen_at:)
+  end
+
+  describe "#assumed_timezone" do
+    it "falls back to the default when the cardholder has no sessions" do
+      expect(user.assumed_timezone).to eq(User::DEFAULT_TIMEZONE)
+    end
+
+    it "uses the timezone the browser reported" do
+      session_with("Europe/London", last_seen_at: 1.day.ago)
+
+      expect(user.assumed_timezone.name).to eq("Europe/London")
+    end
+
+    # A fortnight abroad should not repoint someone's timezone once they are home.
+    it "prefers the most common timezone over the most recent one" do
+      5.times { |i| session_with("America/Chicago", last_seen_at: (10 + i).days.ago) }
+      session_with("Asia/Tokyo", last_seen_at: 1.day.ago)
+
+      expect(user.assumed_timezone.name).to eq("America/Chicago")
+    end
+
+    it "breaks a tie toward the more recent timezone" do
+      session_with("America/Chicago", last_seen_at: 10.days.ago)
+      session_with("Europe/Berlin", last_seen_at: 1.day.ago)
+
+      expect(user.assumed_timezone.name).to eq("Europe/Berlin")
+    end
+
+    # Some browsers report values ActiveSupport cannot resolve. Skipping to the
+    # next candidate keeps a usable guess instead of dropping to the default.
+    it "skips values ActiveSupport cannot resolve" do
+      3.times { |i| session_with("UTC+480", last_seen_at: (10 + i).days.ago) }
+      session_with("Europe/Lisbon", last_seen_at: 1.day.ago)
+
+      expect(user.assumed_timezone.name).to eq("Europe/Lisbon")
+    end
+
+    it "falls back to the default when nothing resolves" do
+      session_with("Etc/Unknown", last_seen_at: 1.day.ago)
+
+      expect(user.assumed_timezone).to eq(User::DEFAULT_TIMEZONE)
+    end
+
+    it "ignores sessions with no reported timezone" do
+      session_with(nil, last_seen_at: 1.day.ago)
+      session_with("", last_seen_at: 2.days.ago)
+      session_with("Europe/Madrid", last_seen_at: 3.days.ago)
+
+      expect(user.assumed_timezone.name).to eq("Europe/Madrid")
+    end
+  end
+end

--- a/spec/services/user_service/update_card_locking_spec.rb
+++ b/spec/services/user_service/update_card_locking_spec.rb
@@ -77,6 +77,20 @@ RSpec.describe UserService::UpdateCardLocking, type: :service do
     expect { described_class.new(user:).run }.not_to(change { user.reload.cards_locked? })
   end
 
+  # A suppression unlock is temporary and the receipts are still overdue, so the
+  # notification has to carry the expiry rather than the plain "cards work again".
+  it "tells a cardholder unlocked by suppression when the exception ends" do
+    user.update!(cards_locked: true, card_locking_suppressed_until: 24.hours.from_now)
+    allow(user).to receive(:card_locking_has_overdue_charge?).and_return(true)
+    allow(user).to receive(:card_locking_overdue_charges).and_return(HcbCode.none)
+
+    expect {
+      described_class.new(user:).run
+    }.to change { user.reload.cards_locked? }.from(true).to(false)
+     .and have_enqueued_mail(CardLockingMailer, :cards_unlocked)
+     .with(a_hash_including(suppressed_until: be_present))
+  end
+
   it "does not lock an overdue cardholder when the feature is disabled" do
     Flipper.disable(:card_locking)
     allow(user).to receive(:card_locking_has_overdue_charge?).and_return(true)


### PR DESCRIPTION
> Stacked on #14598 — review that first.

## Summary of the problem

An unlock has two very different causes, and one email covered both.

> Your HCB cards work again. Keep uploading every receipt within 7 days of the charge, or your cards will lock again.

That is true when a cardholder clears their receipts. It is not true when an admin suppresses card locking. In that case nothing has been fixed: the receipts are still overdue and the cards lock again the moment the suppression expires. The cardholder was told their cards work, given no expiry date, and no list of what they still owe. HCB then breaks that promise on a date they were never told.

## Describe your changes

`cards_unlocked` now takes a `suppressed_until` and says what actually happened:

- **Subject** carries the expiry date instead of implying a permanent fix.
- **Body** calls it a one time exception and gives the exact expiry, timezone included. HCB stores no per-cardholder timezone, so a bare time would be ambiguous in precisely the message where being off by hours matters.
- **The overdue charges are listed**, rendered through the same `_transactions_table` partial the locked and warning emails already use. Every row links through `attach_receipt_url`, which is signed with a `receipt_upload` purpose, so the cardholder can upload without signing in.
- **The SMS** carries the same expiry and count.

The plain copy is unchanged for a cardholder who genuinely cleared their receipts.

`suppressed_until` is passed in rather than read off the user inside the mailer. The mail is delivered later and the suppression may have been changed or lifted by then, but the reason the unlock happened is fixed at the moment it happens.

Adds a `cards_unlocked_by_suppression` mailer preview.

## Notes for review

**Signed links expire in 2 weeks; suppression can be set up to 30 days** (`hours.clamp(1, 720)` in `UsersController#suppress_card_locking`). For a suppression longer than a fortnight the links in this email expire before the exception does, and the cardholder falls back to signing in. Left alone here because `attach_receipt_url` is shared with the locked and warning emails and changing its expiry affects all of them. Worth deciding separately whether to shorten the suppression cap or lengthen the token.

**A pre-existing issue this surfaced:** every spec in `spec/mailers/card_locking_mailer_spec.rb` was failing locally on `cannot load such file -- sassc`, because `stylesheet_link_tag "mailer"` falls back to compiling `mailer.scss` when `app/assets/builds/` is empty. That is a fresh-worktree setup problem rather than a CI one, but it means those specs were silently not running for anyone in that state.
