### PR TITLE
[Comments] Migrate comments from HcbCode to Ledger::Item (2/4): prep

### DIFF
--- a/app/models/export/event/transactions/ledger.rb
+++ b/app/models/export/event/transactions/ledger.rb
@@ -53,7 +53,7 @@ class Export
               if merchant && !public_only
                 category = merchant["category"].humanize.titleize.delete(" ")
                 metadata[:merchant] = merchant
-                metadata[:comments] = ct.local_hcb_code.comments.not_admin_only.pluck(:content) unless public_only && ct.local_hcb_code.comments.count.zero?
+                metadata[:comments] = ct.local_hcb_code.all_comments.not_admin_only.pluck(:content) unless public_only && ct.local_hcb_code.all_comments.count.zero?
               elsif merchant
                 category = "CardCharge"
               end

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -734,14 +734,19 @@ class HcbCode < ApplicationRecord
   end
 
   def not_admin_only_comments_count
-    # `not_admin_only.count` always issues a new query to the DB because a scope is being applied.
-    # However, if comments have been preloaded, it's more likely to be faster to count
-    # the non admin comments in memory. The vast majority of HcbCodes have fewer than 4 comments
-    @not_admin_only_comments_count ||= if comments.loaded?
-                                         comments.count { |c| !c.admin_only }
-                                       else
-                                         comments.not_admin_only.count
-                                       end
+    @not_admin_only_comments_count ||= all_comments.not_admin_only.count
+  end
+
+  # TODO: TEMPORARY, remove once comments are fully migrated from HcbCode to
+  # Ledger::Item. Comments are being moved over in stages; until that finishes,
+  # a transaction's comments may live on either this HcbCode or its Ledger::Item.
+  # Overrides Commentable#all_comments to fold both in, on top of the existing
+  # shared_commentable (disbursement/invoice) union.
+  def all_comments
+    scope = comments
+    scope = scope.or(Comment.where(commentable: ledger_item)) if ledger_item
+    scope = scope.or(Comment.where(commentable: shared_commentable)) if shared_commentable
+    scope.order(:created_at)
   end
 
   def pinnable?

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -58,7 +58,6 @@ class Ledger
     belongs_to :author, class_name: "User", optional: true
 
     # TODO: THIS IS SO TEMPORARY REMOVE ASAP
-    has_many :comments, -> { order(:created_at) }, as: :commentable, inverse_of: :commentable, through: :hcb_code
     has_many :receipts, as: :receiptable, after_add: :update_task_completion, after_remove: :update_task_completion, through: :hcb_code
     has_many :tags, through: :hcb_code
 
@@ -189,16 +188,13 @@ class Ledger
       nil
     end
 
-    # TODO: this union will simplify once the Comment->Ledger::Item migration
-    # finishes and comments live directly on Ledger::Item. For now, comments
-    # live on hcb_code — deliberately built on a plain Comment.where rather
-    # than the `comments` association (which goes through hcb_code and so
-    # brings its own INNER JOIN): combining that with an unrelated
-    # Comment.where(commentable: shared_commentable) via `.or` silently drops
-    # every shared_commentable row, since the join still applies to the whole
-    # query regardless of which side of the WHERE-level OR would've matched.
+    # TODO: TEMPORARY, remove the hcb_code term once comments are fully
+    # migrated from HcbCode to Ledger::Item. Comments are being moved over in
+    # stages; until that finishes, a transaction's comments may still live on
+    # its HcbCode instead of here. Overrides Commentable#all_comments to fold
+    # those in too, on top of the shared_commentable union above.
     def all_comments
-      scope = Comment.where(commentable: hcb_code)
+      scope = Comment.where(commentable: self).or(Comment.where(commentable: hcb_code))
       scope = scope.or(Comment.where(commentable: shared_commentable)) if shared_commentable
       scope.order(:created_at)
     end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -46,7 +46,11 @@ class CommentPolicy < ApplicationPolicy
   def users
     user_list = []
 
