### PR TITLE
[User] Block email domains behind a wave of spam signups

### DIFF
--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -121,6 +121,59 @@ Nondisposable.configure do |config|
     toolzim.com
     kedaiqq.com
     f5.si
+    dnsink.com
+    careney.com
+    aghism.com
+    amupx.com
+    priyomail.site
+    upstary.com
+    rpaintel.com
+    primetor.com
+    vitreu.com
+    tarscon.com
+    vemzite.com
+    murkstar.com
+    sureido.com
+    chackaut.com
+    emalupe.com
+    netiren.com
+    missfuli.com
+    mrworlds.com
+    aganseo.com
+    seolaner.com
+    sagesole.com
+    shortapk.com
+    iapapi.com
+    sskaid.com
+    tixpad.com
+    westecom.com
+    donumart.com
+    videocel.com
+    vektoru.com
+    lanvos.com
+    dyleris.com
+    disiok.com
+    woraco.com
+    copawoke.com
+    brixozu.com
+    theaumos.com
+    buloan.com
+    trepolan.com
+    tikwel.com
+    tongtode.com
+    taoxe.com
+    savdz.com
+    widenely.com
+    fanchatu.com
+    uswaid.com
+    topkute.com
+    web5h.com
+    lovadio.com
+    soliset.com
+    candaba.com
+    5nek.com
+    skyprofy.com
+    velpai.com
   ].freeze
 
   # https://www.okta.com/blog/threat-intelligence/opportunistic-sms-pumping-attacks-target-customer-sign-up-pages/

--- a/lib/email_typo_domains.rb
+++ b/lib/email_typo_domains.rb
@@ -15,9 +15,12 @@ module EmailTypoDomains
       gmail.con gmail.co gamil.com gmail.ocm gmail.ckm gmail.cok gmail.xom
       gmali.com gamail.com gmail.cpom gmail.cokm gmail.fom gmil.com
       gmail.cm gmail.om gmai.com gnail.com
+      gmial.com gmaill.com gmailc.om gmail.cim gmail.cpm gmail.clm gmail.vom
+      gmail.comm gmail.comn gmail.comh gmail.coma gmail.comb
+      gmail.copm gmail.coim gmail.conm gmail.coom
       googlemail.com
     ],
-    "icloud.com"     => %w[icloud.con],
+    "icloud.com"     => %w[icloud.con icloud.co],
     "hackclub.com"   => %w[hackclub.co hackclub.con],
     "outlook.com"    => %w[outlook.con],
     "protonmail.com" => %w[protonmail.con],

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe User, type: :model do
         expect(user).to be_valid, "expected #{domain} to be allowed"
       end
     end
+
+    it "allows a provider's regional domains" do
+      %w[outlook.de outlook.fr yahoo.fr yahoo.ca hotmail.co.uk].each do |domain|
+        user = build(:user, email: "someone@#{domain}")
+
+        expect(user).to be_valid, "expected #{domain} to be allowed"
+      end
+    end
+
+    it "suggests icloud.com for icloud.co" do
+      user = build(:user, email: "someone@icloud.co")
+
+      expect(user).to_not be_valid
+      expect(user.errors[:email]).to eq(["looks like a typo. Did you mean someone@icloud.com?"])
+    end
   end
 
   context "birthday validations" do


### PR DESCRIPTION
## Summary of the problem

A wave of bulk fake signups is coming in on a batch of throwaway email domains. They're newly registered, run on shared throwaway-mail infrastructure alongside domains blocked in earlier rounds, and show no product usage beyond creating the account.

Separately, the typo/alias list was missing a long tail of common misspellings of `gmail.com` and `icloud.com`, so people who fat-finger their address get a generic "provider is unsupported" instead of a fix they can act on.

## Describe your changes

- Adds the throwaway domains to `hcb_sourced_domains`.

  A handful of them do have a stray API token, event application, or receipt attached. Those are still included: they aren't domains anyone holds a durable mailbox at, and both validations are `on: :create`, so existing accounts keep working and only new signups (and email changes) are affected.

- Extends `EmailTypoDomains` with more unambiguous misspellings of `gmail.com` and `icloud.com`. None of them resolve or accept mail, so blocking costs nothing, and the signup form now suggests the intended address.

- Adds a spec pinning that a provider's regional domains (`outlook.de`, `yahoo.ca`, `hotmail.co.uk`, ...) stay allowed, since those look superficially like the TLD typos sitting next to them in the list.

**Known gap:** some signups arrive on randomly generated subdomains of a wildcard domain. The blocklist only matches exact domains, so this change doesn't stop them. Closing that needs parent-domain matching, which is a separate change.