### PR TITLE
[User] Block another batch of disposable email domains

### DIFF
--- a/config/initializers/nondisposable.rb
+++ b/config/initializers/nondisposable.rb
@@ -174,6 +174,33 @@ Nondisposable.configure do |config|
     5nek.com
     skyprofy.com
     velpai.com
+    toooby.com
+    text0.com
+    usmary.com
+    webonews.com
+    tabeebee.com
+    sepmaf.com
+    novelv.com
+    playboot.com
+    hutdot.com
+    joystill.com
+    beiwoh.com
+    ittiv.com
+    neplis.com
+    luhupo.com
+    gouziben.com
+    ecorpmail.cfd
+    goncolos.cfd
+    lottery-sambad.site
+    instaddr.org
+    adadad.uk
+    nanana.uk
+    oemails.com
+    oletters.com
+    yanemail.com
+    ghostmail.live
+    tempkit.io
+    vexomail.xyz
   ].freeze
 
   # https://www.okta.com/blog/threat-intelligence/opportunistic-sms-pumping-attacks-target-customer-sign-up-pages/

--- a/lib/email_typo_domains.rb
+++ b/lib/email_typo_domains.rb
@@ -18,11 +18,13 @@ module EmailTypoDomains
       gmial.com gmaill.com gmailc.om gmail.cim gmail.cpm gmail.clm gmail.vom
       gmail.comm gmail.comn gmail.comh gmail.coma gmail.comb
       gmail.copm gmail.coim gmail.conm gmail.coom
+      gmal.com gmail.col gmail.comc gmail.coms gmail.clom
+      gmaol.com gmile.com gimial.com gmaip.com gmailc.com
       googlemail.com
     ],
     "icloud.com"     => %w[icloud.con icloud.co],
     "hackclub.com"   => %w[hackclub.co hackclub.con],
-    "outlook.com"    => %w[outlook.con],
+    "outlook.com"    => %w[outlook.con oulook.com ouylook.com],
     "protonmail.com" => %w[protonmail.con],
   }.freeze
 


### PR DESCRIPTION
## Summary of the problem

Another batch of throwaway email domains is being used to create accounts. They run on shared throwaway-mail infrastructure alongside domains blocked in earlier rounds, and none of them is a provider anyone holds a real mailbox at.

Separately, the typo list was still missing a number of common misspellings of `gmail.com` and `outlook.com`. Some of those are parked on typosquat mail hosts, so they actively accept misdirected mail; the rest don't resolve at all.

## Describe your changes

- Adds the throwaway domains to `hcb_sourced_domains`.
- Adds the misspellings to `EmailTypoDomains`, so the signup form suggests the intended address instead of returning a generic rejection.

Both validations are `on: :create`, so existing accounts are unaffected and only new signups (and email changes) are blocked.

**Known gap:** some signups arrive on randomly generated subdomains of a wildcard domain. The blocklist only matches exact domains, so this change doesn't stop them. Closing that needs parent-domain matching against an explicit opt-in list, which can't be automatic since plenty of legitimate school domains are subdomains.