### PR TITLE
[Donations] Add Turnstile protection to donation flows

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -6,6 +6,7 @@ class DonationsController < ApplicationController
   include SetEvent
   include DonationPageSetup
   include Rails::Pagination
+  include TurnstileProtection
 
   skip_after_action :verify_authorized, only: [:finish_donation, :finished, :qr_code]
   skip_before_action :signed_in_user, only: [:start_donation, :make_donation, :finish_donation, :finished, :qr_code]
@@ -39,6 +40,13 @@ class DonationsController < ApplicationController
   end
 
   invisible_captcha only: [:make_donation], honeypot: :subtitle, on_timestamp_spam: :redirect_to_404
+
+  # Saving a Donation mints a Stripe PaymentIntent, which is what card testers
+  # are after: script this form and you get a fresh intent to burn stolen card
+  # numbers against. The honeypot above doesn't slow down a bot that fills the
+  # form out properly, so require a solved Turnstile challenge before we create
+  # anything on Stripe.
+  turnstile_protect only: [:make_donation], action: TurnstileService::DONATION_ACTION
 
   # GET /donations/1
   def show
@@ -209,6 +217,34 @@ class DonationsController < ApplicationController
   end
 
   private
+
+  # The donation page hides flashes and the form sits in a Turbo frame, so put
+  # the error on the form the way a failed save does — and keep what they'd
+  # already typed, since re-rendering the frame otherwise empties it.
+  def turnstile_failed
+    return unless build_donation_page!(event: @event, params:, request:)
+
+    @donation.assign_attributes(resubmitted_donation_attributes)
+    @donation.errors.add(:base, TurnstileProtection::FAILURE_MESSAGE)
+    # The POST carries no tier, and the tier picker renders *instead of* the
+    # form — which would swallow the error. Show the form.
+    @show_tiers = false
+    @top_donors = []
+    @recent_donors = []
+    @hide_flash = true
+
+    render :start_donation, status: :unprocessable_content
+  end
+
+  # Deliberately not `donation_params`: that one requires the key, so a bot's
+  # bare POST would raise here. The amount also arrives as dollars.
+  def resubmitted_donation_attributes
+    submitted = params[:donation]
+    return {} unless submitted.is_a?(ActionController::Parameters)
+
+    attributes = submitted.permit(:name, :email, :message, :anonymous, :amount).to_h
+    attributes.merge("amount" => (Monetize.parse(attributes["amount"]).cents if attributes["amount"].present?))
+  end
 
   def stream_donations_csv
     set_file_headers_csv

--- a/app/controllers/recurring_donations_controller.rb
+++ b/app/controllers/recurring_donations_controller.rb
@@ -2,6 +2,7 @@
 
 class RecurringDonationsController < ApplicationController
   include SetEvent
+  include TurnstileProtection
 
   before_action :set_event, only: [:create, :pay, :finished]
   before_action :set_recurring_donation_by_hashid, only: [:pay, :finished]
@@ -11,6 +12,11 @@ class RecurringDonationsController < ApplicationController
   skip_before_action :redirect_to_onboarding
 
   invisible_captcha only: [:create], honeypot: :subtitle
+
+  # The monthly half of the donation form, gated for the same reason as the
+  # one-time one: saving a RecurringDonation creates a Stripe subscription and
+  # with it a PaymentIntent for card testers to work against.
+  turnstile_protect only: [:create], action: TurnstileService::DONATION_ACTION
 
   def create
     params[:recurring_donation][:amount] = Monetize.parse(params[:recurring_donation][:amount]).cents
@@ -82,6 +88,31 @@ class RecurringDonationsController < ApplicationController
   end
 
   private
