### PR TITLE
[Card Locking] Tell cardholders when their next receipt is due

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -96,10 +96,10 @@ class MyController < ApplicationController
 
   def inbox
     @count = current_user.transactions_missing_receipt.count
-    @locking_count = current_user.card_locking_overdue_charges.count
-    # Drives the countdown in the card locking callout. Only queried for
-    # cardholders who can actually see that callout.
-    @locking_next_due_at = current_user.card_locking_next_due_at if CardLocking.enabled?
+    if CardLocking.enabled?
+      @locking_count = current_user.card_locking_overdue_charges.count
+      @locking_next_due_at = current_user.card_locking_next_due_at
+    end
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
 

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -97,6 +97,9 @@ class MyController < ApplicationController
   def inbox
     @count = current_user.transactions_missing_receipt.count
     @locking_count = current_user.card_locking_overdue_charges.count
+    # Drives the countdown in the card locking callout. Only queried for
+    # cardholders who can actually see that callout.
+    @locking_next_due_at = current_user.card_locking_next_due_at if CardLocking.enabled?
 
     hcb_code_ids_missing_receipt = current_user.hcb_code_ids_missing_receipt
 

--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -37,6 +37,9 @@ class CardLockingMailer < ApplicationMailer
     @user = user
     @hcb_codes = user.card_locking_outstanding_charges.to_a
     @count = @hcb_codes.size
+    # Same countdown the warning SMS carries, off the same pile. Taken from the
+    # loaded rows rather than a second query, so mail and text agree exactly.
+    @due_in = CardLocking.time_remaining_in_words(@hcb_codes.filter_map(&:receipt_due_at).min)
     @show_org = user.events.size > 1
     mail to: user.email, subject: "You have #{@count} receipt#{'s' unless @count == 1} to upload"
   end

--- a/app/mailers/card_locking_mailer.rb
+++ b/app/mailers/card_locking_mailer.rb
@@ -39,7 +39,7 @@ class CardLockingMailer < ApplicationMailer
     @count = @hcb_codes.size
     # Same countdown the warning SMS carries, off the same pile. Taken from the
     # loaded rows rather than a second query, so mail and text agree exactly.
-    @due_in = CardLocking.time_remaining_in_words(@hcb_codes.filter_map(&:receipt_due_at).min)
+    @due_in = CardLocking.time_remaining_in_words(@user.card_locking_next_due_at)
     @show_org = user.events.size > 1
     mail to: user.email, subject: "You have #{@count} receipt#{'s' unless @count == 1} to upload"
   end

--- a/app/models/concerns/card_locking/cardholder_behavior.rb
+++ b/app/models/concerns/card_locking/cardholder_behavior.rb
@@ -110,5 +110,13 @@ module CardLocking
     def card_locking_outstanding_count
       card_locking_outstanding_charges.count
     end
+
+    # The soonest deadline in the outstanding pile, or nil when nothing is
+    # outstanding (or this cardholder isn't enrolled, so their charges carry no
+    # receipt_due_at and MIN ignores the NULLs). This is what every "your next
+    # receipt is due in X" countdown counts down to.
+    def card_locking_next_due_at
+      card_locking_outstanding_charges.minimum(:receipt_due_at)
+    end
   end
 end

--- a/app/services/card_locking.rb
+++ b/app/services/card_locking.rb
@@ -87,4 +87,30 @@ module CardLocking
   def self.inbox_url
     Rails.application.routes.url_helpers.my_inbox_url
   end
+
+  # A deadline countdown for cardholder-facing copy: "45 minutes", "11 hours",
+  # "3 days". Always rounds DOWN, so a cardholder is never told they have more
+  # runway than they really do. Returns nil when there is no deadline or it has
+  # already passed; callers say something other than a countdown in that case.
+  #
+  # Switches from hours to days at 48h (WARNING_LEAD_TIME) so the pre-lock
+  # warning, which only fires inside that window, always counts down in hours.
+  def self.time_remaining_in_words(due_at, now: Time.current)
+    return nil if due_at.blank?
+
+    seconds = (due_at - now).to_i
+    return nil if seconds <= 0
+
+    if seconds < 1.hour.to_i
+      # Never round down to "0 minutes"; a deadline this close is still ahead.
+      minutes = [seconds / 1.minute.to_i, 1].max
+      "#{minutes} #{'minute'.pluralize(minutes)}"
+    elsif seconds < WARNING_LEAD_TIME.to_i
+      hours = seconds / 1.hour.to_i
+      "#{hours} #{'hour'.pluralize(hours)}"
+    else
+      days = seconds / 1.day.to_i
+      "#{days} #{'day'.pluralize(days)}"
+    end
+  end
 end

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -66,6 +66,7 @@ module UserService
 
       deadline =
         if remaining.nil?
