### PR TITLE
Stop the fee reimbursement backstop from creating orphaned CPTs

### DIFF
--- a/app/models/fee_reimbursement.rb
+++ b/app/models/fee_reimbursement.rb
@@ -137,4 +137,62 @@ class FeeReimbursement < ApplicationRecord
     @canonical_transaction ||= event.canonical_transactions.where("memo ilike ? and date >= ?", "#{sanitize_sql_like(transaction_memo)}%", created_at - 1.day).first
   end
 
+  # Has this reimbursement's OWN Stripe top-up already posted as a real,
+  # settled bank transaction? NOTE this is deliberately separate from
+  # #canonical_transaction above, which checks something else entirely: it's
+  # scoped to the *org's* event and matched on the *invoice/donation's* short
+  # code (`transaction_memo`), because it's asking whether the underlying
+  # invoice/donation payout settled. The reimbursement's own top-up settles
+  # under Hack Club Bank (see OUTGOING_FEE_REIMBURSEMENT_CODE), grouped by
+  # week, under a *different* short code — so it needs its own lookup.
+  #
+  # Matched two ways:
+  # 1. By the weekly HCB-900-<week> short code embedded in the topup's
+  #    statement descriptor (Nightly#local_hcb_code, since 5c932154). This is
+  #    reliable regardless of which ISO week the transaction actually clears
+  #    in — bank/ACH settlement can land a few business days after
+  #    `processed_at`, crossing into the following week.
+  # 2. Falling back to a week + amount match for reimbursements processed
+  #    before short codes were embedded (pre-2025-05-18), where the settled
+  #    memo ("STRIPE FEE REIMBU" / "HCKCLB FEE REIMBU") carries no code to
+  #    match on at all — see
+  #    TransactionGroupingEngine::Calculate::HcbCode#outgoing_fee_reimbursement?.
+  #    This is a best-effort match: it can only key off week + amount, so a
+  #    coincidental duplicate amount in the same window could match the wrong
+  #    transaction.
+  def settled_fee_reimbursement_transaction
+    return @settled_fee_reimbursement_transaction if defined?(@settled_fee_reimbursement_transaction)
+
+    @settled_fee_reimbursement_transaction = settled_transaction_by_weekly_short_code || settled_transaction_by_week_and_amount
+  end
+
+  private
+
+  def outgoing_fee_reimbursement_hcb_code
+    [
+      ::TransactionGroupingEngine::Calculate::HcbCode::HCB_CODE,
+      ::TransactionGroupingEngine::Calculate::HcbCode::OUTGOING_FEE_REIMBURSEMENT_CODE,
+      processed_at.strftime("%G_%V"),
+    ].join(::TransactionGroupingEngine::Calculate::HcbCode::SEPARATOR)
+  end
+
+  def settled_transaction_by_weekly_short_code
+    return nil unless processed_at
+
+    short_code = ::HcbCode.find_by(hcb_code: outgoing_fee_reimbursement_hcb_code)&.short_code
+    return nil unless short_code.present?
+
+    ::CanonicalTransaction.where("memo ilike ?", "%HCB-#{short_code}%").first
+  end
+
+  def settled_transaction_by_week_and_amount
+    return nil unless processed_at && amount.present?
+
+    ::CanonicalTransaction
+      .where("hcb_code ilike ?", "HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::OUTGOING_FEE_REIMBURSEMENT_CODE}-%")
+      .where(date: (processed_at.to_date - 1.day)..(processed_at.to_date + 10.days))
+      .where(amount_cents: -amount)
+      .first
+  end
+
 end

--- a/app/services/fee_reimbursement_service/create_canonical_pending_transaction.rb
+++ b/app/services/fee_reimbursement_service/create_canonical_pending_transaction.rb
@@ -7,12 +7,20 @@ module FeeReimbursementService
     end
 
     # Idempotent: safe to re-run (e.g. from the nightly) — it no-ops once the
