### PR TITLE
[Admin] Sort the emails page by sent at desc

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1576,7 +1576,9 @@ class AdminController < Admin::BaseController
 
     @count = messages.count
 
-    @messages = messages.page(@page).per(@per).order(sent_at: :desc)
+    # `reorder` because `search_subject` (pg_search) orders by relevance rank,
+    # which would otherwise take precedence over `sent_at`.
+    @messages = messages.reorder(sent_at: :desc).page(@page).per(@per)
   end
 
   def unknown_merchants

--- a/spec/requests/admin/emails_spec.rb
+++ b/spec/requests/admin/emails_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /admin/emails", type: :request do
+  let(:admin) { create(:user, :make_admin) }
+
+  before do
+    admin_session = create(:user_session, user: admin, verified: true, expiration_at: 1.hour.from_now)
+
+    allow_any_instance_of(SessionsHelper)
+      .to receive(:find_current_session)
+      .and_return(admin_session)
+  end
+
+  # Ordered so that neither `id` nor insertion order matches `sent_at desc`.
+  let!(:oldest) { Ahoy::Message.create!(subject: "Upload a receipt", sent_at: 3.days.ago) }
+  let!(:newest) { Ahoy::Message.create!(subject: "Upload a receipt", sent_at: 1.hour.ago) }
+  let!(:middle) { Ahoy::Message.create!(subject: "Upload a receipt", sent_at: 1.day.ago) }
+
+  # The rendered row order, taken from each row's modal trigger.
+  def listed_ids
+    response.body.scan(/data-modal="message_(\d+)"/).flatten.map(&:to_i)
+  end
+
+  it "lists emails newest first" do
+    get "/admin/emails"
+
+    expect(response).to have_http_status(:ok)
+    expect(listed_ids).to eq([newest.id, middle.id, oldest.id])
+  end
+
+  it "lists search results newest first" do
+    get "/admin/emails", params: { q: "receipt" }
+
+    expect(response).to have_http_status(:ok)
+    expect(listed_ids).to eq([newest.id, middle.id, oldest.id])
+  end
+end


### PR DESCRIPTION
## Summary of the problem

The admin emails page wasn't sorted by `sent at` when a search query was used. Rows came back grouped by search relevance and then by ID ascending, so the dates jumped around.

## Describe your changes

`Ahoy::Message.search_subject` is a `pg_search_scope`, which prepends `ORDER BY rank DESC, id ASC` to the relation. The controller's `order(sent_at: :desc)` was appended *after* that, so it only ever acted as a tiebreaker between rows of identical rank.

Switched to `reorder(sent_at: :desc)`, which replaces pg_search's relevance ordering. Also moved it ahead of the pagination call for readability.

Added a request spec covering both the plain listing and the search path. It fails on the search path without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)