### PR TITLE
[Ledger] Only load stripe card and card grant transactions when `new_ledger_everywhere_2026_07_13` enabled

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -44,10 +44,12 @@ class CardGrantsController < ApplicationController
 
     @per = params[:per] || 25
     @table_only = true
-    @ledger = @event.ledger
-    @items = ledger_query.execute(ledgers: @ledgers)
-    @items = @items.where(id: HcbCode.where(id: HcbCodeTag.where(tag_id: @tag.id).select(:hcb_code_id)).select(:ledger_item_id)) if @tag&.id.present?
-    @items = @items.page(params[:page]).per(@per)
+    if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
+      @ledger = @event.ledger
+      @items = ledger_query.execute(ledgers: @ledgers)
+      @items = @items.where(id: HcbCode.where(id: HcbCodeTag.where(tag_id: @tag.id).select(:hcb_code_id)).select(:ledger_item_id)) if @tag&.id.present?
+      @items = @items.page(params[:page]).per(@per)
+    end
   end
 
   def new
@@ -223,10 +225,12 @@ class CardGrantsController < ApplicationController
     @card = @card_grant.stripe_card
     @hcb_codes = @card_grant.visible_hcb_codes
 
-    @per = params[:per] || 25
-    @table_only = true
-    @ledger = @card_grant.ledger
-    @items = Ledger::Query.new({}).execute(ledgers: [@card_grant.ledger]).page(params[:page]).per(@per)
+    if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
+      @per = params[:per] || 25
+      @table_only = true
+      @ledger = @card_grant.ledger
+      @items = Ledger::Query.new({}).execute(ledgers: [@card_grant.ledger]).page(params[:page]).per(@per)
+    end
 
     @show_card_details = params[:show_details] == "true"
 

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -83,17 +83,19 @@ class StripeCardsController < ApplicationController
                       .includes(canonical_pending_transactions: [:raw_pending_stripe_transaction], canonical_transactions: :transaction_source)
                       .page(params[:page]).per(params[:per] || 25)
 
-    # Grant cards (viewable here by auditors) keep their charges on the card
-    # grant's ledger rather than the event's.
-    @per = params[:per] || 25
-    @table_only = true
-    @ledger = @card.card_grant&.ledger || @event.ledger
-    # TODO: Swap this out for Ledger::Query once Stripe cards have their own non-primary ledgers
-    @items = @ledger.items
-                    .includes(:canonical_transactions, :canonical_pending_transactions, :linked_object)
-                    .where(linked_object_type: "CardCharge", linked_object_id: @card.card_charges.select(:id))
-                    .order(datetime: :desc, created_at: :desc, id: :desc)
-                    .page(params[:page]).per(@per)
+    if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
+      # Grant cards (viewable here by auditors) keep their charges on the card
+      # grant's ledger rather than the event's.
+      @per = params[:per] || 25
+      @table_only = true
+      @ledger = @card.card_grant&.ledger || @event.ledger
+      # TODO: Swap this out for Ledger::Query once Stripe cards have their own non-primary ledgers
+      @items = @ledger.items
+                      .includes(:canonical_transactions, :canonical_pending_transactions, :linked_object)
+                      .where(linked_object_type: "CardCharge", linked_object_id: @card.card_charges.select(:id))
+                      .order(datetime: :desc, created_at: :desc, id: :desc)
+                      .page(params[:page]).per(@per)
+    end
 
     if params[:frame] == "true" && turbo_frame_request?
       @frame = true


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were always loading the records.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Only load records when the Flipper is enabled.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

