### PR TITLE
[Card Grant] Say when a card was frozen by one time use

### DIFF
--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -335,8 +335,10 @@ class CardGrant < ApplicationRecord
     )
   end
 
-  def frozen_by_otu?
-    (stripe_card.frozen? || stripe_card.inactive?) && stripe_card.last_frozen_by == User.system_user
+  def frozen_by_one_time_use?
+    return false unless stripe_card
+
+    (stripe_card.frozen? || stripe_card.inactive?) && stripe_card.last_frozen_by == User.system_user && self.one_time_use
   end
 
   private

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -141,7 +141,7 @@ class CardGrant < ApplicationRecord
     elsif pending_invite?
       "Invitation sent"
     elsif stripe_card.frozen? || stripe_card.inactive?
-      "Frozen"
+      stripe_card.last_frozen_by == User.system_user ? "Frozen by one time use, contact the org for any inquiries" : "Frozen"
     else
       "Active"
     end

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -141,7 +141,7 @@ class CardGrant < ApplicationRecord
     elsif pending_invite?
       "Invitation sent"
     elsif stripe_card.frozen? || stripe_card.inactive?
-      stripe_card.last_frozen_by == User.system_user ? "Frozen by one time use, contact the org for any inquiries" : "Frozen"
+      "Frozen"
     else
       "Active"
     end
@@ -333,6 +333,10 @@ class CardGrant < ApplicationRecord
       inviter: sent_by,
       card_grant: self
     )
+  end
+
+  def frozen_by_otu?
+    (stripe_card.frozen? || stripe_card.inactive?) && stripe_card.last_frozen_by == User.system_user
   end
 
   private

--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -23,7 +23,7 @@
         <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && stripe_card.last_frozen_by == User.system_user %>
           <div class="fs-mask">
             <strong>Frozen by</strong>
-            <span title="Contact Org for any issues with this"><%= "One Time Purchase" %></span>
+            <span title="Contact Org for any issues with this"><%= "One Time Use" %></span>
           </div>
         <% end %>
 

--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -20,6 +20,11 @@
             <strong>Frozen by</strong>
             <%= user_mention stripe_card.last_frozen_by %>
           </div>
+        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && stripe_card.last_frozen_by == User.system_user %>
+          <div class="fs-mask">
+            <strong>Frozen by</strong>
+            <span title="Contact Org for any issues with this"><%= "One Time Purchase" %></span>
+          </div>
         <% end %>
 
         <div class="fs-mask">

--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -20,10 +20,15 @@
             <strong>Frozen by</strong>
             <%= user_mention stripe_card.last_frozen_by %>
           </div>
-        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && card_grant.frozen_by_one_time_use? %>
+        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && card_grant.frozen_by_one_time_use? && !organizer_signed_in? %>
           <div class="fs-mask">
-            <strong>Frozen by</strong>
-            <span title="Contact <%= card_grant.event.name %> for any issues with this"><%= "One Time Use" %></span>
+            <strong>Frozen</strong>
+            <span title="Contact <%= card_grant.event.name %> for any issues with this">Automatically by <%= card_grant.event.name %> after your first purchase</span>
+          </div>
+        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && card_grant.frozen_by_one_time_use? && organizer_signed_in? %>
+          <div class="fs-mask">
+            <strong>Frozen</strong>
+            <span title="Contact <%= card_grant.event.name %> for any issues with this">Automatically by <%= card_grant.event.name %> after the user's first purchase</span>
           </div>
         <% end %>
 

--- a/app/views/card_grants/_card_details.html.erb
+++ b/app/views/card_grants/_card_details.html.erb
@@ -20,10 +20,10 @@
             <strong>Frozen by</strong>
             <%= user_mention stripe_card.last_frozen_by %>
           </div>
-        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && stripe_card.last_frozen_by == User.system_user %>
+        <% elsif stripe_card.frozen? && stripe_card.last_frozen_by && card_grant.frozen_by_one_time_use? %>
           <div class="fs-mask">
             <strong>Frozen by</strong>
-            <span title="Contact Org for any issues with this"><%= "One Time Use" %></span>
+            <span title="Contact <%= card_grant.event.name %> for any issues with this"><%= "One Time Use" %></span>
           </div>
         <% end %>
 

--- a/app/views/card_grants/_header_banner.html.erb
+++ b/app/views/card_grants/_header_banner.html.erb
@@ -14,7 +14,6 @@
       </h2>
       <p class="my-0 flex items-baseline g-1 items-center">
         <%= status_badge card_grant.status_badge_type %>
-        
         <% if card_grant.frozen_by_otu? %>
             Frozen by One-Time-Use
             <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="If this is not meant to be frozen reach out to the org">