+
+  # Mirrors the failed-save path in `create`: the donation page hides flashes
+  # and the form sits in a Turbo frame, so the error belongs on the form. Keep
+  # what they'd already typed, since re-rendering the frame otherwise empties
+  # it.
+  def turnstile_failed
+    @recurring_donation = @event.recurring_donations.build(resubmitted_attributes)
+    @recurring_donation.errors.add(:base, TurnstileProtection::FAILURE_MESSAGE)
+    @monthly = true
+    @top_donors = []
+    @recent_donors = []
+    @hide_flash = true
+
+    render "donations/start_donation", status: :unprocessable_content
+  end
+
+  # A bot's POST needn't include the key at all, so don't assume it's there;
+  # the amount arrives from the form as dollars.
+  def resubmitted_attributes
+    submitted = params[:recurring_donation]
+    return {} unless submitted.is_a?(ActionController::Parameters)
+
+    attributes = submitted.permit(:name, :email, :message, :anonymous, :amount).to_h
+    attributes.merge("amount" => (Monetize.parse(attributes["amount"]).cents if attributes["amount"].present?))
+  end
 
   def set_recurring_donation_by_hashid
     @recurring_donation = @event.recurring_donations.find_by_hashid!(params[:id])

--- a/app/javascript/controllers/turnstile_controller.js
+++ b/app/javascript/controllers/turnstile_controller.js
@@ -1,0 +1,68 @@
+/*
+  Renders a Cloudflare Turnstile widget inside a form, parks the solved token
+  in a hidden field, and holds the form's submit button until there is one.
+
+  The hidden field is named `cf-turnstile-response`, which is where
+  `TurnstileProtection` reads the token from on the server. Cloudflare can
+  inject that field itself, but we turn that off and write it by hand so the
+  token can't go stale without the button going back to disabled alongside it.
+*/
+
+import { Controller } from '@hotwired/stimulus'
+import loadTurnstile from '../common/turnstile'
+
+export default class extends Controller {
+  static targets = ['widget', 'token', 'submit', 'error']
+  static values = {
+    sitekey: String,
+    action: String,
+  }
+
+  connect() {
+    this.#setToken(null)
+
+    // We render explicitly rather than letting Cloudflare's script scan for
+    // `.cf-turnstile` elements: this form lives in a Turbo frame that's swapped
+    // in after load, which the automatic scan never sees.
+    loadTurnstile()
+      .then(turnstile => {
+        if (!this.element.isConnected) return
+
+        this.widgetId = turnstile.render(this.widgetTarget, {
+          sitekey: this.sitekeyValue,
+          action: this.actionValue,
+          'response-field': false,
+          callback: token => this.#setToken(token),
+          'expired-callback': () => this.#setToken(null),
+          'error-callback': () => this.#setToken(null),
+        })
+      })
+      .catch(() => {
+        // The server rejects a tokenless submission anyway, so say why the
+        // button is stuck rather than letting someone fill the form for
+        // nothing.
+        if (this.hasErrorTarget) this.errorTarget.hidden = false
+      })
+  }
+
+  disconnect() {
+    if (this.widgetId === undefined) return
+
+    // Throws if the widget's element has already been torn out from under us,
+    // which a Turbo frame swap can do.
+    try {
+      window.turnstile?.remove(this.widgetId)
+    } catch {
+      // The widget is gone either way.
+    }
+    this.widgetId = undefined
+  }
+
+  #setToken(token) {
+    if (this.hasTokenTarget) this.tokenTarget.value = token || ''
+
+    this.submitTargets.forEach(submit => {
+      submit.disabled = !token
+    })
+  }
+}

--- a/app/services/turnstile_service.rb
+++ b/app/services/turnstile_service.rb
@@ -1,18 +1,28 @@
 # frozen_string_literal: true
 
-# Cloudflare Turnstile — a bot check in front of phone-number verification,
-# the one flow that texts a Twilio Verify code to an unverified, user-typed
-# number. That's the surface spam signups have abused to run up our Twilio
-# bill; login SMS codes only ever go to numbers verified through here.
+# Cloudflare Turnstile — a bot check in front of the two unauthenticated flows
+# that cost us money when scripted:
 #
