### PR TITLE
fix syntax errors for CodeQL

### DIFF
--- a/app/views/ach_transfers/_form.html.erb
+++ b/app/views/ach_transfers/_form.html.erb
@@ -148,8 +148,8 @@
       <%= form.date_field :invoiced_at, disabled:, style: "max-width: 190px", max: Date.current %>
     </div>
 
-    <%= render "events/transfers/notify_recipient", form:, disabled: %>
-    <%= render "events/transfers/attach_receipt", form:, disabled: %>
+    <%= render "events/transfers/notify_recipient", form:, disabled: disabled %>
+    <%= render "events/transfers/attach_receipt", form:, disabled: disabled %>
   </div>
   </div>
 

--- a/app/views/admin/account_numbers.html.erb
+++ b/app/views/admin/account_numbers.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with method: :get, class: "card overflow-visible" do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     <%= form.select :account_number_type, [["All", "0"], ["Deposit only", "1"], ["Spend + Deposit", "2"]], selected: @account_number_type %>
   </div>

--- a/app/views/admin/ach.html.erb
+++ b/app/views/admin/ach.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: ach_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     <%= render "admin/date_range_filter", start_date: @start_date, end_date: @end_date %>
   </div>

--- a/app/views/admin/applications.html.erb
+++ b/app/views/admin/applications.html.erb
@@ -1,7 +1,7 @@
 <% title "Applications (HCB)" %>
 
 <%= form_with local: true, class: "card", url: applications_admin_index_path, method: :get do |form| %>
-  <%= render "events/filters/search", form: %>
+  <%= render "events/filters/search", form: form %>
 
   <div class="flex flex-col sm:flex-row items-center gap-2 mt-2">
     <div>

--- a/app/views/admin/contracts.html.erb
+++ b/app/views/admin/contracts.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: contracts_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.select :type, Contract.subclasses.map { |subclass| [subclass.name.demodulize.underscore.humanize, subclass.name] }, { include_blank: "All contract types", selected: @type } %>
     <%= form.select :status, Contract.aasm.states_for_select, { include_blank: "All statuses", selected: @status } %>
     <%= form.select :service, Contract.external_services.keys.map { |name| [name.humanize, name] }, { include_blank: "All services", selected: @service } %>

--- a/app/views/admin/disbursements.html.erb
+++ b/app/views/admin/disbursements.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: disbursements_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     <%= render "admin/date_range_filter", start_date: @start_date, end_date: @end_date %>
   </div>

--- a/app/views/admin/donations.html.erb
+++ b/app/views/admin/donations.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: donations_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.text_field :ip_address, value: params[:ip_address], placeholder: "IP Address" %>
     <%= form.text_field :user_agent, value: params[:user_agent], placeholder: "User Agent" %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>

--- a/app/views/admin/emails.html.erb
+++ b/app/views/admin/emails.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: emails_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.text_field :to, value: params[:to], placeholder: "Email address (to)" %>
     <%= form.text_field :user_id, value: params[:user_id], placeholder: "User ID" %>
   </div>

--- a/app/views/admin/employee_payments.html.erb
+++ b/app/views/admin/employee_payments.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with method: :get, class: "card" do |form| %>
   <div class="flex items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.submit "Search", class: "ml-auto" %>
   </div>
 <% end %>

--- a/app/views/admin/employees.html.erb
+++ b/app/views/admin/employees.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with method: :get, class: "card" do |form| %>
   <div class="flex items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.submit "Search", class: "ml-auto" %>
   </div>
 <% end %>

--- a/app/views/admin/events.html.erb
+++ b/app/views/admin/events.html.erb
@@ -1,7 +1,7 @@
 <% title "Organizations" %>
 
 <%= form_with local: true, class: "card overflow-visible", url: events_admin_index_path, method: :get do |form| %>
-  <%= render "events/filters/search", form: %>
+  <%= render "events/filters/search", form: form %>
   <div class="block mt-2">
     <% export_button = capture do %>
       <button class="mt-2 mr-1 btn bg-info">Search</button>

--- a/app/views/admin/google_workspaces.html.erb
+++ b/app/views/admin/google_workspaces.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: google_workspaces_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>
   <div class="flex items-center mt-2 gap-4 flex-wrap">

--- a/app/views/admin/hcb_codes.html.erb
+++ b/app/views/admin/hcb_codes.html.erb
@@ -1,7 +1,7 @@
 <% title "HCB Codes" %>
 
 <%= form_with local: true, class: "card overflow-visible items-center gap-2", url: hcb_codes_admin_index_path, method: :get do |form| %>
-  <%= render "events/filters/search", form: %>
+  <%= render "events/filters/search", form: form %>
   <div class="flex flex-col sm:flex-row items-center gap-2 mt-2">
   <%= form.label :has_receipt do %>
     <b class="mr1">Receipt status:</b>

--- a/app/views/admin/invoices.html.erb
+++ b/app/views/admin/invoices.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: invoices_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.text_field :number, value: params[:number], placeholder: "Stripe Invoice Number" %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>

--- a/app/views/admin/ledger.html.erb
+++ b/app/views/admin/ledger.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, url: ledger_admin_index_path, method: :get, class: "card overflow-visible" do |form| %>
   <div class="flex flex-col sm:flex-row items-center mt-1 gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.text_field :amount, value: params[:amount], placeholder: "Amount (¢)", class: "!max-w-full sm:!max-w-[200px]" %>
     <div class="flex flex-col sm:flex-row shrink-0 gap-2 -mt-1 w-full sm:w-[unset]">
         <%= combobox_tag :user_id, user_search_admin_index_path, placeholder: "User", class: "!max-w-full !min-w-full sm:!min-w-56", value: @user&.to_combobox_display %>

--- a/app/views/admin/legal_entities/index.html.erb
+++ b/app/views/admin/legal_entities/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: admin_legal_entities_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.select :entity_type, [%w[Person person], %w[Business business]], { include_blank: "All types", selected: @entity_type } %>
     <label class="flex items-center gap-1 nowrap">
       <%= form.check_box :managed, checked: @managed %> Managed

--- a/app/views/admin/payments/index.html.erb
+++ b/app/views/admin/payments/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: admin_payments_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.select :state, Payment.aasm.states_for_select, { include_blank: "All states", selected: @state } %>
   </div>
   <div class="flex items-center mt-2">

--- a/app/views/admin/paypal_transfers.html.erb
+++ b/app/views/admin/paypal_transfers.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: paypal_transfers_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>
   <div class="flex items-center mt-2">

--- a/app/views/admin/payroll_positions/index.html.erb
+++ b/app/views/admin/payroll_positions/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: admin_payroll_positions_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.select :state, Payroll::Position.aasm.states_for_select, { include_blank: "All states", selected: @state } %>
   </div>
   <div class="flex items-center mt-2">

--- a/app/views/admin/pending_ledger.html.erb
+++ b/app/views/admin/pending_ledger.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: pending_ledger_admin_index_path, method: :get do |form| %>
     <div class="flex flex-col sm:flex-row items-center gap-2">
-        <%= render "events/filters/search", form: %>
+        <%= render "events/filters/search", form: form %>
         <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     </div>
     <div class="flex items-center mt-2 gap-4 flex-wrap">

--- a/app/views/admin/reimbursements.html.erb
+++ b/app/views/admin/reimbursements.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: reimbursements_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>
   <div class="flex items-center mt-2 gap-4 flex-wrap">

--- a/app/views/admin/sponsors.html.erb
+++ b/app/views/admin/sponsors.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: sponsors_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>
   <div class="flex items-center mt-2 gap-4 flex-wrap">

--- a/app/views/admin/tax_forms/index.html.erb
+++ b/app/views/admin/tax_forms/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card", url: admin_tax_forms_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.select :state, Tax::Form.aasm.states_for_select, { include_blank: "All states", selected: @state } %>
     <%= form.select :form_type, Tax::Form.form_types.keys, { include_blank: "All form types", selected: @form_type } %>
   </div>

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: users_admin_index_path, method: :get do |form| %>
   <div class="flex gap-2 items-center">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
   </div>
 

--- a/app/views/admin/w9s/index.html.erb
+++ b/app/views/admin/w9s/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with method: :get, class: "card" do |form| %>
   <div class="flex items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.submit "Search", class: "ml-auto" %>
   </div>
 <% end %>

--- a/app/views/admin/wires.html.erb
+++ b/app/views/admin/wires.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: wires_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     <%= render "admin/date_range_filter", start_date: @start_date, end_date: @end_date %>
   </div>

--- a/app/views/admin/wise_transfers.html.erb
+++ b/app/views/admin/wise_transfers.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_with local: true, class: "card overflow-visible", url: wise_transfers_admin_index_path, method: :get do |form| %>
   <div class="flex flex-col sm:flex-row items-center gap-2">
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= combobox_tag :event_id, event_search_admin_index_path, placeholder: "Event", class: "!max-w-full !min-w-full sm:!min-w-72", value: @event&.to_combobox_display %>
     <%= form.collection_select(:status, WiseTransfer.aasm.states, :name, :human_name, { include_blank: "Filter by status", selected: @status }) %>
     <%= render "admin/date_range_filter", start_date: @start_date, end_date: @end_date %>

--- a/app/views/announcements/modals/_top_categories.html.erb
+++ b/app/views/announcements/modals/_top_categories.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (block: nil) %>
 
 <%= render "announcements/modals/modal_shell", block:, type: "topCategories", header: "#{block.present? ? "Edit this" : "Insert a"} top categories graph" do %>
-  <%= render "announcements/modals/date_inputs", block: %>
+  <%= render "announcements/modals/date_inputs", block: block %>
 <% end %>

--- a/app/views/announcements/modals/_top_merchants.html.erb
+++ b/app/views/announcements/modals/_top_merchants.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (block: nil) %>
 
 <%= render "announcements/modals/modal_shell", block:, type: "topMerchants", header: "#{block.present? ? "Edit this" : "Insert a"} top merchants graph" do %>
-  <%= render "announcements/modals/date_inputs", block: %>
+  <%= render "announcements/modals/date_inputs", block: block %>
 <% end %>

--- a/app/views/announcements/modals/_top_tags.html.erb
+++ b/app/views/announcements/modals/_top_tags.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (block: nil) %>
 
 <%= render "announcements/modals/modal_shell", block:, type: "topTags", header: "#{block.present? ? "Edit this" : "Insert a"} top tags graph" do %>