-    if record.commentable.respond_to?(:events)
+    if record.commentable.is_a?(Ledger::Item)
+      # Ledger::Item deliberately has no generic event/events method (it can be
+      # mapped onto more than one ledger) — go straight to its ledger mappings.
+      user_list = record.commentable.all_ledgers.filter_map(&:event).flat_map(&:ancestor_users)
+    elsif record.commentable.respond_to?(:events)
       user_list = record.commentable.events.collect(&:ancestor_users).flatten
     elsif record.commentable.is_a?(Reimbursement::Report)
       user_list = [record.commentable.user]

--- a/app/views/admin/ledger_audits/tasks/show.html.erb
+++ b/app/views/admin/ledger_audits/tasks/show.html.erb
@@ -124,7 +124,7 @@
 
 <div style="max-width: 600px; margin-left: auto; margin-right: auto;" class="mt4">
   <h3>HCB Code Comments</h3>
-  <%= render "comments/list", comments: @hcb_code.comments %>
+  <%= render "comments/list", comments: @hcb_code.all_comments %>
   <%= render "comments/form", commentable: @hcb_code %>
 </div>
 

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -123,7 +123,7 @@
         <% end %>
       <% end %>
       <% if pt.local_hcb_code %>
-        <%= list_badge_for auditor_signed_in? ? pt.local_hcb_code.comments.size : pt.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
+        <%= list_badge_for auditor_signed_in? ? pt.local_hcb_code.all_comments.count : pt.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
         <% receipts_count = if pt.local_hcb_code.reimbursement_expense_payout?
                               Rails.cache.fetch("pt_#{pt.hcb_code}/receipts_count", expires_in: 12.hours) { pt.local_hcb_code.receipts.size }
                             else

--- a/app/views/canonical_pending_transactions/show.html.erb
+++ b/app/views/canonical_pending_transactions/show.html.erb
@@ -134,6 +134,6 @@
       } %>
 
   <h2>Comments</h2>
-  <%= render "comments/list", comments: @hcb_code.comments %>
+  <%= render "comments/list", comments: @hcb_code.all_comments %>
   <%= render "comments/form", commentable: @hcb_code %>
 <% end %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -132,7 +132,7 @@
         <% end %>
       <% end %>
       <% if ct.local_hcb_code %>
-        <%= list_badge_for auditor_signed_in? ? ct.local_hcb_code.comments.size : ct.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
+        <%= list_badge_for auditor_signed_in? ? ct.local_hcb_code.all_comments.count : ct.local_hcb_code.not_admin_only_comments_count, "comment", "post", optional: true %>
         <% receipts_count = if ct.local_hcb_code.reimbursement_expense_payout?
                               Rails.cache.fetch("ct_#{ct.hcb_code}/receipts_count", expires_in: 12.hours) { ct.local_hcb_code.receipts.size }
                             else

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -52,10 +52,10 @@
   <% viewing_disbursement = @hcb_code.outgoing_disbursement || @hcb_code.incoming_disbursement %>
   <% if viewing_disbursement %>
     <% counterparty_hcb_code = viewing_disbursement.counterparty.local_hcb_code %>
-    <% if policy(counterparty_hcb_code).show? && counterparty_hcb_code.comments.count > 0 %>
+    <% if policy(counterparty_hcb_code).show? && counterparty_hcb_code.all_comments.count > 0 %>
       <p class="muted">
         <%= link_to counterparty_hcb_code do %>
-          View <%= pluralize(counterparty_hcb_code.comments.count, "other comment") %> from <%= viewing_disbursement.counterparty_label %>
+          View <%= pluralize(counterparty_hcb_code.all_comments.count, "other comment") %> from <%= viewing_disbursement.counterparty_label %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/ledger/items/show.html.erb
+++ b/app/views/ledger/items/show.html.erb
@@ -173,7 +173,7 @@
         include_spacing: true,
         turbo: true
       } %>