-# The server half lives in TurnstileService::Verify; the widget is rendered by
-# the `settings/SmsVerification` React component via `common/turnstile.js`.
+#   * phone-number verification, which texts a Twilio Verify code to an
+#     unverified, user-typed number (login SMS codes only ever go to numbers
+#     verified through here);
+#   * starting a donation, which mints a Stripe PaymentIntent that a card
+#     tester can then throw stolen numbers at.
+#
+# The server half lives in TurnstileService::Verify; widgets are rendered by
+# the `settings/SmsVerification` React component and the `turnstile` Stimulus
+# controller, both via `common/turnstile.js`.
 module TurnstileService
   # Widget action. Cloudflare records it when a token is solved and echoes it
   # back at siteverify, so a token minted by any other widget on our sitekey
   # can't be replayed here. Referenced by both the component and the controller
   # to keep the two from drifting apart.
   SMS_VERIFICATION_ACTION = "sms-verification"
+
+  # Shared by the one-time and monthly donation forms: they're the same widget
+  # on the same page, and both land on a controller that creates Stripe
+  # objects.
+  DONATION_ACTION = "donation"
 
   def self.site_key
     Credentials.fetch(:TURNSTILE, :SITE_KEY)

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -10,12 +10,17 @@
     </ul>
   <% end %>
 
+  <%# Cloudflare Turnstile gates the submit button; see the `turnstile` Stimulus controller. %>
+  <% turnstile_sitekey = TurnstileService.site_key if TurnstileService.enabled? %>
+  <% form_data = { turbo: true, turbo_action: "advance" } %>
+  <% form_data.merge!(controller: "turnstile", turnstile_sitekey_value: turnstile_sitekey, turnstile_action_value: TurnstileService::DONATION_ACTION) if turnstile_sitekey %>
+
   <%= form_with(model: @monthly ? [@event, @recurring_donation] : donation, local: true, url: (make_donation_donations_path unless @monthly),
-                class: "card mx-auto max-w-96 mb3", data: { turbo: true, turbo_action: "advance" }, html: { autocomplete: "off" }) do |form| %>
+                class: "card mx-auto max-w-96 mb3", data: form_data, html: { autocomplete: "off" }) do |form| %>
     <% donation = @recurring_donation if @monthly %>
 
     <%= form.invisible_captcha :subtitle %>
-    <%= form_errors(donation, nil, "We couldn't start this") unless @monthly %>
+    <%= form_errors(donation, nil, "We couldn't start this") %>
 
     <div class="field mb2">
       <%= form.label :name, "Your name" %>
@@ -115,10 +120,19 @@
     <%= form.hidden_field :utm_content %>
     <%= form.hidden_field :referrer %>
 
+    <% if turnstile_sitekey %>
+      <%= hidden_field_tag TurnstileProtection::TOKEN_PARAM, nil, id: nil, data: { turnstile_target: "token" } %>
+      <div class="mt1" data-turnstile-target="widget"></div>
+      <div class="primary h5 mt1" data-turnstile-target="error" hidden>
+        We couldn’t load the human-verification check. Please disable any ad blocker for this page and reload.
+      </div>
+    <% end %>
+
     <% if @event.demo_mode? %>
       <%= form.submit "Continue →", class: "w-100 bg-success mt1", disabled: "true" %>
     <% else %>