-  <%= render "announcements/modals/date_inputs", block: %>
+  <%= render "announcements/modals/date_inputs", block: block %>
 <% end %>

--- a/app/views/announcements/modals/_top_users.html.erb
+++ b/app/views/announcements/modals/_top_users.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (block: nil) %>
 
 <%= render "announcements/modals/modal_shell", block:, type: "topUsers", header: "#{block.present? ? "Edit this" : "Insert a"} top users graph" do %>
-  <%= render "announcements/modals/date_inputs", block: %>
+  <%= render "announcements/modals/date_inputs", block: block %>
 <% end %>

--- a/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
+++ b/app/views/canonical_pending_transactions/_canonical_pending_transaction.html.erb
@@ -83,7 +83,7 @@
         </div>
 
         <% if local_assigns[:show_event_name] %>
-          <%= render "hcb_codes/event_name", event: %>
+          <%= render "hcb_codes/event_name", event: event %>
         <% end %>
 
         <% if !event&.demo_mode? && defined?(show_tags) && show_tags %>

--- a/app/views/canonical_transactions/_canonical_transaction.html.erb
+++ b/app/views/canonical_transactions/_canonical_transaction.html.erb
@@ -91,7 +91,7 @@
         </div>
 
         <% if local_assigns[:show_event_name] %>
-          <%= render "hcb_codes/event_name", event: %>
+          <%= render "hcb_codes/event_name", event: event %>
         <% end %>
 
         <% if !event&.demo_mode? && defined?(show_tags) && show_tags %>

--- a/app/views/card_grants/_actions.html.erb
+++ b/app/views/card_grants/_actions.html.erb
@@ -7,16 +7,16 @@
       <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
       <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: card_grant.user == current_user ? "Get reimbursed" : "Create reimbursement report" %>
       <% if card_grant.user == current_user %>
-        <%= render "card_grants/actions/return", card_grant: %>
+        <%= render "card_grants/actions/return", card_grant: card_grant %>
       <% else %>
-        <%= render "card_grants/actions/cancel", card_grant: %>
+        <%= render "card_grants/actions/cancel", card_grant: card_grant %>
       <% end %>
-      <%= render "card_grants/actions/support", card_grant: %>
+      <%= render "card_grants/actions/support", card_grant: card_grant %>
     <% elsif card_grant.user == current_user %>
       <%= render "stripe_cards/actions/freeze", stripe_card: card_grant.stripe_card if card_grant.stripe_card.present? %>
       <%= render "card_grants/actions/convert_to_reimbursement_report", card_grant:, label: "Get reimbursed" %>
-      <%= render "card_grants/actions/return", card_grant: %>
-      <%= render "card_grants/actions/support", card_grant: %>
+      <%= render "card_grants/actions/return", card_grant: card_grant %>
+      <%= render "card_grants/actions/support", card_grant: card_grant %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/card_grants/_create_form.html.erb
+++ b/app/views/card_grants/_create_form.html.erb
@@ -5,20 +5,20 @@
     <div class="w-full flex-grow">
       <div class="field">
         <%= form.label :email %>
-        <%= form.email_field :email, value: card_grant.email, placeholder: "fiona@hackclub.com", autofocus: true, required: true, disabled: %>
+        <%= form.email_field :email, value: card_grant.email, placeholder: "fiona@hackclub.com", autofocus: true, required: true, disabled: disabled %>
       </div>
 
       <div class="field">
         <%= form.label :amount_cents, "Amount" %>
         <div class="flex items-center">
           <span class="bold muted shrink-none" style="width: 1rem;">$</span>
-          <%= form.number_field :amount_cents, value: (card_grant.amount_cents.nil? ? nil : ("%.2f" % (card_grant.amount_cents.to_f / 100))), placeholder: "10.00", required: true, min: 0.01, step: 0.01, data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" }, disabled: %>
+          <%= form.number_field :amount_cents, value: (card_grant.amount_cents.nil? ? nil : ("%.2f" % (card_grant.amount_cents.to_f / 100))), placeholder: "10.00", required: true, min: 0.01, step: 0.01, data: { controller: "truncate-decimal", action: "truncate-decimal#truncate blur->truncate-decimal#pad" }, disabled: disabled %>
         </div>
       </div>
 
       <div class="field">
         <%= form.label :expiration_at, "Expires on" %>
-        <%= form.date_field :expiration_at, value: card_grant.default_expiration_at, disabled: %>
+        <%= form.date_field :expiration_at, value: card_grant.default_expiration_at, disabled: disabled %>
       </div>
 
       <div class="field">
@@ -28,7 +28,7 @@
 
       <div class="field">
         <%= form.label :one_time_use, class: "flex gap-2 items-center" do %>
-          <%= form.check_box :one_time_use, disabled: %>
+          <%= form.check_box :one_time_use, disabled: disabled %>
           One time use?
           <span class="info tooltipped tooltipped--e h-5" aria-label="Card will freeze after the first charge">
             <%= inline_icon "info", size: 20 %>
@@ -38,7 +38,7 @@
 
       <div class="field">
         <%= form.label :pre_authorization_required, class: "flex gap-2 items-center" do %>
-          <%= form.check_box :pre_authorization_required, disabled: %>
+          <%= form.check_box :pre_authorization_required, disabled: disabled %>
           Require pre-authorization?
           <span class="info tooltipped tooltipped--e h-5" aria-label="Recipient will submit documentation of their purchase before activation, which will be compared with the grant's purpose and flagged if it is potentially fraudulent">
             <%= inline_icon "info", size: 20 %>
@@ -87,6 +87,6 @@
       <% end %>
     <% end %>
     <span></span>
-    <%= form.submit "Send grant", disabled: %>
+    <%= form.submit "Send grant", disabled: disabled %>
   </footer>
 <% end %>

--- a/app/views/card_grants/_transactions.html.erb
+++ b/app/views/card_grants/_transactions.html.erb
@@ -5,7 +5,7 @@
   <%= render "ledgers/ledger", ledger: @ledger, items: @items, show_author: false %>
 <% else %>
   <% if hcb_codes&.any? %>
-    <%= render "application/merchant_not_allowed_callout", hcb_codes: %>
+    <%= render "application/merchant_not_allowed_callout", hcb_codes: hcb_codes %>
     <div style="overflow-x: auto;" class="table-container">
       <table>
         <tbody data-behavior="transactions">

--- a/app/views/card_grants/card_index.html.erb
+++ b/app/views/card_grants/card_index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :card_grant_card_overview do %>
   <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
   </div>
 
@@ -41,7 +41,7 @@
                 <%= render_money card_grant.balance %>
               </td>
               <td>
-                <%= render "events/card_grant_actions", card_grant: %>
+                <%= render "events/card_grant_actions", card_grant: card_grant %>
               </td>
             </tr>
           <% end %>

--- a/app/views/check_deposits/_new.html.erb
+++ b/app/views/check_deposits/_new.html.erb
@@ -23,7 +23,7 @@
     <%= form.label :amount_cents, "Amount on check" %>
     <div class="flex items-center">
       <span class="bold muted shrink-none" style="width: 1rem;">$</span>
-      <%= form.number_field :amount_cents, placeholder: "10.00", required: true, min: 0.01, step: 0.01, disabled: %>
+      <%= form.number_field :amount_cents, placeholder: "10.00", required: true, min: 0.01, step: 0.01, disabled: disabled %>
     </div>
   </div>
 

--- a/app/views/comments/reactions/react.turbo_stream.erb
+++ b/app/views/comments/reactions/react.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace "reactions_#{comment.id}" do %>
-  <%= render "comments/reaction_bar", comment: %>
+  <%= render "comments/reaction_bar", comment: comment %>
 <% end %>

--- a/app/views/disbursements/_form.html.erb
+++ b/app/views/disbursements/_form.html.erb
@@ -11,10 +11,10 @@
       <div class="field">
         <%= form.label :name, "What is the transfer for?" %>
         <span class="muted block mb-1">This is to help HCB keep record of our transactions.</span>
-        <%= form.text_field :name, placeholder: "Donating extra funds to another organization", maxlength: 60, required: true, class: "!max-w-full", disabled: %>
+        <%= form.text_field :name, placeholder: "Donating extra funds to another organization", maxlength: 60, required: true, class: "!max-w-full", disabled: disabled %>
       </div>
 
-      <%= render "events/transfers/attach_receipt", form:, disabled: %>
+      <%= render "events/transfers/attach_receipt", form:, disabled: disabled %>
     </div>
   </div>
 

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,7 +1,7 @@
 <%= link_to auditor_signed_in? ? document : document_download_path(document) do %>
   <li class="card card--hover h-100 w-fit">
     <div class="overflow-hidden" style="max-height: 270px;">
-      <%= render "documents/preview", document: %>
+      <%= render "documents/preview", document: document %>
     </div>
     <strong class="font-brand h3 block mt1 leading-[1.125]"><%= document.name %>
       <% if document.archived? %>

--- a/app/views/employees/_payments.html.erb
+++ b/app/views/employees/_payments.html.erb
@@ -54,7 +54,7 @@
             <% end %>
             <td>
               <%= link_to payment.title, "#", data: { behavior: "modal_trigger", modal: "employee_payment_#{payment.id}" } %>
-              <%= render "employee/payments/modal", payment: %>
+              <%= render "employee/payments/modal", payment: payment %>
             </td>
             <td>
               <%= render_money payment.amount_cents %>

--- a/app/views/event/applications/edit.html.erb
+++ b/app/views/event/applications/edit.html.erb
@@ -245,7 +245,7 @@
       <div class="card mb3">
         <% affiliation = Event::Affiliation.new(affiliable: @application) %>
         <%= form_with(url: affiliations_path(affiliable_type: @application.class.name, affiliable_id: @application.id), local: true, html: { "x-data": "{ type: '', disabled: #{!policy(affiliation).update?} }" }) do |form| %>
-          <%= render "events/settings/affiliation_form", affiliation:, form: %>
+          <%= render "events/settings/affiliation_form", affiliation:, form: form %>
         <% end %>
       </div>
 

