### PR TITLE
Add payment_page_drag_and_drop receipt upload method

### DIFF
--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -124,7 +124,8 @@ class Receipt < ApplicationRecord
     duplicate: 21,
     discord_bot_modal: 22,
     payment_page: 23,
-    contractor_invoice: 24
+    contractor_invoice: 24,
+    payment_page_drag_and_drop: 25
   }
 
   enum :textual_content_source, {


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
file_drop Stimulus controller adds _drag_and_drop to receipt upload methods when the user drags and drops the file. We didn't add this in the upload method enum.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add payment_page_drag_and_drop to the upload method enum

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

