### PR TITLE
[Custom Memo] Use `update_all` instead of `update`

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -794,8 +794,8 @@ class HcbCode < ApplicationRecord
       ledger_item.update_custom_memo!(memo)
       return
     end
-    canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-    canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
+    canonical_transactions.update_all(custom_memo: memo)
+    canonical_pending_transactions.update_all(custom_memo: memo)
   end
 
 end

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -193,8 +193,8 @@ class Ledger
       # TODO: remove CT and CPT updates because they are HCB code specific
       ActiveRecord::Base.transaction do
         if hcb_code.present?
-          hcb_code.canonical_transactions.each { |ct| ct.update!(custom_memo: memo) }
-          hcb_code.canonical_pending_transactions.each { |cpt| cpt.update!(custom_memo: memo) }
+          hcb_code.canonical_transactions.update_all(custom_memo: memo)
+          hcb_code.canonical_pending_transactions.update_all(custom_memo: memo)
         end
         update!(custom_memo: memo)
       end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
There are too many records in an HCB-900 to use `update`


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Use `update_all`


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

