### PR TITLE
[Help Center] Use hack.club links instead of direct help center links

### DIFF
--- a/app/javascript/controllers/transfer_form_controller.js
+++ b/app/javascript/controllers/transfer_form_controller.js
@@ -36,11 +36,11 @@ export default class extends Controller {
       question: 'Do you have their account & routing number?',
       yes: {
         type: 'ACH transfer',
-        link: 'https://help.hcb.hackclub.com/en/articles/15410090-how-do-i-send-an-ach-transfer',
+        link: 'https://hack.club/hcb-help-ach-transfer',
       },
       no: {
         type: 'Mailed check',
-        link: 'https://help.hcb.hackclub.com/en/articles/15410094-how-do-i-send-a-check',
+        link: 'https://hack.club/hcb-help-send-check',
       },
     },
     {
@@ -48,11 +48,11 @@ export default class extends Controller {
       question: 'Is your transfer amount over $500?',
       yes: {
         type: 'International wire',
-        link: 'https://help.hcb.hackclub.com/en/articles/15410092-how-do-i-send-a-wire-transfer',
+        link: 'https://hack.club/hcb-help-wire-transfer',
       },
       no: {
         type: 'Wise transfer',
-        link: 'https://help.hcb.hackclub.com/en/articles/15410093-how-do-i-send-a-wise-transfer',
+        link: 'https://hack.club/hcb-help-wise-transfer',
       },
     },
   ]

--- a/app/views/card_grants/index.html.erb
+++ b/app/views/card_grants/index.html.erb
@@ -24,7 +24,7 @@
 
  <%= render "events/one_pager",
     title: "Card grants",
