### PR TITLE
[Payroll::Position] Only show terminate button if may terminate

### DIFF
--- a/app/views/payroll/positions/show.html.erb
+++ b/app/views/payroll/positions/show.html.erb
@@ -15,19 +15,21 @@
         <span class="badge h4 bg-<%= @position.status_color %> nowrap order-1"><%= @position.status_text %></span>
       </span>
 
-      <div data-controller="menu" data-menu-placement-value="bottom-end">
-        <%= pop_icon_to "more",
-            "#",
-            class: "align-middle", "aria-label": "More Options",
-            data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
+      <% if @position.may_mark_terminated? %>
+        <div data-controller="menu" data-menu-placement-value="bottom-end">
+          <%= pop_icon_to "more",
+              "#",
+              class: "align-middle", "aria-label": "More Options",
+              data: { turbo: true, "menu-target": "toggle", action: "menu#toggle click@document->menu#close keydown@document->menu#keydown" } %>
 
-        <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
-          <%= link_to terminate_event_payroll_position_path(event: @event, payroll_position: @position), class: "flex items-center", data: { turbo_method: :post, turbo_confirm: "Are you sure you want to terminate this contractor immediately? We will notify the contractor." } do %>
-            <%= inline_icon "profile-forbidden", size: 24 %>
-            Terminate
-          <% end %>
+          <div class="menu__content menu__content--2 h5 menu__content--compact" data-menu-target="content">
+            <%= link_to terminate_event_payroll_position_path(event: @event, payroll_position: @position), class: "flex items-center", data: { turbo_method: :post, turbo_confirm: "Are you sure you want to terminate this contractor immediately? We will notify the contractor." } do %>
+              <%= inline_icon "profile-forbidden", size: 24 %>
+              Terminate
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </h2>
 
     <section class="hcb-code--info">


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We were always rendering the terminate button, even though you can only terminate an active payroll position.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Only show the button (since it's the only button in the menu right now, the whole menu) if the position can be terminated.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

