### PR TITLE
[Card Locking] Stop nagging cardholders during an suppresion

### DIFF
--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -11,12 +11,10 @@ class CardLockingMailer < ApplicationMailer
     mail to: user.email, subject: "[Urgent] Your HCB cards are locked until you upload your receipts"
   end
 
-  # suppressed_until is set when the unlock came from an admin suppression rather
-  # than from the cardholder clearing their receipts. Their receipts are still
-  # overdue and their cards lock again when it expires, so the copy has to say so
-  # and show them what to upload. Passed in rather than read off the user here,
-  # because the mail is delivered later and the suppression may have been changed
-  # or lifted by then; the reason for the unlock is fixed at the moment it happens.
+  # suppressed_until means an admin granted the unlock rather than the cardholder
+  # clearing receipts: the receipts are still overdue and the cards lock again
+  # when it expires, so the copy has to say so. Passed in rather than read off the
+  # user, because delivery is deferred and the suppression may change by then.
   def cards_unlocked(user:, suppressed_until: nil)
     @user = user
     @suppressed_until = suppressed_until
@@ -33,12 +31,49 @@ class CardLockingMailer < ApplicationMailer
     end
   end
 
+  # A courtesy nudge partway through an exception. Names the deadline the
+  # cardholder already has rather than threatening a lock, as the ordinary
+  # pre-lock digest would.
+  def suppression_reminder(user:, suppressed_until:)
+    assign_suppression(user:, suppressed_until:)
+
+    mail to: user.email, subject: "You have #{@count} #{'receipt'.pluralize(@count)} to upload before #{@suppressed_until.in_time_zone(@timezone).strftime('%b %-d')}"
+  end
+
+  # `final` is the last call, roughly an hour out. Deliberately vague about how
+  # long: the sweep runs every few minutes, so a countdown would be wrong.
+  def suppression_ending(user:, suppressed_until:, final: false)
+    assign_suppression(user:, suppressed_until:)
+    @final = final
+
+    subject = if final
+                "Your card locking exception ends in about an hour"
+              else
+                "Your card locking exception ends #{@suppressed_until.in_time_zone(@timezone).strftime('%b %-d')}"
+              end
+
+    mail to: user.email, subject:
+  end
+
   def warning(user:)
     @user = user
     @hcb_codes = user.card_locking_outstanding_charges.to_a
     @count = @hcb_codes.size
     @show_org = user.events.size > 1
     mail to: user.email, subject: "You have #{@count} receipt#{'s' unless @count == 1} to upload"
+  end
+
+  private
+
+  # Overdue charges rather than the whole outstanding pile, because overdue is
+  # what locks the cards when the exception ends.
+  def assign_suppression(user:, suppressed_until:)
+    @user = user
+    @suppressed_until = suppressed_until
+    @hcb_codes = user.card_locking_overdue_charges.to_a
+    @count = @hcb_codes.size
+    @show_org = user.events.size > 1
+    @timezone = user.assumed_timezone
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -366,19 +366,15 @@ class User < ApplicationRecord
     words.any? ? words.map(&:first).join.upcase : name
   end
 
-  # HCB stores no timezone preference, so this infers one from sessions, whose
-  # timezone the browser reports at sign-in. A guess, only ever for presenting a
-  # time back to the user. Never compute a deadline from it.
+  # HCB stores no timezone preference, so this infers one from the timezone the
+  # browser reports at sign-in. A guess, only for presenting a time back to the
+  # user; never compute a deadline from it. (VPNs need no handling: the browser
+  # reads this from the OS, not the IP.)
   #
-  # Takes the most common value across recent sessions rather than the latest, so
-  # a trip does not repoint someone's timezone for a fortnight after they get
-  # home. Ties go to the more recent. A VPN needs no handling: the browser reads
-  # this from the operating system, not from the IP address, so tunnelling through
-  # another country does not change it.
-  #
-  # Most values are IANA names, but some browsers report things ActiveSupport
-  # cannot resolve ("Etc/Unknown", "UTC+480", bare offsets). Those are skipped in
-  # favour of the next best candidate rather than falling straight to the default.
+  # Most common value across recent sessions rather than the latest, so a trip
+  # does not repoint someone's timezone for weeks after they get home; ties go to
+  # the more recent. Values ActiveSupport cannot resolve ("Etc/Unknown", "UTC+480")
+  # are skipped in favour of the next candidate rather than dropping to the default.
   DEFAULT_TIMEZONE = ActiveSupport::TimeZone["America/New_York"]
   TIMEZONE_SESSION_SAMPLE = 20
 