--- a/app/views/event/applications/project_info.html.erb
+++ b/app/views/event/applications/project_info.html.erb
@@ -139,7 +139,7 @@
   <div class="card mb3">
     <% affiliation = Event::Affiliation.new(affiliable: @application) %>
     <%= form_with(url: affiliations_path(affiliable_type: @application.class.name, affiliable_id: @application.id), local: true, html: { "x-data": "{ type: '', disabled: #{!policy(affiliation).update?} }", "x-init": "$watch('type', val => (val ? document.getElementById('submit_application').setAttribute('data-turbo-confirm', 'You have an unsaved affiliation. Are you sure you want to continue?') : document.getElementById('submit_application').removeAttribute('data-turbo-confirm')))", "@turbo:submit-end": "type = ''" }) do |form| %>
-      <%= render "events/settings/affiliation_form", affiliation:, form: %>
+      <%= render "events/settings/affiliation_form", affiliation:, form: form %>
     <% end %>
   </div>
 

--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -106,7 +106,7 @@
       <% admin_tool do %>
         <% disabled = @application.teen_led? && pending_parties.any? %>
         <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>">
-          <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: %>
+          <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: disabled %>
         </p>
       <% end %>
     <% elsif @application.approved? && @application.event.nil? && @application.contract.present? %>

--- a/app/views/events/_heading.html.erb
+++ b/app/views/events/_heading.html.erb
@@ -26,7 +26,7 @@
       <% end %>
     <% end %>
 
-    <%= render "events/follow_button", event:, event_follow: %>
-    <%= render "events/donations/button", event: %>
+    <%= render "events/follow_button", event:, event_follow: event_follow %>
+    <%= render "events/donations/button", event: event %>
   </div>
 </h1>

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -65,7 +65,7 @@
 
   <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
   </div>
 

--- a/app/views/events/donation_overview.html.erb
+++ b/app/views/events/donation_overview.html.erb
@@ -108,7 +108,7 @@
 
   <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
     <div class="filterbar">
       <%= link_to "Deposited", "?filter=deposited", class: "filterbar__item", "aria-selected": !["refunded"].include?(params[:filter]), role: "tab" %>

--- a/app/views/events/employees.html.erb
+++ b/app/views/events/employees.html.erb
@@ -76,7 +76,7 @@
             </td>
             <td>
               <%= link_to "Process", "#", data: { behavior: "modal_trigger", modal: "employee_payment_#{payment.id}" } %>
-              <%= render "employee/payments/modal", payment: %>
+              <%= render "employee/payments/modal", payment: payment %>
             </td>
           </tr>
         <% end %>
@@ -89,7 +89,7 @@
 
 <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-3">
   <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
   <% end %>
   <div class="filterbar">
     <%= link_to "All", "?filter=all", class: "filterbar__item", "aria-selected": !["terminated", "onboarding"].include?(params[:filter]), role: "tab" %>

--- a/app/views/events/filters/_bar.html.erb
+++ b/app/views/events/filters/_bar.html.erb
@@ -1,5 +1,5 @@
 <div class="flex items-center filter-menu -mt-2 mb-1">
-  <%= render "events/filters/menu", filters: %>
+  <%= render "events/filters/menu", filters: filters %>
   <%= link_to nil,
               class: "-ml-2 pop muted tooltipped tooltipped--s",
               aria: { label: "Clear filters" },

--- a/app/views/events/filters/_filter.html.erb
+++ b/app/views/events/filters/_filter.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex flex-row justify-between items-center width-100 gap-2 mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% if @tag %>
       <%= form.hidden_field :tag, value: @tag.label %>
     <% end %>

--- a/app/views/events/payments.html.erb
+++ b/app/views/events/payments.html.erb
@@ -71,7 +71,7 @@
 
   <div class="flex items-center gap-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
 
     <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>

--- a/app/views/events/reimbursements.html.erb
+++ b/app/views/events/reimbursements.html.erb
@@ -34,7 +34,7 @@
 
   <div class="flex items-center gap-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
     <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>
   </div>

--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -51,7 +51,7 @@
 
       <div class="field" id="admin_settings">
         <%= form.label :name %>
-        <%= form.text_field :name, disabled: %>
+        <%= form.text_field :name, disabled: disabled %>
       </div>
 
       <div class="field">
@@ -80,7 +80,7 @@
 
       <div class="field">
         <%= form.label :postal_code %>
-        <%= form.text_field :postal_code, placeholder: "90069", disabled: %>
+        <%= form.text_field :postal_code, placeholder: "90069", disabled: disabled %>
       </div>
 
       <div class="field">
@@ -105,17 +105,17 @@
 
       <div class="field field--checkbox">
         <%= form.label :demo_mode, "Is in Playground Mode?" %>
-        <%= form.check_box :demo_mode, switch: true, disabled: %>
+        <%= form.check_box :demo_mode, switch: true, disabled: disabled %>
       </div>
 
       <div class="field field--checkbox">
         <%= form.label :financially_frozen, "Is financially frozen? ⚠️ 🚨#{" (⚠️ has active recurring donations - please handle before freezing)" if event.recurring_donations.active.exists?}" %>
-        <%= form.check_box :financially_frozen, switch: true, disabled: %>
+        <%= form.check_box :financially_frozen, switch: true, disabled: disabled %>
       </div>
 
       <div class="field field--checkbox">
         <%= form.label :can_front_balance, "Front incoming transactions?" %>
-        <%= form.check_box :can_front_balance, switch: true, disabled: %>
+        <%= form.check_box :can_front_balance, switch: true, disabled: disabled %>
       </div>
 
       <div class="action">
@@ -183,11 +183,11 @@
     <%= form_with(model: [event, Fee], local: true, class: "mb3", data: { turbo_frame: "_top" }) do |form| %>
       <div class="field">
         <%= form.label :memo %>
-        <%= form.text_field :memo, placeholder: "Fee for inbound wire.", required: true, disabled: %>
+        <%= form.text_field :memo, placeholder: "Fee for inbound wire.", required: true, disabled: disabled %>
       </div>
       <div class="field">
         <%= form.label :amount, "Amount" %>
-        <%= form.number_field :amount, placeholder: 100, min: 1, step: 0.01, required: true, disabled: %>
+        <%= form.number_field :amount, placeholder: 100, min: 1, step: 0.01, required: true, disabled: disabled %>
       </div>
       <div class="action">
         <%= form.submit "Charge fee", disabled: !policy(event.fees.build).create? %>
@@ -207,9 +207,9 @@
     <% admin_tool "p-3" do %>
       <h3 id="admin_fees" class="mb2 mt1">Wire minimum exemption</h3>
       <% if Flipper.enabled?(:exempt_from_wire_minimum, event) %>
-        <%= link_to "Disable", disable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-accent", data: { turbo_method: :post }, disabled: %>
+        <%= link_to "Disable", disable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-accent", data: { turbo_method: :post }, disabled: disabled %>
       <% else %>
-        <%= link_to "Enable", enable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-info", disabled: %>
+        <%= link_to "Enable", enable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-info", disabled: disabled %>
       <% end %>
     <% end %>
   <% end %>
@@ -222,7 +222,7 @@
   <% end %>
 
   <% admin_tool "p-3" do %>
-    <%= render "events/settings/admin/tags", event: %>
+    <%= render "events/settings/admin/tags", event: event %>
   <% end %>
 
   <% admin_tool "p-3" do %>

--- a/app/views/events/settings/_affiliation.html.erb
+++ b/app/views/events/settings/_affiliation.html.erb
@@ -36,11 +36,11 @@
         "#",
         class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this affiliation",
         data: { behavior: "modal_trigger", modal: "edit_affiliation_#{affiliation.id}" },
-        disabled: %>
+        disabled: disabled %>
       <section class="modal modal--scroll max-w-md bg-snow" data-behavior="modal" role="dialog" id="edit_affiliation_<%= affiliation.id %>">
         <%= modal_header("Edit affiliation") %>
         <%= form_with(url: affiliation_path(affiliation.id), method: :patch, local: true, html: { "x-data": "{ type: '#{affiliation.name}', disabled: #{disabled} }" }) do |form| %>
-          <%= render "events/settings/affiliation_form", affiliation:, form: %>
+          <%= render "events/settings/affiliation_form", affiliation:, form: form %>
         <% end %>
       </section>
     </div>
@@ -51,6 +51,6 @@
       style: "background: #ec375020; color: #ec3750",
       data: { turbo_confirm: "Are you sure you would like to delete this affiliation?", turbo_method: :delete, turbo_confirm_danger: true },
       'aria-label': "Delete this affiliation",
-      disabled: %>
+      disabled: disabled %>
   </div>
 </div>

--- a/app/views/events/settings/_affiliation_form.html.erb
+++ b/app/views/events/settings/_affiliation_form.html.erb
@@ -29,7 +29,7 @@
 <template x-if="type == 'first'">
   <div class="field">
     <%= form.label :league, "League" %>
-    <%= form.select :league, [["FRC", "frc"], ["FTC", "ftc"], ["FLL", "fll"]], { required: true, include_blank: "Select a league", selected: affiliation.league }, disabled: %>
+    <%= form.select :league, [["FRC", "frc"], ["FTC", "ftc"], ["FLL", "fll"]], { required: true, include_blank: "Select a league", selected: affiliation.league }, disabled: disabled %>
   </div>
 </template>
 <template x-if="type == 'first'">
@@ -53,7 +53,7 @@
 <template x-if="type == 'vex'">
   <div class="field">
     <%= form.label :league, "League" %>
-    <%= form.select :league, [["123", "123"], ["GO", "go"], ["AIM", "aim"], ["IQ", "iq"], ["EXP", "exp"], ["V5", "v5"], ["CTE", "cte"], ["AIR", "air"]], { required: true, include_blank: "Select a league", selected: affiliation.league }, disabled: %>
+    <%= form.select :league, [["123", "123"], ["GO", "go"], ["AIM", "aim"], ["IQ", "iq"], ["EXP", "exp"], ["V5", "v5"], ["CTE", "cte"], ["AIR", "air"]], { required: true, include_blank: "Select a league", selected: affiliation.league }, disabled: disabled %>
   </div>
 </template>
 <template x-if="type == 'vex'">

--- a/app/views/events/settings/_affiliations.html.erb
+++ b/app/views/events/settings/_affiliations.html.erb
@@ -5,7 +5,7 @@
   <div class="card mb3">
     <% affiliation = Event::Affiliation.new(affiliable: event) %>
     <%= form_with(url: affiliations_path(affiliable_type: event.class.name, affiliable_id: event.id), local: true, html: { "x-data": "{ type: 'first', disabled: #{!policy(affiliation).update?} }" }) do |form| %>
