### PR TITLE
[Ledger::Item] Fix intermittent failure to clear a custom memo

### DIFF
--- a/app/javascript/controllers/memo_controller.js
+++ b/app/javascript/controllers/memo_controller.js
@@ -43,6 +43,9 @@ export default class extends Controller {
   }
 
   save() {
+    // showDisplay's hidden toggle can force a blur that re-enters here; ignore it.
+    if (this.closingForm) return
+
     this.formTarget.requestSubmit()
   }
 
@@ -54,8 +57,12 @@ export default class extends Controller {
   }
 
   showDisplay() {
+    // Hiding a still-focused input (e.g. after confirming with Enter) forces
+    // a blur, which would otherwise re-trigger save() with a stale value.
+    this.closingForm = true
     this.formTarget.hidden = true
     this.displayTarget.hidden = false
+    this.closingForm = false
   }
 
   flashRenamed() {


### PR DESCRIPTION
## Summary of the problem
Sometimes, shift-clicking a transaction's memo on the new ledger, clearing it, and confirming with Enter would not actually clear the custom memo — the old text would silently come back.

## Describe your changes
Confirming an inline memo edit with Enter leaves the input focused. When the turbo-stream response comes back, `submitEnd()` → `showDisplay()` hides the (still-focused) form, which forces a native blur → re-fires `blur->memo#save`, submitting the form a second time.

What that second submission sends races the `MutationObserver` that syncs `inputTarget`'s value from the newly-rendered display span: if the sync wins, the second submit resends the just-displayed system memo text as a brand new custom memo, silently undoing the clear. This only visibly affects clearing, since a normal rename resends equivalent text either way — which is why it was hard to pin down.

Adds a reentrancy guard so `showDisplay` (called from both `submitEnd` and `cancel`/Escape) suppresses the blur it itself provokes, instead of resubmitting.

I also seriously chased a server-side theory (a cross-transaction lost-update race in `Ledger::Item#refresh!`), but a live repro spec showed it self-heals due to Rails' partial-write dirty tracking, so no server-side changes here.

No JS test harness exists in this repo (no Jest/Vitest/system specs), so this is verified by reading Turbo's source rather than an automated test. Manual repro: shift-click a transaction memo on the new ledger, clear it, confirm with **Enter**, then refresh — the memo should stay cleared (system memo shown) instead of reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)