+          # We think this isn't possible??? maybe 🤷‍♂️
           "Your cards lock once a receipt goes past its deadline."
         elsif count == 1
           "It's due in #{remaining}. Miss it and your cards lock."

--- a/app/services/user_service/send_card_locking_notification.rb
+++ b/app/services/user_service/send_card_locking_notification.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module UserService
-  # Sends a once-a-day "you have receipts to upload" pile warning. No per-charge
-  # countdown; names a count, never a deadline. Deduped per cardholder per day.
+  # Sends a once-a-day "you have receipts to upload" pile warning: the size of the
+  # outstanding pile plus a countdown to the soonest deadline in it. Deduped per
+  # cardholder per day.
   class SendCardLockingNotification
     def initialize(user:)
       @user = user
@@ -27,6 +28,8 @@ module UserService
       count = @user.card_locking_outstanding_count
       return if count.zero?
 
+      due_at = @user.card_locking_next_due_at
+
       # The recurring job runs every few minutes; this dedup key is the only thing
       # that makes the digest daily. TTL is under 24h on purpose: at 23h the send
       # time drifts a little earlier each day, guaranteeing one per calendar date.
@@ -34,25 +37,43 @@ module UserService
       key = "card_locking_digest:#{@user.id}"
       return unless Rails.cache.write(key, true, expires_in: 23.hours, unless_exist: true)
 
-      deliver(count:, key:)
+      deliver(count:, due_at:, key:)
     end
 
     private
 
     # Keys are claimed before enqueue; release on failure so a transient error
     # does not mute the notification for the cache TTL.
-    def deliver(count:, key:)
+    def deliver(count:, due_at:, key:)
       CardLockingMailer.warning(user: @user).deliver_later
     rescue
       Rails.cache.delete(key)
       raise
     else
-      User::SendSmsJob.perform_later(user_id: @user.id, body: sms_message(count))
+      User::SendSmsJob.perform_later(user_id: @user.id, body: sms_message(count, due_at))
     end
 
-    def sms_message(count)
+    # Cards are NOT locked here (see the guard above), so the copy has to be a
+    # countdown, not a status: name the pile, then the soonest deadline in it.
+    # A bare count plus "your cards will lock" reads as if they already have.
+    #
+    # The deadline can be missing (a suppressed cardholder, or one whose pile is
+    # all pre-enforcement) or already past (the enforcement job has not caught up
+    # yet); neither can carry a countdown, so those fall back to the rule itself.
+    def sms_message(count, due_at)
       noun = "receipt".pluralize(count)
-      "You have #{count} #{noun} to upload. Your cards will lock until you do. Upload at #{CardLocking.inbox_url}."
+      remaining = CardLocking.time_remaining_in_words(due_at)
+
+      deadline =
+        if remaining.nil?
+          "Your cards lock once a receipt goes past its deadline."
+        elsif count == 1
+          "It's due in #{remaining}. Miss it and your cards lock."
+        else
+          "Your next receipt is due in #{remaining}. Miss it and your cards lock."
+        end
+
+      "You have #{count} #{noun} to upload. #{deadline} Upload at #{CardLocking.inbox_url}."
     end
 
   end

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,11 +1,10 @@
 <p>
-  You have <%= @count %> <%= "receipt".pluralize(@count) %> we still need.
+  You have <%= @count %> <%= "outstanding receipt".pluralize(@count) %>.
   <% if @due_in %>
-    Your <%= "next " unless @count == 1 %>receipt is due in <strong><%= @due_in %></strong> &mdash; miss that deadline and your cards lock until you upload.
-  <% else %>
-    Charges that go more than 7 days without a receipt will lock your cards.
+    Your <%= "next " unless @count == 1 %>receipt is due in <strong><%= @due_in %></strong>. Miss that deadline, and your cards lock until you upload that missing receipt.
   <% end %>
-  Upload these to stay ahead.
+
+  Charges that go more than 7 days without a receipt will lock your cards. Upload these to stay ahead.
 </p>
 <p>
   Every charge needs a receipt within 7 days. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/card_locking_mailer/warning.html.erb
+++ b/app/views/card_locking_mailer/warning.html.erb
@@ -1,5 +1,11 @@
 <p>
