### PR TITLE
[SMS] Create eligible_for_sms_auth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -202,6 +202,7 @@ class User < ApplicationRecord
   before_create :format_number
   before_save :on_phone_number_update
   validate :second_factor_present_for_2fa
+  validate :sms_auth_eligibility, if: -> { use_sms_auth_changed?(to: true) }
 
   after_update :update_stripe_cardholder, if: -> { phone_number_previously_changed? || email_previously_changed? || phone_number_verified_previously_changed? }
   after_create :create_legal_entity
@@ -560,6 +561,10 @@ class User < ApplicationRecord
     charge_notifications_sms? || charge_notifications_email_and_sms?
   end
 
+  def eligible_for_sms_auth?
+    organizer_positions.any? || card_grants.any?
+  end
+
   def queue_sync_with_loops_job
     new_user = was_onboarding? && !onboarding?
     User::SyncUserToLoopsJob.perform_later(user_id: id, new_user:)
@@ -794,6 +799,12 @@ class User < ApplicationRecord
   def second_factor_present_for_2fa
     if use_two_factor_authentication? && !use_sms_auth? && !totp.present? && webauthn_credentials.none?
       errors.add(:use_two_factor_authentication, "can not be enabled without a second authentication factor")
+    end
+  end
+
+  def sms_auth_eligibility
+    unless eligible_for_sms_auth?
+      errors.add(:use_sms_auth, "can not be enabled without being part of an organization or having a card grant")
     end
   end
 

--- a/app/services/user_service/enroll_sms_auth.rb
+++ b/app/services/user_service/enroll_sms_auth.rb
@@ -15,8 +15,8 @@ module UserService
       # doing this here to be safe.
       raise ArgumentError.new("phone number for user: #{@user.id} not in E.164 format") unless @user.phone_number =~ /\A\+[1-9]\d{1,14}\z/
 
-      unless has_meaningful_activity? || has_verified_phone_number_before? || not_fresh_user?
-        raise SMSEnrollmentError, "SMS authentication currently unavailable for your account, please try again later."
+      unless @user.eligible_for_sms_auth?
+        raise SMSEnrollmentError, "SMS authentication is only available to users in an organization or with a card grant."
       end
 
       disallow_excessive_sms_verifications
@@ -44,6 +44,7 @@ module UserService
     def enroll_sms_auth
       raise SMSEnrollmentError, "user has no phone number" if @user.phone_number.blank?
       raise SMSEnrollmentError, "user has not verified phone number" unless @user.phone_number_verified
+      raise SMSEnrollmentError, "SMS authentication is only available to users in an organization or with a card grant." unless @user.eligible_for_sms_auth?
 
       @user.use_sms_auth = true
       @user.save!
@@ -64,18 +65,6 @@ module UserService
 
       Rails.error.report(Errors::TwilioAbuseError.new("User #{@user.id} exceeded SMS verification send limit (count: #{count})."))
       raise SMSEnrollmentError, "You've requested too many verification codes. Please try again tomorrow or contact support at hcb@hackclub.com."
-    end
-
-    def has_verified_phone_number_before?
-      @user.versions.where_object_changes_to(phone_number_verified: true).any?
-    end
-
-    def has_meaningful_activity?
-      @user.organizer_position_invites.any? || @user.card_grants.any? || @user.organizer_positions.any? || @user.reimbursement_reports.any? || @user.applications.any?
-    end
-
-    def not_fresh_user?
-      @user.created_at >= 1.day.ago
     end
 
   end

--- a/app/views/users/edit_security.html.erb
+++ b/app/views/users/edit_security.html.erb
@@ -44,6 +44,10 @@
           <% else %>
             <% if disabled %>
               <p><%= @user.name %> doesn't have their phone number verified.</p>
+            <% elsif !@user.eligible_for_sms_auth? %>
+              <p>
+                Login codes via SMS are only available to users who are part of an organization or have a card grant.
+              </p>
             <% else %>
               <p>
                 To send login codes to your phone or enable two factor authentication, first

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe LoginsController do
 
     it "sends an SMS code if the user has opted-in and verified their phone number" do
       user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
       # This can't be done through the factory because we have validation logic
       # that clears out `phone_number_verified` when the phone number changes.
       user.update!(use_sms_auth: true, phone_number_verified: true)
