### PR TITLE
[Comments] Migrate comments from HcbCode to Ledger::Item (1/4): shared commentable groundwork

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -78,7 +78,7 @@ class CommentsController < ApplicationController
   COMMENTABLE_TYPE_MAP = [AchTransfer, Disbursement, EmburseCardRequest, EmburseTransaction,
                           EmburseTransfer, Event, GSuite, HcbCode, Api::Models::CardCharge,
                           OrganizerPositionDeletionRequest, User, Reimbursement::Report, CardGrant,
-                          Ledger::Item, Payment].index_by(&:to_s).freeze
+                          Ledger::Item, Payment, Invoice].index_by(&:to_s).freeze
 
   # Given a route "/transactions/25/comments", this method sets @commentable to
   # Transaction with ID 25

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -507,11 +507,14 @@ class HcbCode < ApplicationRecord
   # Overrides shared_commentable? in Commentable concern to avoid
   # unnecessary database read
   def shared_commentable?
-    outgoing_disbursement? || incoming_disbursement?
+    outgoing_disbursement? || incoming_disbursement? || invoice?
   end
 
   def shared_commentable
-    (outgoing_disbursement || incoming_disbursement)&.disbursement
+    return (outgoing_disbursement || incoming_disbursement)&.disbursement if outgoing_disbursement? || incoming_disbursement?
+    return invoice if invoice?
+
+    nil
   end
 
   def card_grant

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -114,6 +114,8 @@ class Invoice < ApplicationRecord
 
   include Freezable
 
+  include Commentable
+
   include PublicActivity::Model
   tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
@@ -373,6 +375,35 @@ class Invoice < ApplicationRecord
 
   def smart_memo
     sponsor.name
+  end
+
+  def comment_recipients_for(comment)
+    users = []
+    users += comments.map(&:user)
+    users += comments.flat_map(&:mentioned_users)
+    users += (event&.users || []).reject(&:my_threads?)
+    users += [creator]
+
+    if comment.admin_only?
+      users += [event&.point_of_contact].compact
+      return users.uniq.select(&:auditor?).reject(&:no_threads?).excluding(comment.user).collect(&:email_address_with_name)
+    end
+
+    users.uniq.excluding(comment.user).reject(&:no_threads?).collect(&:email_address_with_name)
+  end
+
+  def comment_mailer_subject
+    "New comment on invoice for #{item_description}."
+  end
+
+  def comment_mentionable(current_user: nil)
+    users = []
+    users += comments.includes(:user).map(&:user)
+    users += comments.flat_map(&:mentioned_users)
+    users += event.users if event && (!current_user || Pundit.policy(current_user, event).team?)
+    users += [event&.point_of_contact].compact
+
+    users.compact.uniq
   end
 
   include HasHcbCode

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -155,6 +155,54 @@ class Ledger
       receipt_required? && marked_no_or_lost_receipt_at.nil? && receipt_count == 0
     end
 
