### PR TITLE
[SMS] Turnstile protect the login page when SMS will trigger

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -251,6 +251,9 @@ class LoginsController < ApplicationController
   def turnstile_required?
     @login.authentication_factors_count.zero?
   end
+  # The views mirror this so nobody is handed a challenge whose token the
+  # server wouldn't read.
+  helper_method :turnstile_required?
 
   def turnstile_failed
     redirect_to auth_users_path, flash: { error: TurnstileProtection::FAILURE_MESSAGE }

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 class LoginsController < ApplicationController
+  include TurnstileProtection
+
   skip_before_action :signed_in_user, except: [:reauthenticate]
   skip_after_action :verify_authorized
   before_action :set_login, except: [:new, :create, :reauthenticate]
   before_action :set_user, except: [:new, :create, :reauthenticate]
   invisible_captcha only: [:create, :complete], honeypot: :remember_me
+
+  # `#sms` spends a Twilio Verify message on whatever phone number the email
+  # resolves to, and needs no session to reach. The token comes from the widget
+  # on the form that started the login and rides through `continue_login`'s 307
+  # redirect. Declared after `set_login` so `@login` is loaded.
+  turnstile_protect only: [:sms], action: TurnstileService::LOGIN_ACTION, if: :turnstile_required?
 
   layout ->{ @login&.for_application? ? "apply" : "login" }
 
@@ -234,6 +242,18 @@ class LoginsController < ApplicationController
     else
       redirect_to choose_login_preference_login_path(@login)
     end
+  end
+
+  # `#sms` is also reached from `#complete` (via `continue_login`) when a login
+  # needs a second factor. Those requests come from the factor forms and carry
+  # no token, but the login has already cleared a factor by then, so it isn't
+  # the anonymous traffic Turnstile is here to stop.
+  def turnstile_required?
+    @login.authentication_factors_count.zero?
+  end
+
+  def turnstile_failed
+    redirect_to auth_users_path, flash: { error: TurnstileProtection::FAILURE_MESSAGE }
   end
 
   def login_params

--- a/app/javascript/common/turnstile.js
+++ b/app/javascript/common/turnstile.js
@@ -8,8 +8,8 @@ let loader
 // widget still fetches the script a single time.
 //
 // We render explicitly rather than letting the script scan for `.cf-turnstile`
