### PR TITLE
[Comments] Migrate comments from HcbCode to Ledger::Item (3/4): cut over + backfill

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -59,7 +59,7 @@ class Comment < ApplicationRecord
   }
 
   include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user || record&.user }, event_id: proc { |controller, record| record.admin_only? ? nil : record.commentable.try(:event)&.id }, only: [:create, :update, :destroy]
+  tracked owner: proc{ |controller, record| controller&.current_user || record&.user }, event_id: proc { |controller, record| record.tracked_event_id }, only: [:create, :update, :destroy]
 
   after_create_commit :send_notification_email
 
@@ -99,6 +99,16 @@ class Comment < ApplicationRecord
   def shared?
     # currently the only situation where we share comments at the moment. If we expand this, do something smarter
     commentable_type == "Disbursement"
+  end
+
+  # Used by the `tracked` event_id: proc above. Ledger::Item has no generic
+  # event/events method (it can be mapped onto more than one ledger), so it
+  # needs its own branch here rather than the general `commentable.try(:event)`.
+  def tracked_event_id
+    return nil if admin_only?
+
+    event = commentable.is_a?(Ledger::Item) ? commentable.primary_ledger&.event : commentable.try(:event)
+    event&.id
   end
 
   # This regex was stolen from URI::MailTo::EMAIL_REGEXP

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -199,6 +199,39 @@ class Ledger
       scope.order(:created_at)
     end
 
+    def comment_recipients_for(comment)
+      users = []
+      users += all_comments.map(&:user)
+      users += all_comments.flat_map(&:mentioned_users)
+      # No generic event/events method on Ledger::Item (it can be mapped onto
+      # more than one ledger) — go straight to the events its ledger mappings touch.
+      event_list = Event.where(id: all_ledgers.pluck(:event_id).compact.uniq)
+      users += event_list.flat_map(&:users).reject(&:my_threads?)
+      users += [author] if author
+
+      if comment.admin_only?
+        users += event_list.map(&:point_of_contact)
+        return users.uniq.select(&:auditor?).reject(&:no_threads?).excluding(comment.user).collect(&:email_address_with_name)
+      end
+
+      users.uniq.excluding(comment.user).reject(&:no_threads?).collect(&:email_address_with_name)
+    end
+
+    def comment_mailer_subject
+      "New comment on #{memo}."
+    end
+
+    def comment_mentionable(current_user: nil)
+      users = []
+      users += all_comments.includes(:user).map(&:user)
+      users += all_comments.flat_map(&:mentioned_users)
+      event_list = Event.where(id: all_ledgers.pluck(:event_id).compact.uniq).includes(:users, :point_of_contact)
+      users += event_list.select { |e| !current_user || Pundit.policy(current_user, e).team? }.flat_map(&:users)
+      users += event_list.map(&:point_of_contact)
+
+      users.compact.uniq
+    end
+
     # refresh! should always be called after any non-caching aspect of a ledger item changes (e.g. remapped or custom memo changes).
     # refresh! will update all cached aspects of a ledger item after this non-caching change occurs.
     # refresh! should not update any non-caching columns

--- a/app/tasks/maintenance/backfill_comment_commentables_to_ledger_item_task.rb
+++ b/app/tasks/maintenance/backfill_comment_commentables_to_ledger_item_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Part of migrating comments from HcbCode to Ledger::Item. Moves every
+  # comment still attached to an HcbCode over to that HcbCode's Ledger::Item.
+  #
+  # Skips HcbCodes with no ledger_item (a known, small set as of this writing
+  # — see Maintenance::BackfillOrphanedInvoiceCommentsTask) — their comments
+  # stay on the HcbCode for now.
+  #
+  # Includes soft-deleted comments (Comment.with_deleted) so a later restore
+  # doesn't resurrect one still pointed at the old commentable.
+  #
+  # process uses a normal `update!` rather than a bulk `update_all` so the
+  # existing `belongs_to :commentable, touch: true` on Comment fires per
+  # record, which touches the new Ledger::Item and refreshes its cached
+  # comment counts as a side effect — no separate recount pass needed.
+  class BackfillCommentCommentablesToLedgerItemTask < MaintenanceTasks::Task
+    def collection
+      Comment
+        .with_deleted
+        .where(commentable_type: "HcbCode")
+        .where(commentable_id: HcbCode.where.not(ledger_item_id: nil).select(:id))
+    end
+
+    def process(comment)
+      ledger_item_id = comment.commentable.ledger_item_id
+      return if ledger_item_id.nil?
+
+      comment.update!(commentable_type: "Ledger::Item", commentable_id: ledger_item_id)
+    end
+
+  end
+end