-    # fee reimbursement already has its raw pending transaction, and skips
-    # zero-amount reimbursements (which move no money and get no topup).
+    # fee reimbursement already has its raw pending transaction, skips
+    # zero-amount reimbursements (which move no money and get no topup), and
+    # skips reimbursements whose top-up has already settled as a real
+    # CanonicalTransaction. That last case matters for old, backfilled
+    # reimbursements: their money already moved and reconciled months/years
+    # ago, so inventing a fresh "pending" leg for them now would never settle
+    # (nothing ever maps a CPT back to a CT that already exists) and, worse,
+    # can land on a different HcbCode/Ledger::Item than the one the real
+    # settled transaction lives on — see FeeReimbursement#settled_fee_reimbursement_transaction.
     def run
       existing = fee_reimbursement.raw_pending_fee_reimbursement_transaction
       return existing.canonical_pending_transaction if existing.present?
       return if fee_reimbursement.amount.to_i.zero?
+      return if fee_reimbursement.settled_fee_reimbursement_transaction.present?
 
       ActiveRecord::Base.transaction do
         rpfrt = fee_reimbursement.create_raw_pending_fee_reimbursement_transaction!(

--- a/app/services/fee_reimbursement_service/nightly.rb
+++ b/app/services/fee_reimbursement_service/nightly.rb
@@ -13,6 +13,14 @@
 
 module FeeReimbursementService
   class Nightly
+    # There's a large historical backlog of reimbursements that predate the
+    # CPT/Ledger::Item backfill (some going back years). Chewing through all
+    # of it in one run — each one doing a handful of creates plus a
+    # Ledger::Mapper pass — is what ran the job out of memory. Bound it to a
+    # slice per night; missing_pending_transaction shrinks as the backlog
+    # catches up over several nights instead.
+    BACKSTOP_BATCH_LIMIT = 500
+
     def run
       # Rescued per-record below — one org's Stripe hiccup shouldn't take down
       # the whole run and, with it, the backstop loop that follows.
@@ -22,7 +30,7 @@ module FeeReimbursementService
 
       # Backstop: catch any already-processed reimbursements that still lack a
       # pending transaction (idempotent — no-ops for ones that already have one).
-      FeeReimbursement.missing_pending_transaction.find_each(batch_size: 100) do |fee_reimbursement|
+      FeeReimbursement.missing_pending_transaction.order(:processed_at).limit(BACKSTOP_BATCH_LIMIT).find_each(batch_size: 100) do |fee_reimbursement|
         create_canonical_pending_transaction(fee_reimbursement)
       end
     end

--- a/app/tasks/maintenance/delete_orphaned_fee_reimbursement_cpts_task.rb
+++ b/app/tasks/maintenance/delete_orphaned_fee_reimbursement_cpts_task.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # FeeReimbursementService::Nightly's backstop used to create a
+  # CanonicalPendingTransaction for any processed-but-CPT-less fee
+  # reimbursement without checking whether its top-up had already settled as
+  # a real CanonicalTransaction. For old reimbursements whose money already
+  # moved and reconciled, the backfilled CPT's week-based hcb_code can land on
+  # a *different* HcbCode/Ledger::Item than the one the real settled
+  # transaction lives on (bank/ACH clearing routinely crosses an ISO week
+  # boundary) — producing an orphaned, permanently-unmapped, never-settling
+  # duplicate. See FeeReimbursement#settled_fee_reimbursement_transaction.
+  #
+  # FeeReimbursementService::CreateCanonicalPendingTransaction now checks for
+  # this before creating anything — this task removes what the bug already
+  # created before that fix shipped.
+  #
+  # Only removes the CPT chain (raw pending transaction, category mapping,
+  # event mapping, CPT) and the Ledger::Item/Ledger::Mapping it lives on, and
+  # only when that item is left completely empty afterward — if anything else
+  # (a settled CT, a comment, a receipt) is attached, the item is left alone
+  # rather than guessing. Safe to rerun: once a reimbursement's erroneous CPT
+  # is gone, it drops out of the collection.
+  class DeleteOrphanedFeeReimbursementCptsTask < MaintenanceTasks::Task
+    def collection
+      FeeReimbursement.where.associated(:raw_pending_fee_reimbursement_transaction)
+    end
+
+    def process(fee_reimbursement)
+      return unless fee_reimbursement.settled_fee_reimbursement_transaction.present?
+
+      rpfrt = fee_reimbursement.raw_pending_fee_reimbursement_transaction
+      cpt = rpfrt&.canonical_pending_transaction
+      return unless cpt
+
+      ledger_item_id = cpt.ledger_item_id
+
+      # Destroying the CPT and its ledger item in the same transaction would
+      # trip CanonicalPendingTransaction's own after_commit (it fires on
+      # destroy too, unconditioned on create/update): it calls
+      # ledger_item.map!/.refresh! once this transaction commits, which
+      # reloads the ledger item — raising RecordNotFound if that row is
+      # *also* already gone by then. Commit the CPT/rpfrt removal first (that
+      # callback runs safely against a still-existing, now-childless ledger
+      # item) and only then decide whether to remove the ledger item itself.
+      ActiveRecord::Base.transaction do
+        TransactionCategoryMapping.where(categorizable: cpt).delete_all
+        CanonicalPendingEventMapping.where(canonical_pending_transaction: cpt).delete_all
+        cpt.destroy!
+        rpfrt.destroy!
+      end
+
+      destroy_if_empty(Ledger::Item.find_by(id: ledger_item_id)) if ledger_item_id
+    end
+
+    private
+
+    def destroy_if_empty(ledger_item)
+      return unless ledger_item
+
+      ledger_item.reload
+      return if ledger_item.canonical_transactions.any?
+      return if ledger_item.canonical_pending_transactions.any?
+      return if ledger_item.comments.any?
+      return if ledger_item.receipts.any?
+
+      ActiveRecord::Base.transaction do
+        Ledger::Mapping.where(ledger_item:).delete_all
+        ledger_item.destroy!
+      end
+    end
+
+  end
+end

--- a/spec/models/fee_reimbursement_spec.rb
+++ b/spec/models/fee_reimbursement_spec.rb
@@ -26,4 +26,41 @@ RSpec.describe FeeReimbursement, type: :model do
       expect(FeeReimbursement.pending).to include(processed)
     end
   end
+
+  describe "#settled_fee_reimbursement_transaction" do
+    it "is nil when the reimbursement hasn't been processed yet" do
+      unprocessed = create(:fee_reimbursement, processed_at: nil)
+
+      expect(unprocessed.settled_fee_reimbursement_transaction).to be_nil
+    end
+
+    it "is nil when nothing has settled for that week" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+
+      expect(fr.settled_fee_reimbursement_transaction).to be_nil
+    end
+
+    it "finds the settled transaction by the weekly HCB-900 short code, regardless of its own date" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+      weekly_hcb_code = HcbCode.create!(hcb_code: "HCB-900-#{fr.processed_at.strftime("%G_%V")}")
+      settled = create(:canonical_transaction, memo: "HCBCLB HCB-#{weekly_hcb_code.short_code}", amount_cents: -1234, date: Date.current)
+
+      expect(fr.settled_fee_reimbursement_transaction).to eq(settled)
+    end
+
+    it "falls back to a week + amount match when the settled memo carries no short code" do
+      # Pre-2025-05-18 memo format, settlement crossed into the next ISO week.
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0)) # Friday
+      settled = create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -1234, date: Date.new(2025, 1, 13)) # Monday
+
+      expect(fr.settled_fee_reimbursement_transaction).to eq(settled)
+    end
+
+    it "does not match a differently-sized settlement in the same window" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0))
+      create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -9_999, date: Date.new(2025, 1, 13))
+
+      expect(fr.settled_fee_reimbursement_transaction).to be_nil
+    end
+  end
 end

