### PR TITLE
[Wire] Remove manually send transfer

### DIFF
--- a/app/controllers/wires_controller.rb
+++ b/app/controllers/wires_controller.rb
@@ -5,7 +5,7 @@ class WiresController < ApplicationController
   include Admin::TransferApprovable
 
   before_action :set_event, only: %i[new create]
-  before_action :set_wire, only: %i[approve reject send_wire edit update]
+  before_action :set_wire, only: %i[reject send_wire edit update]
 
   def new
     @wire = @event.wires.build
@@ -37,19 +37,6 @@ class WiresController < ApplicationController
     else
       render "new", status: :unprocessable_content
     end
-  end
-
-  def approve
-    authorize @wire
-    return unless enforce_sudo_mode
-
-    ensure_admin_may_approve!(@wire, amount_cents: @wire.usd_amount_cents)
-    @wire.mark_approved!
-
-    redirect_to wire_process_admin_path(@wire), flash: { success: "Thanks for sending that wire." }
-
-  rescue => e
-    redirect_to wire_process_admin_path(@wire), flash: { error: e.message }
   end
 
   def edit

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -13,10 +13,6 @@ class WirePolicy < ApplicationPolicy
     user_who_can_transfer?
   end
 
-  def approve?
-    user&.admin?
-  end
-
   def send_wire?
     user&.admin?
   end

--- a/app/views/admin/wire_process.html.erb
+++ b/app/views/admin/wire_process.html.erb
@@ -148,8 +148,6 @@
           </div>
           <%= form.submit "💸 Approve and automatically send transfer", data: { turbo_confirm: "This will automatically send the wire. You don't need to send it manually!" }, class: "mb-0" %>
         <% end %>
-        <hr>
-        <%= button_to "🔧 Approve and manually send transfer", approve_wire_path(@wire), method: :post, data: { turbo_confirm: "Have you manually sent this wire? This option requires you send this wire." } %>
       </fieldset>
 
       <fieldset class="px-6 py-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -499,7 +499,6 @@ Rails.application.routes.draw do
 
   resources :wires, only: [:edit, :update] do
     member do
-      post "approve"
       post "send", to: "wires#send_wire"
       post "reject"
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
This feature was no longer needed.
closes #14278


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove manually send wire.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