--- a/app/services/card_locking.rb
+++ b/app/services/card_locking.rb
@@ -75,10 +75,25 @@ module CardLocking
     ENFORCEMENT_STAGES.filter_map { |flag, date| date if Flipper.enabled?(flag, user) }.min
   end
 
-  # A deadline as it appears in cardholder-facing copy, in the cardholder's own
-  # timezone (see User#time_zone, inferred from their last session). The zone
-  # abbreviation is kept because the inference can be wrong, and a labelled time
-  # someone can sanity-check beats a bare one they cannot.
+  # How often to remind a cardholder mid-exception that receipts are outstanding.
+  # Far softer than the daily pre-lock digest: they were granted relief, so this
+  # is a courtesy, not a nudge.
+  SUPPRESSION_REMINDER_INTERVAL = 3.days
+
+  # The last call before an exception expires. The sweep runs every few minutes,
+  # so treat this as approximate and never print it as a countdown.
+  SUPPRESSION_FINAL_LEAD = 1.hour
+
+  # Cache key for one suppression message. The ending notices carry the deadline
+  # they were sent for, so extending or shortening an exception re-arms them for
+  # the new date instead of being swallowed by an already-warned flag.
+  def self.suppression_notice_key(stage, user_id, suppressed_until = nil)
+    ["card_locking_suppression", stage, user_id, suppressed_until&.to_i].compact.join(":")
+  end
+
+  # A deadline as it appears in cardholder-facing copy, in their own timezone (see
+  # User#assumed_timezone). The zone abbreviation stays because that inference can
+  # be wrong, and a labelled time can be sanity-checked.
   def self.format_deadline(time, zone)
     time.in_time_zone(zone).strftime("%b %-d at %-l:%M %p %Z")
   end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -4,8 +4,9 @@ module UserService
   # Sends a once-a-day "you have receipts to upload" pile warning. No per-charge
   # countdown; names a count, never a deadline. Deduped per cardholder per day.
   class SendCardLockingNotification
-    def initialize(user:)
+    def initialize(user:, now: Time.current)
       @user = user
+      @now = now
     end
 
     def run
@@ -16,6 +17,11 @@ module UserService
       # email/SMS plus the persistent banner/inbox already cover it; sending
       # this too would nag a locked user with copy about keeping cards active.
       return if @user.cards_locked?
+
+      # A cardholder under an admin exception gets a different, gentler sequence.
+      # The daily digest below would tell someone who was just granted time that
+      # their cards "will lock until you do", every day for up to a month.
+      return run_suppressed if @user.card_locking_suppressed?(now: @now)
 
       # Only nudge when at least one charge is actually approaching its deadline.
       # A cardholder whose charges are all still fresh (a full week of runway)
@@ -38,6 +44,72 @@ module UserService
     end
 
     private
