### PR TITLE
[HcbCode] Fix #events re-querying on every call

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -264,23 +264,26 @@ class HcbCode < ApplicationRecord
                 .compact
                 .uniq
 
-        return Event.where(id: ids) unless ids.empty?
+        # Only fall back to the linked objects when the mappings gave us nothing.
+        # This can't `return` early: that would exit the method before `@events`
+        # is assigned, so every call would re-run the two plucks above.
+        if ids.empty?
+          ids.concat([
+            invoice.try(:event).try(:id),
+            donation.try(:event).try(:id),
+            ach_transfer.try(:event).try(:id),
+            check.try(:event).try(:id),
+            increase_check.try(:event).try(:id),
+            outgoing_disbursement.try(:event).try(:id),
+            incoming_disbursement.try(:event).try(:id),
+            check_deposit.try(:event).try(:id),
+            bank_fee.try(:event).try(:id),
+          ].compact.uniq)
 
-        ids.concat([
-          invoice.try(:event).try(:id),
-          donation.try(:event).try(:id),
-          ach_transfer.try(:event).try(:id),
-          check.try(:event).try(:id),
-          increase_check.try(:event).try(:id),
-          outgoing_disbursement.try(:event).try(:id),
-          incoming_disbursement.try(:event).try(:id),
-          check_deposit.try(:event).try(:id),
-          bank_fee.try(:event).try(:id),
-        ].compact.uniq)
-
-        ids << EventMappingEngine::EventIds::INCOMING_FEES if incoming_bank_fee?
-        ids << EventMappingEngine::EventIds::HACK_CLUB_BANK if fee_revenue? || stripe_service_fee? || outgoing_fee_reimbursement?
-        ids << EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING if reimbursement_payout_holding?
+          ids << EventMappingEngine::EventIds::INCOMING_FEES if incoming_bank_fee?
+          ids << EventMappingEngine::EventIds::HACK_CLUB_BANK if fee_revenue? || stripe_service_fee? || outgoing_fee_reimbursement?
+          ids << EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING if reimbursement_payout_holding?
+        end
 
         Event.where(id: ids)
       end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe HcbCode, type: :model do
+  def query_count(&block)
+    count = 0
+    callback = ->(*, payload) { count += 1 unless payload[:name] == "SCHEMA" || payload[:cached] }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    count
+  end
+
   describe "disbursement integration" do
     describe "#outgoing_disbursement?" do
       it "returns true for HCB-500-* codes" do
@@ -172,9 +179,17 @@ RSpec.describe HcbCode, type: :model do
 
         it "returns both source and destination events" do
           hcb_code = HcbCode.find_by(hcb_code: disbursement.outgoing_hcb_code)
-          hcb_code.instance_variable_set(:@events, nil)
 
           expect(hcb_code.events).to contain_exactly(source_event, destination_event)
+        end
+
+        # The ledger calls this once per row, so a miss here is an N+1 across the
+        # whole page.
+        it "does not re-run the mapping lookup on repeat calls" do
+          hcb_code = HcbCode.find_by(hcb_code: disbursement.outgoing_hcb_code)
+
+          expect(query_count { hcb_code.events.to_a }).to be_positive
+          expect(query_count { hcb_code.events.to_a }).to eq(0)
         end
       end
 
@@ -215,7 +230,6 @@ RSpec.describe HcbCode, type: :model do
 
         it "returns the first event" do
           hcb_code = HcbCode.find_by(hcb_code: disbursement.outgoing_hcb_code)
-          hcb_code.instance_variable_set(:@events, nil)
 
           expect(hcb_code.event).to eq(source_event)
         end


### PR DESCRIPTION
## Summary of the problem

`HcbCode#events` wraps its body in `@events ||=`, but the mapped-events path returns from inside that block:

```ruby
def events
  @events ||=
    begin
      ids = [...plucks...]

      return Event.where(id: ids) unless ids.empty?   # exits the method
      ...
    end
end
```

`return` exits the method, so the assignment never happens. Every call re-runs both plucks, for the whole life of the object. The memoization has never worked on the common path, only on the fallback one.

This shows up worst on the ledger, which asks per row whether a transaction belongs to the organization: 100 rows meant 200 queries where 2 would do.

## Describe your changes

Replaces the early return with a conditional so the fallback to linked objects still only runs when the mappings produced nothing. Behaviour is otherwise identical; both existing `#events` cases keep passing.

Added a spec asserting the first call queries and a repeat call does not. It fails without the fix (3 queries on the repeat).

Also removed two `hcb_code.instance_variable_set(:@events, nil)` pokes from the existing specs. They read as though they were resetting memoized state, but `HcbCode.find_by` returns a fresh instance every time, so they were no-ops.
