### PR TITLE
[Wire] Change approved callback to after instead of after_commit

### DIFF
--- a/app/models/wire.rb
+++ b/app/models/wire.rb
@@ -114,7 +114,7 @@ class Wire < ApplicationRecord
     state :failed
 
     event :mark_approved do
-      after_commit do
+      after do
         WireMailer.with(wire: self).notify_recipient.deliver_later if self.send_email_notification
         payment_attempt.mark_sent! if payment_attempt.present?
       end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Turns out `after_commit` callbacks don't run when you don't use the auto-saving `!` event method, which meant we never triggered the attempt to update here, since `send_wire!` uses the non-bang method.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Change the callback to just be `after` instead of `after_commit`. While this does bring up the possibility that a transaction rolls back and we send an email we shouldn't have, other transfers also use the `after` callback, and I don't see a reason in our current code why a transaction approving a wire might roll back.

We should review our usage of `after_commit` in other places in the codebase as well, and weigh whether or not the risk of writing code that doesn't trigger callbacks at all is worth the chance of sending an email we shouldn't.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