+
+    # The exception sequence, one message per sweep, most urgent first. The
+    # reminder is only eligible while more than WARNING_LEAD_TIME remains and the
+    # notices only once less does, so a short exception cannot fire a reminder and
+    # an ending notice minutes apart.
+    #
+    # Keyed off time remaining rather than how long the exception was granted for:
+    # only card_locking_suppressed_until is stored, so the window length is not
+    # knowable here.
+    def run_suppressed
+      suppressed_until = @user.card_locking_suppressed_until
+      remaining = suppressed_until - @now
+
+      count = @user.card_locking_overdue_charges(now: @now).count("hcb_codes.id")
+      return if count.zero?
+
+      if remaining <= CardLocking::SUPPRESSION_FINAL_LEAD
+        deliver_ending(suppressed_until:, stage: :final, final: true)
+      elsif remaining <= CardLocking::WARNING_LEAD_TIME
+        deliver_ending(suppressed_until:, stage: :ending, final: false)
+      else
+        deliver_reminder(suppressed_until:, count:)
+      end
+    end
+
+    # Once per deadline. Keying on suppressed_until is what re-arms an extended or
+    # shortened exception: a new deadline is a new key, so the cardholder is told
+    # about the date that now applies.
+    def deliver_ending(suppressed_until:, stage:, final:)
+      key = CardLocking.suppression_notice_key(stage, @user.id, suppressed_until)
+      return unless Rails.cache.write(key, true, expires_in: 30.days, unless_exist: true)
+
+      begin
+        CardLockingMailer.suppression_ending(user: @user, suppressed_until:, final:).deliver_later
+      rescue
+        Rails.cache.delete(key)
+        raise
+      end
+
+      User::SendSmsJob.perform_later(user_id: @user.id, body: ending_sms(suppressed_until:, final:))
+    end
+
+    # Email only. SMS is the intrusive channel and this cardholder was granted
+    # relief, so it is held back for the ending notices and the lock itself. The
+    # unlock notice claims this key when the exception starts, so the first
+    # reminder lands an interval later rather than on the next sweep.
+    def deliver_reminder(suppressed_until:, count:)
+      key = CardLocking.suppression_notice_key(:reminder, @user.id)
+      return unless Rails.cache.write(key, true, expires_in: CardLocking::SUPPRESSION_REMINDER_INTERVAL, unless_exist: true)
+
+      begin
+        CardLockingMailer.suppression_reminder(user: @user, suppressed_until:).deliver_later
+      rescue
+        Rails.cache.delete(key)
+        raise
+      end
+    end
+
+    def ending_sms(suppressed_until:, final:)
+      count = @user.card_locking_overdue_charges(now: @now).count("hcb_codes.id")
+      noun = "receipt".pluralize(count)
+      deadline = CardLocking.format_deadline(suppressed_until, @user.assumed_timezone)
+      when_it_ends = final ? "in about an hour, at #{deadline}" : "on #{deadline}"
+
+      "Your HCB card locking exception ends #{when_it_ends}. Upload your #{count} overdue #{noun} before then or your cards will lock. #{CardLocking.inbox_url}"
+    end
 
     # Keys are claimed before enqueue; release on failure so a transient error
     # does not mute the notification for the cache TTL.

--- a/app/services/user_service/update_card_locking.rb
+++ b/app/services/user_service/update_card_locking.rb
@@ -73,13 +73,22 @@ module UserService
       send_sms(locked_message(now:))
     end
 
-    # An unlock has two very different causes. Clearing your receipts earns the
-    # plain "your cards work again". An admin suppression does not: the receipts
-    # are still overdue and the cards lock again when it expires, so telling that
-    # cardholder their cards work again full stop would be a promise HCB breaks on
-    # a date they were never told.
+    # Clearing your receipts earns the plain "your cards work again". A suppression
+    # does not: the receipts are still overdue and the cards lock again when it
+    # expires, so the plain copy would be a promise broken on a date the
+    # cardholder was never told.
     def notify_unlocked(now:)
       suppressed_until = @user.card_locking_suppressed_until if @user.card_locking_suppressed?(now:)
+
+      # Start the reminder clock here: the reminder fires when its key is absent,
+      # so without this claim the sweep would send one moments from now saying the
+      # same thing as this notice.
+      if suppressed_until
+        Rails.cache.write(
+          CardLocking.suppression_notice_key(:reminder, @user.id),
+          true, expires_in: CardLocking::SUPPRESSION_REMINDER_INTERVAL
+        )
+      end
 
       CardLockingMailer.cards_unlocked(user: @user, suppressed_until:).deliver_later
       send_sms(unlocked_message(suppressed_until, now:))

--- a/app/views/card_locking_mailer/_transactions_table.html.erb
+++ b/app/views/card_locking_mailer/_transactions_table.html.erb
@@ -10,8 +10,7 @@
     </tr>
   </thead>
   <tbody>
