### PR TITLE
[User] Add a configurable timezone setting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -539,6 +539,7 @@ class UsersController < ApplicationController
       :birthday,
       :profile_picture,
       :seasonal_themes_enabled,
+      :timezone,
       # admin
       :pretend_is_not_admin,
       # security

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@
 #  slug                          :string
 #  subscribed_to_loops_at        :datetime
 #  teenager                      :boolean
+#  timezone                      :string
 #  use_sms_auth                  :boolean          default(FALSE)
 #  use_two_factor_authentication :boolean          default(FALSE)
 #  verified                      :boolean          default(FALSE), not null
@@ -244,6 +245,15 @@ class User < ApplicationRecord
 
   validates(:session_validity_preference, presence: true, inclusion: { in: SessionsHelper::SESSION_DURATION_OPTIONS.values })
 
+  # Blank collapses to nil so that "cleared the preference" and "never set one"
+  # stay the same state. Anything we cannot resolve is left alone for the
+  # validation below to reject, rather than silently thrown away.
+  normalizes :timezone, with: ->(timezone) { timezone.presence && (User.selectable_timezone_name(timezone) || timezone) }
+  validates :timezone, inclusion: {
+    in: ->(_user) { ActiveSupport::TimeZone.all.map(&:name) },
+    message: "isn't recognized.",
+  }, allow_nil: true
+
   validate :profile_picture_format
 
   validate(:admins_cannot_disable_2fa, on: :update)
@@ -364,6 +374,57 @@ class User < ApplicationRecord
   def initials
     words = name.split(/[^[[:word:]]]+/)
     words.any? ? words.map(&:first).join.upcase : name
+  end
+
+  DEFAULT_TIMEZONE = ActiveSupport::TimeZone["America/New_York"]
+  TIMEZONE_SESSION_SAMPLE = 20
+
+  # The timezone every other part of HCB should ask for. An explicit preference
+  # always wins; otherwise fall back to a guess, and finally to the default.
+  def resolved_timezone
+    (timezone && ActiveSupport::TimeZone[timezone]) || assumed_timezone
+  end
+
+  def assumed_timezone
+    inferred_timezone || DEFAULT_TIMEZONE
+  end
+
+  # Infers a timezone from sessions, whose timezone the browser reports at
+  # sign-in. A guess, only ever for presenting a time back to the user. Never
+  # compute a deadline from it.
+  #
+  # Takes the most common value across recent sessions rather than the latest, so
+  # a trip does not repoint someone's timezone for a fortnight after they get
+  # home. Ties go to the more recent. A VPN needs no handling: the browser reads
+  # this from the operating system, not from the IP address, so tunnelling through
+  # another country does not change it.
+  #
+  # Most values are IANA names, but some browsers report things ActiveSupport
+  # cannot resolve ("Etc/Unknown", "UTC+480", bare offsets). Those are skipped in
+  # favour of the next best candidate. Returns nil when nothing usable was
+  # reported, so callers can tell a real guess apart from the default.
+  def inferred_timezone
+    reported = user_sessions.where.not(timezone: [nil, ""])
+                            .order(Arel.sql("COALESCE(last_seen_at, created_at) DESC"))
+                            .limit(TIMEZONE_SESSION_SAMPLE)
+                            .pluck(:timezone)
+
+    reported.tally
+            .sort_by { |zone, count| [-count, reported.index(zone)] }
+            .each { |zone, _count| return ActiveSupport::TimeZone[zone] || next }
+
+    nil
+  end
+
+  # ActiveSupport::TimeZone resolves both IANA identifiers ("America/New_York")
+  # and Rails' friendlier names ("Eastern Time (US & Canada)"), but the picker
+  # only offers the latter. Storing anything else would leave the select unable to
+  # show a saved choice back to the user, so translate where an equivalent exists.
+  def self.selectable_timezone_name(zone)
+    zone = ActiveSupport::TimeZone[zone.to_s] unless zone.is_a?(ActiveSupport::TimeZone)
+    return nil if zone.nil?
+
+    ActiveSupport::TimeZone.all.find { |selectable| selectable.tzinfo == zone.tzinfo }&.name
   end
 
   # gary@hackclub.com → g***y@hackclub.com

--- a/app/tasks/maintenance/backfill_user_timezones_task.rb
+++ b/app/tasks/maintenance/backfill_user_timezones_task.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Seeds the timezone preference from the guess we can already make off a user's
+  # sessions, so most people find it already pointing somewhere sensible.
+  #
+  # Users we cannot infer a timezone for are left NULL rather than written with
+  # the default, otherwise "we guessed Eastern" would become indistinguishable
+  # from "this user chose Eastern".
+  class BackfillUserTimezonesTask < MaintenanceTasks::Task
+    def collection
+      User.where(timezone: nil)
+          .where(id: User::Session.where.not(timezone: [nil, ""]).select(:user_id))
+    end
+
+    def process(user)
+      selectable = User.selectable_timezone_name(user.inferred_timezone)
+      return if selectable.nil?
+
+      user.update!(timezone: selectable)
+    end
+
+  end
+end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -219,6 +219,15 @@
           </div>
         </div>
 
