### PR TITLE
[Ledger::Mapper] Fix slow mapping via missing index + N+1 preload

### DIFF
--- a/app/models/column/account_number.rb
+++ b/app/models/column/account_number.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_column_account_numbers_on_account_number_bidx  (account_number_bidx) UNIQUE
+#  index_column_account_numbers_on_column_id            (column_id) UNIQUE
 #  index_column_account_numbers_on_event_id             (event_id) UNIQUE
 #
 # Foreign Keys

--- a/app/services/ledger/mapper.rb
+++ b/app/services/ledger/mapper.rb
@@ -11,12 +11,30 @@ class Ledger
 
     def run
       return if @ledger_item.primary_mapping&.mapped_by_human?
+
+      preload_transaction_sources!
       return if (ledger = calculate_ledger).nil?
 
       Ledger::Mapping.map_primary!(ledger:, ledger_item: @ledger_item, mapped_by: SYSTEM)
     end
 
     private
+
+    # calculate_card_grant and calculate_event both iterate every canonical_(pending_)transaction
+    # and read its raw/(poly)morphic transaction (raw_column_transaction, raw_stripe_transaction,
+    # etc.). Without this, each ct/cpt beyond the first triggers its own SELECT to load that
+    # association; batch-loading them here turns that into one query per type.
+    def preload_transaction_sources!
+      ActiveRecord::Associations::Preloader.new(
+        records: @ledger_item.canonical_transactions,
+        associations: :transaction_source
+      ).call
+
+      ActiveRecord::Associations::Preloader.new(
+        records: @ledger_item.canonical_pending_transactions,
+        associations: [:raw_pending_stripe_transaction, :raw_pending_column_transaction]
+      ).call
+    end
 
     def calculate_event
       event_from_canonical_transactions ||

--- a/db/migrate/20260823003730_add_index_on_column_id_to_column_account_numbers.rb
+++ b/db/migrate/20260823003730_add_index_on_column_id_to_column_account_numbers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# column_id had no index at all, so every `Column::AccountNumber.find_by(column_id:)`
+# lookup (e.g. Ledger::Mapper#event_from_canonical_transactions) was a sequential
+# scan of the whole table. Unique because a Column account number belongs to
+# exactly one event.
+class AddIndexOnColumnIdToColumnAccountNumbers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :column_account_numbers, :column_id, unique: true, algorithm: :concurrently
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_003730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -590,6 +590,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_120100) do
     t.text "routing_number_ciphertext"
     t.datetime "updated_at", null: false
     t.index ["account_number_bidx"], name: "index_column_account_numbers_on_account_number_bidx", unique: true
+    t.index ["column_id"], name: "index_column_account_numbers_on_column_id", unique: true
     t.index ["event_id"], name: "index_column_account_numbers_on_event_id", unique: true
   end
 


### PR DESCRIPTION
## Problem

`Ledger::Mapper#run` was slow, and interrupting it usually landed inside the `raw_column_transaction` code path.

## Root causes

1. **Missing index.** `column_account_numbers.column_id` had no index at all, so every `Column::AccountNumber.find_by(column_id:)` call — in [`Ledger::Mapper#event_from_canonical_transactions`](app/services/ledger/mapper.rb) and the identical pattern in `app/services/event_mapping_engine/nightly.rb` — was a sequential scan of the whole table. The sibling table `raw_pending_column_transactions` already has a unique index on the equivalent column, so this looks like an oversight rather than intentional.
2. **N+1 on transaction sources.** `Ledger::Mapper` iterates `canonical_transactions`/`canonical_pending_transactions` and reads each row's raw/polymorphic transaction (`raw_column_transaction`, `raw_stripe_transaction`, `raw_pending_column_transaction`, etc.) without eager loading. Any ledger item with more than one transaction triggered a separate `SELECT` per transaction beyond the first.

This compounds because `Ledger::Item` runs `Mapper#run` synchronously on every `after_create`/`after_touch`, so bulk creates/touches (backfills, migrations) hit both issues once per item.

## Changes

- `db/migrate/20260823003730_add_index_on_column_id_to_column_account_numbers.rb` — unique, concurrent index on `column_account_numbers.column_id`.
- `app/services/ledger/mapper.rb` — added `preload_transaction_sources!`, called once per `run` (after the "already mapped by a human" fast-path check, so that path stays free), batching the transaction-source loads into one query per type instead of one per row.
- `db/schema.rb` / `app/models/column/account_number.rb` — regenerated from the migration.

## Verification

- Diffed `calculate_ledger` output for every `Ledger::Item` in the dev DB before/after the mapper change — identical results.
- `bundle exec rspec spec/services/ledger/mapper_spec.rb` — 11/11 passing.
- `bundle exec rubocop app/services/ledger/mapper.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)