### PR TITLE
[Ledger] Always render nonzero transactions

### DIFF
--- a/app/controllers/concerns/set_ledger_filters.rb
+++ b/app/controllers/concerns/set_ledger_filters.rb
@@ -129,7 +129,16 @@ module SetLedgerFilters
         query << { linked_object_type: }
       end
 
-      query << { status: { "$in": ["settled", "pending", "reversed"] } }
+      # Amount trumps status: an item that moved any non-zero amount should
+      # always render (e.g. a declined/failed transaction that still posted a
+      # partial charge), regardless of its status. Only zero-amount items are
+      # subject to the status allowlist.
+      query << {
+        "$or": [
+          { amount_cents: { "$ne": 0 } },
+          { status: { "$in": ["settled", "pending", "reversed"] } }
+        ]
+      }
       Ledger::Query.new({ "$and": query })
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -142,6 +142,8 @@ RSpec.describe EventsController do
   end
 
   describe "#ledger" do
+    render_views
+
     let(:admin) { create(:user, :make_admin) }
     let(:event) { create(:event) }
 
@@ -167,6 +169,33 @@ RSpec.describe EventsController do
         get(:ledger, params: { event_id: event.slug, maximum_amount: 500 })
 
         expect(response).to have_http_status(:ok)
+      end
+
+      # The default status filter hides declined/failed/rejected/canceled/
+      # released items, but a non-zero amount should trump that: e.g. a
+      # declined card charge that still posted a partial hold must still show.
+      #
+      # `status`/`amount_cents`/`memo` are derived columns recalculated by
+      # Ledger::Item#refresh! (triggered by Ledger::Mapping's after_commit)
+      # whenever a bare, unlinked item is created or mapped — `memo` in
+      # particular falls back to custom_memo/system_memo/fallback_memo, so the
+      # factory's plain `memo:` gets overwritten. Set `custom_memo` so it
+      # survives refresh, and set status/amount_cents via update_columns
+      # (bypasses callbacks) after mapping, to simulate a real
+      # declined-but-moved-money item.
+      it "shows a non-settled item with a non-zero amount, but hides one with a zero amount" do
+        moved_money = create(:ledger_item, custom_memo: "Declined but moved money", datetime: Time.current)
+        Ledger::Mapping.create!(ledger: event.ledger, ledger_item: moved_money, on_primary_ledger: true)
+        moved_money.update_columns(status: "declined", amount_cents: 500)
+
+        no_money_moved = create(:ledger_item, custom_memo: "Declined with no amount", datetime: Time.current)
+        Ledger::Mapping.create!(ledger: event.ledger, ledger_item: no_money_moved, on_primary_ledger: true)
+        no_money_moved.update_columns(status: "declined", amount_cents: 0)
+
+        get(:ledger, params: { event_id: event.slug })
+
+        expect(response.body).to include("Declined but moved money")
+        expect(response.body).not_to include("Declined with no amount")
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some transactions might have a status that is bugged but we still want to see them if they have a nonzero amount.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Render all transactions that have a nonzero amount.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