--- a/app/views/card_grants/_header_banner.html.erb
+++ b/app/views/card_grants/_header_banner.html.erb
@@ -16,8 +16,8 @@
         <%= status_badge card_grant.status_badge_type %>
         <% if card_grant.frozen_by_one_time_use? %>
             Frozen by One Time Use
-            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="For help with your grant, please reach out to the organization.">
-              <%= inline_icon "info", size: 18, style: "position: unset; transform: translateX(25%)" %>
+            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="For help with your grant, please reach out to <%= card_grant.event.name %>.">
+              <%= inline_icon "info", size: 18, style: "position: unset;" %>
             </span>
         <% else %>
           <%= card_grant.state_text %>

--- a/app/views/card_grants/_header_banner.html.erb
+++ b/app/views/card_grants/_header_banner.html.erb
@@ -14,8 +14,13 @@
       </h2>
       <p class="my-0 flex items-baseline g-1 items-center">
         <%= status_badge card_grant.status_badge_type %>
-        <% if card_grant.frozen_by_one_time_use? %>
-            Frozen by One Time Use
+        <% if card_grant.frozen_by_one_time_use? && organizer_signed_in? %>
+            Frozen automactically by one time use
+            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="Defrosting clears one time use from the grant card.">
+              <%= inline_icon "info", size: 18, style: "position: unset;" %>
+            </span>
+        <% elsif card_grant.frozen_by_one_time_use? && !organizer_signed_in? %>
+            Frozen by <%= card_grant.event.name %> after first purchase
             <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="For help with your grant, please reach out to <%= card_grant.event.name %>.">
               <%= inline_icon "info", size: 18, style: "position: unset;" %>
             </span>

--- a/app/views/card_grants/_header_banner.html.erb
+++ b/app/views/card_grants/_header_banner.html.erb
@@ -14,9 +14,9 @@
       </h2>
       <p class="my-0 flex items-baseline g-1 items-center">
         <%= status_badge card_grant.status_badge_type %>
-        <% if card_grant.frozen_by_otu? %>
-            Frozen by One-Time-Use
-            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="If this is not meant to be frozen reach out to the org">
+        <% if card_grant.frozen_by_one_time_use? %>
+            Frozen by One Time Use
+            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="For help with your grant, please reach out to the organization.">
               <%= inline_icon "info", size: 18, style: "position: unset; transform: translateX(25%)" %>
             </span>
         <% else %>

--- a/app/views/card_grants/_header_banner.html.erb
+++ b/app/views/card_grants/_header_banner.html.erb
@@ -12,9 +12,17 @@
       <h2 class="border-none !mx-0 !px-0 !mt-0 inline-flex items-center flex-wrap">
         Grant to &nbsp; <%= user_mention(card_grant.user, class: "mr-2") %> for <%= render_money card_grant.amount %>
       </h2>
-      <p class="my-0 flex items-baseline g-1">
+      <p class="my-0 flex items-baseline g-1 items-center">
         <%= status_badge card_grant.status_badge_type %>
-        <%= card_grant.state_text %>
+        
+        <% if card_grant.frozen_by_otu? %>
+            Frozen by One-Time-Use
+            <span class="info tooltipped tooltipped--e inline-flex items-center" aria-label="If this is not meant to be frozen reach out to the org">
+              <%= inline_icon "info", size: 18, style: "position: unset; transform: translateX(25%)" %>
+            </span>
+        <% else %>
+          <%= card_grant.state_text %>
+        <% end %>
         <% if card_grant.purpose.present? %>
           • <%= card_grant.purpose %>
         <% end %>

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CardGrant, type: :model do
   end
 
   describe "#state_text" do
-    let(:system_user) { create(:user, email: User::SYSTEM_USER_EMAIL) }
+    let(:system_user) { User.find_or_create_by!(email: User::SYSTEM_USER_EMAIL) { |u| u.name = "System User" } }
 
     before do
       allow_any_instance_of(CardGrant).to receive(:transfer_money)
@@ -43,7 +43,8 @@ RSpec.describe CardGrant, type: :model do
         card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: system_user)
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
 
-        expect(card_grant.state_text).to eq("Frozen by one time use, contact the org for any inquiries")
+        expect(card_grant.state_text).to eq("Frozen")
+        expect(card_grant.frozen_by_otu?).to eq(true)
       end
     end
 
@@ -75,7 +76,8 @@ RSpec.describe CardGrant, type: :model do
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(false)
         allow(card_grant.stripe_card).to receive(:inactive?).and_return(true)
 
