### PR TITLE
[FeeReimbursement] Fix nil error when there are no CTs

### DIFF
--- a/app/models/hcb_code/memo.rb
+++ b/app/models/hcb_code/memo.rb
@@ -94,7 +94,7 @@ class HcbCode
       end
 
       def outgoing_fee_reimbursement_memo
-        "🗂️ Stripe fee reimbursements for week of #{ct.date.beginning_of_week.strftime("%-m/%-d")}"
+        "🗂️ Stripe fee reimbursements for week of #{(ct || pt).date.beginning_of_week.strftime("%-m/%-d")}"
       end
 
       def reimbursement_payout_holding_memo


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Some broken fee reimbursements have no CTs but I still need to be able to view these.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Pull date from `pt`.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

