### PR TITLE
[Ledger] Scroll long memos horizontally instead of truncating them

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -159,23 +159,22 @@ html[data-dark='true'] {
   color: map-get($palette, muted);
 }
 
-// Fills the remaining table width and truncates with an ellipsis instead of
-// widening the table (max-width: 0 keeps the content from sizing the cell)
+// Fills the remaining table width when the memo is short, but lets the cell
+// grow with its content when it isn't (overriding .transaction__memo's
+// max-width) instead of truncating it — .table-container's overflow-x: auto
+// then turns that extra width into a horizontal scrollbar.
 .transaction__memo--fluid {
   width: 100%;
-  max-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  max-width: none;
   white-space: nowrap;
 }
 
+// visibility (not width) is what reveals this on hover — the badge always
+// takes up its natural width so the row's width, and thus the fluid memo
+// column's, stays constant whether or not it's hovered.
 .transaction:hover .add-tag-badge,
 .add-tag-badge[aria-expanded='true'] {
   visibility: visible;
-}
-
-.transaction:not(:hover) .add-tag-badge {
-  width: 1px;
 }
 
 .transaction:hover .suggested_tag,

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -12,7 +12,7 @@
       <div class="flex-auto">
         <div class="flex items-center gap-[1ch] min-w-0">
           <%= render "ledger/items/status", ledger_item: item %>
-          <div class="min-w-0 overflow-hidden text-ellipsis">
+          <div class="min-w-0">
             <%= render "ledger/items/memo/memo", item: %>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The ledger's memo column was truncating long memos with an ellipsis. This switches it to horizontal scroll instead, and fixes a related hover layout-shift bug in the same row.

- `.transaction__memo--fluid` forced `max-width: 0; overflow: hidden; text-overflow: ellipsis` on the memo `<td>`, and a matching Tailwind `overflow-hidden text-ellipsis` wrapper in the view did the same at the element level. `.table-container` already sets `overflow-x: auto`, so instead of clipping the memo, the cell is now allowed to grow with its content and that existing horizontal scrollbar takes over for long memos.
- The "+ Add tag" badge collapsed to `width: 1px` when not hovered and snapped back to its natural width on hover — an un-transitioned width jump living in the same flex row as the memo, so hovering a row shifted its content (more noticeably now that the memo column can grow). `visibility: hidden` already hides it, so letting it keep its natural width at all times makes the row's width hover-invariant.

Both changes are scoped to the `--fluid` memo variant / ledger's `.transaction` rows, so the other (non-ledger) transaction tables that reuse `.transaction__memo` without `--fluid` are unaffected.

## Test plan
- [x] Manually verified in-app: long memos in the ledger table now scroll horizontally instead of being clipped.
- [x] Manually verified hovering a row (revealing "+ Add tag") no longer shifts row content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)