--- a/app/views/admin/ledger_audits/tasks/show.html.erb
+++ b/app/views/admin/ledger_audits/tasks/show.html.erb
@@ -125,7 +125,7 @@
 <div style="max-width: 600px; margin-left: auto; margin-right: auto;" class="mt4">
   <h3>HCB Code Comments</h3>
   <%= render "comments/list", comments: @hcb_code.all_comments %>
-  <%= render "comments/form", commentable: @hcb_code %>
+  <%= render "comments/form", commentable: @hcb_code.ledger_item || @hcb_code %>
 </div>
 
 <style>

--- a/app/views/canonical_pending_transactions/show.html.erb
+++ b/app/views/canonical_pending_transactions/show.html.erb
@@ -135,5 +135,5 @@
 
   <h2>Comments</h2>
   <%= render "comments/list", comments: @hcb_code.all_comments %>
-  <%= render "comments/form", commentable: @hcb_code %>
+  <%= render "comments/form", commentable: @hcb_code.ledger_item || @hcb_code %>
 <% end %>

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -60,7 +60,10 @@
       </p>
     <% end %>
   <% end %>
-  <%= render "comments/form", commentable: @hcb_code %>
+  <%# New comments attach to this transaction's Ledger::Item; fall back to the
+      HcbCode itself for the small number of transactions with no ledger_item
+      yet (see the Comment->Ledger::Item migration). %>
+  <%= render "comments/form", commentable: @hcb_code.ledger_item || @hcb_code %>
 
   <% admin_tool("mt2 p-3") do %>
     <%= render partial: "hcb_codes/transaction_history" %>

--- a/app/views/ledger/items/show.html.erb
+++ b/app/views/ledger/items/show.html.erb
@@ -174,7 +174,7 @@
         turbo: true
       } %>
   <%= render "comments/list", comments: @item.all_comments %>
-  <%= render "comments/form", commentable: @item.hcb_code %>
+  <%= render "comments/form", commentable: @item %>
 <% end %>
 
 <% admin_tool("p-2 my-3") do %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -177,5 +177,5 @@
 
   <h2>Comments</h2>
   <%= render "comments/list", comments: @hcb_code.all_comments %>
-  <%= render "comments/form", commentable: @hcb_code %>
+  <%= render "comments/form", commentable: @hcb_code.ledger_item || @hcb_code %>
 <% end %>

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,4 +14,39 @@ RSpec.describe CommentsController do
       end
     end
   end
+
+  # TODO: TEMPORARY — part of migrating comments from HcbCode to Ledger::Item;
+  # this asserts new comments can attach directly to a Ledger::Item, which is
+  # what comments/_form now submits to (see hcb_codes/show, ledger/items/show).
+  describe "#create" do
+    include SessionSupport
+
+    let(:event) { create(:event) }
+    let(:ledger) { event.ledger }
+    let(:item) { create(:ledger_item) }
+    let(:member_user) { create(:user) }
+
+    before do
+      create(:ledger_mapping, :on_primary, ledger:, ledger_item: item)
+      create(:organizer_position, event:, user: member_user, role: :member)
+      create_session(member_user, verified: true)
+    end
+
+    it "creates a comment attached to a Ledger::Item" do
+      expect {
+        post :create, params: {
+          ledger_item_id: item.hashid,
+          comment: {
+            content: "a new comment",
+            commentable_type: "Ledger::Item",
+            commentable_id: item.id
+          }
+        }
+      }.to change { item.comments.count }.by(1)
+
+      comment = item.comments.last
+      expect(comment.content).to eq("a new comment")
+      expect(comment.commentable).to eq(item)
+    end
+  end
 end

--- a/spec/controllers/hcb_codes_controller_spec.rb
+++ b/spec/controllers/hcb_codes_controller_spec.rb
@@ -64,5 +64,45 @@ RSpec.describe HcbCodesController, type: :controller do
       expect(response).to be_successful
       expect(response.body).to include("other comment")
     end