-      <%= render "events/settings/affiliation_form", affiliation:, form: %>
+      <%= render "events/settings/affiliation_form", affiliation:, form: form %>
     <% end %>
   </div>
 

--- a/app/views/events/settings/_card_grants.html.erb
+++ b/app/views/events/settings/_card_grants.html.erb
@@ -18,7 +18,7 @@
             This message is included in emails sent to card grant recipients when invited to activate a card grant.
           </p>
 
-          <%= card_grant_setting_fields.text_area :invite_message, placeholder: "It's pizza time!", value: event.card_grant_setting.invite_message, disabled: %>
+          <%= card_grant_setting_fields.text_area :invite_message, placeholder: "It's pizza time!", value: event.card_grant_setting.invite_message, disabled: disabled %>
           <p class="h5 muted mt0 mb1">
             <%= link_to "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#table-of-contents", target: "_blank", class: "flex items-center" do %>
               <%= inline_icon "markdown", size: 32 %> Styling with Markdown is supported
@@ -97,7 +97,7 @@
             This message will be shown when card grant recipients need support with their grant.
           </p>
 
-          <%= card_grant_setting_fields.text_area :support_message, placeholder: "You can find us on Slack if you need support", value: event.card_grant_setting.support_message, disabled: %>
+          <%= card_grant_setting_fields.text_area :support_message, placeholder: "You can find us on Slack if you need support", value: event.card_grant_setting.support_message, disabled: disabled %>
           <p class="h5 muted mt0 mb1">
             <%= link_to "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#table-of-contents", target: "_blank", class: "flex items-center" do %>
               <%= inline_icon "markdown", size: 32 %> Styling with Markdown is supported
@@ -111,7 +111,7 @@
             HCB will automatically detect email addresses and Slack channel links.
           </p>
 
-          <%= card_grant_setting_fields.text_field :support_url, placeholder: "mailto:orpheus@hackclub.com", value: event.card_grant_setting.support_url, disabled: %>
+          <%= card_grant_setting_fields.text_field :support_url, placeholder: "mailto:orpheus@hackclub.com", value: event.card_grant_setting.support_url, disabled: disabled %>
         </div>
 
         <%= form.submit "Update", disabled:, class: "mt-4" %>
@@ -132,7 +132,7 @@
 
             <div class="field">
               <%= card_grant_setting_fields.label :merchant_lock, "Approved merchant IDs" %>
-              <%= card_grant_setting_fields.text_field :merchant_lock, placeholder: "123456789", class: "w-100 fit", value: event.card_grant_setting.merchant_lock.join(", "), disabled: %>
+              <%= card_grant_setting_fields.text_field :merchant_lock, placeholder: "123456789", class: "w-100 fit", value: event.card_grant_setting.merchant_lock.join(", "), disabled: disabled %>
               <p class="h5 muted mt-0 mb-2">
                 Provide a comma-separated list of merchant network IDs to lock all card grants issued from this event to.
               </p>
@@ -140,13 +140,13 @@
 
             <div class="field">
               <%= card_grant_setting_fields.label :category_lock, "Approved merchant categories" %>
-              <%= card_grant_setting_fields.text_field :category_lock, placeholder: "fast_food_restaurants", value: event.card_grant_setting.category_lock.join(", "), disabled: %>
+              <%= card_grant_setting_fields.text_field :category_lock, placeholder: "fast_food_restaurants", value: event.card_grant_setting.category_lock.join(", "), disabled: disabled %>
               <p class="h5 muted mt-0 mb-2">Provide a comma-separated list of <a href="https://stripe.com/docs/issuing/categories">merchant categories</a> to lock all card grants issued from this event to.</p>
             </div>
 
             <div class="field mb-0">
               <%= card_grant_setting_fields.label :keyword_lock, "Approved merchant names" %>
-              <%= card_grant_setting_fields.text_field :keyword_lock, placeholder: "\\AApple[a-zA-Z]{0,2}\\z", value: event.card_grant_setting.keyword_lock, disabled: %>
+              <%= card_grant_setting_fields.text_field :keyword_lock, placeholder: "\\AApple[a-zA-Z]{0,2}\\z", value: event.card_grant_setting.keyword_lock, disabled: disabled %>
               <p class="h5 muted my-0">Provide a <a href="https://rubular.com">Ruby regular expression</a> string for us to match the merchant name to.</p>
             </div>
           </div>
@@ -164,7 +164,7 @@
 
             <div class="field">
               <%= card_grant_setting_fields.label :banned_merchants, "Blocked merchant IDs" %>
-              <%= card_grant_setting_fields.text_field :banned_merchants, placeholder: "123456789", class: "w-100 fit", value: event.card_grant_setting.banned_merchants.join(", "), disabled: %>
+              <%= card_grant_setting_fields.text_field :banned_merchants, placeholder: "123456789", class: "w-100 fit", value: event.card_grant_setting.banned_merchants.join(", "), disabled: disabled %>
               <p class="h5 muted mt-0 mb-2">
                 Provide a comma-separated list of merchant network IDs to block across all grants issued from this event.
               </p>
@@ -172,7 +172,7 @@
 
             <div class="field">
               <%= card_grant_setting_fields.label :banned_categories, "Blocked merchant categories" %>
-              <%= card_grant_setting_fields.text_field :banned_categories, placeholder: "fast_food_restaurants", value: event.card_grant_setting.banned_categories.join(", "), disabled: %>
+              <%= card_grant_setting_fields.text_field :banned_categories, placeholder: "fast_food_restaurants", value: event.card_grant_setting.banned_categories.join(", "), disabled: disabled %>
               <p class="h5 muted mt-0 mb-0">Provide a comma-separated list of <a href="https://stripe.com/docs/issuing/categories">merchant categories</a> to block across all grants issued from this event.</p>
             </div>
 
@@ -189,7 +189,7 @@
           </ul>
         </div>
 
-        <%= form.submit "Update", disabled: %>
+        <%= form.submit "Update", disabled: disabled %>
 
       </div>
     <% end %>

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -63,7 +63,7 @@
               </div>
               <% if event.logo.attached? %>
                 <div class="menu__divider"></div>
-                <%= link_to "Remove logo", event_remove_logo_path(event), method: :post, style: "padding: 0.25rem 0.5rem", disabled: %>
+                <%= link_to "Remove logo", event_remove_logo_path(event), method: :post, style: "padding: 0.25rem 0.5rem", disabled: disabled %>
               <% end %>
             </div>
           </div>
@@ -79,16 +79,16 @@
             <p class="h5 muted mt0 mb1">
               At most sixteen characters long; used on statement descriptors and printed on your event's HCB card.
             </p>
-            <%= form.text_field :short_name, placeholder: "#{event.name[0...Event::MAX_SHORT_NAME_LENGTH]}...", maxlength: Event::MAX_SHORT_NAME_LENGTH, disabled: %>
+            <%= form.text_field :short_name, placeholder: "#{event.name[0...Event::MAX_SHORT_NAME_LENGTH]}...", maxlength: Event::MAX_SHORT_NAME_LENGTH, disabled: disabled %>
           </div>
         <% end %>
         <div class="field flex-1">
           <%= form.label :website, "Website URL" %>
-          <%= form.text_field :website, type: :url, placeholder: "https://hackclub.com", disabled: %>
+          <%= form.text_field :website, type: :url, placeholder: "https://hackclub.com", disabled: disabled %>
         </div>
         <div class="field flex-1">
           <%= form.label :description, "Mission statement" %>
-          <%= form.text_area :description, placeholder: "A short description of your organization’s goals.", disabled: %>
+          <%= form.text_area :description, placeholder: "A short description of your organization’s goals.", disabled: disabled %>
         </div>
       </div>
       <div class="md:flex items-end">
@@ -141,7 +141,7 @@
       <div class="field mt-2">
         <%= inline_icon "markdown", size: 32, class: "muted right" %>
         <%= form.label :public_message, "Message to show visitors" %>
-        <%= form.text_area :public_message, class: "w-100 fit", disabled: %>
+        <%= form.text_area :public_message, class: "w-100 fit", disabled: disabled %>
       </div>
       <div class="field field--checkbox">
         <%= form.check_box :is_indexable, disabled:, switch: true %>
@@ -154,7 +154,7 @@
         </div>
       <% end %>
     </div>
-    <%= form.submit "Update", disabled: %>
+    <%= form.submit "Update", disabled: disabled %>
   </div>
 
   <h3 class="mb1" id="cards_heading">HCB card</h3>
@@ -174,7 +174,7 @@
         <div data-file-upload-target="clear"></div>
       </div>
     </div>
-    <%= form.submit "Update", disabled: %>
+    <%= form.submit "Update", disabled: disabled %>
   </div>
 
   <h3 class="mb1" id="announcements_heading">Announcements</h3>
@@ -198,7 +198,7 @@
         <% end %>
       </div>
     </div>
-    <%= form.submit "Update", disabled: %>
+    <%= form.submit "Update", disabled: disabled %>
   </div>
 
   <h3 class="mb1" id="cards_heading">Contact information</h3>
@@ -209,10 +209,10 @@
         <p class="h5 muted mt0 mb1">
           If you’d prefer for the HCB operations team to reach out to a shared email, configure that here.
         </p>
-        <%= config.email_field :contact_email, placeholder: "team@lioncityhacks.com", disabled: %>
+        <%= config.email_field :contact_email, placeholder: "team@lioncityhacks.com", disabled: disabled %>
       <% end %>
     </div>
-    <%= form.submit "Update", disabled: %>
+    <%= form.submit "Update", disabled: disabled %>
   </div>
 
   <h3 class="mb1">Danger zone</h3>
@@ -244,11 +244,11 @@
         <span>hcb.hackclub.com</span>
         <span>/</span>
       </span>
-      <%= form.text_field :slug, class: "!p-0 !border-none !shadow-none min-h-auto", placeholder: event.persisted? ? event.name.parameterize : nil, data: { action: "input->external-validation#validate" }, disabled: %>
+      <%= form.text_field :slug, class: "!p-0 !border-none !shadow-none min-h-auto", placeholder: event.persisted? ? event.name.parameterize : nil, data: { action: "input->external-validation#validate" }, disabled: disabled %>
     </div>
     <span data-external-validation-target="hint" style="grid-column-start: 2"></span>
     <div class="actions">