-      <%= form.submit "Continue →", class: "w-100 bg-success mt1" %>
+      <%# The Turnstile controller keeps this disabled until the challenge is solved. %>
+      <%= form.submit "Continue →", class: "w-100 bg-success mt1", disabled: turnstile_sitekey.present?, data: ({ turnstile_target: "submit" } if turnstile_sitekey) %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/requests/donations_turnstile_spec.rb
+++ b/spec/requests/donations_turnstile_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Saving a donation mints a Stripe PaymentIntent (or, for a monthly one, a
+# subscription), which is exactly what card testers want to farm. Both halves
+# of the donation form are gated on a solved Turnstile challenge.
+RSpec.describe "Donation Turnstile", type: :request do
+  include DonationSupport
+
+  let(:event) { create(:event) }
+  let(:token) { "0.turnstile-token" }
+
+  before do
+    allow(TurnstileService).to receive_messages(site_key: "0x0000site", secret_key: "0x0000secret")
+  end
+
+  def stub_siteverify(success:, action: TurnstileService::DONATION_ACTION)
+    stub_request(:post, TurnstileService::Verify::SITEVERIFY_URL).to_return(
+      status: 200,
+      body: { "success" => success, "action" => action, "hostname" => "www.example.com" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
+  it "renders the widget on the donation page" do
+    get start_donation_donations_path(event.slug)
+
+    expect(response.body).to include(%(data-turnstile-action-value="#{TurnstileService::DONATION_ACTION}"))
+  end
+
+  describe "POST make_donation" do
+    def make_donation(params = {})
+      post make_donation_donations_path(event.slug), params: {
+        donation: { name: "Jane Smith", email: "jane@example.com", amount: "12.34" }
+      }.deep_merge(params)
+    end
+
+    it "creates the donation when the token verifies" do
+      stub_donation_payment_intent_creation
+      stub_siteverify(success: true)
+
+      expect { make_donation("cf-turnstile-response" => token) }.to change(Donation, :count).by(1)
+    end
+
+    it "refuses without reaching Stripe when the token is missing" do
+      expect(StripeService::Customer).not_to receive(:create)
+
+      expect { make_donation }.not_to change(Donation, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(ERB::Util.html_escape(TurnstileProtection::FAILURE_MESSAGE))
+    end
+
+    it "refuses when Cloudflare rejects the token" do
+      expect(StripeService::Customer).not_to receive(:create)
+
+      stub_siteverify(success: false)
+
+      expect { make_donation("cf-turnstile-response" => token) }.not_to change(Donation, :count)
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    # A token minted by any other widget on our sitekey carries a different
+    # action, so it can't be spent here.
+    it "refuses a token solved for a different widget" do
+      expect(StripeService::Customer).not_to receive(:create)
+
+      stub_siteverify(success: true, action: TurnstileService::SMS_VERIFICATION_ACTION)
+
+      expect { make_donation("cf-turnstile-response" => token) }.not_to change(Donation, :count)
+    end
+
+    # The rejected form comes back filled in, so someone whose token merely
+    # expired doesn't have to type everything again.
+    it "keeps the submitted details on the re-rendered form" do
+      stub_siteverify(success: false)
+
+      make_donation("cf-turnstile-response" => token)
+
+      expect(response.body).to include("Jane Smith", "jane@example.com", "12.34")
+    end
+
+    context "when Turnstile isn't configured" do
+      before { allow(TurnstileService).to receive_messages(site_key: nil, secret_key: nil) }
+
+      it "creates the donation without calling Cloudflare" do
+        stub_donation_payment_intent_creation
+
+        expect { make_donation }.to change(Donation, :count).by(1)
+        expect(a_request(:post, TurnstileService::Verify::SITEVERIFY_URL)).not_to have_been_made
+      end
+    end
+  end
+
+  describe "POST create (monthly)" do
+    def create_recurring_donation(params = {})
+      post event_recurring_donations_path(event.slug), params: {
+        recurring_donation: { name: "Jane Smith", email: "jane@example.com", amount: "12.34" }
+      }.deep_merge(params)
+    end
+
+    it "refuses without reaching Stripe when the token is missing" do
+      expect(StripeService::Customer).not_to receive(:create)
+
+      expect { create_recurring_donation }.not_to change(RecurringDonation, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(ERB::Util.html_escape(TurnstileProtection::FAILURE_MESSAGE))
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Donation forms can be scripted to create Stripe PaymentIntents and subscriptions, enabling card testing and payment abuse. The existing honeypot protection does not prevent bots that submit valid-looking forms.

## Describe your changes

- Added Cloudflare Turnstile protection to one-time and recurring donation flows.
- Added a Stimulus controller to render the widget, manage tokens, and disable submission until verification succeeds.
- Added server-side verification, failure handling, form repopulation, and request coverage.
- Tightened new-ledger access to organizers/readers and restored ledger memo truncation behavior.
- Updated payment payout lookup naming and related call sites.