### PR TITLE
Hotfix: stop unknown hcb_code from being rewritten on recompute

### DIFF
--- a/app/services/transaction_grouping_engine/calculate/hcb_code.rb
+++ b/app/services/transaction_grouping_engine/calculate/hcb_code.rb
@@ -316,6 +316,20 @@ module TransactionGroupingEngine
       end
 
       def unknown_hcb_code
+        # `run` gets re-invoked periodically for any transaction still
+        # classified as unknown (see TransactionGroupingEngine::NightlyJob,
+        # which reprocesses every CanonicalTransaction with a `000` code every
+        # 5 minutes). That means this method MUST be idempotent for a given
+        # record: once an "unknown" code has been assigned and stored, we
+        # have to keep returning that exact same string forever. Computing a
+        # *different* string here — even one that's equally "correct" as an
+        # unknown code — would make the caller (`write_hcb_code`/the nightly
+        # job) find-or-create a brand new, disconnected HcbCode row and
+        # silently reassign the transaction to it, orphaning its real
+        # ledger_item, comments, receipts, and tags (which stay behind on the
+        # original HcbCode row). See #14680/incident writeup.
+        return @ct_or_cp.hcb_code if already_unknown?
+
         [
           HCB_CODE,
           UNKNOWN_CODE,
@@ -323,11 +337,17 @@ module TransactionGroupingEngine
         ].join(SEPARATOR)
       end
 
+      def already_unknown?
+        @ct_or_cp.hcb_code&.start_with?("#{HCB_CODE}#{SEPARATOR}#{UNKNOWN_CODE}#{SEPARATOR}")
+      end
+
       # CanonicalTransaction and CanonicalPendingTransaction each have their
       # own `id` sequence, so an unrelated CT and CPT can end up with the same
       # id. Prefixing with the model name keeps their "unknown" hcb_codes from
       # colliding with each other (which would otherwise merge two unrelated
-      # transactions onto the same HcbCode/ledger item).
+      # transactions onto the same HcbCode/ledger item). This only ever runs
+      # for a transaction's first-ever "unknown" assignment — see
+      # `already_unknown?` above.
       def unknown_identifier
         "#{@ct_or_cp.model_name.param_key}_#{@ct_or_cp.id}"
       end

--- a/spec/services/transaction_grouping_engine/calculate/hcb_code_spec.rb
+++ b/spec/services/transaction_grouping_engine/calculate/hcb_code_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransactionGroupingEngine::Calculate::HcbCode do
+  subject(:run) { described_class.new(canonical_transaction_or_canonical_pending_transaction: ct_or_cp).run }
+
+  describe "unknown transactions" do
+    context "when the transaction has never been assigned an hcb_code" do
+      let(:ct_or_cp) { build_stubbed(:canonical_transaction, hcb_code: nil) }
+
+      it "computes a fresh unknown code" do
+        expect(run).to eq("HCB-000-canonical_transaction_#{ct_or_cp.id}")
+      end
+    end
+
+    context "when the transaction already has a legacy unknown code" do
+      let(:ct_or_cp) { build_stubbed(:canonical_transaction, hcb_code: "HCB-000-#{id}") }
+      let(:id) { 42 }
+
+      before { allow(ct_or_cp).to receive(:id).and_return(id) }
+
+      it "does not change it" do
+        # Regression test: `run` gets re-invoked periodically (see
+        # TransactionGroupingEngine::NightlyJob) for any transaction still
+        # classified as unknown. Recomputing MUST return the exact stored
+        # string, or the caller will find-or-create a brand new HcbCode row
+        # and silently reassign the transaction away from its real
+        # ledger_item/comments/receipts/tags.
+        expect(run).to eq("HCB-000-42")
+      end
+    end
+
+    context "when the transaction already has a post-fix unknown code" do
+      let(:ct_or_cp) { build_stubbed(:canonical_transaction, hcb_code: "HCB-000-canonical_transaction_42") }
+
+      before { allow(ct_or_cp).to receive(:id).and_return(42) }
+
+      it "does not change it" do
+        expect(run).to eq("HCB-000-canonical_transaction_42")
+      end
+    end
+
+    context "when a CanonicalTransaction and CanonicalPendingTransaction share the same id" do
+      it "computes distinct codes for each" do
+        ct = build_stubbed(:canonical_transaction, hcb_code: nil)
+        cpt = build_stubbed(:canonical_pending_transaction, hcb_code: nil)
+        allow(cpt).to receive(:id).and_return(ct.id)
+
+        ct_code = described_class.new(canonical_transaction_or_canonical_pending_transaction: ct).run
+        cpt_code = described_class.new(canonical_transaction_or_canonical_pending_transaction: cpt).run
+
+        expect(ct_code).not_to eq(cpt_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Incident

#14680 fixed a real id-collision bug (a `CanonicalTransaction` and an unrelated `CanonicalPendingTransaction` could compute the same fallback `unknown_hcb_code` string when their independent id sequences happened to align) by changing the fallback identifier from the bare `id` to a model-name-prefixed one.

That was the wrong shape of fix: `unknown_hcb_code` is not just computed once. It's recomputed for every still-"unknown" `CanonicalTransaction`:

- by `TransactionGroupingEngine::NightlyJob`, which runs **every 5 minutes** over `CanonicalTransaction.missing_or_unknown_hcb_code`
- whenever a `CanonicalEventMapping` is created (`CanonicalEventMapping#write_hcb_code`)

Because the new format is a different string than the old `"HCB-000-<id>"` format, the very next time either path touched an already-existing "unknown" transaction, it computed a *different* code than what was stored. Both paths write that new code via `update_column`/`find_or_create_by!`, which:

1. Creates a brand new, empty `HcbCode` row for the new string.
2. Reassigns the transaction's `hcb_code` (and therefore `local_hcb_code`) to that new, empty row.
3. **Never touches `ledger_item_id`** on the transaction, which still points at the original ledger item.

Net effect in production: for every pre-existing "unknown" `CanonicalTransaction` the nightly job reprocessed after #14680 deployed, `local_hcb_code` and `ledger_item` now disagree, and anything reachable only through the (now orphaned) original `HcbCode` row — comments, receipts, tags — became unreachable from the transaction. Since the job runs every 5 minutes, this was already affecting most/all in-window unknown transactions by the time it was caught.

## Fix

`unknown_hcb_code` now returns the already-persisted code unchanged once a transaction has *any* `"HCB-000-*"` code — making recompute a true no-op for anything already classified as unknown, restoring the invariant that an hcb_code, once assigned, never silently changes format out from under existing associations. The disambiguated identifier from #14680 still applies, but only the first time a code is ever computed for a transaction — which still fixes the original id-collision bug for new records.

## Not covered by this PR

This stops **further** damage. Production data already rewritten by #14680 (any `CanonicalTransaction` with an `hcb_code` matching `HCB-000-canonical_transaction_<id>` whose `ledger_item` doesn't match its `local_hcb_code`'s ledger_item) still needs a separate repair pass:
- restore `hcb_code` back to `HCB-000-<id>` where that original `HcbCode` row still exists
- verify/move any data (comments, receipts, tags) that landed on the new orphaned `HcbCode` rows in the interim before removing them

Flagging so we can scope and run that separately with production access.

## Testing

Added `spec/services/transaction_grouping_engine/calculate/hcb_code_spec.rb`, covering:
- fresh unknown classification still gets the disambiguated identifier
- a transaction with a legacy `HCB-000-<id>` code is left untouched on recompute
- a transaction with a post-#14680 code is left untouched on recompute
- a CT and CPT sharing an id still get distinct codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)