### PR TITLE
[Stripe] Block authorizations by merchant name prefix

### DIFF
--- a/app/services/stripe_authorization_service.rb
+++ b/app/services/stripe_authorization_service.rb
@@ -24,6 +24,17 @@ module StripeAuthorizationService
       ]
     ).freeze
 
+  # Merchant name prefixes blocked HCB-wide. Matched case-insensitively against
+  # the beginning of the merchant name, so "FAWRA*" also blocks
+  # "FAWRA*A1B2C3". Like FORBIDDEN_MERCHANT_NETWORK_IDS, a merchant matching
+  # one of these can never be allowlisted.
+  FORBIDDEN_MERCHANT_NAME_PREFIXES =
+    Set.new(
+      [
+        "FAWRA*" # Fawra Pay, primarily used for fraud on HQ satellites. Requested by the HQ Events team.
+      ]
+    ).freeze
+
   # Network IDs that are allowed even when their merchant category is forbidden.
   # This does NOT override FORBIDDEN_MERCHANT_NETWORK_IDS — explicitly blocked
   # network IDs (e.g. fraud) can never be allowlisted.
@@ -33,4 +44,11 @@ module StripeAuthorizationService
         "088011245800" # AlipayHK "Add Card" to wallet (non_fi_money_orders)
       ]
     ).freeze
+
+  def self.forbidden_merchant_name?(merchant_name)
+    normalized = merchant_name.to_s.strip.downcase
+    return false if normalized.blank?
+
+    FORBIDDEN_MERCHANT_NAME_PREFIXES.any? { |prefix| normalized.start_with?(prefix.downcase) }
+  end
 end

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -108,9 +108,15 @@ module StripeAuthorizationService
         auth[:merchant_data][:network_id]
       end
 
+      def merchant_name
+        auth[:merchant_data][:name]
+      end
+
       def forbidden_merchant?
-        # Explicitly blocked network IDs (e.g. fraud) can never be allowlisted.
+        # Explicitly blocked network IDs and name prefixes (e.g. fraud) can
+        # never be allowlisted.
         return true if StripeAuthorizationService::FORBIDDEN_MERCHANT_NETWORK_IDS.include?(merchant_network_id)
+        return true if StripeAuthorizationService.forbidden_merchant_name?(merchant_name)
 
         StripeAuthorizationService::FORBIDDEN_MERCHANT_CATEGORIES.include?(merchant_category) &&
           StripeAuthorizationService::ALLOWLISTED_MERCHANT_NETWORK_IDS.exclude?(merchant_network_id)
@@ -132,7 +138,7 @@ module StripeAuthorizationService
 
         return true if allowed_categories&.include?(merchant_category)
         return true if allowed_merchants&.include?(merchant_network_id)
-        return true if keyword_lock.present? && Regexp.new(keyword_lock).match?(auth[:merchant_data][:name])
+        return true if keyword_lock.present? && Regexp.new(keyword_lock).match?(merchant_name)
 
         false # decline transaction if none of the above match
       end

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -58,6 +58,17 @@ FactoryBot.define do
       end
     end
 
+    trait :forbidden_name_prefix do
+      merchant_data do
+        {
+          category: "employment_temp_agencies",
+          category_code: "7361",
+          network_id: "9999999999",
+          name: "FAWRA*A1B2C3"
+        }
+      end
+    end
+
     # A merchant whose category is forbidden but whose network ID is allowlisted.
     trait :allowlisted_network_id do
       merchant_data do

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -101,6 +101,66 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
     end
   end
 
+  context "forbidden merchant name prefixes" do
+    let(:stripe_authorization) do
+      build(
+        :stripe_authorization,
+        :forbidden_name_prefix,
+        card: { id: stripe_card.stripe_id }
+      )
+    end
+
+    it "declines and notifies ops" do
+      create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+
+      sent_emails = capture_emails do
+        expect(service.run).to be(false)
+      end
+
+      expect(service.declined_reason).to eq("merchant_not_allowed_globally")
+
+      ops_email =
+        sent_emails
+        .filter { |mail| mail.recipients.include?(ApplicationMailer::OPERATIONS_EMAIL) }
+        .sole
+
+      expect(ops_email.subject).to eq("#{event.name}: Stripe card authorization blocked")
+    end
+
+    context "when the merchant name only contains the prefix mid-name" do
+      let(:stripe_authorization) do
+        build(
+          :stripe_authorization,
+          :forbidden_name_prefix,
+          card: { id: stripe_card.stripe_id },
+          merchant_data: {
+            category: "employment_temp_agencies",
+            category_code: "7361",
+            network_id: "9999999999",
+            name: "TOTALLY NOT FAWRA*A1B2C3"
+          }
+        )
+      end
+
+      it "approves" do
+        create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+
+        expect(service.run).to be(true)
+      end
+    end
+
+    context "when user is admin" do
+      let(:user) { create(:user, :make_admin) }
+      let(:stripe_cardholder) { create(:stripe_cardholder, user:) }
+      let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:, stripe_cardholder:) }
+
+      it "approves when sufficient funds" do
+        create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+        expect(service.run).to be(true)
+      end
+    end
+  end
+
   context "allowlisted merchant network IDs" do
     let(:stripe_authorization) do
       build(

--- a/spec/services/stripe_authorization_service_spec.rb
+++ b/spec/services/stripe_authorization_service_spec.rb
@@ -10,4 +10,34 @@ RSpec.describe StripeAuthorizationService do
       end
     end
   end
+
+  describe ".forbidden_merchant_name?" do
+    before do
+      stub_const(
+        "StripeAuthorizationService::FORBIDDEN_MERCHANT_NAME_PREFIXES",
+        Set.new(["FAWRA*"]).freeze
+      )
+    end
+
+    it "matches a merchant name starting with a forbidden prefix" do
+      expect(described_class.forbidden_merchant_name?("FAWRA*A1B2C3")).to be(true)
+    end
+
+    it "matches regardless of case or surrounding whitespace" do
+      expect(described_class.forbidden_merchant_name?("  fawra*a1b2c3 ")).to be(true)
+    end
+
+    it "does not match when the prefix appears mid-name" do
+      expect(described_class.forbidden_merchant_name?("NOT FAWRA*A1B2C3")).to be(false)
+    end
+
+    it "does not match an unrelated merchant" do
+      expect(described_class.forbidden_merchant_name?("HCB-TEST")).to be(false)
+    end
+
+    it "does not match a blank name" do
+      expect(described_class.forbidden_merchant_name?(nil)).to be(false)
+      expect(described_class.forbidden_merchant_name?("  ")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

Some fraudulent Stripe merchants use dynamic names beginning with a known prefix, allowing them to evade existing merchant category and network ID blocks.

## Describe your changes

- Add HCB-wide, case-insensitive merchant name prefix blocking.
- Block authorizations whose merchant name starts with the configured `FAWRA*` prefix, regardless of allowlists. #14586 
- Reuse the merchant name accessor in authorization handling.
- Add unit and webhook coverage for matching, non-matching, admin, and notification behavior.