### PR TITLE
[Card Grant] Show reimbursement conversion status

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -24,7 +24,7 @@ class CardGrantsController < ApplicationController
     card_grants_page = (params[:page] || 1).to_i
     card_grants_per_page = (params[:per] || 20).to_i
 
-    @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger).order(created_at: :desc)
+    @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger, :reimbursement_report).order(created_at: :desc)
     @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?
     @paginated_card_grants = @card_grants.page(card_grants_page).per(card_grants_per_page)
   end

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -134,6 +134,8 @@ class CardGrant < ApplicationRecord
   def state_text
     if suspected_fraud?
       "Fraudulent"
+    elsif converted_to_reimbursement_report?
+      "Converted to reimbursement"
     elsif canceled?
       "Canceled"
     elsif expired?
@@ -154,6 +156,10 @@ class CardGrant < ApplicationRecord
     return :warning if s == :info
 
     :muted
+  end
+
+  def converted_to_reimbursement_report?
+    canceled? && reimbursement_report.present?
   end
 
   def suspected_fraud?

--- a/app/views/card_grants/_canceled_warning.html.erb
+++ b/app/views/card_grants/_canceled_warning.html.erb
@@ -5,7 +5,11 @@
     <div class="flex items-center info">
       <%= inline_icon "info", size: 32, class: "mr1" %>
       <p class="bold mt0 mb0">
-        This grant has been canceled
+        <% if card_grant.converted_to_reimbursement_report? %>
+          This grant has been canceled and converted into a reimbursement report
+        <% else %>
+          This grant has been canceled
+        <% end %>
         <% if canceled_by = card_grant.last_user_change_to(status: :canceled) %>
           by <%= user_mention canceled_by, disable_tooltip: true %>
         <% end %>
@@ -13,6 +17,9 @@
           <span class="tooltipped" aria-label="<%= canceled_at.to_formatted_s(:long) %>">
             <%= time_ago_in_words canceled_at %> ago
           </span>
+        <% end %>
+        <% if card_grant.converted_to_reimbursement_report? && policy(card_grant.reimbursement_report).show? %>
+          • <%= link_to "View reimbursement report", card_grant.reimbursement_report %>
         <% end %>
       </p>
     </div>

--- a/app/views/card_grants/show.html.erb
+++ b/app/views/card_grants/show.html.erb
@@ -33,7 +33,16 @@
 <div class="sm:mt-5 check--form flex justify-center <%= "flex-wrap" if @frame %> mb-5" style="gap: 3rem">
   <%# Grantee has pending invite %>
   <% if @card_grant.user == current_user && @card_grant.pending_invite? %>
-    <% if @card_grant.canceled? %>
+    <% if @card_grant.converted_to_reimbursement_report? %>
+      <div class="flex-grow">
+        <%= blankslate "This grant was converted into a reimbursement report." %>
+        <% if policy(@card_grant.reimbursement_report).show? %>
+          <p class="text-center">
+            <%= link_to "View reimbursement report", @card_grant.reimbursement_report %>
+          </p>
+        <% end %>
+      </div>
+    <% elsif @card_grant.canceled? %>
       <%= blankslate "Sorry, this grant was canceled!", class: "flex-grow" %>
     <% else %>
       <%= render partial: "card_grants/invitation", locals: { card_grant: @card_grant } %>


### PR DESCRIPTION
## Summary of the problem

Card grants converted into reimbursement reports were displayed only as canceled, leaving grantees without clear status information or a direct way to find the resulting reimbursement report.

## Describe your changes

- Detect when a canceled card grant has been converted into a reimbursement report.
- Display “Converted to reimbursement” status and updated messaging on card grant pages.
- Add links to view the reimbursement report when permitted.
- Eager-load reimbursement reports for the card grant overview.
- Add development scripts for creating representative canceled and converted grants, fake Stripe cards, and local sessions.