-      <%= form.submit "Update", disabled: %>
+      <%= form.submit "Update", disabled: disabled %>
     </div>
   </div>
 <% end %>

--- a/app/views/events/settings/_donations.html.erb
+++ b/app/views/events/settings/_donations.html.erb
@@ -26,17 +26,17 @@
           <div class="menu__divider m-0 mb-4"></div>
           <div class="field">
             <%= form.label :donation_page_message, "Message to show on donation page" %>
-            <%= form.text_area :donation_page_message, class: "w-100 fit", disabled: %>
+            <%= form.text_area :donation_page_message, class: "w-100 fit", disabled: disabled %>
             <%= inline_icon "markdown", size: 32, class: "muted right" %>
           </div>
           <div class="field">
             <%= form.label :donation_thank_you_message, "Thank you message to donors" %>
-            <%= form.text_area :donation_thank_you_message, class: "w-100 fit", disabled: %>
+            <%= form.text_area :donation_thank_you_message, class: "w-100 fit", disabled: disabled %>
             <%= inline_icon "markdown", size: 32, class: "muted right" %>
           </div>
           <div class="field">
             <%= form.label :donation_reply_to_email, "Reply-to email for donation receipts" %>
-            <%= form.text_field :donation_reply_to_email, type: "email", placeholder: "fiona@hackclub.com", class: "w-100 fit", disabled: %>
+            <%= form.text_field :donation_reply_to_email, type: "email", placeholder: "fiona@hackclub.com", class: "w-100 fit", disabled: disabled %>
           </div>
           <%= form.fields_for :config do |config| %>
             <div class="field field--checkbox">
@@ -56,8 +56,8 @@
     <% end %>
   <% end %>
 
-  <%= render "events/settings/donation_goals", event:, frame: %>
+  <%= render "events/settings/donation_goals", event:, frame: frame %>
 
-  <%= render "events/settings/donation_tiers", event:, frame: %>
-  <%= render "events/settings/donation_stats", disabled:, event:, frame: %>
+  <%= render "events/settings/donation_tiers", event:, frame: frame %>
+  <%= render "events/settings/donation_stats", disabled:, event:, frame: frame %>
 <% end %>

--- a/app/views/events/settings/_integrations.html.erb
+++ b/app/views/events/settings/_integrations.html.erb
@@ -7,7 +7,7 @@
 
   <ol>
     <li>Create a channel for HCB in your team's Discord server - we recommend calling it <code>#finance</code>.</li>
-    <li><%= link_to "Add bot", Discord::Bot.install_link, target: "_blank", disabled: %> to Discord server.</li>
+    <li><%= link_to "Add bot", Discord::Bot.install_link, target: "_blank", disabled: disabled %> to Discord server.</li>
     <li>Run <code>/link</code> in the channel you created for HCB.</li>
   </ol>
 <% end %>

--- a/app/views/events/settings/_reimbursements.html.erb
+++ b/app/views/events/settings/_reimbursements.html.erb
@@ -31,7 +31,7 @@
 
       <div class="field">
         <%= form.label :public_reimbursement_page_message, "Message to show for public reimbursements" %>
-        <%= form.text_area :public_reimbursement_page_message, placeholder: "#{event.name} uses HCB to reimburse its volunteers…", class: "w-100 fit mt1", disabled: %>
+        <%= form.text_area :public_reimbursement_page_message, placeholder: "#{event.name} uses HCB to reimburse its volunteers…", class: "w-100 fit mt1", disabled: disabled %>
         <%= inline_icon "markdown", size: 32, class: "muted right" %>
       </div>
       <%= form.submit "Update", disabled:, data: { turbo_frame: frame ? "_top" : "" } %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -34,13 +34,13 @@
         <% Tag::COLORS.each do |color| %>
           <label class="tags__radio w-8 mt-[2px] mx-1">
             <%# Default color: Muted %>
-            <%= form.radio_button :color, color, checked: color == "muted", disabled: %>
+            <%= form.radio_button :color, color, checked: color == "muted", disabled: disabled %>
             <div class="radio__control tag-darker tag-<%= color %>"></div>
           </label>
         <% end %>
       </div>
 
-      <%= form.submit "Create tag", disabled: %>
+      <%= form.submit "Create tag", disabled: disabled %>
     <% end %>
   </div>
   <% if event.tags.any? %>
@@ -58,7 +58,7 @@
             "#",
             class: "tooltipped tooltipped--w mr2 h-8 w-8", "aria-label": "Edit this tag",
             data: { behavior: "modal_trigger", modal: "edit_tag_#{tag.id}" },
-            disabled: %>
+            disabled: disabled %>
           <section class="modal modal--scroll max-w-md bg-snow" data-behavior="modal" role="dialog" id="edit_tag_<%= tag.id %>">
             <%= modal_header("Edit tag") %>
             <%= form_with url: event_tag_path(event, tag.id), method: :patch, id: "edit_tag_form" do |form| %>
@@ -91,7 +91,7 @@
           class: "tooltipped tooltipped--w h-8 w-8",
           style: "background: #ec375020; color: #ec3750",
           'aria-label': "Delete this tag",
-          disabled: %>
+          disabled: disabled %>
       </div>
     </div>
   <% end %>

--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -53,7 +53,7 @@
 
 <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
   <% end %>
   <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>
 </div>

--- a/app/views/events/team.html.erb
+++ b/app/views/events/team.html.erb
@@ -62,7 +62,7 @@
 
 <div class="mb-4 flex flex-row justify-between items-center width-100 gap-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
     <%= form.hidden_field :filter, value: params[:filter] if params[:filter] %>
     <%= form.hidden_field :view, value: @view if @view %>
   <% end %>
@@ -124,7 +124,7 @@
       <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog" id="approve_invite_request_<%= invite_request.hashid %>">
         <%= modal_header "Approve invite request" %>
 
-        <%= render "organizer_position_invite/requests/approval_form", invite_request: %>
+        <%= render "organizer_position_invite/requests/approval_form", invite_request: invite_request %>
       </section>
       <li class="overflow-visible card card--hover flex flex-row justify-between items-center gap-2">
         <span class="w-full flex gap-2 items-center align-middle">

--- a/app/views/events/transfers.html.erb
+++ b/app/views/events/transfers.html.erb
@@ -73,7 +73,7 @@
 
   <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
 
     <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>

--- a/app/views/events/transfers/_attach_receipt.html.erb
+++ b/app/views/events/transfers/_attach_receipt.html.erb
@@ -27,7 +27,7 @@
           "file-drop-target"   => "fileInput",
           "file-upload-target" => "input"
         },
-        disabled: %>
+        disabled: disabled %>
     <button data-file-upload-target="preview" type="button"></button>
     <div data-file-upload-target="clear"></div>
   </div>

--- a/app/views/g_suite_accounts/_new.html.erb
+++ b/app/views/g_suite_accounts/_new.html.erb
@@ -10,26 +10,26 @@
   <div class="flex items-center">
   <div class="field mr2">
     <%= form.label :first_name %>
-    <%= form.text_field :first_name, value: current_user&.first_name, required: true, disabled: %>
+    <%= form.text_field :first_name, value: current_user&.first_name, required: true, disabled: disabled %>
   </div>
   <div class="field">
     <%= form.label :last_name %>
-    <%= form.text_field :last_name, value: current_user&.last_name, required: true, disabled: %>
+    <%= form.text_field :last_name, value: current_user&.last_name, required: true, disabled: disabled %>
   </div>
   </div>
   <div class="field">
     <%= form.label :address %>
     <div class="flex items-center">
-      <%= form.text_field :address, value: example_email_username, class: "input--narrow text-right", required: true, disabled: %>
+      <%= form.text_field :address, value: example_email_username, class: "input--narrow text-right", required: true, disabled: disabled %>
       <span style="margin-left: 2px;">@<%= g_suite_account.g_suite.domain %></span>
     </div>
   </div>
   <div class="field">
     <%= form.label :backup_email %>
-    <%= form.email_field :backup_email, value: current_user&.email, required: true, disabled: %>
+    <%= form.email_field :backup_email, value: current_user&.email, required: true, disabled: disabled %>
     <span class="block muted h5">(To sign into your account for the first time, you’ll receive your initial password to this email.)</span>
   </div>
   <div class="actions">
-    <%= form.submit "Create", disabled: %>
+    <%= form.submit "Create", disabled: disabled %>
   </div>
 <% end %>

--- a/app/views/grants/_activate_form.html.erb
+++ b/app/views/grants/_activate_form.html.erb
@@ -67,11 +67,11 @@
       <%= form.hidden_field :receipt_method, "x-model" => "receipt_method" %>
 
       <div x-show="receipt_method == 'ach_transfer'">
-        <%= render "ach_transfer_form", form: %>
+        <%= render "ach_transfer_form", form: form %>
       </div>
 
       <div x-show="receipt_method == 'check'">
-        <%= render "check_form", form: %>
+        <%= render "check_form", form: form %>
       </div>
 
       <div x-show="receipt_method == 'manual'" class="card">

--- a/app/views/hcb_codes/_heading.html.erb
+++ b/app/views/hcb_codes/_heading.html.erb
@@ -12,7 +12,7 @@
       </span>
     <% end %>
 
-    <%= render "hcb_codes/memo/stream", hcb_code: %>
+    <%= render "hcb_codes/memo/stream", hcb_code: hcb_code %>
     <%= render partial: "hcb_codes/memo/ai", locals: { hcb_code: } %>
     <div class="flex-1"></div>
     <%= pop_icon_to "edit",

--- a/app/views/hcb_codes/_icon.html.erb
+++ b/app/views/hcb_codes/_icon.html.erb
@@ -34,7 +34,7 @@
     <% icon = inline_icon "view-reload" %>
   <% elsif tx.try(:raw_stripe_transaction) || tx.try(:raw_pending_stripe_transaction_id) %>
     <% label = "Card transaction#{!local_assigns[:authorless] && tx.stripe_cardholder ? " by " + tx.stripe_cardholder.user.initial_name : "" }" %>
-    <% icon = render "hcb_codes/merchant_icon", tx: %>
+    <% icon = render "hcb_codes/merchant_icon", tx: tx %>
   <% elsif tx.local_hcb_code.invoice? %>
     <% label = "Invoice" %>
     <% icon = inline_icon "payment-docs" %>