@@ -379,11 +380,11 @@ RSpec.describe LoginsController do
 
     context "2fa" do
       it "requests a second factor if 2fa is enabled" do
-        user = create(:user,
-                      phone_number: "+18556254225",
-                      phone_number_verified: true,
-                      use_sms_auth: true,
-                      use_two_factor_authentication: true)
+        user = create(:user, phone_number: "+18556254225")
+        create(:organizer_position, user:)
+        user.update!(phone_number_verified: true,
+                     use_sms_auth: true,
+                     use_two_factor_authentication: true)
         totp = user.create_totp!
         login = create(:login, user:)
         login_code = create(:login_code, user:)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe UsersController do
 
     it "requires sudo mode in order to change 2fa settings" do
       user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
       user.update!(phone_number_verified: true)
       user.update!(use_sms_auth: true)
       user.update!(use_two_factor_authentication: true)
@@ -246,6 +247,7 @@ RSpec.describe UsersController do
 
     it "does not require sudo mode unless the feature flag is enabled" do
       user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
       user.update!(phone_number_verified: true)
       user.update!(use_sms_auth: true)
       user.update!(use_two_factor_authentication: true)

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Login do
     end
 
     it "is false when 2fa is enabled and one factor was used" do
-      user = create(:user, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
       login = create(:login, user:)
 
       login.update!(authenticated_with_email: true)
@@ -23,7 +25,9 @@ RSpec.describe Login do
     end
 
     it "is true when 2fa is enabled and two factors were used" do
-      user = create(:user, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
       login = create(:login, user:)
 
       login.update!(authenticated_with_email: true)
@@ -33,7 +37,9 @@ RSpec.describe Login do
     end
 
     it "is true when the login is a reauthentication and one factor was used regardless of 2fa" do
-      user = create(:user, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
       login = create(:login, user:, is_reauthentication: true)
 
       login.update!(authenticated_with_email: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -334,27 +334,34 @@ RSpec.describe User, type: :model do
 
   describe "#use_two_factor_authentication" do
     it "cannot be disabled by admins" do
-      user = create(:user, :make_admin, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, :make_admin, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
 
       expect(user.update(use_two_factor_authentication: false)).to eq(false)
       expect(user.errors[:use_two_factor_authentication]).to contain_exactly("cannot be disabled for admin accounts")
     end
 
     it "cannot be disabled by admins pretending not to be admins" do
-      user = create(:user, :make_admin, use_two_factor_authentication: true, pretend_is_not_admin: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, :make_admin, pretend_is_not_admin: true, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
 
       expect(user.update(use_two_factor_authentication: false)).to eq(false)
       expect(user.errors[:use_two_factor_authentication]).to contain_exactly("cannot be disabled for admin accounts")
     end
 
     it "can be disabled by regular users" do
-      user = create(:user, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)
+      user = create(:user, phone_number: "+18556254225")
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true, use_sms_auth: true, use_two_factor_authentication: true)
 
       expect(user.update(use_two_factor_authentication: false)).to eq(true)
     end
 
     it "can be enabled with SMS auth" do
       user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+      create(:organizer_position, user:)
       user.update!(use_sms_auth: true)
 
       expect(user.use_sms_auth).to eq(true)
@@ -366,6 +373,38 @@ RSpec.describe User, type: :model do
 
       expect(user.update(use_two_factor_authentication: true)).to eq(false)
       expect(user.errors[:use_two_factor_authentication]).to contain_exactly("can not be enabled without a second authentication factor")
+    end
+  end
+
+  describe "#use_sms_auth" do
+    it "cannot be enabled without an organizer position or card grant" do
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+
+      expect(user.update(use_sms_auth: true)).to eq(false)
+      expect(user.errors[:use_sms_auth]).to contain_exactly("can not be enabled without being part of an organization or having a card grant")
+    end
+
+    it "can be enabled with an organizer position" do
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+      create(:organizer_position, user:)
+
+      expect(user.update(use_sms_auth: true)).to eq(true)
+    end
+
+    it "can be enabled with a card grant" do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+      create(:card_grant, user:)
+
+      expect(user.update(use_sms_auth: true)).to eq(true)
+    end
+
+    it "can be disabled without an organizer position or card grant" do
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+      user.update_column(:use_sms_auth, true)
+
+      expect(user.update(use_sms_auth: false)).to eq(true)
     end
   end
 
@@ -479,6 +518,7 @@ RSpec.describe User, type: :model do
     describe "use_sms_auth changes" do
       it "sends an email when SMS authentication is enabled" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
 
         expect {
           user.update!(use_sms_auth: true)
@@ -487,6 +527,7 @@ RSpec.describe User, type: :model do
 
       it "sends an email when SMS authentication is disabled" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
         user.update!(use_sms_auth: true)
 
         expect {
@@ -496,6 +537,7 @@ RSpec.describe User, type: :model do
 
       it "does not send an email when use_sms_auth is not changed" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
         user.update!(use_sms_auth: true)
 
         expect {
@@ -507,6 +549,7 @@ RSpec.describe User, type: :model do
     describe "use_two_factor_authentication changes" do
       it "sends an email when two-factor authentication is enabled" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
         user.update!(use_sms_auth: true)
 
         expect {
@@ -516,6 +559,7 @@ RSpec.describe User, type: :model do
 
       it "sends an email when two-factor authentication is disabled" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
         user.update!(use_sms_auth: true)
         user.update!(use_two_factor_authentication: true)
 
@@ -526,6 +570,7 @@ RSpec.describe User, type: :model do
 
       it "does not send an email when use_two_factor_authentication is not changed" do
         user = create(:user, phone_number: "+18556254225", phone_number_verified: true)
+        create(:organizer_position, user:)
         user.update!(use_sms_auth: true)
         user.update!(use_two_factor_authentication: true)
 

--- a/spec/services/user_service/enroll_sms_auth_spec.rb
+++ b/spec/services/user_service/enroll_sms_auth_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserService::EnrollSmsAuth do
+  def create_user_with_phone
+    user = create(:user)
+    user.update!(phone_number: "+18556254225")
+    user
+  end
+
+  describe "#start_verification" do
+    it "raises for users without an organizer position or card grant" do
+      user = create_user_with_phone
+
+      expect(TwilioVerificationService).not_to receive(:new)
+
+      expect {
+        described_class.new(user).start_verification
+      }.to raise_error(UserService::EnrollSmsAuth::SMSEnrollmentError)
+    end
+
+    it "sends a verification request for users with an organizer position" do
+      user = create_user_with_phone
+      create(:organizer_position, user:)
+
+      verification_service = instance_double(TwilioVerificationService)
+      expect(verification_service).to receive(:send_verification_request).with(user.phone_number)
+      expect(TwilioVerificationService).to receive(:new).and_return(verification_service)
+
+      described_class.new(user).start_verification
+    end
+
+    it "sends a verification request for users with a card grant" do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+
+      user = create_user_with_phone
+      create(:card_grant, user:)
+
+      verification_service = instance_double(TwilioVerificationService)
+      expect(verification_service).to receive(:send_verification_request).with(user.phone_number)
+      expect(TwilioVerificationService).to receive(:new).and_return(verification_service)
+
+      described_class.new(user).start_verification
+    end
+  end
+
+  describe "#enroll_sms_auth" do
+    it "raises for users without an organizer position or card grant" do
+      user = create_user_with_phone
+      user.update!(phone_number_verified: true)
+
+      expect {
+        described_class.new(user).enroll_sms_auth
+      }.to raise_error(UserService::EnrollSmsAuth::SMSEnrollmentError)
+
+      expect(user.reload.use_sms_auth).to eq(false)
+    end
+
+    it "enables SMS auth for users with an organizer position" do
+      user = create_user_with_phone
+      create(:organizer_position, user:)
+      user.update!(phone_number_verified: true)
+
+      described_class.new(user).enroll_sms_auth
+
+      expect(user.reload.use_sms_auth).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
We are seeing SMS pumping.

Currently, users could enroll in verification SMS if any of these applied:
- Has an accepted organizer position
- Has a card grant
- Has a pending organizer position invite (not yet accepted)
- Has a reimbursement report
- Has submitted an event application (self-serve, anyone can file one)
- Ever verified a phone number before (paper-trail history)
- **Account is less than 24 hours old (the not_fresh_user? check was inverted)**


## Describe your changes
Reduce eligibility so users are only eligible if either of these apply:
- Has an accepted OrganizerPosition
- Has a CardGrant