-// elements: the widget mounts inside a modal after page load, which the
-// automatic scan never sees.
+// elements: widgets here appear on Turbo-rendered pages and inside a modal that
+// mounts after load, neither of which the automatic scan sees.
 export default function loadTurnstile() {
   if (!loader) {
     loader = new Promise((resolve, reject) => {

--- a/app/javascript/controllers/form_disable_controller.js
+++ b/app/javascript/controllers/form_disable_controller.js
@@ -1,15 +1,36 @@
 import { Controller } from '@hotwired/stimulus'
 
+// Holds the submit button(s) disabled until the form is ready to send: a radio
+// option is chosen (when the form offers them) and — when a Turnstile widget
+// gates the form — the challenge has been solved. The Turnstile controller
+// announces its state via `turnstile:change`; wire it with
+// `data-action="turnstile:change->form-disable#turnstileChanged"`.
 export default class extends Controller {
   static targets = ['radioButton', 'submitButton']
 
   initialize() {
+    // Start not-ready only when a Turnstile widget actually gates this form, so
+    // forms without one (and their `turnstile:change` wiring) behave as before.
+    this.turnstileReady = !this.element.querySelector(
+      '[data-controller~="turnstile"]'
+    )
     this.run()
   }
 
   run() {
-    const enabled = this.radioButtonTargets.some(input => input.checked)
+    const radioReady =
+      this.radioButtonTargets.length === 0 ||
+      this.radioButtonTargets.some(input => input.checked)
 
-    this.submitButtonTarget.disabled = !enabled
+    const disabled = !(radioReady && this.turnstileReady)
+
+    this.submitButtonTargets.forEach(button => {
+      button.disabled = disabled
+    })
+  }
+
+  turnstileChanged(event) {
+    this.turnstileReady = event.detail.ready
+    this.run()
   }
 }

--- a/app/javascript/controllers/turnstile_controller.js
+++ b/app/javascript/controllers/turnstile_controller.js
@@ -24,6 +24,13 @@ export default class extends Controller {
     // Held disabled until the widget produces a token.
     this.setReady(false)
 
+    // Turbo snapshots the page for its cache *before* `disconnect` runs, so
+    // scrub the widget out here too or a restore visit (e.g. the back button)
+    // comes back with a dead iframe and a stale token input, and `connect`
+    // then renders a second widget next to them.
+    this.removeForCache = () => this.removeWidget()
+    document.addEventListener('turbo:before-cache', this.removeForCache)
+
     let turnstile
     try {
       turnstile = await loadTurnstile()
@@ -49,10 +56,22 @@ export default class extends Controller {
     // A torn-down widget (e.g. Turbo navigation) must not leave the button dead.
     this.setReady(true)
 
+    document.removeEventListener('turbo:before-cache', this.removeForCache)
+    this.removeWidget()
+  }
+
+  removeWidget() {
     if (this.widgetId === undefined) return
 
-    window.turnstile?.remove(this.widgetId)
+    // `remove` throws once the widget's DOM has already gone away — same dance
+    // as `withTurnstileWidget` in `settings/SmsVerification`.
+    try {
+      window.turnstile?.remove(this.widgetId)
+    } catch {
+      // Already gone.
+    }
     this.widgetId = undefined
+    this.element.replaceChildren()
   }
 
   setReady(ready) {

--- a/app/javascript/controllers/turnstile_controller.js
+++ b/app/javascript/controllers/turnstile_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from '@hotwired/stimulus'
+import loadTurnstile from '../common/turnstile'
+
+// Renders a Cloudflare Turnstile widget into this element. The widget writes
+// its token into a `cf-turnstile-response` field, so the element has to live
+// inside the form that gets submitted.
+export default class extends Controller {
+  static values = { sitekey: String, action: String }
+
+  async connect() {
+    const turnstile = await loadTurnstile()
+
+    // Turbo can disconnect us while the script is still in flight.
+    if (!this.element.isConnected) return
+
+    this.widgetId = turnstile.render(this.element, {
+      sitekey: this.sitekeyValue,
+      action: this.actionValue,
+    })
+  }
+
+  disconnect() {
+    if (this.widgetId === undefined) return
+
+    window.turnstile?.remove(this.widgetId)
+    this.widgetId = undefined
+  }
+}

--- a/app/javascript/controllers/turnstile_controller.js
+++ b/app/javascript/controllers/turnstile_controller.js
@@ -4,11 +4,34 @@ import loadTurnstile from '../common/turnstile'
 // Renders a Cloudflare Turnstile widget into this element. The widget writes
 // its token into a `cf-turnstile-response` field, so the element has to live
 // inside the form that gets submitted.
+//
+// Until the challenge is solved there is no token, so the form's submit controls
+// are held disabled — a submit before then would only bounce off the
+// server-side check. This is a UX guard, not a security control: the server is
+// the real gate, so we fail *open* (re-enable) whenever the widget can't run
+// (script blocked, hard error, teardown). That keeps a Cloudflare hiccup from
+// locking people out of the shared login form; the money path (`#sms`) still
+// fails closed server-side.
+//
+// When the form already carries a `form-disable` controller — it owns the
+// button for its own reasons, e.g. requiring a radio choice — we defer to it:
+// we only announce readiness via a `turnstile:change` event and let it fold
+// that into its own decision. Otherwise we toggle the submit controls directly.
 export default class extends Controller {
   static values = { sitekey: String, action: String }
 
   async connect() {
-    const turnstile = await loadTurnstile()
+    // Held disabled until the widget produces a token.
+    this.setReady(false)
+
+    let turnstile
+    try {
+      turnstile = await loadTurnstile()
+    } catch {
+      // Script blocked or failed to load — don't strand the form.
+      this.setReady(true)
+      return
+    }
 
     // Turbo can disconnect us while the script is still in flight.
     if (!this.element.isConnected) return
@@ -16,13 +39,50 @@ export default class extends Controller {
     this.widgetId = turnstile.render(this.element, {
       sitekey: this.sitekeyValue,
       action: this.actionValue,
+      callback: () => this.setReady(true),
+      'expired-callback': () => this.setReady(false),
+      'error-callback': () => this.setReady(true),
     })
   }
 
   disconnect() {
+    // A torn-down widget (e.g. Turbo navigation) must not leave the button dead.
+    this.setReady(true)
+
     if (this.widgetId === undefined) return
 
     window.turnstile?.remove(this.widgetId)
     this.widgetId = undefined
+  }
+
+  setReady(ready) {
+    const form = this.element.closest('form')
+    if (!form) return
+
+    // Let a `form-disable` controller own the button when one is present.
+    form.dispatchEvent(
+      new CustomEvent('turnstile:change', { detail: { ready }, bubbles: false })
+    )
+
+    if (
+      form.matches('[data-controller~="form-disable"]') ||
+      form.querySelector('[data-controller~="form-disable"]')
+    ) {
+      return
+    }
+
+    this.submitControls(form).forEach(el => {
+      el.disabled = !ready
+    })
+  }
+
+  // Submit buttons/inputs owned by this form, including any associated from
+  // outside it via a `form=` attribute (e.g. the sticky footer button).
+  submitControls(form) {
+    return Array.from(form.elements).filter(
+      el =>
+        (el.tagName === 'BUTTON' && (el.type === 'submit' || el.type === '')) ||
+        (el.tagName === 'INPUT' && el.type === 'submit')
+    )
   }
 }

--- a/app/services/login_code_service/request.rb
+++ b/app/services/login_code_service/request.rb
@@ -2,6 +2,10 @@
 
 module LoginCodeService
   class Request
+    # Far above what a person retrying login needs; far below what makes a
+    # pumped premium number pay.
+    DAILY_SMS_LIMIT = 10
+
     def initialize(email:, ip_address:, user_agent:, sms: false)
       @email = email
       @sms = sms
@@ -21,6 +25,14 @@ module LoginCodeService
 
     def send_login_code_by_sms(user)
       return { error: "no phone number provided", method: :sms } if user.phone_number.empty?
+
+      # Turnstile gates the zero-factor login form, but this service is also
+      # reachable once a factor has cleared and from sudo-mode
+      # reauthentication, where no widget runs. Cap what a single account can
+      # spend in a day so a once-verified premium number can't be pumped
+      # through those paths. Mirrors
+      # `UserService::EnrollSmsAuth#disallow_excessive_sms_verifications`.
+      return send_login_code_by_email(user) if daily_sms_limit_reached?(user)
 
       begin
         TwilioVerificationService.new.send_verification_request(user.phone_number)
@@ -56,6 +68,18 @@ module LoginCodeService
         method: :email,
         login_code:
       }
+    end
+
+    private
+
+    def daily_sms_limit_reached?(user)
+      cache_key = "login_sms_count:#{user.id}:#{Date.current}"
+      count = Rails.cache.increment(cache_key, 1, expires_in: 25.hours).to_i
+
+      return false if count <= DAILY_SMS_LIMIT
+
+      Rails.error.report(Errors::TwilioAbuseError.new("User #{user.id} exceeded login SMS send limit (count: #{count})."))
+      true
     end
 
   end

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
-# Cloudflare Turnstile — a bot check in front of phone-number verification,
-# the one flow that texts a Twilio Verify code to an unverified, user-typed
-# number. That's the surface spam signups have abused to run up our Twilio
-# bill; login SMS codes only ever go to numbers verified through here.
+# Cloudflare Turnstile — a bot check in front of the flows that dispatch a
+# Twilio Verify SMS. Each SMS costs us money and lands on someone's phone, so
+# these are the flows spam signups have historically abused to run up our
+# Twilio bill: verifying a user-typed number, and requesting an SMS login code
+# (which an attacker can pump at a premium number they've verified once).
 #
-# The server half lives in TurnstileService::Verify; the widget is rendered by
-# the `settings/SmsVerification` React component via `common/turnstile.js`.
+# The server half lives in TurnstileService::Verify. The login widget is
+# rendered by the `application/turnstile` partial and the `turnstile` Stimulus
+# controller; the enrollment widget by the `settings/SmsVerification` React
+# component. Both go through `common/turnstile.js`.
 module TurnstileService
-  # Widget action. Cloudflare records it when a token is solved and echoes it
-  # back at siteverify, so a token minted by any other widget on our sitekey
-  # can't be replayed here. Referenced by both the component and the controller
-  # to keep the two from drifting apart.
+  # Widget actions. Cloudflare records these when a token is solved and echoes
+  # them back at siteverify, so a token minted on one form can't be replayed
+  # against another. Referenced by both the view and the controller to keep the
+  # two from drifting apart.
+  LOGIN_ACTION = "login"
   SMS_VERIFICATION_ACTION = "sms-verification"
 
   def self.site_key

--- a/app/views/application/_turnstile.html.erb
+++ b/app/views/application/_turnstile.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (action:) %>
+<%# Cloudflare Turnstile widget. Render this inside the form whose submission
+    leads to an SMS being sent; `action` must match what the controller
+    verifies against (see TurnstileService). Renders nothing when Turnstile
+    isn't configured, in which case the controller skips the check too. %>
+<% if TurnstileService.enabled? %>
+  <div class="my-2"
+       data-controller="turnstile"
+       data-turnstile-sitekey-value="<%= TurnstileService.site_key %>"
+       data-turnstile-action-value="<%= action %>"></div>
+<% end %>

--- a/app/views/logins/choose_login_preference.html.erb
+++ b/app/views/logins/choose_login_preference.html.erb
@@ -55,7 +55,11 @@
     </div>
 
     <%= form.hidden_field :email, value: @email, data: { "webauthn-auth-target" => "loginEmailInput" } %>
-    <%= render partial: "application/turnstile", locals: { action: TurnstileService::LOGIN_ACTION } %>
+    <%# Mid-2FA the server skips the check (`turnstile_required?`), so don't
+        hand people a challenge whose token nothing would read. %>
+    <% if turnstile_required? %>
+      <%= render partial: "application/turnstile", locals: { action: TurnstileService::LOGIN_ACTION } %>
+    <% end %>
 
     <div class="flex flex-row justify-between items-center my-4">
       <%= link_to "Cancel", logout_users_path, method: :delete, class: "no-underline block" %>

--- a/app/views/logins/choose_login_preference.html.erb
+++ b/app/views/logins/choose_login_preference.html.erb
@@ -13,7 +13,7 @@
   <%= render "logins/badge", user: @login.user %>
   <%= render partial: "users/login_code_auth_notice" %>
 
-  <%= form_with url: set_login_preference_login_path(@login), method: :post, data: @login.webauthn_available? ? { "controller" => "webauthn-auth form-disable", "webauthn-auth-target" => "authForm", "action" => "webauthn-auth#submit", webauthn_auth_login_id_value: @login.hashid } : {} do |form| %>
+  <%= form_with url: set_login_preference_login_path(@login), method: :post, data: @login.webauthn_available? ? { "controller" => "webauthn-auth form-disable", "webauthn-auth-target" => "authForm", "action" => "webauthn-auth#submit turnstile:change->form-disable#turnstileChanged", webauthn_auth_login_id_value: @login.hashid } : {} do |form| %>
     <div data-webauthn-auth-target="error" class="mb2 display-none">
       <div class="absolute top-7 left-1/2 transform -translate-x-1/2 z-10">
         <p class="flash error mb1 mx-auto">Security key authentication failed.</p>

--- a/app/views/logins/choose_login_preference.html.erb
+++ b/app/views/logins/choose_login_preference.html.erb
@@ -55,6 +55,7 @@
     </div>
 
     <%= form.hidden_field :email, value: @email, data: { "webauthn-auth-target" => "loginEmailInput" } %>
+    <%= render partial: "application/turnstile", locals: { action: TurnstileService::LOGIN_ACTION } %>
 
     <div class="flex flex-row justify-between items-center my-4">
       <%= link_to "Cancel", logout_users_path, method: :delete, class: "no-underline block" %>

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -23,6 +23,7 @@
 
       <%= email_field_tag :email, @prefill_email, placeholder: "Enter your email...", autofocus: true, autocomplete: "username", class: "!max-w-full w-full", style: "padding: 12px 15px", required: true, "data-webauthn-auth-target" => "loginEmailInput" %>
       <%= invisible_captcha :remember_me %>
+      <%= render partial: "application/turnstile", locals: { action: TurnstileService::LOGIN_ACTION } %>
 
       <div class="flex justify-between items-center gap-4">
         <% if @login.for_application? %>

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -6,6 +6,7 @@ require "webauthn/fake_client"
 RSpec.describe LoginsController do
   include SessionSupport
   include WebAuthnSupport
+  include TurnstileSupport
   render_views
 
   describe "#new" do
@@ -72,7 +73,7 @@ RSpec.describe LoginsController do
       # they are for anyone with `TURNSTILE__*` in their environment. This
       # example is about the send, not the bot check; the gate has its own
       # coverage in spec/requests/logins_turnstile_spec.rb.
-      allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil)
+      disable_turnstile!
 
       user = create(:user, phone_number: "+18556254225")
       # This can't be done through the factory because we have validation logic
@@ -98,7 +99,7 @@ RSpec.describe LoginsController do
     it "sends no SMS if the phone number isn't verified" do
       # Keep this example about the `sms_available?` guard, not the Turnstile
       # gate that sits in front of it (covered in logins_turnstile_spec.rb).
-      allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil)
+      disable_turnstile!
 
       user = create(:user, phone_number: "+18556254225")
       login = create(:login, user:)

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe LoginsController do
     end
 
     it "sends an SMS code if the user has opted-in and verified their phone number" do
+      # `#sms` is Turnstile-gated whenever the credentials are configured, which
+      # they are for anyone with `TURNSTILE__*` in their environment. This
+      # example is about the send, not the bot check; the gate has its own
+      # coverage in spec/requests/logins_turnstile_spec.rb.
+      allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil)
+
       user = create(:user, phone_number: "+18556254225")
       # This can't be done through the factory because we have validation logic
       # that clears out `phone_number_verified` when the phone number changes.
@@ -90,6 +96,10 @@ RSpec.describe LoginsController do
     # comes from a script POSTing at the endpoint directly to spend Twilio
     # messages on made-up numbers.
     it "sends no SMS if the phone number isn't verified" do
+      # Keep this example about the `sms_available?` guard, not the Turnstile
+      # gate that sits in front of it (covered in logins_turnstile_spec.rb).
+      allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil)
+
       user = create(:user, phone_number: "+18556254225")
       login = create(:login, user:)
 

--- a/spec/controllers/users_sms_verification_turnstile_spec.rb
+++ b/spec/controllers/users_sms_verification_turnstile_spec.rb
@@ -10,23 +10,22 @@ require "rails_helper"
 # (in a request spec it collides with `ActionDispatch::Integration::Runner`).
 RSpec.describe UsersController do
   include SessionSupport
+  include TurnstileSupport
 
   let(:user) { create(:user, phone_number: "+18005550100") }
   let(:token) { "0.turnstile-token" }
   let(:enroll_service) { instance_double(UserService::EnrollSmsAuth, start_verification: nil) }
 
   before do
-    allow(TurnstileService).to receive_messages(site_key: "0x0000site", secret_key: "0x0000secret")
+    enable_turnstile!
     allow(UserService::EnrollSmsAuth).to receive(:new).and_return(enroll_service)
     create_session(user, verified: true)
   end
 
-  def stub_siteverify(success:, action: TurnstileService::SMS_VERIFICATION_ACTION)
-    stub_request(:post, TurnstileService::Verify::SITEVERIFY_URL).to_return(
-      status: 200,
-      body: { "success" => success, "action" => action, "hostname" => "test.host" }.to_json,
-      headers: { "Content-Type" => "application/json" }
-    )
+  # This widget carries its own action, and controller specs run on another
+  # host than request specs do.
+  def stub_sms_siteverify(success:, action: TurnstileService::SMS_VERIFICATION_ACTION)
+    stub_siteverify(success:, action:, hostname: "test.host")
   end
 
   def start_verification(params = {})
@@ -34,7 +33,7 @@ RSpec.describe UsersController do
   end
 
   it "starts the verification when the token verifies" do
-    stub_siteverify(success: true)
+    stub_sms_siteverify(success: true)
 
     start_verification("cf-turnstile-response" => token)
 
@@ -51,7 +50,7 @@ RSpec.describe UsersController do
   end
 
   it "refuses when Cloudflare rejects the token" do
-    stub_siteverify(success: false)
+    stub_sms_siteverify(success: false)
 
     start_verification("cf-turnstile-response" => token)
 
@@ -62,7 +61,7 @@ RSpec.describe UsersController do
   # A token minted by any other widget on our sitekey carries a different
   # action, so it can't be spent here.
   it "refuses a token solved for a different widget" do
-    stub_siteverify(success: true, action: "some-other-widget")
+    stub_sms_siteverify(success: true, action: "some-other-widget")
 
     start_verification("cf-turnstile-response" => token)
 
@@ -71,7 +70,7 @@ RSpec.describe UsersController do
   end
 
   context "when Turnstile isn't configured" do
-    before { allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil) }
+    before { disable_turnstile! }
 
     it "starts the verification without calling Cloudflare" do
       start_verification

--- a/spec/requests/logins_turnstile_spec.rb
+++ b/spec/requests/logins_turnstile_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# `POST /logins/:id/sms` spends a Twilio Verify message and needs no session to
+# reach, so it's gated on a solved Turnstile challenge.
+RSpec.describe "LoginsController Turnstile protection", type: :request do
+  let(:user) { create(:user, phone_number: "+18005550100", phone_number_verified: true) }
+  let(:login) { create(:login, user:) }
+  let(:token) { "0.turnstile-token" }
+
+  before do
+    allow(TurnstileService).to receive_messages(site_key: "0x0000site", secret_key: "0x0000secret")
+    allow(TwilioVerificationService).to receive(:new).and_return(
+      instance_double(TwilioVerificationService, send_verification_request: nil)
+    )
+  end
+
+  def stub_siteverify(success:, action: TurnstileService::LOGIN_ACTION, hostname: "www.example.com")
+    stub_request(:post, TurnstileService::Verify::SITEVERIFY_URL).to_return(
+      status: 200,
+      body: { "success" => success, "action" => action, "hostname" => hostname }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
+  def request_sms_code(params = {})
+    post "/logins/#{login.hashid}/sms", params: { email: user.email }.merge(params)
+  end
+
+  it "sends the code when the token verifies" do
+    stub_siteverify(success: true)
+
+    request_sms_code("cf-turnstile-response" => token)
+
+    expect(TwilioVerificationService.new).to have_received(:send_verification_request).with(user.phone_number)
+  end
+
+  it "sends no SMS and returns the user to the start when the token is missing" do
+    request_sms_code
+
+    expect(TwilioVerificationService.new).not_to have_received(:send_verification_request)
+    expect(response).to redirect_to(auth_users_path)
+    expect(flash[:error]).to eq(TurnstileProtection::FAILURE_MESSAGE)
+  end
+
+  it "sends no SMS when Cloudflare rejects the token" do
+    stub_siteverify(success: false)
+
+    request_sms_code("cf-turnstile-response" => token)
+
+    expect(TwilioVerificationService.new).not_to have_received(:send_verification_request)
+    expect(response).to redirect_to(auth_users_path)
+  end
+
+  # The widget stamps the hostname it was solved on, so a token minted against
+  # our sitekey somewhere else must not be accepted here.
+  it "sends no SMS when the token was solved on another hostname" do
+    stub_siteverify(success: true, hostname: "evil.example")
+
+    request_sms_code("cf-turnstile-response" => token)
+
+    expect(TwilioVerificationService.new).not_to have_received(:send_verification_request)
+  end
+
+  # `#complete` reaches `#sms` through `continue_login` when a login needs a
+  # second factor; those requests carry no token by design.
+  it "skips the check for a login that has already cleared a factor" do
+    # A login stays incomplete after one factor only when a second is required,
+    # otherwise `Login`'s `before_save` completes it and `set_login` can no
+    # longer find it.
+    user.update!(use_sms_auth: true, use_two_factor_authentication: true)
+    login.update!(authenticated_with_email: true)
+
+    request_sms_code
+
+    expect(TwilioVerificationService.new).to have_received(:send_verification_request).with(user.phone_number)
+  end
+
+  # The forms that 307 into `#sms` are the ones that have to carry a token.
+  it "renders the widget on the forms that lead to an SMS code" do
+    get auth_users_path
+    expect(response.body).to include('data-controller="turnstile"')
+    expect(response.body).to include(TurnstileService.site_key)
+
+    get choose_login_preference_login_path(login)
+    expect(response.body).to include('data-controller="turnstile"')
+  end
+
+  context "when Turnstile isn't configured" do
+    before { allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil) }
+
+    it "sends the code without calling Cloudflare" do
+      request_sms_code
+
+      expect(TwilioVerificationService.new).to have_received(:send_verification_request).with(user.phone_number)
+      expect(a_request(:post, TurnstileService::Verify::SITEVERIFY_URL)).not_to have_been_made
+    end
+
+    it "renders no widget" do
+      get auth_users_path
+
+      expect(response.body).not_to include('data-controller="turnstile"')
+    end
+  end
+end

--- a/spec/requests/logins_turnstile_spec.rb
+++ b/spec/requests/logins_turnstile_spec.rb
@@ -5,23 +5,22 @@ require "rails_helper"
 # `POST /logins/:id/sms` spends a Twilio Verify message and needs no session to
 # reach, so it's gated on a solved Turnstile challenge.
 RSpec.describe "LoginsController Turnstile protection", type: :request do
-  let(:user) { create(:user, phone_number: "+18005550100", phone_number_verified: true) }
+  include TurnstileSupport
+  include TwilioSupport
+
+  let(:user) do
+    create(:user, phone_number: "+18005550100").tap do |u|
+      # Can't be set through the factory: `User#on_phone_number_update` clears
+      # verification whenever the number changes, creation included.
+      u.update!(phone_number_verified: true)
+    end
+  end
   let(:login) { create(:login, user:) }
   let(:token) { "0.turnstile-token" }
 
   before do
-    allow(TurnstileService).to receive_messages(site_key: "0x0000site", secret_key: "0x0000secret")
-    allow(TwilioVerificationService).to receive(:new).and_return(
-      instance_double(TwilioVerificationService, send_verification_request: nil)
-    )
-  end
-
-  def stub_siteverify(success:, action: TurnstileService::LOGIN_ACTION, hostname: "www.example.com")
-    stub_request(:post, TurnstileService::Verify::SITEVERIFY_URL).to_return(
-      status: 200,
-      body: { "success" => success, "action" => action, "hostname" => hostname }.to_json,
-      headers: { "Content-Type" => "application/json" }
-    )
+    enable_turnstile!
+    stub_twilio_sms_verification(phone_number: user.phone_number)
   end
 
   def request_sms_code(params = {})
@@ -87,8 +86,19 @@ RSpec.describe "LoginsController Turnstile protection", type: :request do
     expect(response.body).to include('data-controller="turnstile"')
   end
 
+  # Once a factor has cleared, the server skips the check (`turnstile_required?`),
+  # so don't make people mid-2FA run a challenge whose token nothing reads.
+  it "renders no widget once a factor has been cleared" do
+    user.update!(use_sms_auth: true, use_two_factor_authentication: true)
+    login.update!(authenticated_with_email: true)
+
+    get choose_login_preference_login_path(login)
+
+    expect(response.body).not_to include('data-controller="turnstile"')
+  end
+
   context "when Turnstile isn't configured" do
-    before { allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil) }
+    before { disable_turnstile! }
 
     it "sends the code without calling Cloudflare" do
       request_sms_code

--- a/spec/services/login_code_service/request_spec.rb
+++ b/spec/services/login_code_service/request_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe LoginCodeService::Request do
+  include TwilioSupport
+
   let(:ip_address) { "127.0.0.1" }
   let(:user_agent) { "fake firefox" }
 
@@ -60,6 +62,35 @@ describe LoginCodeService::Request do
                                method: :email,
                                login_code:
                              })