-  You have <%= @count %> <%= "receipt".pluralize(@count) %> we still need. Charges that go more than 7 days without a receipt will lock your cards. Upload these to stay ahead.
+  You have <%= @count %> <%= "receipt".pluralize(@count) %> we still need.
+  <% if @due_in %>
+    Your <%= "next " unless @count == 1 %>receipt is due in <strong><%= @due_in %></strong> &mdash; miss that deadline and your cards lock until you upload.
+  <% else %>
+    Charges that go more than 7 days without a receipt will lock your cards.
+  <% end %>
+  Upload these to stay ahead.
 </p>
 <p>
   Every charge needs a receipt within 7 days. Manage your receipts on the HCB <%= link_to "receipts page", my_inbox_url %>.

--- a/app/views/my/inbox.html.erb
+++ b/app/views/my/inbox.html.erb
@@ -9,11 +9,28 @@
 </h1>
 
 <% if CardLocking.enabled? %>
-  <%= render "application/callout", class: "mt-2", type: "info", title: "Card locking" do %>
+  <% locked = current_user.cards_locked? %>
+  <% due_in = CardLocking.time_remaining_in_words(@locking_next_due_at) %>
+  <%# A calm green "active" is misleading when the next deadline is an hour out, %>
+  <%# so the callout escalates as that deadline approaches (or is already blown). %>
+  <% urgent = !locked && (@locking_count.positive? || (@locking_next_due_at.present? && @locking_next_due_at <= CardLocking::WARNING_LEAD_TIME.from_now)) %>
+  <% callout_type = if locked
+                      "error"
+                    elsif urgent
+                      "warning"
+                    else
+                      "info"
+                    end %>
+  <%= render "application/callout", class: "mt-2", type: callout_type, title: "Card locking" do %>
     <p class="my-0">
+      <%# The rule states the consequence once; each status below is only a status. %>
       Upload a receipt within <strong>7 days</strong> of every card charge. Miss it and your cards <strong>will lock</strong> until you upload.
-      <% if current_user.cards_locked? %>
+      <% if locked %>
         Your cards are currently <strong class="error">locked</strong>. Uploading a receipt will unlock them in seconds.
+      <% elsif @locking_count.positive? %>
+        Your cards are currently <strong class="success">active</strong>, but <%= pluralize(@locking_count, "receipt") %> <%= @locking_count == 1 ? "is" : "are" %> already overdue.
+      <% elsif due_in %>
+        Your cards are currently <strong class="success">active</strong>. Your next receipt is due in <strong class="<%= "warning" if urgent %>"><%= due_in %></strong>.
       <% else %>
         Your cards are currently <strong class="success">active</strong>.
       <% end %>

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe MyController do
 
     it "sets @locking_count from card_locking_overdue_charges" do
       user = sign_in_verified
+      Flipper.enable(:card_locking)
 
       get :inbox
 

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -69,6 +69,27 @@ RSpec.describe MyController do
       expect(response).to have_http_status(:ok)
       expect(controller.instance_variable_get(:@locking_count)).to eq(user.card_locking_overdue_charges.count)
     end
+
+    it "sets @locking_next_due_at for the card locking callout's countdown" do
+      sign_in_verified
+      Flipper.enable(:card_locking)
+      deadline = 11.hours.from_now
+      allow_any_instance_of(User).to receive(:card_locking_next_due_at).and_return(deadline)
+
+      get :inbox
+
+      expect(controller.instance_variable_get(:@locking_next_due_at)).to eq(deadline)
+    end
+
+    # The callout is behind the kill switch, so cardholders who cannot see it
+    # should not pay for the query behind it.
+    it "does not query the next deadline when card locking is off" do
+      sign_in_verified
+      Flipper.disable(:card_locking)
+      expect_any_instance_of(User).not_to receive(:card_locking_next_due_at)
+
+      get :inbox
+    end
   end
 
   describe "GET #pay" do

--- a/spec/mailers/card_locking_mailer_spec.rb
+++ b/spec/mailers/card_locking_mailer_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe CardLockingMailer, type: :mailer do
 
   before { travel_to(Time.zone.parse("2026-10-10 12:00:00")) }
 
+  # Quoted-printable soft-wraps the encoded body every 76 characters, which can
+  # split a sentence mid-phrase; assert against the decoded HTML instead.
+  def html_body(mail)
+    (mail.html_part || mail).body.decoded
+  end
+
   describe "#cards_locked" do
     it "names the overdue count and avoids countdown/violation language" do
       hcb_code = create_settled_card_charge(user:, settled_at: 10.days.ago)