-    support_article: "https://help.hcb.hackclub.com/en/articles/15410084-how-do-i-spend-money-on-hcb",
+    support_article: "https://hack.club/hcb-help-spending-money",
     screenshots: {
       light: "https://user-cdn.hackclub-assets.com/019c3c76-536d-7efe-8ce6-2a31869ee3f1/hcb.hackclub.com_hq_card_grants.png",
       dark: "https://user-cdn.hackclub-assets.com/019c3c76-3749-7024-83f1-5c45cd847f79/hcb.hackclub.com_hq_card_grants%20(1).png"

--- a/app/views/check_deposits/index.html.erb
+++ b/app/views/check_deposits/index.html.erb
@@ -21,7 +21,7 @@
       <li>We only accept checks from U.S. financial institutions, in U.S.
         dollars.
       </li>
-      <li>For information on how to physically deposit checks, <%= link_to "view our Help Center", "https://help.hcb.hackclub.com/en/articles/15409994-how-do-i-receive-and-deposit-checks" %>.</li>
+      <li>For information on how to physically deposit checks, <%= link_to "view our Help Center", "https://hack.club/hcb-help-deposit-checks" %>.</li>
     </ul>
   <% end %>
 </div>

--- a/app/views/events/card_overview.html.erb
+++ b/app/views/events/card_overview.html.erb
@@ -86,7 +86,7 @@
 <% else %>
  <%= render "events/one_pager",
     title: "Cards",
-    support_article: "https://help.hcb.hackclub.com/en/articles/15410084-how-do-i-spend-money-on-hcb",
+    support_article: "https://hack.club/hcb-help-spending-money",
     screenshots: {
       light: "https://cdn.hackclub.com/019eb7bb-a291-7fe9-a78f-4656eaa80629/file-cb800d0bbd987c998a23ae387d7ebaa4.png",
       dark: "https://cdn.hackclub.com/019eb7bb-a001-7bde-a802-612f6c523c69/image.png",

--- a/app/views/events/donation_overview.html.erb
+++ b/app/views/events/donation_overview.html.erb
@@ -180,7 +180,7 @@
 <% else %>
   <%= render "events/one_pager",
     title: "Donations",
-    support_article: "https://help.hcb.hackclub.com/en/articles/15410000-how-do-i-set-up-and-share-my-donation-page",
+    support_article: "https://hack.club/hcb-help-donation-page",
     screenshots: {
       light: "https://cdn.hackclub.com/019e7c92-1acf-7866-80cf-5946f5515639/image.png",
       dark: "https://cdn.hackclub.com/019e7c95-f032-727c-9379-ae4cc062889b/image.png"

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -95,7 +95,7 @@
 <% else %>
  <%= render "events/one_pager",
       title: "Reimbursements",
-      support_article: "https://help.hcb.hackclub.com/en/articles/15410232-how-do-i-request-a-reimbursement",
+      support_article: "https://hack.club/hcb-help-reimbursement",
       screenshots: {
         light: "https://user-cdn.hackclub-assets.com/019c3c7a-827e-779a-80bd-505c00c0f793/hcb.hackclub.com_hq_reimbursements.png",
         dark: "https://user-cdn.hackclub-assets.com/019c3c7a-6f5b-7e30-aada-7f7ee823679e/hcb.hackclub.com_hq_reimbursements%20(1).png"

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -74,7 +74,7 @@
 
   <p class="my-0">
     <% if hcb_decline_reason == :merchant_not_allowed_globally %>
-      This merchant is blocked because it is commonly associated with fraudulent transactions. If you are trying to make a payment, please use a <%= link_to "different transfer method", "https://help.hcb.hackclub.com/en/articles/15033356-how-do-i-transfer-money" %>.
+      This merchant is blocked because it is commonly associated with fraudulent transactions. If you are trying to make a payment, please use a <%= link_to "different transfer method", "https://hack.club/hcb-help-pay-someone" %>.
     <% elsif hcb_decline_reason == :merchant_not_allowed %>
       If you believe that this merchant should be enabled, please reach out to the <%= hcb_code.event.name %> team.
     <% elsif hcb_decline_reason == :cash_withdrawals_not_allowed %>

--- a/app/views/hcb_codes/reimbursement/_expense_payout.html.erb
+++ b/app/views/hcb_codes/reimbursement/_expense_payout.html.erb
@@ -37,7 +37,7 @@
       <div class="flex md:flex-row flex-col items-start justify-start gap-1 flex-grow">
         Wise imposes fees for processing reimbursements
         <span class="md:flex-grow"></span>
-        <%= link_to "Learn more about Wise transfers on HCB →", "https://help.hcb.hackclub.com/article/65-wise", class: "dark:!text-[#9FE870] !text-[#163300] bold no-underline after:content-[''] after:top-0 after:left-0 after:bottom-0 after:right-0 after:z-index-1 after:absolute", target: "_blank" %>
+        <%= link_to "Learn more about Wise transfers on HCB →", "https://hack.club/hcb-help-wise-transfer", class: "dark:!text-[#9FE870] !text-[#163300] bold no-underline after:content-[''] after:top-0 after:left-0 after:bottom-0 after:right-0 after:z-index-1 after:absolute", target: "_blank" %>
       </div>
     </section>
   <% end %>

--- a/app/views/hcb_codes/transaction_types/_wise_transfer.html.erb
+++ b/app/views/hcb_codes/transaction_types/_wise_transfer.html.erb
@@ -95,7 +95,7 @@
         <div class="flex md:flex-row flex-col items-start justify-start gap-1 flex-grow">
           The amount you pay (<%= render_money @hcb_code.amount_cents.abs %> USD) might change.
           <span class="md:flex-grow"></span>
-          <%= link_to "Learn more about Wise transfers on HCB →", "https://help.hcb.hackclub.com/article/65-wise", class: "dark:!text-[#9FE870] !text-[#163300] bold no-underline after:content-[''] after:top-0 after:left-0 after:bottom-0 after:right-0 after:z-index-1 after:absolute", target: "_blank" %>
+          <%= link_to "Learn more about Wise transfers on HCB →", "https://hack.club/hcb-help-wise-transfer", class: "dark:!text-[#9FE870] !text-[#163300] bold no-underline after:content-[''] after:top-0 after:left-0 after:bottom-0 after:right-0 after:z-index-1 after:absolute", target: "_blank" %>
         </div>
       </section>
     <% end %>

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -86,7 +86,7 @@
 <% else %>
   <%= render "events/one_pager",
     title: "Invoices",
-    support_article: "https://help.hcb.hackclub.com/en/articles/15409995-what-are-invoices-and-how-do-i-send-one",
+    support_article: "https://hack.club/hcb-help-invoices",
     screenshots: {
       light: "https://user-cdn.hackclub-assets.com/019c3c6d-7bf6-7727-a408-d6e64aec72c4/hcb.hackclub.com_hcb_yXHEvYE%20(3).png",
       dark: "https://user-cdn.hackclub-assets.com/019c3c6d-8e47-7c2c-8f84-9d1171f27519/hcb.hackclub.com_hcb_yXHEvYE%20(2).png",

--- a/app/views/marketing/_footer.html.erb
+++ b/app/views/marketing/_footer.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div>
         <h3>Resources</h3>
-        <a href="https://help.hcb.hackclub.com">Docs &amp; help</a>
+        <a href="https://hack.club/hcb-help">Docs &amp; help</a>
         <a href="https://blog.hcb.hackclub.com">Blog</a>
         <a href="https://hackclub.com/fiscal-sponsorship/directory">Organizations</a>
         <a href="https://hackclub.com/fiscal-sponsorship/open-source">Open source</a>

--- a/app/views/my/cards.html.erb
+++ b/app/views/my/cards.html.erb
@@ -68,7 +68,7 @@
 <% else %>
  <%= render "events/one_pager",
     title: "Cards",
-    support_article: "https://help.hcb.hackclub.com/en/articles/15410085-hcb-cards-how-to-order-activate-and-use-them",
+    support_article: "https://hack.club/hcb-help-cards",
     screenshots: {
       light: "https://user-cdn.hackclub-assets.com/019c3c72-e7a5-7cf8-b207-f03b9071a748/hcb.hackclub.com_hq_cards%20(1).png",
       dark: "https://cdn.hackclub.com/019c3c73-25d9-79b3-b1ae-08bc8e7cb88b/hcb.hackclub.com_hq_cards.png"

--- a/app/views/my/reimbursements.html.erb
+++ b/app/views/my/reimbursements.html.erb
@@ -142,7 +142,7 @@
 <% else %>
  <%= render "events/one_pager",
       title: "Reimbursements",
-      support_article: "https://help.hcb.hackclub.com/en/articles/15410232-how-do-i-request-a-reimbursement",
+      support_article: "https://hack.club/hcb-help-reimbursement",
       screenshots: {
         light: "https://user-cdn.hackclub-assets.com/019c3c7a-827e-779a-80bd-505c00c0f793/hcb.hackclub.com_hq_reimbursements.png",
         dark: "https://user-cdn.hackclub-assets.com/019c3c7a-6f5b-7e30-aada-7f7ee823679e/hcb.hackclub.com_hq_reimbursements%20(1).png"

--- a/app/views/organizer_position/spending/controls/index.html.erb
+++ b/app/views/organizer_position/spending/controls/index.html.erb
@@ -131,7 +131,7 @@
     <%= inline_icon "clock" %>
   <% end %>
 
-  <%= link_to "https://help.hcb.hackclub.com/en/articles/14061706-how-do-i-limit-organization-members-spending", class: "card flex justify-between" do %>
+  <%= link_to "https://hack.club/hcb-help-spending-limits", class: "card flex justify-between" do %>
     <div class="flex flex-col">
       <p class="bold black">More info</p>
       <p class="muted">Learn about HCB's spending controls feature</p>

--- a/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
+++ b/app/views/organizer_position/spending/controls_mailer/new_allowance.html.erb
@@ -5,4 +5,4 @@
 
 <p>Your spending balance is now <%= render_money @control.balance_cents %>.</p>
 
-<p><em><%= link_to "See our blog post to learn more about spending controls on HCB.", "https://help.hcb.hackclub.com/en/articles/14061706-how-do-i-limit-organization-members-spending" %></em></p>
+<p><em><%= link_to "See our blog post to learn more about spending controls on HCB.", "https://hack.club/hcb-help-spending-limits" %></em></p>

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -93,7 +93,7 @@
             <% end %>
           </span>
 
-          <p class="center muted">Or drag & drop your receipt here (find more info for receipts on <a href="https://help.hcb.hackclub.com/en/collections/19657949-receipts-compliance" class="link">our help page</a>)</p>
+          <p class="center muted">Or drag & drop your receipt here (find more info for receipts on <a href="https://hack.club/hcb-help-receipts" class="link">our help page</a>)</p>
         </div>
       </div>
 

--- a/app/views/reimbursement/expenses/_receipts.html.erb
+++ b/app/views/reimbursement/expenses/_receipts.html.erb
@@ -22,7 +22,7 @@
         "
       }) do |form| %>
       <% if expense.is_fee? %>
-        <p class="my-0">This fee is imposed by Wise to process your transaction. <%= link_to "Learn more about Wise on HCB →", "https://help.hcb.hackclub.com/article/65-wise" %></p>
+        <p class="my-0">This fee is imposed by Wise to process your transaction. <%= link_to "Learn more about Wise on HCB →", "https://hack.club/hcb-help-wise-transfer" %></p>
       <% elsif expense.receipts.any? %>
         <div class="flex flex-col p1" id="link_receipt__form">
           <% column_amount = [((expense.receipts.length - 1) / 2.to_f).ceil, expense.receipts.length == 2 ? 2 : 1].max %>

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -164,7 +164,7 @@
               <% elsif report.event.nil? %>
                <span class="bold warning">Warning</span>: please <%= link_to "select an event", "#", data: { behavior: "modal_trigger", modal: "edit" } %> to request reimbursement from.
               <% elsif report.below_minimum_amount? %>
-               <span class="bold warning">Warning</span>: your report is below <%= "#{render_money report.event.minimum_wire_amount_cents}," if report.event.minimum_wire_amount_cents == 500_00 %> the minimum amount for a wire transfer. <%= link_to "Learn more", "https://help.hcb.hackclub.com/article/61-what-are-international-wires", data: { behavior: "modal_trigger", modal: "wire_requirements" } %>.
+               <span class="bold warning">Warning</span>: your report is below <%= "#{render_money report.event.minimum_wire_amount_cents}," if report.event.minimum_wire_amount_cents == 500_00 %> the minimum amount for a wire transfer. <%= link_to "Learn more", "https://hack.club/hcb-help-wire-transfer", data: { behavior: "modal_trigger", modal: "wire_requirements" } %>.
               <% end %>
             <% end %>
           </div>

--- a/app/views/reimbursement/reports/wise_transfer_breakdown.html.erb
+++ b/app/views/reimbursement/reports/wise_transfer_breakdown.html.erb
@@ -54,7 +54,7 @@
 
     <footer class="flex flex-row justify-between items-center">
       <img src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/b574a59805cf292d77458a187750674aa7858dd3_vector__10_.svg" alt="Wise logo" height="16">
-      <%= link_to "Learn more about Wise on HCB →", "https://help.hcb.hackclub.com/article/65-wise", target: :_blank %>
+      <%= link_to "Learn more about Wise on HCB →", "https://hack.club/hcb-help-wise-transfer", target: :_blank %>
     </footer>
   </section>
 <% end %>

--- a/app/views/users/payout_form/_fields.html.erb
+++ b/app/views/users/payout_form/_fields.html.erb
@@ -103,7 +103,7 @@
   <%= form.fields_for :payout_method_wise_transfer, detail_for.call(LegalEntity::PayoutMethod::WiseTransfer) do |form| %>
     <p class="muted mt-2 mb-5">
       We've integrated Wise into HCB to offer international reimbursements to over 100 countries. HCB never charges fees on reimbursements, however Wise will charge processing fees to the organization reimbursing you. An account with Wise is not required; funds will be sent directly via a local bank transfer.
-      <%= link_to "Learn more about Wise on HCB →", "https://help.hcb.hackclub.com/article/65-wise" %>
+      <%= link_to "Learn more about Wise on HCB →", "https://hack.club/hcb-help-wise-transfer" %>
     </p>
 
     <%= render partial: "transfers/recipient_details", locals: { form:, disabled: false, required: false } %>

--- a/app/views/wise_transfers/new.html.erb
+++ b/app/views/wise_transfers/new.html.erb
@@ -16,7 +16,7 @@
       icon: "wise",
       title: "Heads up!",
       class: "my-4 !border-[#9FE870] [&>div.flex]:text-[#163300] dark:[&>div.flex]:text-[#9FE870]",
-      footer: link_to("Learn more about Wise on HCB →", "https://help.hcb.hackclub.com/article/65-wise") do %>
+      footer: link_to("Learn more about Wise on HCB →", "https://hack.club/hcb-help-wise-transfer") do %>
     <ul>
       <li>We've integrated Wise into HCB to offer international transfers to over 100 countries.</li>
       <li>HCB never charges fees to send transfers, however Wise will charge processing fees to your organization.</li>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Every time we edit a help center article on Intercom the link changes, so we then need to edit HCB code to change this. 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use a permanent hack.club link (hack.club/hcb-help-[whatever]), which means that we don't need to make a Pull Request whenever we change a help article to change the linked help article.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