+    end
+  end
+
+  context "when SMS is requested" do
+    let(:user) { create(:user, phone_number: "+18005550100") }
+
+    it "sends the SMS while under the daily cap" do
+      stub_twilio_sms_verification(phone_number: user.phone_number)
+      allow(Rails.cache).to receive(:increment).and_return(1)
+
+      response = described_class.new(email: user.email, sms: true, ip_address:, user_agent:).run
+
+      expect(TwilioVerificationService.new).to have_received(:send_verification_request).with(user.phone_number)
+      expect(response[:method]).to eq(:sms)
+    end
+
+    # The Turnstile gate covers the zero-factor login form, but not the paths
+    # that reach this service with a factor already cleared (or from sudo-mode
+    # reauthentication) — the cap is the backstop for those.
+    it "falls back to email once the daily cap is spent" do
+      allow(Rails.cache).to receive(:increment).and_return(LoginCodeService::Request::DAILY_SMS_LIMIT + 1)
+      allow(Rails.error).to receive(:report)
+      expect(TwilioVerificationService).not_to receive(:new)
+      expect(LoginCodeMailer).to receive_message_chain(:send_code, :deliver_now)
+
+      response = described_class.new(email: user.email, sms: true, ip_address:, user_agent:).run
+
+      expect(response[:method]).to eq(:email)
+      expect(Rails.error).to have_received(:report).with(an_instance_of(Errors::TwilioAbuseError))
     end
   end
 

