### PR TITLE
[Sub-org] Collapse sub-rows in Excel exports

### DIFF
--- a/app/models/event/sub_organizations_export.rb
+++ b/app/models/event/sub_organizations_export.rb
@@ -59,14 +59,21 @@ class Event
       worksheet.write_number(@current_row, 3, event.balance_v2_cents / 100.0)
       worksheet.write_string(@current_row, 4, tags_for_parent.map(&:name).join(", "))
 
-      if depth.positive?
+      children = children_of(event.id)
+      hidden = depth.positive?
+      # `symbols_below: 0` puts each group's toggle on the parent row above it,
+      # so the `collapsed` flag belongs on any row that has children.
+      collapsed = children.any?
+
+      if hidden || collapsed
         # Syntax: set_row(row, height, format, hidden, level, collapsed)
-        worksheet.set_row(@current_row, nil, nil, 0, depth.clamp(0, MAX_OUTLINE_LEVEL))
+        worksheet.set_row(@current_row, nil, nil, hidden ? 1 : 0,
+                          depth.clamp(0, MAX_OUTLINE_LEVEL), collapsed ? 1 : 0)
       end
 
       @current_row += 1
 
-      children_of(event.id).each { |child| write_subtree(worksheet, child, depth + 1) }
+      children.each { |child| write_subtree(worksheet, child, depth + 1) }
     end
 
     def children_of(parent_id)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -397,6 +397,10 @@ RSpec.describe EventsController do
         # ...and grouped so Excel renders them collapsible.
         sheet = xlsx_entry(response.body, "xl/worksheets/sheet1.xml")
         expect(sheet).to include('outlineLevel="1"')
+        # Descendants start hidden, and every row with children carries the
+        # collapsed flag, so the tree opens fully collapsed.
+        expect(sheet).to include('hidden="1"')
+        expect(sheet).to include('collapsed="1"')
         # Excel hides the grouping gutter entirely when this attribute is set,
         # even though Google Sheets ignores it. See SubOrganizationsExport.
         expect(sheet).not_to include("showOutlineSymbols")


### PR DESCRIPTION
## Summary of the problem

Sub-organization rows in Excel exports were grouped but not initially collapsed, making nested organization trees difficult to scan. The new ledger opt-in also needed to be restricted to organizers with reader access.

## Describe your changes

- Mark rows with children as collapsed and hide descendant rows in sub-organization Excel exports so exported trees open fully collapsed.
- Restrict new ledger access to organizers with reader-level permissions, while preserving auditor access.
- Simplify payment payout lookup and update related receipt and payment views.
- Update policy, controller, and export specs to cover the new behavior.