+        <div class="field">
+          <%= form.label :timezone %>
+          <p class="h5 muted mt0 mb1">
+            Emails from HCB show times in this timezone. Pages on the website always use whichever
+            timezone your browser is in right now.
+          </p>
+          <%= form.time_zone_select :timezone, nil, { include_blank: "Detect automatically" }, { disabled: } %>
+        </div>
+
         <fieldset>
           <legend class="medium">Share usage data with HCB</legend>
           <p class="h5 muted mt-0 mb-3">

--- a/db/migrate/20260812120000_add_timezone_to_users.rb
+++ b/db/migrate/20260812120000_add_timezone_to_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddTimezoneToUsers < ActiveRecord::Migration[8.1]
+  def change
+    # Nullable on purpose: NULL means the user has never picked a timezone, which
+    # has to stay distinguishable from them explicitly picking the default one.
+    add_column :users, :timezone, :string
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -2923,6 +2923,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
     t.string "slug"
     t.datetime "subscribed_to_loops_at"
     t.boolean "teenager"
+    t.string "timezone"
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "use_sms_auth", default: false
     t.boolean "use_two_factor_authentication", default: false

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -133,6 +133,20 @@ RSpec.describe UsersController do
     end
   end
 
+  describe "#edit" do
+    render_views
+
+    it "offers a timezone picker that starts on automatic detection" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      get(:edit, params: { id: user.id })
+
+      expect(response.body).to include("Detect automatically")
+      expect(response.body).to include("Pacific Time (US &amp; Canada)")
+    end
+  end
+
   describe "#update" do
     render_views
 
@@ -258,6 +272,27 @@ RSpec.describe UsersController do
       expect(response).to have_http_status(:unprocessable_content)
       expect(flash.to_h["error"]).to include(reason)
       expect(user.reload.default_payout_method).to be_nil
+    end
+
+    it "saves the chosen timezone" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      patch(:update, params: { id: user.id, user: { timezone: "Pacific Time (US & Canada)" } })
+
+      expect(response).to have_http_status(:found)
+      expect(user.reload.timezone).to eq("Pacific Time (US & Canada)")
+      expect(user.resolved_timezone.tzinfo.identifier).to eq("America/Los_Angeles")
+    end
+
+    it "clears the timezone back to the inferred guess when left blank" do
+      user = create(:user, timezone: "Pacific Time (US & Canada)")
+      create_session(user, verified: true)
+
+      patch(:update, params: { id: user.id, user: { timezone: "" } })
+
+      expect(response).to have_http_status(:found)
+      expect(user.reload.timezone).to be_nil
     end
   end
 

--- a/spec/models/user/timezone_spec.rb
+++ b/spec/models/user/timezone_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User do
+  let(:user) { create(:user) }
+
+  def report_timezone(timezone, last_seen_at: Time.current, count: 1)
+    count.times { create(:user_session, user:, timezone:, last_seen_at:) }
+  end
+
+  describe "#resolved_timezone" do
+    it "prefers the configured timezone over anything the browser reported" do
+      report_timezone("America/Los_Angeles", count: 5)
+      user.update!(timezone: "Eastern Time (US & Canada)")
+
+      expect(user.resolved_timezone.tzinfo.identifier).to eq("America/New_York")
+    end
+
+    it "falls back to the inferred timezone when nothing is configured" do
+      report_timezone("America/Los_Angeles", count: 5)
+
+      expect(user.timezone).to be_nil
+      expect(user.resolved_timezone).to eq(ActiveSupport::TimeZone["America/Los_Angeles"])
+    end
+
+    it "falls back to the default when there is nothing to infer from" do
+      expect(user.resolved_timezone).to eq(User::DEFAULT_TIMEZONE)
+    end
+  end
+
+  describe "#inferred_timezone" do
+    it "takes the most common value rather than the most recent one" do
+      report_timezone("America/Chicago", last_seen_at: 1.month.ago, count: 4)
+      report_timezone("Europe/Berlin", last_seen_at: 1.day.ago)
+
+      expect(user.inferred_timezone).to eq(ActiveSupport::TimeZone["America/Chicago"])
+    end
+
+    it "breaks ties in favour of the more recently seen session" do
+      report_timezone("America/Chicago", last_seen_at: 1.month.ago)
+      report_timezone("Europe/Berlin", last_seen_at: 1.day.ago)
+
+      expect(user.inferred_timezone).to eq(ActiveSupport::TimeZone["Europe/Berlin"])
+    end
+
+    it "skips values ActiveSupport cannot resolve in favour of the next candidate" do
+      report_timezone("Etc/Unknown", count: 3)
+      report_timezone("UTC+480", count: 2)
+      report_timezone("Europe/Berlin")
+
+      expect(user.inferred_timezone).to eq(ActiveSupport::TimeZone["Europe/Berlin"])
+    end
+
+    it "is nil when no session reported anything usable" do
+      report_timezone("Etc/Unknown", count: 3)
+      report_timezone(nil)
+      report_timezone("")
+
+      expect(user.inferred_timezone).to be_nil
+    end
+  end
+
+  describe "the timezone attribute" do
+    it "stores an IANA identifier under the name the picker offers" do
+      user.update!(timezone: "America/New_York")
+
+      expect(user.reload.timezone).to eq("Eastern Time (US & Canada)")
+    end
+
+    it "collapses a blank choice back to nil so the guess resumes" do
+      user.update!(timezone: "Eastern Time (US & Canada)")
+      user.update!(timezone: "")
+
+      expect(user.reload.timezone).to be_nil
+    end
+
+    it "rejects a timezone that is not a real one" do
+      user.timezone = "Middle Earth"
+
+      expect(user).not_to be_valid
+      expect(user.errors[:timezone]).to be_present
+    end
+  end
+
+  describe ".selectable_timezone_name" do
+    it "translates an IANA identifier into the equivalent option" do
+      expect(described_class.selectable_timezone_name("Europe/Berlin")).to eq("Berlin")
+    end
+
+    it "is nil for a zone with no equivalent option" do
+      expect(described_class.selectable_timezone_name("Etc/Unknown")).to be_nil
+      expect(described_class.selectable_timezone_name(nil)).to be_nil
+    end
+  end
+end