--- a/spec/support/turnstile_support.rb
+++ b/spec/support/turnstile_support.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Helpers for specs that cross the Turnstile gate. `Credentials.fetch` prefers
+# ENV, so a machine with real `TURNSTILE__*` keys loaded would otherwise flip
+# the gate on under specs that never asked for it — stub the keys explicitly in
+# whichever direction the spec needs.
+module TurnstileSupport
+  def enable_turnstile!(site_key: "0x0000site", secret_key: "0x0000secret")
+    allow(TurnstileService).to receive_messages(site_key:, secret_key:)
+  end
+
+  def disable_turnstile!
+    allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil)
+  end
+
+  # Stubs Cloudflare's siteverify endpoint with a canned verdict. The defaults
+  # suit the login widget in a request spec; pass `action:`/`hostname:` for
+  # other widgets or hosts (controller specs run on "test.host").
+  def stub_siteverify(success:, action: TurnstileService::LOGIN_ACTION, hostname: "www.example.com")
+    stub_request(:post, TurnstileService::Verify::SITEVERIFY_URL).to_return(
+      status: 200,
+      body: { "success" => success, "action" => action, "hostname" => hostname }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+end

--- a/spec/support/twilio_support.rb
+++ b/spec/support/twilio_support.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module TwilioSupport
-  def stub_twilio_sms_verification(phone_number:, code:)
+  # Replaces `TwilioVerificationService` with a double that accepts a
+  # verification send for `phone_number` and — when a spec exercises the code
+  # exchange — a successful check of `code`.
+  def stub_twilio_sms_verification(phone_number:, code: nil)
     verification_service = instance_double(TwilioVerificationService)
 
     allow(verification_service).to(
@@ -9,11 +12,13 @@ module TwilioSupport
         .with(phone_number)
     )
 
-    allow(verification_service).to(
-      receive(:check_verification_token)
-        .with(phone_number, code)
-        .and_return(true)
-    )
+    if code
+      allow(verification_service).to(
+        receive(:check_verification_token)
+          .with(phone_number, code)
+          .and_return(true)
+      )
+    end
 
     allow(TwilioVerificationService).to receive(:new).and_return(verification_service)
   end


### PR DESCRIPTION
## Summary of the problem
Bots are running up our Twilio bill.


## Describe your changes
Require turnstile verification on login screen when sms triggers.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