-        expect(card_grant.state_text).to eq("Frozen by one time use, contact the org for any inquiries")
+        expect(card_grant.state_text).to eq("Frozen")
+        expect(card_grant.frozen_by_otu?).to eq(true)
       end
     end
   end

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CardGrant, type: :model do
   end
 
   describe "#state_text" do
-    let(:system_user) { User.find_or_create_by!(email: User::SYSTEM_USER_EMAIL) { |u| u.name = "System User" } }
+    let(:system_user) { User.find_or_create_by!(email: User::SYSTEM_USER_EMAIL) }
 
     before do
       allow_any_instance_of(CardGrant).to receive(:transfer_money)

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -28,4 +28,55 @@ RSpec.describe CardGrant, type: :model do
       expect(card_grant.ledger).to be_a(Ledger)
     end
   end
+
+  describe "#state_text" do
+    let(:system_user) { create(:user, email: User::SYSTEM_USER_EMAIL) }
+
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+      allow(User).to receive(:system_user).and_return(system_user)
+    end
+
+    context "when card is frozen by the system user (one time use)" do
+      it "returns the one-time-use frozen message" do
+        card_grant = create(:card_grant)
+        card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: system_user)
+        allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
+
+        expect(card_grant.state_text).to eq("Frozen by one time use, contact the org for any inquiries")
+      end
+    end
+
+    context "when card is frozen by a non-system user" do
+      it "returns 'Frozen'" do
+        card_grant = create(:card_grant)
+        other_user = create(:user)
+        card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: other_user)
+        allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
+
+        expect(card_grant.state_text).to eq("Frozen")
+      end
+    end
+
+    context "when card is frozen with no last_frozen_by" do
+      it "returns 'Frozen'" do
+        card_grant = create(:card_grant)
+        card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: nil)
+        allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
+
+        expect(card_grant.state_text).to eq("Frozen")
+      end
+    end
+
+    context "when card is inactive (never activated) by system user" do
+      it "returns the one-time-use frozen message" do
+        card_grant = create(:card_grant)
+        card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: system_user)
+        allow(card_grant.stripe_card).to receive(:frozen?).and_return(false)
+        allow(card_grant.stripe_card).to receive(:inactive?).and_return(true)
+
+        expect(card_grant.state_text).to eq("Frozen by one time use, contact the org for any inquiries")
+      end
+    end
+  end
 end

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -40,11 +40,12 @@ RSpec.describe CardGrant, type: :model do
     context "when card is frozen by the system user (one time use)" do
       it "returns the one-time-use frozen message" do
         card_grant = create(:card_grant)
+        card_grant.one_time_use = true
         card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: system_user)
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
 
         expect(card_grant.state_text).to eq("Frozen")
-        expect(card_grant.frozen_by_otu?).to eq(true)
+        expect(card_grant.frozen_by_one_time_use?).to eq(true)
       end
     end
 
@@ -56,6 +57,7 @@ RSpec.describe CardGrant, type: :model do
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
 
         expect(card_grant.state_text).to eq("Frozen")
+        expect(card_grant.frozen_by_one_time_use?).to eq(false)
       end
     end
 
@@ -66,6 +68,7 @@ RSpec.describe CardGrant, type: :model do
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(true)
 
         expect(card_grant.state_text).to eq("Frozen")
+        expect(card_grant.frozen_by_one_time_use?).to eq(false)
       end
     end
 
@@ -73,11 +76,12 @@ RSpec.describe CardGrant, type: :model do
       it "returns the one-time-use frozen message" do
         card_grant = create(:card_grant)
         card_grant.stripe_card.update!(stripe_status: "inactive", last_frozen_by: system_user)
+        card_grant.one_time_use = false
         allow(card_grant.stripe_card).to receive(:frozen?).and_return(false)
         allow(card_grant.stripe_card).to receive(:inactive?).and_return(true)
 
         expect(card_grant.state_text).to eq("Frozen")
-        expect(card_grant.frozen_by_otu?).to eq(true)
+        expect(card_grant.frozen_by_one_time_use?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem
When someone spends on a one time use grant card, the card freezes automatically (`StripeAuthorizationService::CreateFromWebhook` freezes it as the system user). The grant page just says "Frozen" with no reason, so recipients assume something broke and message #hcb when they should be going to the org that issued the grant.

## Describe your changes
Added `CardGrant#frozen_by_one_time_use?`, which is true when the grant is one time use and its card was frozen by the system user. When that's the case:

- the header banner says the card was frozen by one time use instead of a bare "Frozen", with an info tooltip pointing the recipient at the issuing org
- the card details section shows the freeze reason instead of omitting the "Frozen by" row (it's skipped today, since there's no real user to mention)

Specs cover the system user case, a freeze by a regular user, a freeze with no `last_frozen_by`, and a card that's inactive without being one time use.