+    # Mirrors HcbCode#outgoing_disbursement/#incoming_disbursement, but this is
+    # simpler: a disbursement leg's ledger item already has linked_object set
+    # directly to the Disbursement::Outgoing/Incoming side, no lookup needed.
+    def outgoing_disbursement
+      linked_object if linked_object_type == "Disbursement::Outgoing"
+    end
+
+    def incoming_disbursement
+      linked_object if linked_object_type == "Disbursement::Incoming"
+    end
+
+    # Overrides shared_commentable?/shared_commentable in Commentable so a
+    # disbursement's two ledger items (one per side) share a comment thread
+    # through the parent Disbursement, and a linked object that's itself
+    # Commentable (e.g. Invoice) shares one through that object directly —
+    # a stable home for comments that predate/outlive this specific ledger
+    # item (e.g. discussion on an invoice that's never paid).
+    #
+    # The disbursement case can't be folded into the general linked_object
+    # check below: linked_object for a disbursement leg is a
+    # Disbursement::Outgoing/Incoming (from Disbursement#outgoing_disbursement/
+    # #incoming_disbursement), and Commentable is only included on the plain
+    # Disbursement class, not that wrapper — hence #disbursement to convert.
+    def shared_commentable?
+      shared_commentable.present?
+    end
+
+    def shared_commentable
+      return (outgoing_disbursement || incoming_disbursement)&.disbursement if outgoing_disbursement || incoming_disbursement
+      return linked_object if linked_object.is_a?(Commentable)
+
+      nil
+    end
+
+    # TODO: this union will simplify once the Comment->Ledger::Item migration
+    # finishes and comments live directly on Ledger::Item. For now, comments
+    # live on hcb_code — deliberately built on a plain Comment.where rather
+    # than the `comments` association (which goes through hcb_code and so
+    # brings its own INNER JOIN): combining that with an unrelated
+    # Comment.where(commentable: shared_commentable) via `.or` silently drops
+    # every shared_commentable row, since the join still applies to the whole
+    # query regardless of which side of the WHERE-level OR would've matched.
+    def all_comments
+      scope = Comment.where(commentable: hcb_code)
+      scope = scope.or(Comment.where(commentable: shared_commentable)) if shared_commentable
+      scope.order(:created_at)
+    end
+
     # refresh! should always be called after any non-caching aspect of a ledger item changes (e.g. remapped or custom memo changes).
     # refresh! will update all cached aspects of a ledger item after this non-caching change occurs.
     # refresh! should not update any non-caching columns
@@ -169,8 +217,8 @@ class Ledger
       # Counter caches
       self.ct_count = canonical_transactions.size
       self.cpt_count = canonical_pending_transactions.size
-      self.comment_count = comments.size
-      self.not_admin_only_comment_count = comments.not_admin_only.size
+      self.comment_count = all_comments.count
+      self.not_admin_only_comment_count = all_comments.not_admin_only.count
       self.receipt_count = receipts.size
 
       self.amount_cents = calculate_amount_cents

--- a/app/tasks/maintenance/backfill_orphaned_invoice_comments_task.rb
+++ b/app/tasks/maintenance/backfill_orphaned_invoice_comments_task.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Comments on an HcbCode with no ledger_item have nowhere else to surface
+  # (a ledger_item may never exist, e.g. an invoice that's never paid). As of
+  # this writing every such orphan is invoice-related, so move those
+  # comments onto the Invoice itself instead — a stable home that exists
+  # independent of whether/when the invoice is ever paid, and that now
+  # participates in shared_commentable the same way Disbursement does.
+  #
+  # Includes soft-deleted comments (Comment.with_deleted) so a later restore
+  # doesn't resurrect one still pointed at the old commentable.
+  class BackfillOrphanedInvoiceCommentsTask < MaintenanceTasks::Task
+    def collection
+      Comment
+        .with_deleted
+        .where(commentable_type: "HcbCode")
+        .where(commentable_id: HcbCode.where(ledger_item_id: nil).select(:id))
+    end
+
+    def process(comment)
+      hcb_code = comment.commentable
+      return unless hcb_code.invoice?
+
+      invoice = hcb_code.invoice
+      return if invoice.nil?
+
+      comment.update!(commentable: invoice)
+    end
+
+  end
+end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -55,8 +55,17 @@
 
   </div>
 
-  <% if commentable.shared_commentable? && !@comment&.persisted? %>
-    <% disbursement = commentable.outgoing_disbursement || commentable.incoming_disbursement %>
+  <%# The "share with counterparty" choice below is a disbursement-specific
+      feature (it needs a counterparty to share with) — gate on that directly
+      rather than the generic shared_commentable?, which other commentables
+      (e.g. Invoice) can also be true for without having a counterparty.
+      Scoped to HcbCode/Ledger::Item specifically: Disbursement itself also
+      defines same-named methods for an unrelated purpose (always truthy),
+      and most other commentables (User, Event, ...) don't define them at all. %>
+  <% if commentable.is_a?(HcbCode) || commentable.is_a?(Ledger::Item)
+       disbursement = commentable.outgoing_disbursement || commentable.incoming_disbursement
+     end %>
+  <% if disbursement && !@comment&.persisted? %>
     <div data-controller="commentable"
          data-commentable-shared-type-value="<%= commentable.shared_commentable.class.to_s %>"
          data-commentable-shared-id-value="<%= commentable.shared_commentable.id %>">

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -46,8 +46,11 @@
   <%= turbo_frame_tag :subscriptions, src: subscriptions_transactions_hcb_code_path(@hcb_code) if @hcb_code.stripe_card? %>
 
   <%= render "comments/list", comments: @hcb_code.all_comments, viewing_commentable: @hcb_code %>