-    <%# Oldest first: the charge that has been outstanding longest is the most %>
-    <%# overdue, so it is the one to upload first. %>
+    <%# Oldest first: the longest-outstanding charge is the most overdue. %>
     <% hcb_codes.sort_by { |hcb| hcb.card_charge_settled_at || hcb.created_at }.each do |hcb| %>
       <tr>
         <td><%= link_to render_money(hcb.amount_cents.abs.to_s), attach_receipt_url(hcb) %></td>

--- a/app/views/card_locking_mailer/suppression_ending.html.erb
+++ b/app/views/card_locking_mailer/suppression_ending.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <% if @final %>
+    Your one time exception from the HCB team ends in about an hour, at <strong><%= CardLocking.format_deadline(@suppressed_until, @timezone) %></strong>.
+  <% else %>
+    Your one time exception from the HCB team ends on <strong><%= CardLocking.format_deadline(@suppressed_until, @timezone) %></strong>.
+  <% end %>
+</p>
+<p>
+  You still have <%= @count %> overdue <%= "receipt".pluralize(@count) %>, and your cards will lock when the exception ends. Upload <%= @count == 1 ? "it" : "them" %> before then and your cards keep working.
+</p>
+<%= render "transactions_table", hcb_codes: @hcb_codes, show_org: @show_org %>

--- a/app/views/card_locking_mailer/suppression_reminder.html.erb
+++ b/app/views/card_locking_mailer/suppression_reminder.html.erb
@@ -1,0 +1,7 @@
+<p>
+  Your cards work again until <strong><%= CardLocking.format_deadline(@suppressed_until, @timezone) %></strong>, as a one time exception from the HCB team.
+</p>
+<p>
+  Upload your overdue <%= "receipt".pluralize(@count) %> before the exception ends, or your cards will lock again. <%= @count == 1 ? "This receipt is" : "These #{@count} receipts are" %> still missing:
+</p>
+<%= render "transactions_table", hcb_codes: @hcb_codes, show_org: @show_org %>

--- a/spec/mailers/card_locking_mailer_spec.rb
+++ b/spec/mailers/card_locking_mailer_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe CardLockingMailer, type: :mailer do
     end
 
     # No sessions on this cardholder, so the deadline renders in the default zone
-    # rather than UTC. Getting this wrong shows someone a time hours off the one
-    # their cards actually lock at.
+    # rather than UTC.
     it "renders the deadline in the cardholder's assumed timezone" do
       hcb_code = create_settled_card_charge(user:, settled_at: 10.days.ago)
       hcb_code.update!(card_charge_settled_at: 10.days.ago, receipt_due_at: 1.day.ago)

--- a/spec/models/user/assumed_timezone_spec.rb
+++ b/spec/models/user/assumed_timezone_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe User, type: :model do
       expect(user.assumed_timezone.name).to eq("Europe/London")
     end
 
-    # A fortnight abroad should not repoint someone's timezone once they are home.
     it "prefers the most common timezone over the most recent one" do
       5.times { |i| session_with("America/Chicago", last_seen_at: (10 + i).days.ago) }
       session_with("Asia/Tokyo", last_seen_at: 1.day.ago)
@@ -35,8 +34,6 @@ RSpec.describe User, type: :model do
       expect(user.assumed_timezone.name).to eq("Europe/Berlin")
     end
 
-    # Some browsers report values ActiveSupport cannot resolve. Skipping to the
-    # next candidate keeps a usable guess instead of dropping to the default.
     it "skips values ActiveSupport cannot resolve" do
       3.times { |i| session_with("UTC+480", last_seen_at: (10 + i).days.ago) }
       session_with("Europe/Lisbon", last_seen_at: 1.day.ago)