--- a/spec/tasks/maintenance/backfill_user_timezones_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_user_timezones_task_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::BackfillUserTimezonesTask do
+  describe "#collection" do
+    it "includes a user with a reported session timezone and no preference" do
+      user = create(:user)
+      create(:user_session, user:, timezone: "America/Los_Angeles")
+
+      expect(described_class.new.collection).to include(user)
+    end
+
+    it "excludes a user who has already chosen a timezone" do
+      user = create(:user, timezone: "Eastern Time (US & Canada)")
+      create(:user_session, user:, timezone: "America/Los_Angeles")
+
+      expect(described_class.new.collection).not_to include(user)
+    end
+
+    it "excludes a user whose sessions reported nothing" do
+      user = create(:user)
+      create(:user_session, user:, timezone: nil)
+
+      expect(described_class.new.collection).not_to include(user)
+    end
+  end
+
+  describe "#process" do
+    it "writes the inferred timezone under the name the picker offers" do
+      user = create(:user)
+      create(:user_session, user:, timezone: "America/Los_Angeles")
+
+      described_class.new.process(user)
+
+      expect(user.reload.timezone).to eq("Pacific Time (US & Canada)")
+    end
+
+    it "leaves the preference unset when nothing usable was reported" do
+      user = create(:user)
+      create(:user_session, user:, timezone: "Etc/Unknown")
+
+      described_class.new.process(user)
+
+      expect(user.reload.timezone).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

HCB stores no timezone preference for users, so anything that has to render a time outside the browser (emails, most notably) has no way to know which timezone the recipient actually reads times in. The best we can do today is guess.

## Describe your changes

Adds a nullable `timezone` column to `users` and a picker for it in account settings, alongside the guess rather than instead of it.

- **`User#resolved_timezone`** is the single method the rest of the app should call. Precedence: the configured timezone, then a timezone inferred from what the browser reported at sign-in across recent sessions, then `User::DEFAULT_TIMEZONE`.
- **`User#inferred_timezone`** takes the mode over recent sessions (not the latest) so a trip does not repoint someone for a fortnight after they get home, and skips values `ActiveSupport::TimeZone` cannot resolve. It returns `nil` when nothing usable was reported, so callers can tell a real guess apart from the default.
- **The column is nullable on purpose.** NULL means "never chosen" and has to stay distinguishable from someone explicitly choosing the default, which is also why the picker has a "Detect automatically" blank option and why `Maintenance::BackfillUserTimezonesTask` only writes a value for users we can actually infer one for.
- `ActiveSupport::TimeZone` resolves both IANA identifiers and Rails' friendlier names, but the picker only offers the latter. A `normalizes` translates to the picker's form on write, so a saved choice is always one the select can show back to the user. A validation rejects anything else.
- Copy under the picker notes that the website always renders in the browser's current timezone while emails use this setting.

Specs cover the resolution precedence, the inference rules, normalization and validation, the controller params path, and the backfill task.

### Follow-ups

- Nothing reads `resolved_timezone` yet. Moving existing mailers, views, and reports onto it is deliberately left to a separate PR so this one stays reviewable.
- No sweep of the codebase for timezone correctness was done here.

### Conflict note

#14601 (`card-locking-suppression-copy`) adds `assumed_timezone`, `DEFAULT_TIMEZONE`, and `TIMEZONE_SESSION_SAMPLE` to `app/models/user.rb` in the same spot, so whichever merges second will conflict there. **This branch's side should win.** It keeps `assumed_timezone` behaviourally identical, just splitting the session lookup out into `inferred_timezone` so the "no usable guess" case is expressible, and the constants are the same on both sides.