--- a/spec/services/fee_reimbursement_service/create_canonical_pending_transaction_spec.rb
+++ b/spec/services/fee_reimbursement_service/create_canonical_pending_transaction_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe FeeReimbursementService::CreateCanonicalPendingTransaction, type: :service do
   # The pending transaction is mapped to the Hack Club Bank event, which must
   # exist for the service to succeed.
-  let!(:hack_club_bank) { create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK) }
+  let!(:hack_club_bank) { Event.find_by(id: EventMappingEngine::EventIds::HACK_CLUB_BANK) || create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK) }
 
   let(:fee_reimbursement) { create(:fee_reimbursement, amount: 12_34) }
 
@@ -56,6 +56,41 @@ RSpec.describe FeeReimbursementService::CreateCanonicalPendingTransaction, type:
 
       expect(result).to be_nil
       expect(zero.reload.raw_pending_fee_reimbursement_transaction).to be_nil
+    end
+
+    # Regression test: creating a fresh (and inevitably unmapped) Ledger::Item
+    # for a reimbursement whose top-up already settled, instead of finding
+    # the settled transaction's existing one.
+    context "when the reimbursement's top-up already settled" do
+      it "does nothing when the settled transaction embeds the weekly short code" do
+        old = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+        weekly_hcb_code = HcbCode.create!(hcb_code: "HCB-900-#{old.processed_at.strftime("%G_%V")}")
+        create(:canonical_transaction, memo: "HCBCLB HCB-#{weekly_hcb_code.short_code}", amount_cents: -1234)
+
+        result = described_class.new(fee_reimbursement_id: old.id).run
+
+        expect(result).to be_nil
+        expect(old.reload.raw_pending_fee_reimbursement_transaction).to be_nil
+      end
+
+      it "does nothing when settlement crossed into the next ISO week (no short code, old memo format)" do
+        old = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0)) # Friday
+        create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -1234, date: Date.new(2025, 1, 13)) # following Monday
+
+        result = described_class.new(fee_reimbursement_id: old.id).run
+
+        expect(result).to be_nil
+        expect(old.reload.raw_pending_fee_reimbursement_transaction).to be_nil
+      end
+
+      it "still creates the pending transaction when nothing has settled yet" do
+        old = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+
+        result = described_class.new(fee_reimbursement_id: old.id).run
+
+        expect(result).to be_present
+        expect(old.reload.raw_pending_fee_reimbursement_transaction).to be_present
+      end
     end
   end
 