-  <% if @hcb_code.shared_commentable? %>
-    <% viewing_disbursement = @hcb_code.outgoing_disbursement || @hcb_code.incoming_disbursement %>
+  <%# The counterparty link below is a disbursement-specific feature — gate on
+      that directly rather than the generic shared_commentable?, which other
+      commentables (e.g. Invoice) can also be true for without a counterparty. %>
+  <% viewing_disbursement = @hcb_code.outgoing_disbursement || @hcb_code.incoming_disbursement %>
+  <% if viewing_disbursement %>
     <% counterparty_hcb_code = viewing_disbursement.counterparty.local_hcb_code %>
     <% if policy(counterparty_hcb_code).show? && counterparty_hcb_code.comments.count > 0 %>
       <p class="muted">

--- a/spec/controllers/hcb_codes_controller_spec.rb
+++ b/spec/controllers/hcb_codes_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HcbCodesController, type: :controller do
+  include SessionSupport
+  render_views
+
+  describe "GET #show" do
+    # Part of adding shared_commentable support for Invoice-linked HcbCodes —
+    # this page's comment list/form used to assume shared_commentable? meant
+    # "this is a disbursement leg" and would crash on an invoice-type HcbCode.
+    it "renders an invoice-type HcbCode's comments, including the Invoice's own, without crashing" do
+      expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+      invoice = create(:invoice)
+      hcb_code = invoice.local_hcb_code
+      event = invoice.event
+      member_user = create(:user)
+      create(:organizer_position, event:, user: member_user, role: :member)
+      create_session(member_user, verified: true)
+
+      # HcbCodePolicy#show? relies on HcbCode#events (derived from its
+      # canonical (pending) transactions), not the invoice's own event.
+      cpt = create(:canonical_pending_transaction)
+      cpt.update_column(:hcb_code, hcb_code.hcb_code)
+      create(:canonical_pending_event_mapping, canonical_pending_transaction: cpt, event:)
+
+      hcb_code_comment = create(:comment, commentable: hcb_code, user: member_user, content: "comment on the hcb code")
+      invoice_comment = create(:comment, commentable: invoice, user: member_user, content: "comment on the invoice")
+
+      get :show, params: { id: hcb_code.hcb_code }
+
+      expect(response).to be_successful
+      expect(response.body).to include(hcb_code_comment.content)
+      expect(response.body).to include(invoice_comment.content)
+    end
+
+    it "renders a disbursement leg's counterparty comment link without crashing" do
+      disbursement = create(:disbursement)
+      outgoing = HcbCode.find_or_create_by(hcb_code: disbursement.outgoing_hcb_code)
+      incoming = HcbCode.find_or_create_by(hcb_code: disbursement.incoming_hcb_code)
+      member_user = create(:user)
+      create(:organizer_position, event: disbursement.source_event, user: member_user, role: :member)
+      # Also a member of the destination event, so HcbCodePolicy#show? passes
+      # for the counterparty's HcbCode too (the link is gated on that).
+      create(:organizer_position, event: disbursement.event, user: member_user, role: :member)
+      create_session(member_user, verified: true)
+
+      # HcbCodePolicy#show? relies on HcbCode#events (derived from its
+      # canonical (pending) transactions) — needed for both legs, since the
+      # counterparty link also runs `policy(counterparty_hcb_code).show?`.
+      outgoing_cpt = create(:canonical_pending_transaction)
+      outgoing_cpt.update_column(:hcb_code, outgoing.hcb_code)
+      create(:canonical_pending_event_mapping, canonical_pending_transaction: outgoing_cpt, event: disbursement.source_event)
+
+      incoming_cpt = create(:canonical_pending_transaction)
+      incoming_cpt.update_column(:hcb_code, incoming.hcb_code)
+      create(:canonical_pending_event_mapping, canonical_pending_transaction: incoming_cpt, event: disbursement.event)
+
+      create(:comment, commentable: incoming, user: member_user, content: "comment from the destination org")
+
+      get :show, params: { id: outgoing.hcb_code }
+
+      expect(response).to be_successful
+      expect(response.body).to include("other comment")
+    end
+  end
+end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -281,10 +281,19 @@ RSpec.describe HcbCode, type: :model do
         expect(incoming.shared_commentable?).to be true
       end
 