--- a/app/views/hcb_codes/memo/_memo.html.erb
+++ b/app/views/hcb_codes/memo/_memo.html.erb
@@ -56,7 +56,7 @@
       <% end %>
       <%= ledger_instance ? link_to(contents, details_link, style: "color: inherit; min-width: 0;", data: popovers_enabled? && !@force_no_popover ? memo_popover_attrs : { turbo_frame: "_top" }) : content_tag(:span) { contents } %>
       <% if renamed %>
-        <%= render "hcb_codes/memo/stream", hcb_code: %>
+        <%= render "hcb_codes/memo/stream", hcb_code: hcb_code %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/increase_checks/new.html.erb
+++ b/app/views/increase_checks/new.html.erb
@@ -300,7 +300,7 @@
         </div>
       </div>
 
-      <%= render "events/transfers/attach_receipt", form:, disabled: %>
+      <%= render "events/transfers/attach_receipt", form:, disabled: disabled %>
     </div>
   </div>
 

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -41,7 +41,7 @@
 
   <div class="flex items-center gap-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
 
     <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to_unless current_page.first?, raw(inline_icon("view-back", style: "margin:0!important") + "Previous"), url, class: "btn bg-info pl-2 gap-1", rel: "prev", remote: %>
+<%= link_to_unless current_page.first?, raw(inline_icon("view-back", style: "margin:0!important") + "Previous"), url, class: "btn bg-info pl-2 gap-1", rel: "prev", remote: remote %>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -13,14 +13,14 @@
         <div class="flex items-center gap-[1ch] min-w-0">
           <%= render "ledger/items/status", ledger_item: item %>
           <div class="min-w-0 overflow-hidden text-ellipsis">
-            <%= render "ledger/items/memo/memo", item: %>
+            <%= render "ledger/items/memo/memo", item: item %>
           </div>
         </div>
 
-        <%= render "ledger/items/tags", item: %>
+        <%= render "ledger/items/tags", item: item %>
       </div>
 
-      <%= render "ledger/items/tag_menu", item: %>
+      <%= render "ledger/items/tag_menu", item: item %>
 
       <%= list_badge_for auditor_signed_in? ? item.comment_count : item.not_admin_only_comment_count, "comment", "post", optional: true %>
       <%= list_badge_for item.receipt_count, "receipt", "payment-docs", optional: item.receipt_optional?, required: item.missing_receipt? %>

--- a/app/views/ledger/items/memo/_memo.html.erb
+++ b/app/views/ledger/items/memo/_memo.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (item:) -%>
 
 <% if !policy(item).show? %>
-  <span title="<%= item.memo %>"><%= render "ledger/items/memo/memo_text", item: %></span>
+  <span title="<%= item.memo %>"><%= render "ledger/items/memo/memo_text", item: item %></span>
 <% elsif policy(item).rename? %>
   <div class="flex gap-1" style="flex-grow: 1; min-height: 28px" data-controller="memo">
     <% link_data = (popovers_enabled? ? ledger_item_popover_data(item) : { turbo: false }).merge(
@@ -9,7 +9,7 @@
          action: "click->memo#editOnShiftClick"
        ) %>
     <%= link_to ledger_item_path(item), style: "color: inherit; min-width: 0;", data: link_data do %>
-      <%= render "ledger/items/memo/span", item: %>
+      <%= render "ledger/items/memo/span", item: item %>
     <% end %>
 
     <%= form_with model: item, url: ledger_item_rename_path(item), method: :patch, class: "renaming", html: { hidden: true }, data: { memo_target: "form", turbo_stream: true, action: "turbo:submit-end->memo#submitEnd" } do |form| %>

--- a/app/views/ledger/items/memo/_span.html.erb
+++ b/app/views/ledger/items/memo/_span.html.erb
@@ -6,5 +6,5 @@
       aria-label="Shift+click to rename this transaction"
       data-memo-for="<%= dom_id(item) %>"
       data-memo-target="tooltip">
-  <%= render "ledger/items/memo/memo_text", item: %>
+  <%= render "ledger/items/memo/memo_text", item: item %>
 </span>

--- a/app/views/ledger/items/memo/_stream.turbo_stream.erb
+++ b/app/views/ledger/items/memo/_stream.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%# locals: (item:) -%>
 
 <%= turbo_stream.update_all "span[data-memo-for='#{dom_id(item)}']" do %>
-  <%= render "ledger/items/memo/memo_text", item: %>
+  <%= render "ledger/items/memo/memo_text", item: item %>
 <% end %>

--- a/app/views/ledgers/_pinned_items.html.erb
+++ b/app/views/ledgers/_pinned_items.html.erb
@@ -20,7 +20,7 @@
 
         <p class="font-bold m0 flex items-center g2">
           <%= format_date ledger_item.datetime %>
-          <%= render "ledger/items/status", ledger_item: %>
+          <%= render "ledger/items/status", ledger_item: ledger_item %>
         </p>
         <p class="pinned__transaction__text pinned__transaction__text--memo mt1 mb1 leading-[1.25] h3">
           <%= ledger_item.memo %>
@@ -29,7 +29,7 @@
           <span class="m0 muted">
             <%= render_money ledger_item.amount_cents %>
           </span>
-          <%= render "ledger/items/icon", ledger_item: %>
+          <%= render "ledger/items/icon", ledger_item: ledger_item %>
         </footer>
       <% end %>
     <% end %>

--- a/app/views/ledgers/filters/_filter.html.erb
+++ b/app/views/ledgers/filters/_filter.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex flex-row justify-between items-center width-100 gap-2 mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-auto") do |form| %>
-      <%= render "ledgers/filters/search", form: %>
+      <%= render "ledgers/filters/search", form: form %>
     <% if @tag %>
       <%= form.hidden_field :tag, value: @tag.label %>
     <% end %>

--- a/app/views/my/pay.html.erb
+++ b/app/views/my/pay.html.erb
@@ -195,7 +195,7 @@
 
 <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb-2">
   <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-    <%= render "events/filters/search", form: %>
+    <%= render "events/filters/search", form: form %>
   <% end %>
 
   <%= render "events/filters/menu", filters: @filter_options unless @has_filter %>

--- a/app/views/my/reimbursements.html.erb
+++ b/app/views/my/reimbursements.html.erb
@@ -81,7 +81,7 @@
 
   <div class="flex items-center gap-2 flex-col-reverse sm:flex-row mb2 mt1">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
-      <%= render "events/filters/search", form: %>
+      <%= render "events/filters/search", form: form %>
     <% end %>
     <div class="filterbar" role="tablist" aria-label="Reimbursement report filters">
       <%= link_to "All", "?filter=all", class: "filterbar__item", "aria-selected": !["mine", "review"].include?(params[:filter]), role: "tab" %>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     <% else %>
       <% disabled = @invite.contract.present? && !@invite.contract.signed? %>
-      <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
+      <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: disabled %></p>
     <% end %>
   </div>
 </main>

--- a/app/views/organizer_positions/_organizer_position.html.erb
+++ b/app/views/organizer_positions/_organizer_position.html.erb
@@ -34,7 +34,7 @@
     </div>
     <% if organizer_signed_in? %>
       <div class="flex flex-wrap g1 h-fit justify-end w-full">
-        <%= render "organizer_positions/actions", organizer_position: %>
+        <%= render "organizer_positions/actions", organizer_position: organizer_position %>
       </div>
     <% end %>
   </div>

--- a/app/views/organizer_positions/_organizer_position_row.html.erb
+++ b/app/views/organizer_positions/_organizer_position_row.html.erb
@@ -66,7 +66,7 @@
           </div>
         </div>
       <% end %>
-      <%= render "organizer_positions/actions", organizer_position: %>
+      <%= render "organizer_positions/actions", organizer_position: organizer_position %>
     </div>
   </td>
 </tr>

--- a/app/views/payees/_recipient_section.html.erb
+++ b/app/views/payees/_recipient_section.html.erb
@@ -25,11 +25,11 @@
         <span class="muted ml-auto shrink-0 text-sm">Edit</span>
       </summary>
       <div class="menu__divider my-0"></div>
-      <%= render "payments/payee_picker", event:, destination: %>
+      <%= render "payments/payee_picker", event:, destination: destination %>
     </details>
   <% else %>
     <div class="card mb-4 p-0 overflow-hidden">
-      <%= render "payments/payee_picker", event:, destination: %>
+      <%= render "payments/payee_picker", event:, destination: destination %>
     </div>
   <% end %>
 </div>

--- a/app/views/payments/_form.html.erb
+++ b/app/views/payments/_form.html.erb
@@ -56,7 +56,7 @@
             <div>
               <%= form.label :purpose, "What's this payment for?" %>
               <span class="muted mb-1 block">Helps HCB keep a record of this transaction.</span>
-              <%= form.text_field :purpose, class: "!max-w-full", placeholder: "Shipment of potions", required: true, disabled: %>
+              <%= form.text_field :purpose, class: "!max-w-full", placeholder: "Shipment of potions", required: true, disabled: disabled %>
             </div>
           </div>
         </div>

--- a/app/views/paypal_transfers/new.html.erb
+++ b/app/views/paypal_transfers/new.html.erb
@@ -42,12 +42,12 @@
     <%= form.text_field :memo,
         placeholder: "for venue payment",
         required: true,
-        disabled: %>
+        disabled: disabled %>
   </div>
 
   <div class="field">
     <%= form.label :payment_for, "What are you paying for with this transfer?" %>
-    <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: %>
+    <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: disabled %>
     <span class="muted">This is to help HCB keep record of our transactions.</span>
   </div>
 
@@ -76,7 +76,7 @@
 
   <div class="field">
     <%= form.label :recipient_email, "Recipient's PayPal Email" %>
-    <%= form.email_field :recipient_email, placeholder: "fionah@gmail.com", required: true, disabled: %>
+    <%= form.email_field :recipient_email, placeholder: "fionah@gmail.com", required: true, disabled: disabled %>
   </div>
 
   <%= form.label :file, "Attach a receipt / invoice", class: "mt2 font-semibold" %>
@@ -92,13 +92,13 @@
           "file-drop-target"   => "fileInput",
           "file-upload-target" => "input"
         },