@@ -96,6 +102,28 @@ RSpec.describe CardLockingMailer, type: :mailer do
       mail = described_class.warning(user:)
 
       expect(mail.subject).to eq("You have 2 receipts to upload")
+    end
+
+    it "counts down to the soonest deadline in the pile" do
+      soonest = create_settled_card_charge(user:, settled_at: 6.days.ago)
+      soonest.update!(receipt_due_at: 11.hours.from_now)
+      later = create_settled_card_charge(user:, settled_at: 1.day.ago)
+      later.update!(receipt_due_at: 6.days.from_now)
+
+      mail = described_class.warning(user:)
+
+      expect(html_body(mail)).to include("Your next receipt is due in")
+      expect(html_body(mail)).to include("11 hours")
+    end
+
+    it "states the rule instead of a countdown when the pile carries no deadline" do
+      hcb_code = create_settled_card_charge(user:, settled_at: 2.days.ago)
+      hcb_code.update!(receipt_due_at: nil)
+
+      mail = described_class.warning(user:)
+
+      expect(html_body(mail)).not_to include("is due in")
+      expect(html_body(mail)).to include("more than 7 days without a receipt")
     end
   end
 end

--- a/spec/models/user/card_locking_read_helpers_spec.rb
+++ b/spec/models/user/card_locking_read_helpers_spec.rb
@@ -90,4 +90,37 @@ RSpec.describe User do
       expect(user.card_locking_outstanding_count).to eq(0)
     end
   end
+
+  describe "#card_locking_next_due_at" do
+    it "is the soonest deadline in the outstanding pile" do
+      soonest = create_settled_card_charge(user:, settled_at: 5.days.ago)
+      soonest.update!(receipt_due_at: 11.hours.from_now)
+      later = create_settled_card_charge(user:, settled_at: 1.day.ago)
+      later.update!(receipt_due_at: 6.days.from_now)
+
+      expect(user.card_locking_next_due_at).to eq(soonest.receipt_due_at)
+    end
+
+    it "ignores charges that already have a receipt" do
+      resolved = create_settled_card_charge(user:, settled_at: 5.days.ago, uploaded_at: Time.current)
+      resolved.update!(receipt_due_at: 11.hours.from_now)
+      outstanding = create_settled_card_charge(user:, settled_at: 1.day.ago)
+      outstanding.update!(receipt_due_at: 6.days.from_now)
+
+      expect(user.card_locking_next_due_at).to eq(outstanding.receipt_due_at)
+    end
+
+    # A cardholder in no rollout stage has no deadlines at all; MIN over NULLs is
+    # NULL, so there is nothing to count down to.
+    it "is nil when the outstanding pile carries no deadlines" do
+      hc = create_settled_card_charge(user:, settled_at: 1.day.ago)
+      hc.update!(receipt_due_at: nil)
+
+      expect(user.card_locking_next_due_at).to be_nil
+    end
+
+    it "is nil when nothing is outstanding" do
+      expect(user.card_locking_next_due_at).to be_nil
+    end
+  end
 end

--- a/spec/services/card_locking/time_remaining_in_words_spec.rb
+++ b/spec/services/card_locking/time_remaining_in_words_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CardLocking.time_remaining_in_words" do
+  let(:now) { Time.zone.parse("2026-10-10 12:00:00") }
+
+  def words(due_at)
+    CardLocking.time_remaining_in_words(due_at, now:)
+  end
+
+  it "counts down in days beyond the warning lead time" do
+    expect(words(now + 3.days)).to eq("3 days")
+    expect(words(now + 7.days)).to eq("7 days")
+  end
+
+  it "counts down in hours inside the warning lead time" do
+    expect(words(now + 11.hours)).to eq("11 hours")
+    expect(words(now + 47.hours)).to eq("47 hours")
+  end
+
+  it "counts down in minutes under an hour" do
+    expect(words(now + 45.minutes)).to eq("45 minutes")
+  end
+
+  it "singularizes the unit" do
+    expect(words(now + 1.hour)).to eq("1 hour")
+    expect(words(now + 2.days + 1.hour)).to eq("2 days")
+    expect(words(now + 61.seconds)).to eq("1 minute")
+  end
+
+  # A cardholder must never be told they have more runway than they do, so every
+  # boundary rounds toward the deadline.
+  it "always rounds down" do
+    expect(words(now + 11.hours + 59.minutes)).to eq("11 hours")
+    expect(words(now + 3.days + 23.hours)).to eq("3 days")
+  end
+
+  it "switches from hours to days exactly at the warning lead time" do
+    expect(words(now + CardLocking::WARNING_LEAD_TIME - 1.second)).to eq("47 hours")
+    expect(words(now + CardLocking::WARNING_LEAD_TIME)).to eq("2 days")
+  end
+
+  # Under a minute is still ahead of the deadline; "0 minutes" would read as past.
+  it "floors at one minute rather than zero" do
+    expect(words(now + 30.seconds)).to eq("1 minute")
+  end
+
+  it "is nil once the deadline has passed, so callers say something else" do
+    expect(words(now)).to be_nil
+    expect(words(now - 1.second)).to be_nil
+    expect(words(now - 3.days)).to be_nil
+  end
+
+  it "is nil without a deadline" do
+    expect(words(nil)).to be_nil
+  end
+end