-      it "returns false for non-disbursement codes" do
-        hcb_code = create(:hcb_code)
+      # The :hcb_code factory's default code_type is INVOICE_CODE, so an
+      # explicit non-invoice, non-disbursement code_type is needed here.
+      it "returns false for non-disbursement, non-invoice codes" do
+        hcb_code = create(:hcb_code, code_type: ::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE)
 
         expect(hcb_code.shared_commentable?).to be false
+      end
+
+      it "returns true for invoice codes" do
+        expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+        invoice = create(:invoice)
+
+        expect(invoice.local_hcb_code.shared_commentable?).to be true
       end
     end
 
@@ -303,10 +312,17 @@ RSpec.describe HcbCode, type: :model do
         expect(incoming.shared_commentable).to eq(disbursement)
       end
 
-      it "returns nil for non-disbursement codes" do
-        hcb_code = create(:hcb_code)
+      it "returns nil for non-disbursement, non-invoice codes" do
+        hcb_code = create(:hcb_code, code_type: ::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE)
 
         expect(hcb_code.shared_commentable).to be_nil
+      end
+
+      it "returns the Invoice for invoice codes" do
+        expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+        invoice = create(:invoice)
+
+        expect(invoice.local_hcb_code.shared_commentable).to eq(invoice)
       end
     end
 
@@ -335,6 +351,16 @@ RSpec.describe HcbCode, type: :model do
         comment = create(:comment, commentable: hcb_code, user:)
 
         expect(hcb_code.all_comments).to include(comment)
+      end
+
+      it "includes comments on the associated Invoice for invoice codes" do
+        expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+        invoice = create(:invoice)
+        hcb_code = invoice.local_hcb_code
+        hcb_code_comment = create(:comment, commentable: hcb_code, user:)
+        invoice_comment = create(:comment, commentable: invoice, user:)
+
+        expect(hcb_code.all_comments).to include(hcb_code_comment, invoice_comment)
       end
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,4 +11,48 @@ RSpec.describe Invoice, type: :model do
     invoice = create(:invoice)
     expect(invoice).to be_valid
   end
+
+  # Part of adding shared_commentable support for Invoice-linked HcbCodes/Ledger::Items.
+  describe "as a Commentable" do
+    it "accepts a comment" do
+      invoice = create(:invoice)
+      comment = create(:comment, commentable: invoice)
+
+      expect(comment).to be_valid
+    end
+
+    describe "#comment_recipients_for" do
+      it "includes the creator and event members, but not the commenter" do
+        invoice = create(:invoice)
+        organizer = create(:user)
+        create(:organizer_position, event: invoice.event, user: organizer, role: :member)
+        commenter = create(:user)
+        comment = create(:comment, commentable: invoice, user: commenter, content: "hi")
+
+        recipients = invoice.comment_recipients_for(comment)
+
+        expect(recipients).to include(invoice.creator.email_address_with_name)
+        expect(recipients).to include(organizer.email_address_with_name)
+        expect(recipients).not_to include(commenter.email_address_with_name)
+      end
+    end
+
+    describe "#comment_mentionable" do
+      it "includes event members as mentionable users" do
+        invoice = create(:invoice)
+        organizer = create(:user)
+        create(:organizer_position, event: invoice.event, user: organizer, role: :member)
+
+        expect(invoice.comment_mentionable).to include(organizer)
+      end
+    end
+
+    describe "#comment_mailer_subject" do
+      it "includes the item description" do
+        invoice = create(:invoice, item_description: "Stickers")
+
+        expect(invoice.comment_mailer_subject).to include("Stickers")
+      end
+    end
+  end
 end

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -407,6 +407,115 @@ RSpec.describe Ledger::Item, type: :model do
       item.update!(custom_memo: "  Custom memo  ")
       expect(item.custom_memo).to eq("Custom memo")
     end