--- a/spec/services/user_service/send_card_locking_notification_suppressed_spec.rb
+++ b/spec/services/user_service/send_card_locking_notification_suppressed_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserService::SendCardLockingNotification, "under an admin exception", type: :service do
+  include_context "card locking charges"
+
+  let(:now) { Time.zone.parse("2026-10-10 12:00:00") }
+
+  # The suite runs against a null cache store, but every dedup rule here is
+  # enforced by the cache, so it has to be real for these to mean anything.
+  # Both of these are global state, and both are restored in an ensure so a
+  # failing example cannot leak them into the rest of the suite. The clock in
+  # particular: examples here travel forward to age a dedup key, and leaving it
+  # in 2026-10 breaks unrelated specs whose factories validate against Time.now.
+  around do |example|
+    original_cache = Rails.cache
+    # The suite runs against a null cache store, but every dedup rule here is
+    # enforced by the cache, so it has to be real for these to mean anything.
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    travel_to(now)
+    example.run
+  ensure
+    travel_back
+    Rails.cache = original_cache
+  end
+
+  # The shared context enables the rollout stage flag, not the kill switch.
+  before { Flipper.enable(:card_locking) }
+
+  def enqueued_mailer_methods
+    ActiveJob::Base.queue_adapter.enqueued_jobs
+                   .select { |job| job[:job] == MailDeliveryJob && job[:args].first == "CardLockingMailer" }
+                   .map { |job| job[:args].second }
+  end
+
+  def enqueued_sms_count
+    ActiveJob::Base.queue_adapter.enqueued_jobs.count { |job| job[:job] == User::SendSmsJob }
+  end
+
+  def overdue_charge
+    settled_at = 10.days.ago
+    create_settled_card_charge(user:, settled_at:).tap do |charge|
+      charge.update_columns(card_charge_settled_at: settled_at, receipt_due_at: 1.day.ago)
+    end
+  end
+
+  def suppress_until(time)
+    user.update!(card_locking_suppressed_until: time)
+  end
+
+  # Clear first so assertions cover only what this run enqueued. reload because
+  # the cardholder association is memoized before the charge creates it, without
+  # which card_locking_overdue_charges returns nothing.
+  def run(at: now)
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    described_class.new(user: user.reload, now: at).run
+  end
+
+  it "does not send the ordinary pre-lock digest, which contradicts the exception" do
+    overdue_charge
+    suppress_until(now + 10.days)
+
+    expect { run }.not_to have_enqueued_mail(CardLockingMailer, :warning)
+  end
+
+  describe "the reminder, while there is plenty of time left" do
+    before do
+      overdue_charge
+      suppress_until(now + 10.days)
+    end
+
+    it "sends by email only, holding SMS back for the ending notices" do
+      run
+
+      expect(enqueued_mailer_methods).to eq(["suppression_reminder"])
+      expect(enqueued_sms_count).to eq(0)
+    end
+
+    it "does not repeat within the reminder interval" do
+      run
+      soon = now + CardLocking::SUPPRESSION_REMINDER_INTERVAL - 1.hour
+      travel_to(soon)
+
+      expect { run(at: soon) }.not_to have_enqueued_mail(CardLockingMailer, :suppression_reminder)
+    end
+
+    it "repeats once the interval has passed" do
+      run
+      later = now + CardLocking::SUPPRESSION_REMINDER_INTERVAL + 1.minute
+      travel_to(later)
+
+      expect { run(at: later) }.to have_enqueued_mail(CardLockingMailer, :suppression_reminder)
+    end
+  end
+
+  describe "the ending notices" do
+    it "sends the 48h notice by email and SMS" do
+      overdue_charge
+      suppress_until(now + 40.hours)
+
+      run
+
+      expect(enqueued_mailer_methods).to eq(["suppression_ending"])
+      expect(enqueued_sms_count).to eq(1)
+    end
+
+    it "sends the final notice within the last hour" do
+      overdue_charge
+      suppress_until(now + 30.minutes)
+
+      expect { run }.to have_enqueued_mail(CardLockingMailer, :suppression_ending)
+    end
+
+    it "sends each stage only once for a given deadline" do
+      overdue_charge
+      suppress_until(now + 40.hours)
+      run
+
+      expect { run(at: now + 5.minutes) }.not_to have_enqueued_mail(CardLockingMailer, :suppression_ending)
+    end
+
+    # A plain "already warned" flag would swallow the warning for the new date.
+    it "re-sends after the exception is extended" do
+      overdue_charge
+      suppress_until(now + 40.hours)
+      run
+
+      suppress_until(now + 44.hours)
+
+      expect { run(at: now + 5.minutes) }.to have_enqueued_mail(CardLockingMailer, :suppression_ending)
+    end
+  end
+
+  # A 5 day exception is the colliding case: its 3 day reminder falls exactly on
+  # the 48h notice.
+  it "never sends a reminder alongside an ending notice" do
+    overdue_charge
+    suppress_until(now + 5.days)
+    at = now + 3.days
+    travel_to(at)
+
+    run(at:)
+
+    expect(enqueued_mailer_methods).to eq(["suppression_ending"])
+  end
+
+  it "sends nothing once the cardholder has uploaded everything" do
+    suppress_until(now + 10.days)
+
+    expect { run }.not_to have_enqueued_mail(CardLockingMailer, :suppression_reminder)
+    expect { run }.not_to have_enqueued_mail(CardLockingMailer, :suppression_ending)
+  end
+end