-        disabled: %>
+        disabled: disabled %>
     <button data-file-upload-target="preview" type="button"></button>
     <div data-file-upload-target="clear"></div>
   </div>
   <p class="muted mt0 mb2">Required for reimbursements / goods & services payments.</p>
 
   <div class="actions tooltipped tooltipped--n inline-block mt1" aria-label="Your transfer will be sent out on the next business day.">
-    <%= form.submit "Send transfer", disabled: %>
+    <%= form.submit "Send transfer", disabled: disabled %>
   </div>
 <% end %>

--- a/app/views/payroll/positions/_form.html.erb
+++ b/app/views/payroll/positions/_form.html.erb
@@ -102,7 +102,7 @@
                 <%= form.date_field :starts_on, value: position&.start_date, required: true, disabled:,
                       max: (Date.current + Payroll::Position::MAX_START_LEAD_TIME).iso8601 %>
                 <span class="muted">to</span>
-                <%= form.date_field :ends_on, value: position&.end_date, required: true, disabled: %>
+                <%= form.date_field :ends_on, value: position&.end_date, required: true, disabled: disabled %>
               </div>
             </div>
 

--- a/app/views/raffles/_raffle_modal.html.erb
+++ b/app/views/raffles/_raffle_modal.html.erb
@@ -6,6 +6,6 @@
       <strong>Name:</strong> <%= current_user&.name %>
       <br>
       <strong>Email:</strong> <%= current_user&.email %>
-    <%= render "raffles/raffle_form", program: %>
+    <%= render "raffles/raffle_form", program: program %>
   <% end %>
 </section>

--- a/app/views/stripe_cards/_actions.html.erb
+++ b/app/views/stripe_cards/_actions.html.erb
@@ -2,12 +2,12 @@
 <% if !stripe_card.canceled? %>
   <div class="mt-3 mb-2 flex flex-col justify-center flex-wrap card card--homepage p-2">
     <% if !stripe_card.initially_activated? %>
-      <%= render "stripe_cards/actions/activate", stripe_card: %>
+      <%= render "stripe_cards/actions/activate", stripe_card: stripe_card %>
     <% else %>
-      <%= render "stripe_cards/actions/rename", stripe_card: %>
-      <%= render "stripe_cards/actions/freeze", stripe_card: %>
+      <%= render "stripe_cards/actions/rename", stripe_card: stripe_card %>
+      <%= render "stripe_cards/actions/freeze", stripe_card: stripe_card %>
     <% end %>
-    <%= render "stripe_cards/actions/cancel", stripe_card: %>
+    <%= render "stripe_cards/actions/cancel", stripe_card: stripe_card %>
 
     <% if stripe_card.virtual? && Flipper.enabled?(:onepass_cc_save_2024_04_29, current_user) && params["show_details"] == "true" %>
       <onepassword-save-button

--- a/app/views/transfers/_recipient_details.html.erb
+++ b/app/views/transfers/_recipient_details.html.erb
@@ -3,26 +3,26 @@
 <%= form.label :address_line1, "Street address" %>
 <div class="grid grid--split gap-2">
   <div class="field flex-auto">
-    <%= form.text_field :address_line1, class: "flex-1", placeholder: "Phase II, Udyog Vihar", required:, disabled: %>
+    <%= form.text_field :address_line1, class: "flex-1", placeholder: "Phase II, Udyog Vihar", required:, disabled: disabled %>
   </div>
 
   <div class="field flex-auto">
-    <%= form.text_field :address_line2, class: "flex-1", placeholder: "Sector 20", disabled: %>
+    <%= form.text_field :address_line2, class: "flex-1", placeholder: "Sector 20", disabled: disabled %>
   </div>
 
   <div class="field flex-auto">
     <%= form.label :address_city, "City" %>
-    <%= form.text_field :address_city, placeholder: "Gurgaon", required:, disabled: %>
+    <%= form.text_field :address_city, placeholder: "Gurgaon", required:, disabled: disabled %>
   </div>
 
   <div class="field flex-auto">
     <%= form.label :address_state, "State / province" %>
-    <%= form.text_field :address_state, placeholder: "Haryana", required:, disabled: %>
+    <%= form.text_field :address_state, placeholder: "Haryana", required:, disabled: disabled %>
   </div>
 
   <div class="field flex-auto">
     <%= form.label :address_postal_code, "Postal code / ZIP code" %>
-    <%= form.text_field :address_postal_code, placeholder: "122022", required:, disabled: %>
+    <%= form.text_field :address_postal_code, placeholder: "122022", required:, disabled: disabled %>
   </div>
 
   <div class="field flex-auto">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -132,14 +132,14 @@
         <%= form_errors @user, "profile", "We couldn't update your" %>
         <% if current_season(override_preference: true) %>
           <div class="field field--checkbox">
-            <%= form.check_box :seasonal_themes_enabled, disabled: %>
+            <%= form.check_box :seasonal_themes_enabled, disabled: disabled %>
             <%= form.label :seasonal_themes_enabled, "#{by_season "✨", override_preference: true, fall: "🎃", winter: "🎄"} Enable #{current_season(override_preference: true)} theme", class: "h3 bold" %>
           </div>
         <% end %>
 
         <div class="field">
           <%= form.label :full_name %>
-          <%= form.text_field :full_name, required: true, placeholder: "Fiona Hackworth III", pattern: '^\S+.+', disabled: %>
+          <%= form.text_field :full_name, required: true, placeholder: "Fiona Hackworth III", pattern: '^\S+.+', disabled: disabled %>
           <% @user.errors.full_messages_for(:full_name).each do |message| %>
             <div class="primary"><%= message %></div>
           <% end %>
@@ -147,7 +147,7 @@
         <div class="field">
           <%= form.label :preferred_name %>
           <p class="h5 muted mt0 mb1">If you go by a different name.</p>
-          <%= form.text_field :preferred_name, placeholder: @user.full_name.presence || "FiFi Hacks", maxlength: 30, disabled: %>
+          <%= form.text_field :preferred_name, placeholder: @user.full_name.presence || "FiFi Hacks", maxlength: 30, disabled: disabled %>
         </div>
 
         <div class="field">
@@ -177,7 +177,7 @@
                                  end_year: Date.today.year - 100,
                                  order: [:month, :day, :year],
                                  prompt: @user.birthday.nil?,
-                                 disabled: %>
+                                 disabled: disabled %>
             <% unless @user.birthday.nil? %>
               <% admin_tool("p-1.5 !ml-2") do %>
                 <%= @user.is_teenager? ? "✅ Teenager" : "Not a teenager" %>
@@ -187,7 +187,7 @@
         </div>
         <div class="field">
           <%= form.label :email %>
-          <%= form.email_field :email, disabled: %>
+          <%= form.email_field :email, disabled: disabled %>
           <% if @user.email_updates.active.any? %>
             <p style="max-width: 420px;">
               <small>
@@ -227,12 +227,12 @@
             Off by default.
           </p>
           <div class="field field--options">
-            <%= form.radio_button :sessions_reported, true, disabled: %>
+            <%= form.radio_button :sessions_reported, true, disabled: disabled %>
             <%= form.label :sessions_reported, value: true do %>
               <%= inline_icon "support", size: 28 %>
               <strong>Sure thing!</strong>
             <% end %>
-            <%= form.radio_button :sessions_reported, false, disabled: %>
+            <%= form.radio_button :sessions_reported, false, disabled: disabled %>
             <%= form.label :sessions_reported, value: false do %>
               <%= inline_icon "thumbsdown", size: 28 %>
               <strong>No thanks</strong>
@@ -241,7 +241,7 @@
         </fieldset>
 
         <div class="actions flex">
-          <%= form.submit "Save settings", disabled: %>
+          <%= form.submit "Save settings", disabled: disabled %>
         </div>
       <% end %>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.13/js/intlTelInput.min.js" integrity="sha512-QMUqEPmhXq1f3DnAVdXvu40C8nbTgxvBGvNruP6RFacy3zWKbNTmx7rdQVVM2gkd2auCWhlPYtcW2tHwzso4SA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/app/views/users/edit_address.html.erb
+++ b/app/views/users/edit_address.html.erb
@@ -17,28 +17,28 @@
       <%= form.fields_for :stripe_cardholder, @user.stripe_cardholder do |form| %>
         <div class="field mb1">
           <%= form.label :stripe_billing_address_line1, "Street address" %>
-          <%= form.text_field :stripe_billing_address_line1, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:line1], required: true, disabled: %>
+          <%= form.text_field :stripe_billing_address_line1, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:line1], required: true, disabled: disabled %>
         </div>
 
         <div class="field mt1">
-          <%= form.text_field :stripe_billing_address_line2, placeholder: "(Building / Apartment / Room)", disabled: %>
+          <%= form.text_field :stripe_billing_address_line2, placeholder: "(Building / Apartment / Room)", disabled: disabled %>
         </div>
 
         <div class="grid grid--split">
           <div class="field flex-auto">
             <%= form.label :stripe_billing_address_city, "City" %>
-            <%= form.text_field :stripe_billing_address_city, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:city], required: true, disabled: %>
+            <%= form.text_field :stripe_billing_address_city, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:city], required: true, disabled: disabled %>
           </div>
           <div class="field flex-auto">
             <%= form.label :address_state, "State / Province" %>
-            <%= form.select :stripe_billing_address_state, @states, {}, disabled: %>
+            <%= form.select :stripe_billing_address_state, @states, {}, disabled: disabled %>
           </div>
         </div>
 
         <div class="grid grid--split">
           <div class="field flex-auto">
             <%= form.label :postal_code %>
-            <%= form.text_field :stripe_billing_address_postal_code, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:postal_code], required: true, disabled: %>
+            <%= form.text_field :stripe_billing_address_postal_code, placeholder: StripeCardholder::DEFAULT_BILLING_ADDRESS[:postal_code], required: true, disabled: disabled %>
           </div>
 
           <div class="field flex-auto">

--- a/app/views/users/edit_notifications.html.erb
+++ b/app/views/users/edit_notifications.html.erb
@@ -13,17 +13,17 @@
           Get an email when someone comments on a transaction or reimbursement report.
         </p>
         <div class="field field--options field--green trio">
-          <%= form.radio_button :comment_notifications, :all_threads, disabled: %>
+          <%= form.radio_button :comment_notifications, :all_threads, disabled: disabled %>
           <%= form.label :comment_notifications, value: :all_threads do %>
             <%= inline_icon "notification", size: 28 %>
             <strong>All transactions</strong>
           <% end %>
