### PR TITLE
[Sub-org] Fix Excel export hiding the row grouping gutter

### DIFF
--- a/app/models/event/sub_organizations_export.rb
+++ b/app/models/event/sub_organizations_export.rb
@@ -18,9 +18,20 @@ class Event
       bold = workbook.add_format(bold: 1)
 
       worksheet = workbook.add_worksheet("Sub-organizations")
-      # Attach each group's collapse toggle to the parent row above it rather
-      # than the default summary row below.
-      worksheet.outline_settings(1, 0, 0, 0)
+      # Syntax: outline_settings(visible, symbols_below, symbols_right, auto_style)
+      #
+      # `symbols_below: 0` attaches each group's collapse toggle to the parent
+      # row above it rather than the default summary row below.
+      #
+      # `visible` and `auto_style` are inverted: write_xlsx guards them with a
+      # bare Ruby truthiness check, and `0` is truthy in Ruby, so any number
+      # turns them on. Passing `1` for `visible` writes
+      # `showOutlineSymbols="0"` onto <sheetView>, which hides the grouping
+      # gutter in Excel (Google Sheets ignores the attribute, which is why the
+      # tree looked fine there). `false` is the only value that leaves both
+      # attributes out.
+      # https://github.com/cxn03651/write_xlsx/blob/v1.12.3/lib/write_xlsx/worksheet.rb#L3618
+      worksheet.outline_settings(false, 0, 0, false)
       worksheet.set_column("A:A", 20)
       worksheet.set_column("B:C", 40)
       worksheet.set_column("D:D", 12)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -340,7 +340,11 @@ RSpec.describe EventsController do
         # Nested descendants are indented under their parent...
         expect(strings).to include("    #{nested.name}")
         # ...and grouped so Excel renders them collapsible.
-        expect(xlsx_entry(response.body, "xl/worksheets/sheet1.xml")).to include('outlineLevel="1"')
+        sheet = xlsx_entry(response.body, "xl/worksheets/sheet1.xml")
+        expect(sheet).to include('outlineLevel="1"')
+        # Excel hides the grouping gutter entirely when this attribute is set,
+        # even though Google Sheets ignores it. See SubOrganizationsExport.
+        expect(sheet).not_to include("showOutlineSymbols")
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem

The collapsible tree added in #14540 renders correctly in Google Sheets but the grouping gutter is missing entirely in Excel.

Unzipping an exported file shows the row grouping is present and correct:

```xml
<sheetFormatPr defaultRowHeight="15" outlineLevelRow="3"/>
<row r="3" spans="1:5" outlineLevel="1">
```

...but so is this:

```xml
<sheetView tabSelected="1" showOutlineSymbols="0" workbookViewId="0"/>
```

`showOutlineSymbols="0"` tells Excel to hide the outline gutter. Google Sheets ignores the attribute and draws the grouping anyway, which is why it only reproduced in Excel.

It comes from `outline_settings(1, 0, 0, 0)`. `write_xlsx` guards that flag with a bare truthiness check:

```ruby
# write_xlsx-1.12.3 worksheet.rb:3618 — "Turn outlines off"
attributes << ["showOutlineSymbols", 0] if @outline_on
```

`0` is truthy in Ruby, so *any* number turns it on — passing `1` for `visible` (meaning "show them") is exactly what hides them. The same bug on [line 4322](https://github.com/cxn03651/write_xlsx/blob/v1.12.3/lib/write_xlsx/worksheet.rb#L4322) is why exports also carried a stray `applyStyles="1"` despite `auto_style` being `0`.

## Describe your changes

- Pass `false` for `visible` and `auto_style`, the only value `write_xlsx` reads as off for those two. `symbols_below`/`symbols_right` use a correct `== 0` check, so `0` stays right there.
- Comment the inversion so nobody "cleans up" `false` back to `1`.
- Assert `showOutlineSymbols` is absent from the sheet in the existing tree spec, so this can't silently regress if the gem ever fixes its logic.

Verified against `write_xlsx` 1.12.3 directly — emitted XML after the change:

```xml
<sheetPr><outlinePr summaryBelow="0" summaryRight="0"/></sheetPr>
<sheetView tabSelected="1" workbookViewId="0"/>
<sheetFormatPr defaultRowHeight="15" outlineLevelRow="2"/>
<row r="3" spans="1:5" outlineLevel="1">
```
