### PR TITLE
[Comments] Migrate comments from HcbCode to Ledger::Item (4/4): finalize

### DIFF
--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -188,16 +188,10 @@ class Ledger
       nil
     end
 
-    # TODO: TEMPORARY, remove the hcb_code term once comments are fully
-    # migrated from HcbCode to Ledger::Item. Comments are being moved over in
-    # stages; until that finishes, a transaction's comments may still live on
-    # its HcbCode instead of here. Overrides Commentable#all_comments to fold
-    # those in too, on top of the shared_commentable union above.
-    def all_comments
-      scope = Comment.where(commentable: self).or(Comment.where(commentable: hcb_code))
-      scope = scope.or(Comment.where(commentable: shared_commentable)) if shared_commentable
-      scope.order(:created_at)
-    end
+    # Comments now live solely on Ledger::Item (see the Comment->Ledger::Item
+    # migration), so Commentable#all_comments' default implementation — self
+    # plus shared_commentable, which is real as of #14694 — is exactly right;
+    # no override needed here anymore.
 
     def comment_recipients_for(comment)
       users = []

--- a/spec/controllers/ledger/items_controller_spec.rb
+++ b/spec/controllers/ledger/items_controller_spec.rb
@@ -35,10 +35,7 @@ RSpec.describe Ledger::ItemsController, type: :controller do
     end
 
     describe "GET #show" do
-      # TODO: TEMPORARY — comments are being migrated from HcbCode to
-      # Ledger::Item; this asserts the transitional union rendered by both
-      # commentables (Ledger::Item::all_comments) until that finishes.
-      it "renders comments from both the item and its hcb_code" do
+      it "renders the item's own comments" do
         allow(FlipperGroups).to receive(:hcb_engineer?).and_return(true)
         hcb_code = create(:hcb_code, ledger_item: item)
         # CommentPolicy#users needs an event to determine who can see the comment;
@@ -48,13 +45,26 @@ RSpec.describe Ledger::ItemsController, type: :controller do
         create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:)
 
         item_comment = create(:comment, commentable: item, user: member_user, content: "comment on the ledger item")
-        hcb_code_comment = create(:comment, commentable: hcb_code, user: member_user, content: "comment on the hcb code")
 
         get :show, params: { id: item.hashid }
 
         expect(response).to be_successful
         expect(response.body).to include(item_comment.content)
-        expect(response.body).to include(hcb_code_comment.content)
+      end
+
+      it "does not render comments still attached to its hcb_code" do
+        allow(FlipperGroups).to receive(:hcb_engineer?).and_return(true)
+        hcb_code = create(:hcb_code, ledger_item: item)
+        cpt = create(:canonical_pending_transaction)
+        cpt.update_column(:hcb_code, hcb_code.hcb_code)
+        create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:)
+
+        hcb_code_comment = create(:comment, commentable: hcb_code, user: member_user, content: "comment on the hcb code")
+
+        get :show, params: { id: item.hashid }
+
+        expect(response).to be_successful
+        expect(response.body).not_to include(hcb_code_comment.content)
       end
     end
   end

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -442,9 +442,10 @@ RSpec.describe Ledger::Item, type: :model do
       expect(item.comment_count).to eq(1)
     end
 
-    it "counts comments from both the item and its hcb_code" do
-      # TODO: TEMPORARY — comments are being migrated from HcbCode to Ledger::Item;
-      # remove this once all_comments no longer needs to fold in the hcb_code side.
+    it "counts only the item's own comments, not its hcb_code's" do
+      # Comments now live on Ledger::Item; a comment still attached directly to
+      # the hcb_code (which shouldn't normally happen post-migration) doesn't
+      # count here.
       user = create(:user)
       item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
       item.save(validate: false)
@@ -457,8 +458,8 @@ RSpec.describe Ledger::Item, type: :model do
       item.refresh!
       item.reload
 
-      expect(item.comment_count).to eq(3)
-      expect(item.not_admin_only_comment_count).to eq(2)
+      expect(item.comment_count).to eq(2)
+      expect(item.not_admin_only_comment_count).to eq(1)
     end
   end
 
@@ -536,18 +537,15 @@ RSpec.describe Ledger::Item, type: :model do
       expect(item.all_comments).to include(invoice_comment)
     end
 
-    # TODO: TEMPORARY — remove once comments are fully migrated from HcbCode to
-    # Ledger::Item and this override is no longer needed.
-    it "includes comments on both the item and its hcb_code" do
+    it "does not include comments on its hcb_code" do
       user = create(:user)
       item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
       item.save(validate: false)
       hcb_code = create(:hcb_code, ledger_item: item)
 
-      item_comment = create(:comment, commentable: item, user:)
       hcb_code_comment = create(:comment, commentable: hcb_code, user:)
 
-      expect(item.all_comments).to include(item_comment, hcb_code_comment)
+      expect(item.all_comments).not_to include(hcb_code_comment)
     end
 
     it "does not include comments from unrelated hcb_codes" do


### PR DESCRIPTION
## Summary of the problem
4 of 4 in migrating comments from `HcbCode` to `Ledger::Item` (#14694, #14690, #14691). By this point the backfill from #14691 has moved existing comments over, so this drops the last transitional bit.

## Describe your changes
- `Ledger::Item#all_comments` no longer folds in its `hcb_code`'s comments. `Commentable#all_comments`'s default implementation (self plus `shared_commentable`) is exactly right now that `shared_commentable` is a real, independent implementation (#14694 + #14691). `refresh!` already read through `all_comments`, so the counter cache picks this up for free.
- `HcbCode`'s side of this (its own `#all_comments`, added in #14690) needs no further changes — it already permanently prefers `ledger_item`, falling back to its own comments only for the handful of transactions with no `ledger_item`, and that fallback stays valid indefinitely (so there's nothing left to "finalize" there).
- Updated specs to match the final behavior — a comment left on an `HcbCode` no longer renders/counts on the `Ledger::Item` side once it has a `ledger_item`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)