### PR TITLE
[Event] Decouple ledger access from new_ledger flipper

### DIFF
--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -293,13 +293,13 @@ class EventPolicy < ApplicationPolicy
   end
 
   def ledger?
-    auditor? || Flipper.enabled?(:new_ledger_2026_07_17, user)
+    is_public || auditor_or_reader?
   end
 
   alias_method :ledger_stats?, :ledger?
 
   def toggle_new_ledger?
-    auditor_or_reader?
+    is_public || auditor_or_reader?
   end
 
   alias hide_onboarding_message? request_call?

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -125,24 +125,10 @@ RSpec.describe EventPolicy, type: :policy do
 
     subject { described_class.new(user, event).ledger? }
 
-    context "as a reader" do
-      before { create(:organizer_position, user:, event:, role: :reader) }
-
-      it "is denied without either ledger flag" do
-        is_expected.to eq(false)
-      end
-
-      it "is allowed when the user has opted into new_ledger_2026_07_17" do
-        Flipper.enable_actor(:new_ledger_2026_07_17, user)
-
-        is_expected.to eq(true)
-      end
-    end
-
     context "as an auditor" do
       let(:user) { create(:user, :make_auditor) }
 
-      it "is allowed without either flag" do
+      it "is allowed" do
         is_expected.to eq(true)
       end
     end


### PR DESCRIPTION
## Summary
- `ledger?`/`ledger_stats?` no longer gate on the `new_ledger_2026_07_17` flipper. Access now follows the same `is_public || auditor_or_reader?` rule used elsewhere (e.g. `show?`, `team?`), so users can reach the ledger regardless of whether the flag is enabled for them. The flipper's only remaining job is deciding which page (ledger vs. transactions) a user gets automatically routed to (see the sidebar nav `path_proc` in `app/helpers/events_helper.rb` and the `toggle_new_ledger` controller action).
- `toggle_new_ledger?` previously required `auditor_or_reader?`, which incorrectly excluded members/managers without reader role on transparent events. It now also allows toggling when the event is transparent (`is_public`).

## Test plan
- [ ] Verify a non-reader/non-auditor user can still load `/ledger` on a transparent event.
- [ ] Verify a reader without the flipper enabled can load `/ledger` directly.
- [ ] Verify the "Try the new ledger" / "Go back to the classic ledger" toggle button appears and works on a transparent event even for non-reader users.