--- a/spec/tasks/maintenance/delete_orphaned_fee_reimbursement_cpts_task_spec.rb
+++ b/spec/tasks/maintenance/delete_orphaned_fee_reimbursement_cpts_task_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::DeleteOrphanedFeeReimbursementCptsTask do
+  let!(:hack_club_bank) { Event.find_by(id: EventMappingEngine::EventIds::HACK_CLUB_BANK) || create(:event, id: EventMappingEngine::EventIds::HACK_CLUB_BANK) }
+
+  # Builds the orphaned state the pre-fix backstop used to create — a CPT +
+  # Ledger::Item — bypassing FeeReimbursementService::CreateCanonicalPendingTransaction,
+  # since it now refuses to create this state in the first place.
+  def create_orphaned_cpt(fee_reimbursement)
+    rpfrt = fee_reimbursement.create_raw_pending_fee_reimbursement_transaction!(
+      date_posted: fee_reimbursement.processed_at.to_date,
+      amount_cents: -fee_reimbursement.amount
+    )
+    CanonicalPendingTransaction.create!(date: rpfrt.date, amount_cents: rpfrt.amount_cents, memo: rpfrt.memo, raw_pending_fee_reimbursement_transaction: rpfrt)
+  end
+
+  describe "#collection" do
+    it "only includes reimbursements with a raw pending fee reimbursement transaction" do
+      with_cpt = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+      create_orphaned_cpt(with_cpt)
+      without_cpt = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+
+      expect(described_class.new.collection).to include(with_cpt)
+      expect(described_class.new.collection).not_to include(without_cpt)
+    end
+  end
+
+  describe "#process" do
+    it "deletes the orphaned CPT chain and the now-empty ledger item" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0)) # Friday
+      cpt = create_orphaned_cpt(fr)
+      ledger_item = cpt.ledger_item
+      create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -1234, date: Date.new(2025, 1, 13)) # settled, following week
+
+      described_class.new.process(fr)
+
+      expect(CanonicalPendingTransaction.exists?(cpt.id)).to be false
+      expect(RawPendingFeeReimbursementTransaction.where(fee_reimbursement: fr)).not_to exist
+      expect(Ledger::Item.exists?(ledger_item.id)).to be false
+    end
+
+    it "leaves the reimbursement alone when its CPT isn't actually orphaned" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: 18.months.ago)
+      cpt = create_orphaned_cpt(fr)
+
+      described_class.new.process(fr)
+
+      expect(CanonicalPendingTransaction.exists?(cpt.id)).to be true
+    end
+
+    it "deletes the CPT but leaves the ledger item alone if it has other content attached" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0))
+      cpt = create_orphaned_cpt(fr)
+      ledger_item = cpt.ledger_item
+      create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -1234, date: Date.new(2025, 1, 13))
+      # Something else already settled onto this exact (erroneous) ledger item —
+      # leave it alone rather than guessing which side is "correct".
+      create(:canonical_transaction, ledger_item:)
+
+      described_class.new.process(fr)
+
+      expect(CanonicalPendingTransaction.exists?(cpt.id)).to be false
+      expect(Ledger::Item.exists?(ledger_item.id)).to be true
+    end
+
+    it "is a no-op the second time it's run for the same reimbursement" do
+      fr = create(:fee_reimbursement, amount: 12_34, processed_at: Time.utc(2025, 1, 10, 12, 0, 0))
+      create_orphaned_cpt(fr)
+      create(:canonical_transaction, memo: "HCKCLB FEE REIMBU", amount_cents: -1234, date: Date.new(2025, 1, 13))
+
+      described_class.new.process(fr)
+      expect { described_class.new.process(fr) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

#14652's backstop correctly reaches old, already-processed fee reimbursements now, but it never checked whether a reimbursement's Stripe top-up had already settled as a real `CanonicalTransaction` before creating a new pending one for it. For old reimbursements the backfilled CPT's week-based `hcb_code` can land on a *different* `HcbCode`/`Ledger::Item` than the one the real settled transaction lives on — bank/ACH clearing routinely crosses an ISO week boundary — so instead of finding the existing ledger item it creates a new, orphaned, permanently-unmapped one.

Separately, once the scope fix let the backstop actually reach the (large, multi-year) backlog instead of endlessly re-scanning it, every matching record started doing real work (creates, category/event mapping, cascading `Ledger::Mapper`) instead of an idempotent no-op — which is what ran the job out of memory.

## Describe your changes

- `FeeReimbursement#settled_fee_reimbursement_transaction`: checks whether a reimbursement's own top-up already settled, two ways — by the weekly `HCB-900-<week>` short code embedded in the topup's statement descriptor (works regardless of which week the transaction actually settles in), falling back to a week + amount match for reimbursements processed before short codes were embedded (pre-2025-05-18), whose settled memo carries no code to match on at all.

  This is deliberately separate from the existing `#canonical_transaction`, which checks something else (has the invoice/donation's own payout settled) and doesn't work for what we need here: it's scoped to the org's event rather than Hack Club Bank, and does a prefix match against the invoice/donation's short code rather than a substring match against the reimbursement's own.

- `CreateCanonicalPendingTransaction#run` now skips creating anything when that check finds a match.
- `Nightly`'s backstop is capped at 500 reimbursements/run (`missing_pending_transaction`), so a large backlog gets worked through over several nights instead of all at once.
- `Maintenance::DeleteOrphanedFeeReimbursementCptsTask` cleans up what the bug already created: removes the CPT/rpfrt/mapping chain for any reimbursement whose `settled_fee_reimbursement_transaction` is present, and the ledger item it lived on if that leaves it completely empty (left alone otherwise, rather than guessing).

---------

🤖 Generated with [Claude Code](https://claude.com/claude-code)