--- a/spec/services/user_service/update_card_locking_spec.rb
+++ b/spec/services/user_service/update_card_locking_spec.rb
@@ -77,8 +77,6 @@ RSpec.describe UserService::UpdateCardLocking, type: :service do
     expect { described_class.new(user:).run }.not_to(change { user.reload.cards_locked? })
   end
 
-  # A suppression unlock is temporary and the receipts are still overdue, so the
-  # notification has to carry the expiry rather than the plain "cards work again".
   it "tells a cardholder unlocked by suppression when the exception ends" do
     user.update!(cards_locked: true, card_locking_suppressed_until: 24.hours.from_now)
     allow(user).to receive(:card_locking_has_overdue_charge?).and_return(true)


### PR DESCRIPTION
> Stacked on #14601 — review that first.

## Summary of the problem

`SendCardLockingNotification` only checks `cards_locked?`, and a cardholder under an admin exception is *unlocked*. So they clear every guard and receive the ordinary pre-lock digest:

> You have 4 receipts to upload. Your cards will lock until you do.

Every day, by email and SMS, for as long as the exception runs, which can be a month. It contradicts what the exception just told them, and it lands on the one person who was explicitly granted relief.

There was also no warning before an exception expired. Cards lock on the first sweep after it ends, and the only message that mentioned the date was the unlock notice, possibly weeks earlier.

## Describe your changes

An exception now gets its own sequence, escalating as it runs out:

| Time remaining | Message | Channel |
|---|---|---|
| more than 48h | Reminder, at most once every 3 days | Email |
| 48h or less | Ending notice | Email + SMS |
| 1h or less | Final notice | Email + SMS |

Each carries the oldest-first table of overdue charges with signed upload links. Nothing sends once there are no overdue receipts. The lock at expiry is unchanged.

**The stages cannot collide.** The reminder is the only one eligible above `WARNING_LEAD_TIME`, and the notices are the only ones eligible below it. Without that split, a five day exception would fire its three day reminder and its ending notice minutes apart. The unlock notice claims the reminder key when the exception starts, so the first reminder lands an interval later rather than on the very next sweep.

**Extending an exception re-arms the notices.** Both dedup on the `suppressed_until` they were sent for, so a new deadline is a new key and the cardholder is warned about the date that now applies. An "already warned" flag would swallow the second warning entirely. Shortening re-arms them too, which is also right.

Everything keys off *time remaining* rather than how long the exception was granted for. Only `card_locking_suppressed_until` is stored, so the length of the window is not knowable here.

The final notice says "in about an hour" and gives the clock time rather than a countdown, because the sweep runs every few minutes and cannot honour one.

There is deliberately no "you uploaded everything" variant. Nothing is being asked of the cardholder, and clearing the last overdue receipt already unlocks synchronously and says so.

## Notes for review

**Test isolation.** The new spec swaps `Rails.cache` for a real store (the suite uses a null store, and every dedup rule here is cache-enforced) and travels the clock forward to age keys. Both are restored in an `ensure`. This matters: an earlier version leaked the clock and broke `PayoutService::Invoice::Create` through an unrelated factory's `due_date` validation. Worth knowing that `travel_to` in this suite is not automatically undone.