--- a/spec/services/user_service/send_card_locking_notification_spec.rb
+++ b/spec/services/user_service/send_card_locking_notification_spec.rb
@@ -56,6 +56,68 @@ RSpec.describe UserService::SendCardLockingNotification, type: :service do
     )
   end
 
+  # The cards are NOT locked at this point, so the text has to count down to the
+  # deadline. A bare count plus "your cards will lock until you do" reads as a
+  # lock that has already happened, which is what cardholders reported.
+  #
+  # Time is frozen because the countdown rounds down: a deadline set 11h out and
+  # read a few microseconds later is 10h59m of remaining runway, i.e. "10 hours".
+  it "counts down to the soonest deadline in the pile" do
+    freeze_time do
+      allow(user).to receive(:card_locking_outstanding_count).and_return(11)
+      allow(user).to receive(:card_locking_next_due_at).and_return(11.hours.from_now)
+
+      service.run
+
+      expect(User::SendSmsJob).to have_been_enqueued.with(
+        user_id: user.id,
+        body: "You have 11 receipts to upload. Your next receipt is due in 11 hours. " \
+              "Miss it and your cards lock. Upload at #{CardLocking.inbox_url}."
+      )
+    end
+  end
+
+  it "says 'it' rather than 'your next receipt' for a single outstanding receipt" do
+    freeze_time do
+      allow(user).to receive(:card_locking_outstanding_count).and_return(1)
+      allow(user).to receive(:card_locking_next_due_at).and_return(3.days.from_now)
+
+      service.run
+
+      expect(User::SendSmsJob).to have_been_enqueued.with(
+        user_id: user.id,
+        body: "You have 1 receipt to upload. It's due in 3 days. " \
+              "Miss it and your cards lock. Upload at #{CardLocking.inbox_url}."
+      )
+    end
+  end
+
+  it "falls back to the rule when there is no deadline to count down to" do
+    allow(user).to receive(:card_locking_outstanding_count).and_return(4)
+    allow(user).to receive(:card_locking_next_due_at).and_return(nil)
+
+    service.run
+
+    expect(User::SendSmsJob).to have_been_enqueued.with(
+      user_id: user.id,
+      body: "You have 4 receipts to upload. Your cards lock once a receipt goes past its deadline. " \
+            "Upload at #{CardLocking.inbox_url}."
+    )
+  end
+
+  # Enforcement runs on its own schedule, so the pile can go past due between
+  # sweeps. A negative countdown ("due in -2 hours") would be worse than none.
+  it "falls back to the rule when the soonest deadline has already passed" do
+    allow(user).to receive(:card_locking_outstanding_count).and_return(4)
+    allow(user).to receive(:card_locking_next_due_at).and_return(2.hours.ago)
+
+    service.run
+
+    expect(User::SendSmsJob).to have_been_enqueued.with(
+      user_id: user.id, body: a_string_matching(/goes past its deadline/)
+    )
+  end
+
   it "does not send when no charge is approaching its deadline" do
     allow(user).to receive(:card_locking_has_approaching_charge?).and_return(false)
     allow(user).to receive(:card_locking_outstanding_count).and_return(4)


### PR DESCRIPTION
## Summary of the problem
Users are confused about when cards will lock.

<img width="404" height="392" alt="image" src="https://github.com/user-attachments/assets/423b50cb-935e-49bb-bf25-5ed3cc691504" />

<img width="391" height="733" alt="image" src="https://github.com/user-attachments/assets/b10d94e8-cb3c-4294-af44-83f15ea8508f" />




## Describe your changes
Updates wording in SMS and on my inbox page to count down to when the next receipt is due.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

