### PR TITLE
[Admin] Include user in Admin Transfer denial emails

### DIFF
--- a/app/mailers/governance/admin/transfer/approval_attempt_mailer.rb
+++ b/app/mailers/governance/admin/transfer/approval_attempt_mailer.rb
@@ -18,6 +18,7 @@ module Governance
                                   end
 
           mail to: report_recipients,
+               cc: @approval_attempt.user.email_address_with_name,
                subject: "[HCB] Admin Transfer Denied: #{impersonation_snippet}#{@approval_attempt.user.name} for #{@approval_attempt.attempted_amount.format}"
         end
 

--- a/app/views/governance/admin/transfer/approval_attempt_mailer/report_denial.html.erb
+++ b/app/views/governance/admin/transfer/approval_attempt_mailer/report_denial.html.erb
@@ -12,10 +12,6 @@ but was denied for the following reason:
   <%= @approval_attempt.denial_message %>
 </blockquote>
 
-<% if @approval_attempt.denied_for_insufficient_limit? %>
-  Consider increasing their limit.
-<% end %>
-
 <pre>
   <%== ap @approval_attempt %>
 </pre>


### PR DESCRIPTION
## Summary of the problem

I want to make it clear that there's a notification sent when transfers are denied.


## Describe your changes

Include the button clicker as a CC in the report denial email.

~~gataard: governance admin transfer approval attempt report denial~~