+
+    # TODO: TEMPORARY — comments are being migrated from HcbCode to
+    # Ledger::Item; the comment form should target the ledger_item once one
+    # exists, per PR 2 of that migration.
+    context "form target" do
+      let(:event) { create(:event) }
+      let(:member_user) { create(:user) }
+      let(:hcb_code) { create(:hcb_code, code_type: ::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE) }
+
+      before do
+        create(:organizer_position, event:, user: member_user, role: :member)
+
+        cpt = create(:canonical_pending_transaction)
+        cpt.update_column(:hcb_code, hcb_code.hcb_code)
+        create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:)
+
+        create_session(member_user, verified: true)
+      end
+
+      it "targets the hcb_code's ledger_item for new comments when one exists" do
+        item = create(:ledger_item)
+        hcb_code.update!(ledger_item: item)
+
+        get :show, params: { id: hcb_code.hcb_code }
+        page = Nokogiri::HTML5.fragment(response.body)
+
+        expect(response).to be_successful
+        expect(page.at_css("#comment_commentable_type")["value"]).to eq("Ledger::Item")
+        expect(page.at_css("#comment_commentable_id")["value"]).to eq(item.id.to_s)
+      end
+
+      it "falls back to the hcb_code itself when it has no ledger_item" do
+        get :show, params: { id: hcb_code.hcb_code }
+        page = Nokogiri::HTML5.fragment(response.body)
+
+        expect(response).to be_successful
+        expect(page.at_css("#comment_commentable_type")["value"]).to eq("HcbCode")
+        expect(page.at_css("#comment_commentable_id")["value"]).to eq(hcb_code.id.to_s)
+      end
+    end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -43,6 +43,35 @@ RSpec.describe Comment, type: :model, versioning: true do
     end
   end
 
+  describe "#tracked_event_id" do
+    it "returns nil for admin_only comments" do
+      hcb_code = create(:hcb_code)
+      hcb_code.update_columns(event_id: event.id)
+      comment = create(:comment, commentable: hcb_code, admin_only: true)
+
+      expect(comment.tracked_event_id).to be_nil
+    end
+
+    it "returns the commentable's event id" do
+      hcb_code = create(:hcb_code)
+      hcb_code.update_columns(event_id: event.id)
+      comment = create(:comment, commentable: hcb_code)
+
+      expect(comment.tracked_event_id).to eq(event.id)
+    end
+
+    # Ledger::Item has no generic event/events method (it can be mapped onto
+    # more than one ledger) — this goes through primary_ledger instead.
+    it "returns the ledger item's primary ledger's event id for a Ledger::Item commentable" do
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      create(:ledger_mapping, :on_primary, ledger: event.ledger, ledger_item: item)
+      comment = create(:comment, commentable: item)
+
+      expect(comment.tracked_event_id).to eq(event.id)
+    end
+  end
+
   context "when missing content" do
     before do
       comment.content = ""

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -562,6 +562,57 @@ RSpec.describe Ledger::Item, type: :model do
     end
   end
 
+  describe "#comment_recipients_for" do
+    it "includes the item's author and event members, but not the commenter" do
+      event = create(:event)
+      author = create(:user)
+      commenter = create(:user)
+      organizer = create(:user)
+      create(:organizer_position, event:, user: organizer, role: :member)
+
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      create(:ledger_mapping, :on_primary, ledger: event.ledger, ledger_item: item)
+      comment = create(:comment, commentable: item, user: commenter, content: "hi")
+
+      # Both the mapping and the comment above touch/refresh! the item, which
+      # recomputes author from a linked_object this item doesn't have — pin it
+      # past that directly, after everything else that would clobber it.
+      item.update_columns(author_id: author.id)
+
+      recipients = item.comment_recipients_for(comment)
+
+      expect(recipients).to include(author.email_address_with_name)
+      expect(recipients).to include(organizer.email_address_with_name)
+      expect(recipients).not_to include(commenter.email_address_with_name)
+    end
+  end
+
+  describe "#comment_mentionable" do
+    it "includes event members as mentionable users" do
+      event = create(:event)
+      organizer = create(:user)
+      create(:organizer_position, event:, user: organizer, role: :member)
+
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+      create(:ledger_mapping, :on_primary, ledger: event.ledger, ledger_item: item)
+
+      expect(item.comment_mentionable).to include(organizer)
+    end
+  end
+
+  describe "#comment_mailer_subject" do
+    it "includes the item's memo" do
+      item = create(:ledger_item)
+      # refresh! (run via after_create) recomputes memo from canonical
+      # transactions this item doesn't have, so pin it past that directly.
+      item.update_columns(memo: "Coffee for the team")
+
+      expect(item.comment_mailer_subject).to include("Coffee for the team")
+    end
+  end
+
   describe "account verification detection" do
     # Pins memo/amount/linked_object_type past the refresh! callbacks (which
     # recompute them from canonical transactions these items don't have),