-  <%= render "comments/list", comments: @item.hcb_code.comments %>
+  <%= render "comments/list", comments: @item.all_comments %>
   <%= render "comments/form", commentable: @item.hcb_code %>
 <% end %>
 

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -176,6 +176,6 @@
       } %>
 
   <h2>Comments</h2>
-  <%= render "comments/list", comments: @hcb_code.comments %>
+  <%= render "comments/list", comments: @hcb_code.all_comments %>
   <%= render "comments/form", commentable: @hcb_code %>
 <% end %>

--- a/spec/controllers/ledger/items_controller_spec.rb
+++ b/spec/controllers/ledger/items_controller_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe Ledger::ItemsController, type: :controller do
         expect(response.body).to include("turbo-stream")
       end
     end
+
+    describe "GET #show" do
+      # TODO: TEMPORARY — comments are being migrated from HcbCode to
+      # Ledger::Item; this asserts the transitional union rendered by both
+      # commentables (Ledger::Item::all_comments) until that finishes.
+      it "renders comments from both the item and its hcb_code" do
+        allow(FlipperGroups).to receive(:hcb_engineer?).and_return(true)
+        hcb_code = create(:hcb_code, ledger_item: item)
+        # CommentPolicy#users needs an event to determine who can see the comment;
+        # for HcbCode that comes from its canonical (pending) transactions.
+        cpt = create(:canonical_pending_transaction)
+        cpt.update_column(:hcb_code, hcb_code.hcb_code)
+        create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:)
+
+        item_comment = create(:comment, commentable: item, user: member_user, content: "comment on the ledger item")
+        hcb_code_comment = create(:comment, commentable: hcb_code, user: member_user, content: "comment on the hcb code")
+
+        get :show, params: { id: item.hashid }
+
+        expect(response).to be_successful
+        expect(response.body).to include(item_comment.content)
+        expect(response.body).to include(hcb_code_comment.content)
+      end
+    end
   end
 
   context "as a reader (not a member)" do

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -362,6 +362,19 @@ RSpec.describe HcbCode, type: :model do
 
         expect(hcb_code.all_comments).to include(hcb_code_comment, invoice_comment)
       end
+
+      # TODO: TEMPORARY — remove once comments are fully migrated from HcbCode to
+      # Ledger::Item and this override is no longer needed.
+      it "includes comments on the hcb_code's ledger_item" do
+        item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+        item.save(validate: false)
+        hcb_code = create(:hcb_code, ledger_item: item)
+
+        hcb_code_comment = create(:comment, commentable: hcb_code, user:)
+        ledger_item_comment = create(:comment, commentable: item, user:)
+
+        expect(hcb_code.all_comments).to include(hcb_code_comment, ledger_item_comment)
+      end
     end
 
     describe "#humanized_type" do

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -441,6 +441,25 @@ RSpec.describe Ledger::Item, type: :model do
 
       expect(item.comment_count).to eq(1)
     end
+
+    it "counts comments from both the item and its hcb_code" do
+      # TODO: TEMPORARY — comments are being migrated from HcbCode to Ledger::Item;
+      # remove this once all_comments no longer needs to fold in the hcb_code side.
+      user = create(:user)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      hcb_code = create(:hcb_code, ledger_item: item)
+
+      create(:comment, commentable: item, user:)
+      create(:comment, commentable: item, admin_only: true, user:)
+      create(:comment, commentable: hcb_code, user:)
+
+      item.refresh!
+      item.reload
+
+      expect(item.comment_count).to eq(3)
+      expect(item.not_admin_only_comment_count).to eq(2)
+    end
   end
 
   describe "#shared_commentable" do
@@ -515,6 +534,31 @@ RSpec.describe Ledger::Item, type: :model do
       invoice_comment = create(:comment, commentable: invoice, user:)
 
       expect(item.all_comments).to include(invoice_comment)
