### PR TITLE
Fix unknown hcb_code id collisions between CanonicalTransaction and CanonicalPendingTransaction

### DIFF
--- a/app/services/transaction_grouping_engine/calculate/hcb_code.rb
+++ b/app/services/transaction_grouping_engine/calculate/hcb_code.rb
@@ -319,8 +319,17 @@ module TransactionGroupingEngine
         [
           HCB_CODE,
           UNKNOWN_CODE,
-          @ct_or_cp.column_transaction_id || @ct_or_cp.id
+          @ct_or_cp.column_transaction_id || unknown_identifier
         ].join(SEPARATOR)
+      end
+
+      # CanonicalTransaction and CanonicalPendingTransaction each have their
+      # own `id` sequence, so an unrelated CT and CPT can end up with the same
+      # id. Prefixing with the model name keeps their "unknown" hcb_codes from
+      # colliding with each other (which would otherwise merge two unrelated
+      # transactions onto the same HcbCode/ledger item).
+      def unknown_identifier
+        "#{@ct_or_cp.model_name.param_key}_#{@ct_or_cp.id}"
       end
 
     end

--- a/spec/models/canonical_pending_transaction_spec.rb
+++ b/spec/models/canonical_pending_transaction_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CanonicalPendingTransaction, type: :model do
     let(:hcb_code) { canonical_pending_transaction.reload.hcb_code }
 
     it "calculates it on create" do
-      expect(hcb_code).to eql("HCB-000-#{canonical_pending_transaction.id}")
+      expect(hcb_code).to eql("HCB-000-canonical_pending_transaction_#{canonical_pending_transaction.id}")
     end
 
     context "when a raw_pending_stripe_transaction is attached" do


### PR DESCRIPTION
## Problem

`TransactionGroupingEngine::Calculate::HcbCode#unknown_hcb_code` computes a fallback code of `"HCB-000-#{id}"` for any `CanonicalTransaction` or `CanonicalPendingTransaction` it can't otherwise classify (no linked object, no short code in the memo, etc).

`CanonicalTransaction` and `CanonicalPendingTransaction` are separate tables with independent `id` sequences, so an unrelated CT and CPT can end up with the same numeric id. When that happens they compute the **identical** `unknown_hcb_code` string. Since `HcbCode` rows are found by exact string match (`HcbCode.find_or_create_by(hcb_code:)`), the second record to be written silently finds and reuses the first record's `HcbCode` row — and therefore its `Ledger::Item` — even though the two transactions are completely unrelated.

This surfaced as an intermittent (seed-dependent) failure in `bad_settled_mapping_spec.rb`:

```
RuntimeError: CanonicalTransaction 4 has calculated a different ledger item from its local_hcb_code. ( vs. 7)
```

Trace: a freshly created `CanonicalTransaction` inherits an already-populated `ledger_item` from an unrelated `CanonicalPendingTransaction`'s `HcbCode` row (because their ids collided), which trips the calculated-vs-actual consistency check in `CanonicalTransaction#assign_ledger_item`. I confirmed this by forcing the two id sequences to align and reproducing the exact same crash/message shape.

## Fix

Prefix the fallback identifier with the model name, so a CT and a CPT can never produce the same "unknown" hcb_code even when their raw ids collide:

```ruby
def unknown_identifier
  "#{@ct_or_cp.model_name.param_key}_#{@ct_or_cp.id}"
end
```

`column_transaction_id` (used when present) is untouched — that's intentionally shared between a Column pending/settled pair and is a legitimate grouping mechanism, not part of this bug.

Also updated the one spec asserting the old literal `"HCB-000-<id>"` format for `CanonicalPendingTransaction`.

## Testing

- Reproduced the crash directly by forcing the CT/CPT id sequences to align, confirmed the fix eliminates it under the same forced collision.
- `bad_settled_mapping_spec.rb` passes across multiple seeds.
- `canonical_pending_transaction_spec.rb`, `canonical_transaction_spec.rb`, `hcb_code_spec.rb`, `transaction_grouping_engine`, and `pending_event_mapping_engine` specs all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)