--- a/spec/tasks/maintenance/backfill_comment_commentables_to_ledger_item_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_comment_commentables_to_ledger_item_task_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::BackfillCommentCommentablesToLedgerItemTask do
+  let(:user) { create(:user) }
+
+  describe "#collection" do
+    it "includes comments on an HcbCode with a ledger_item" do
+      item = create(:ledger_item)
+      hcb_code = create(:hcb_code, ledger_item: item)
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      expect(described_class.new.collection).to include(comment)
+    end
+
+    it "excludes comments on an HcbCode with no ledger_item" do
+      hcb_code = create(:hcb_code)
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      expect(described_class.new.collection).not_to include(comment)
+    end
+
+    it "excludes comments already on a Ledger::Item" do
+      item = create(:ledger_item)
+      comment = create(:comment, commentable: item, user:)
+
+      expect(described_class.new.collection).not_to include(comment)
+    end
+
+    it "includes soft-deleted comments" do
+      item = create(:ledger_item)
+      hcb_code = create(:hcb_code, ledger_item: item)
+      comment = create(:comment, commentable: hcb_code, user:)
+      comment.destroy
+
+      expect(described_class.new.collection).to include(comment)
+    end
+  end
+
+  describe "#process" do
+    it "moves the comment to the HcbCode's ledger_item" do
+      item = create(:ledger_item)
+      hcb_code = create(:hcb_code, ledger_item: item)
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      described_class.new.process(comment)
+
+      expect(comment.reload.commentable).to eq(item)
+    end
+
+    it "refreshes the ledger item's cached comment counts as a side effect" do
+      item = create(:ledger_item)
+      hcb_code = create(:hcb_code, ledger_item: item)
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      described_class.new.process(comment)
+
+      expect(item.reload.comment_count).to eq(1)
+      expect(item.not_admin_only_comment_count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
3 of 4 in migrating comments from `HcbCode` to `Ledger::Item` (stacked on #14694 and #14690). Comments currently attach to `HcbCode`; this PR makes *new* comments attach to `Ledger::Item` and moves existing ones over, so by the end of this PR all comment data lives on `Ledger::Item` (except a small, known set of orphans, handled separately in #14694).

## Describe your changes
- `comments/_form` now submits to the `Ledger::Item` on every page that renders it for a transaction (`hcb_codes/show`, `ledger/items/show`, `transactions/show`, `canonical_pending_transactions/show`, the admin ledger-audits task page), falling back to the `HcbCode` itself for the small number of transactions with no `ledger_item` yet.
- `Ledger::Item#comment_recipients_for`/`#comment_mentionable`/`#comment_mailer_subject` are new — `Ledger::Item`'s `shared_commentable`/`outgoing_disbursement`/etc. already exist from #14694, but it wasn't yet a live target for real comments, so these notification/mention hooks were still missing. None add a generic `event`/`events` method to `Ledger::Item` — each inlines the `all_ledgers`-based lookup it needs directly.
- Fixed `Comment`'s `PublicActivity` `event_id` tracking (extracted to `#tracked_event_id`) to handle a `Ledger::Item` commentable via its `primary_ledger`, for the same reason.
- Added `Maintenance::BackfillCommentCommentablesToLedgerItemTask` to move existing comments from `HcbCode` to `HcbCode#ledger_item` (including soft-deleted ones). Skips the `HcbCode`s with no `ledger_item` (see #14694's `BackfillOrphanedInvoiceCommentsTask` for those) — their comments stay put. Uses a normal per-record `update!` rather than a bulk `update_all` so `Comment`'s existing `belongs_to :commentable, touch: true` fires and refreshes the new `Ledger::Item`'s cached comment counts as a side effect — no separate recount pass needed.
- Added spec coverage across all of the above, including full page-render controller specs for `hcb_codes#show` and `comments#create` — the latter exercises the actual comment-creation flow against a `Ledger::Item`.

## Rollout
After this merges, run `Maintenance::BackfillCommentCommentablesToLedgerItemTask` via the Maintenance Tasks UI to move existing comments over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)