+    end
+
+    # TODO: TEMPORARY — remove once comments are fully migrated from HcbCode to
+    # Ledger::Item and this override is no longer needed.
+    it "includes comments on both the item and its hcb_code" do
+      user = create(:user)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      hcb_code = create(:hcb_code, ledger_item: item)
+
+      item_comment = create(:comment, commentable: item, user:)
+      hcb_code_comment = create(:comment, commentable: hcb_code, user:)
+
+      expect(item.all_comments).to include(item_comment, hcb_code_comment)
+    end
+
+    it "does not include comments from unrelated hcb_codes" do
+      user = create(:user)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      unrelated_hcb_code = create(:hcb_code, code_type: ::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE)
+
+      unrelated_comment = create(:comment, commentable: unrelated_hcb_code, user:)
+
+      expect(item.all_comments).not_to include(unrelated_comment)
     end
   end
 

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -9,6 +9,27 @@ RSpec.describe CommentPolicy, type: :policy do
   end
 
   describe "#users" do
+    context "when commentable is a Ledger::Item" do
+      it "includes users from every ledger it's mapped onto, plus their ancestors" do
+        parent_event = create(:event)
+        ancestor_user = create(:user)
+        create(:organizer_position, event: parent_event, user: ancestor_user)
+
+        child_event = create(:event, parent: parent_event)
+        direct_user = create(:user)
+        create(:organizer_position, event: child_event, user: direct_user)
+
+        item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+        item.save(validate: false)
+        create(:ledger_mapping, :on_primary, ledger: child_event.ledger, ledger_item: item)
+
+        comment = create(:comment, commentable: item)
+        policy = described_class.new(direct_user, comment)
+
+        expect(policy.send(:users)).to include(direct_user, ancestor_user)
+      end
+    end
+
     context "when commentable responds to :events (HcbCode)" do
       it "includes both direct users and ancestor users" do
         parent_event = create(:event)


### PR DESCRIPTION
## Summary of the problem
Comments currently attach to `HcbCode` (`commentable_type: "HcbCode"`). We're migrating them to attach to `Ledger::Item` instead, matching the ongoing move of transaction-page functionality onto `Ledger::Item`. Stacked on #14694 (which brings real `shared_commentable` support to `Ledger::Item`/`Invoice`). This is now 2 of 4:

1. #14694 — shared commentable groundwork for `Ledger::Item`/`Invoice`
2. **This PR** — prep `Ledger::Item` to hold comments alongside `HcbCode`, no user-visible change
3. Cut over: form submits to `Ledger::Item`, backfill existing comments
4. Cleanup: render/count from `Ledger::Item` only

## Describe your changes
- Removed the temporary `has_many :comments, through: :hcb_code` on `Ledger::Item` (marked `# TODO: THIS IS SO TEMPORARY REMOVE ASAP`), falling back to a real polymorphic `has_many :comments`.
- `Ledger::Item#all_comments` (added in #14694 as self plus `shared_commentable`) now also folds in the `hcb_code` side; `HcbCode` gets the same treatment via a new `#all_comments` override (self plus `ledger_item` plus `shared_commentable`). Both marked TEMPORARY, to be removed once the migration finishes.
- `Ledger::Item#refresh!` already read through `all_comments` (from #14694), so it picks up the `hcb_code` side for free.
- `CommentPolicy#users` gets a dedicated `Ledger::Item` branch (via `all_ledgers`), rather than adding a generic `event`/`events` method to `Ledger::Item` purely to satisfy that dispatch — a `Ledger::Item` can be mapped onto more than one ledger, so a single "event" doesn't fit its shape well.
- Updated every comment-count/list call site to stay accurate through the migration: `hcb_codes/show`, `ledger/items/show`, `transactions/show` (deprecated but still routable), `canonical_(pending_)transactions/show` and their list-row badges, the ledger CSV export, and the admin ledger-audits task page.
- Added spec coverage in `ledger/item_spec.rb`, `hcb_code_spec.rb`, `comment_policy_spec.rb`, and a new `GET #show` spec on `ledger/items_controller`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)