+
+    # Regression coverage for a production bug: the counter cache never
+    # included shared_commentable's comments (e.g. a disbursement's shared
+    # thread), because Ledger::Item had no shared_commentable at all.
+    it "counts a disbursement's shared comments" do
+      user = create(:user)
+      disbursement = create(:disbursement)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: disbursement.outgoing_disbursement)
+      item.save(validate: false)
+
+      create(:comment, commentable: disbursement, user:)
+      create(:comment, commentable: disbursement, admin_only: true, user:)
+
+      item.refresh!
+      item.reload
+
+      expect(item.comment_count).to eq(2)
+      expect(item.not_admin_only_comment_count).to eq(1)
+    end
+
+    it "counts an invoice's comments" do
+      expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+      user = create(:user)
+      invoice = create(:invoice)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: invoice)
+      item.save(validate: false)
+
+      create(:comment, commentable: invoice, user:)
+
+      item.refresh!
+      item.reload
+
+      expect(item.comment_count).to eq(1)
+    end
+  end
+
+  describe "#shared_commentable" do
+    it "returns the Disbursement for an outgoing disbursement leg" do
+      disbursement = create(:disbursement)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: disbursement.outgoing_disbursement)
+      item.save(validate: false)
+
+      expect(item.shared_commentable?).to be true
+      expect(item.shared_commentable).to eq(disbursement)
+    end
+
+    it "returns the Disbursement for an incoming disbursement leg" do
+      disbursement = create(:disbursement)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: disbursement.incoming_disbursement)
+      item.save(validate: false)
+
+      expect(item.shared_commentable?).to be true
+      expect(item.shared_commentable).to eq(disbursement)
+    end
+
+    it "returns the Invoice for an invoice-linked item" do
+      expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+      invoice = create(:invoice)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: invoice)
+      item.save(validate: false)
+
+      expect(item.shared_commentable?).to be true
+      expect(item.shared_commentable).to eq(invoice)
+    end
+
+    # Not special-cased on Invoice specifically — any linked_object that's
+    # itself Commentable is shared, so this generalizes for free to whatever
+    # else ends up being both a linked_object and Commentable.
+    it "returns the linked_object itself when it is Commentable, regardless of type" do
+      ach_transfer = create(:ach_transfer, event: create(:event, :with_positive_balance))
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: ach_transfer)
+      item.save(validate: false)
+
+      expect(item.shared_commentable?).to be true
+      expect(item.shared_commentable).to eq(ach_transfer)
+    end
+
+    it "returns nil for items with no shared commentable" do
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current)
+      item.save(validate: false)
+
+      expect(item.shared_commentable?).to be false
+      expect(item.shared_commentable).to be_nil
+    end
+  end
+
+  describe "#all_comments" do
+    it "includes the shared_commentable's comments for a disbursement leg" do
+      user = create(:user)
+      disbursement = create(:disbursement)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: disbursement.outgoing_disbursement)
+      item.save(validate: false)
+
+      disbursement_comment = create(:comment, commentable: disbursement, user:)
+
+      expect(item.all_comments).to include(disbursement_comment)
+    end
+
+    it "includes the Invoice's comments for an invoice-linked item" do
+      expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+      user = create(:user)
+      invoice = create(:invoice)
+      item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: invoice)
+      item.save(validate: false)
+
+      invoice_comment = create(:comment, commentable: invoice, user:)
+
+      expect(item.all_comments).to include(invoice_comment)
+    end
   end
 
   describe "account verification detection" do

