### PR TITLE
Reload local_hcb_code before assigning a ledger item

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -477,6 +477,12 @@ class CanonicalPendingTransaction < ApplicationRecord
 
   def assign_ledger_item
     safely do
+      # `local_hcb_code` is keyed on the `hcb_code` string column, which is
+      # only populated by `write_hcb_code` moments before this callback runs.
+      # If anything accessed `local_hcb_code` on this instance earlier (e.g.
+      # while `hcb_code` was still nil), the association would be memoized as
+      # nil forever, so force a fresh lookup before relying on it.
+      reload_local_hcb_code
       ActiveRecord::Base.transaction do
         li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
         update!(ledger_item: li)

--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -477,11 +477,6 @@ class CanonicalPendingTransaction < ApplicationRecord
 
   def assign_ledger_item
     safely do
-      # `local_hcb_code` is keyed on the `hcb_code` string column, which is
-      # only populated by `write_hcb_code` moments before this callback runs.
-      # If anything accessed `local_hcb_code` on this instance earlier (e.g.
-      # while `hcb_code` was still nil), the association would be memoized as
-      # nil forever, so force a fresh lookup before relying on it.
       reload_local_hcb_code
       ActiveRecord::Base.transaction do
         li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -487,11 +487,6 @@ class CanonicalTransaction < ApplicationRecord
 
   def assign_ledger_item
     safely do
-      # `local_hcb_code` is keyed on the `hcb_code` string column, which is
-      # only populated by `write_hcb_code` moments before this callback runs.
-      # If anything accessed `local_hcb_code` on this instance earlier (e.g.
-      # while `hcb_code` was still nil), the association would be memoized as
-      # nil forever, so force a fresh lookup before relying on it.
       reload_local_hcb_code
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -487,6 +487,12 @@ class CanonicalTransaction < ApplicationRecord
 
   def assign_ledger_item
     safely do
+      # `local_hcb_code` is keyed on the `hcb_code` string column, which is
+      # only populated by `write_hcb_code` moments before this callback runs.
+      # If anything accessed `local_hcb_code` on this instance earlier (e.g.
+      # while `hcb_code` was still nil), the association would be memoized as
+      # nil forever, so force a fresh lookup before relying on it.
+      reload_local_hcb_code
       ActiveRecord::Base.transaction do
         if calculated_ledger_item != local_hcb_code.ledger_item
           Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")


### PR DESCRIPTION
## Problem

`local_hcb_code` is a `has_one` association on `CanonicalTransaction`/`CanonicalPendingTransaction` keyed on the mutable `hcb_code` string column (`foreign_key: "hcb_code", primary_key: "hcb_code"`), rather than `id`. That column is only populated by `write_hcb_code`, which runs immediately before `assign_ledger_item`.

If anything reads `local_hcb_code` on an instance before `hcb_code` has been set (or before the matching `HcbCode` row exists), Rails memoizes that lookup — including `nil` — for the lifetime of the object. Any later call to `local_hcb_code.ledger_item` then raises `NoMethodError: undefined method 'ledger_item' for nil`, rather than gracefully evaluating to `nil`.

Since `assign_ledger_item` wraps its body in a `safely` block, that exception is silently caught and reported (not raised) outside of development/test, and `ActiveRecord::Base.transaction` rolls back the attempted `create_ledger_item!`. Because `assign_ledger_item` only ever runs once (`after_create_commit ... unless: -> { ledger_item.present? }`), the record is left permanently without a `ledger_item`, even though a matching `HcbCode` exists and everything looks fine on a fresh reload afterward.

## Fix

Call `reload_local_hcb_code` at the top of `assign_ledger_item` in both models to force a fresh lookup before relying on the association, instead of trusting whatever (possibly stale) value was memoized earlier in the object's lifecycle.

## Testing

Ran `spec/models/canonical_pending_transaction_spec.rb` and `spec/models/canonical_transaction_spec.rb` before/after this change — same pass/fail counts in both cases (pre-existing failures are unrelated fixture/test-DB state collisions, not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)