-          <%= form.radio_button :comment_notifications, :my_threads, disabled: %>
+          <%= form.radio_button :comment_notifications, :my_threads, disabled: disabled %>
           <%= form.label :comment_notifications, value: :my_threads do %>
             <%= inline_icon "person", size: 32 %>
             <strong>My transactions</strong>
           <% end %>
-          <%= form.radio_button :comment_notifications, :no_threads, disabled: %>
+          <%= form.radio_button :comment_notifications, :no_threads, disabled: disabled %>
           <%= form.label :comment_notifications, value: :no_threads do %>
             <%= inline_icon "forbidden", size: 28 %>
             <strong>None</strong>
@@ -36,22 +36,22 @@
           Get a notification when there’s a charge on any of your cards.
         </p>
         <div class="field field--options max-w-3xl grid grid--narrow">
-          <%= form.radio_button :charge_notifications, :email_and_sms, disabled: %>
+          <%= form.radio_button :charge_notifications, :email_and_sms, disabled: disabled %>
           <%= form.label :charge_notifications, value: :email_and_sms do %>
             <%= inline_icon "announcement", size: 28 %>
             <strong>Email & SMS</strong>
           <% end %>
-          <%= form.radio_button :charge_notifications, :email, disabled: %>
+          <%= form.radio_button :charge_notifications, :email, disabled: disabled %>
           <%= form.label :charge_notifications, value: :email do %>
             <%= inline_icon "email", size: 28 %>
             <strong>Email</strong>
           <% end %>
-          <%= form.radio_button :charge_notifications, :sms, disabled: %>
+          <%= form.radio_button :charge_notifications, :sms, disabled: disabled %>
           <%= form.label :charge_notifications, value: :sms do %>
             <%= inline_icon "message", size: 28 %>
             <strong>SMS</strong>
           <% end %>
-          <%= form.radio_button :charge_notifications, :nothing, disabled: %>
+          <%= form.radio_button :charge_notifications, :nothing, disabled: disabled %>
           <%= form.label :charge_notifications, value: :nothing do %>
             <%= inline_icon "forbidden", size: 28 %>
             <strong>None</strong>
@@ -76,7 +76,7 @@
                 <%= form.check_box :monthly_donation_summary,
                   data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
                   switch: true,
-                  disabled: %>
+                  disabled: disabled %>
                 <span class="slider"></span>
               <% end %>
             </div>
@@ -93,14 +93,14 @@
                 <%= form.check_box :monthly_follower_summary,
                   data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
                   switch: true,
-                  disabled: %>
+                  disabled: disabled %>
                 <span class="slider"></span>
               <% end %>
             </div>
           </div>
         </div>
       </fieldset>
-      <%= form.submit "Save settings", class: "mt2", disabled: %>
+      <%= form.submit "Save settings", class: "mt2", disabled: disabled %>
     <% end %>
   </section>
 </turbo-frame>

--- a/app/views/users/edit_security.html.erb
+++ b/app/views/users/edit_security.html.erb
@@ -22,7 +22,7 @@
                     <%= form.check_box :use_sms_auth,
                       data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
                       switch: true,
-                      disabled: %>
+                      disabled: disabled %>
                     <span class="slider"></span>
                   <% end %>
                 </div>
@@ -34,12 +34,12 @@
                     <%= form.check_box :use_two_factor_authentication,
                       data: { action: "change->accordion#toggle", target: "accordion.checkbox" },
                       switch: true,
-                      disabled: %>
+                      disabled: disabled %>
                     <span class="slider"></span>
                   <% end %>
                 </div>
               </div>
-              <%= form.submit "Update preferences", disabled: %>
+              <%= form.submit "Update preferences", disabled: disabled %>
             <% end %>
           <% else %>
             <% if disabled %>
@@ -172,20 +172,20 @@
 
       <div class="field">
         <%= form.label :session_validity_preference, "Sign me out after" %>
-        <%= form.select :session_validity_preference, SessionsHelper::SESSION_DURATION_OPTIONS.to_a, {}, selected: @user.session_validity_preference, disabled: %>
+        <%= form.select :session_validity_preference, SessionsHelper::SESSION_DURATION_OPTIONS.to_a, {}, selected: @user.session_validity_preference, disabled: disabled %>
       </div>
 
       <div class="submit">
-        <%= form.submit "Save", disabled: %>
+        <%= form.submit "Save", disabled: disabled %>
       </div>
     <% end %>
 
     <div class="grid grid--split">
       <% @all_sessions.each do |session| %>
         <% if session.is_a? User::Session %>
-          <%= render "users/user_session", session: %>
+          <%= render "users/user_session", session: session %>
         <% elsif session.respond_to? :authorization_count %>
-          <%= render "users/oauth_authorization", authorization: session, disabled: %>
+          <%= render "users/oauth_authorization", authorization: session, disabled: disabled %>
         <% end %>
       <% end %>
     </div>
@@ -198,9 +198,9 @@
       <div class="grid grid--split">
         <% @expired_sessions.each do |session| %>
           <% if session.is_a? User::Session %>
-            <%= render "users/user_session", session: %>
+            <%= render "users/user_session", session: session %>
           <% elsif session.respond_to? :authorization_count %>
-            <%= render "users/oauth_authorization", authorization: session, disabled: %>
+            <%= render "users/oauth_authorization", authorization: session, disabled: disabled %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/users/payout_form/_form.html.erb
+++ b/app/views/users/payout_form/_form.html.erb
@@ -6,7 +6,7 @@
 <% if embedded %>
   <div class="<%= form_class %>" x-data="{ country: <%= country_init %> }">
     <%= fields_for :user, user do |form| %>
-      <%= render "users/payout_form/fields", form:, user:, payout_method:, editing:, embedded: true, title: %>
+      <%= render "users/payout_form/fields", form:, user:, payout_method:, editing:, embedded: true, title: title %>
     <% end %>
   </div>
 <% else %>
@@ -18,6 +18,6 @@
     <% if creating && legal_entity %>
       <%= hidden_field_tag :legal_entity_id, legal_entity.id %>
     <% end %>
-    <%= render "users/payout_form/fields", form:, user:, payout_method:, editing:, embedded: false, title: %>
+    <%= render "users/payout_form/fields", form:, user:, payout_method:, editing:, embedded: false, title: title %>
   <% end %>
 <% end %>

--- a/app/views/wires/edit.html.erb
+++ b/app/views/wires/edit.html.erb
@@ -23,7 +23,7 @@
     <%= form.text_field :memo,
         placeholder: "For venue payment...",
         required: true,
-        disabled: %>
+        disabled: disabled %>
   </div>
 
   <h2 class="mb2 mt3">Recipient details</h2>
@@ -35,7 +35,7 @@
 
   <div class="field">
   <%= form.label :recipient_email, "Email" %>
-  <%= form.email_field :recipient_email, placeholder: "fionah@gmail.com", required: true, disabled: %>
+  <%= form.email_field :recipient_email, placeholder: "fionah@gmail.com", required: true, disabled: disabled %>
   </div>
 
   <%= render partial: "transfers/recipient_details", locals: { form:, disabled:, required: true } %>
@@ -44,7 +44,7 @@
 
   <div class="field">
     <%= form.label :payment_for, "What are you paying for with this wire?" %>
-    <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: %>
+    <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: disabled %>
     <span class="muted">This is to help HCB keep record of our transactions.</span>
   </div>
 
@@ -53,6 +53,6 @@
   <%= render partial: "wires/country_specific_details", locals: { form:, disabled:, required: true } %>
 
   <div class="actions inline-block mt1">
-    <%= form.submit "Update wire", disabled: %>
+    <%= form.submit "Update wire", disabled: disabled %>
   </div>
 <% end %>

--- a/app/views/wires/new.html.erb
+++ b/app/views/wires/new.html.erb
@@ -80,7 +80,7 @@
         <%= form.label :recipient_email, "Email" %>
         <%= form.email_field :recipient_email, class: "!max-w-full", placeholder: "fionah@gmail.com", required: true, disabled: disabled %>
       </div>
-      <%= render "events/transfers/notify_recipient", form:, disabled: %>
+      <%= render "events/transfers/notify_recipient", form:, disabled: disabled %>
 
       <template x-if="payment_recipient && !editing">
         <div class="flex flex-col gap-3">
@@ -139,7 +139,7 @@
         </div>
       </template>
 
-      <%= render "events/transfers/attach_receipt", form:, disabled: %>
+      <%= render "events/transfers/attach_receipt", form:, disabled: disabled %>
     </div>
 
     <%= render "transfers/domestic_wire_warning", event: @event %>

--- a/app/views/wise_transfers/new.html.erb
+++ b/app/views/wise_transfers/new.html.erb
@@ -41,7 +41,7 @@
       <div class="field">
         <%= form.label :recipient_name, "Legal name (use company name if applicable)" %>
         <span class="muted mb-1 block">May be used for tax purposes. Match the name on the recipient's account.</span>
-        <%= form.text_field :recipient_name, placeholder: "Raviga Capital", class: "!max-w-full", required: true, maxlength: 250, disabled: %>
+        <%= form.text_field :recipient_name, placeholder: "Raviga Capital", class: "!max-w-full", required: true, maxlength: 250, disabled: disabled %>
       </div>
 
       <div class="field">
@@ -94,11 +94,11 @@
       <div class="field">
         <%= form.label :payment_for, "What are you paying for with this transfer?" %>
         <span class="muted">This is to help HCB keep record of our transactions.</span>
-        <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: %>
+        <%= form.text_field :payment_for, placeholder: "Event venue", required: true, disabled: disabled %>
       </div>
 
       <%= render partial: "wise_transfers/currency_specific_details", locals: { form:, disabled: } %>
-      <%= render "events/transfers/attach_receipt", form:, disabled: %>
+      <%= render "events/transfers/attach_receipt", form:, disabled: disabled %>
     </div>
   </div>
 


### PR DESCRIPTION
CodeQL scanning is setup for HCB, however it is unable to deliever anything usful due to syntax errors.

This PR is pretty much a no-op, Ruby does allow value omission. {x:} translates to {x: x}, however some parsers like CodeQL don't take too kindly to this. 

See https://github.com/github/codeql/issues/16006 for details.

Our rubocop.yml has EnforcedShorthandSyntax set to either so nothing in the CI will stop this from happening again. Perhaps we should enable that guard?