--- a/spec/tasks/maintenance/backfill_orphaned_invoice_comments_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_orphaned_invoice_comments_task_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::BackfillOrphanedInvoiceCommentsTask do
+  let(:user) { create(:user) }
+
+  def create_invoice
+    expect_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+    create(:invoice)
+  end
+
+  describe "#collection" do
+    it "includes comments on an invoice-type HcbCode with no ledger_item" do
+      invoice = create_invoice
+      comment = create(:comment, commentable: invoice.local_hcb_code, user:)
+
+      expect(described_class.new.collection).to include(comment)
+    end
+
+    it "excludes comments on an HcbCode with a ledger_item" do
+      invoice = create_invoice
+      hcb_code = invoice.local_hcb_code
+      hcb_code.update!(ledger_item: create(:ledger_item))
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      expect(described_class.new.collection).not_to include(comment)
+    end
+
+    it "includes soft-deleted comments" do
+      invoice = create_invoice
+      comment = create(:comment, commentable: invoice.local_hcb_code, user:)
+      comment.destroy
+
+      expect(described_class.new.collection).to include(comment)
+    end
+  end
+
+  describe "#process" do
+    it "moves the comment to the HcbCode's Invoice" do
+      invoice = create_invoice
+      comment = create(:comment, commentable: invoice.local_hcb_code, user:)
+
+      described_class.new.process(comment)
+
+      expect(comment.reload.commentable).to eq(invoice)
+    end
+
+    it "leaves non-invoice orphan comments alone" do
+      hcb_code = create(:hcb_code, code_type: ::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE)
+      comment = create(:comment, commentable: hcb_code, user:)
+
+      described_class.new.process(comment)
+
+      expect(comment.reload.commentable).to eq(hcb_code)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
`Ledger::Item` has no `shared_commentable` at all today, so its comment counter cache (`comment_count`/`not_admin_only_comment_count`) never includes a disbursement's shared thread — a production undercount bug. Separately, the ~200 comments left on an `HcbCode` with no `ledger_item` are all invoice-related: unlike a disbursement (two real `HcbCode`s that legitimately need to share a thread), an invoice has a strict 1:1 relationship with its `HcbCode`/`Ledger::Item`, so the real problem is that these comments have no stable home when a `ledger_item` may never exist (an unpaid/canceled invoice).

This is now 1 of 4, the base of the Comment→Ledger::Item migration stack (#14690/#14691/#14692 are rebased on top).

## Describe your changes
- `Invoice` is now `Commentable`, with its own `comment_recipients_for`/`comment_mentionable`/`comment_mailer_subject` (scoped to its one event, via `sponsor`) and registered in `CommentsController::COMMENTABLE_TYPE_MAP`.
- `HcbCode#shared_commentable`/`#shared_commentable?` now also recognize invoice-type codes, returning the `Invoice`.
- `Ledger::Item#shared_commentable`/`#shared_commentable?` are new. A disbursement leg shares through the parent `Disbursement` (via `linked_object`, simpler than `HcbCode`'s `hcb_i2` lookups). Beyond that, it's a general rule, not special-cased on `Invoice`: any `linked_object` that's itself `Commentable` is shared through directly — a stable home for comments that predate/outlive this specific ledger item. `Invoice` is just the first case; it extends for free to whatever else ends up being both a `linked_object` and `Commentable` (verified with `AchTransfer`, which already is, though nothing currently comments on one directly). `all_comments` (also new) unions this in; `refresh!` now reads through it, fixing the counter-cache gap. Built directly on `Comment.where(commentable: hcb_code)` rather than the (still present, soon-to-be-removed) `comments` association — combining that association's own implicit `hcb_codes` JOIN with an unrelated `Comment.where(commentable: shared_commentable)` via `.or` silently drops every `shared_commentable` row, since the join still applies regardless of which side of the WHERE-level OR would've matched. Verified this empirically before relying on it.
- Fixed two views that gated a disbursement-specific UI (the "share with counterparty" form dropdown, the counterparty comment-count link) on the generic `shared_commentable?`, which would now also be true for invoices without a counterparty to share with — narrowed both to check for an actual disbursement leg directly instead.
- Added `Maintenance::BackfillOrphanedInvoiceCommentsTask` to move the existing orphaned comments (on an invoice-type `HcbCode` with no `ledger_item`) onto their `Invoice`.
- Spec coverage throughout, including full page-render controller specs for `hcb_codes#show` covering both the invoice and disbursement cases — the latter is what caught the JOIN bug above.

## Rollout
After this merges, run `Maintenance::BackfillOrphanedInvoiceCommentsTask` via the Maintenance Tasks UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)