### PR TITLE
[Ledger::Query] Filter out items with no CTs and no CPTs

### DIFF
--- a/app/models/ledger/query.rb
+++ b/app/models/ledger/query.rb
@@ -46,6 +46,7 @@ class Ledger
     # another organization's items.
     def execute(ledgers: [], all_ledgers: false)
       results = apply_query(relation: Ledger::Item.all, query: @query_hash)
+      results = results.where.not(ct_count: 0, cpt_count: 0)
 
       # Strict boolean: only a literal true opts out of scoping, so a caller that
       # accidentally passes a truthy value (e.g. the string "false") fails closed.

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -186,11 +186,11 @@ RSpec.describe EventsController do
       it "shows a non-settled item with a non-zero amount, but hides one with a zero amount" do
         moved_money = create(:ledger_item, custom_memo: "Declined but moved money", datetime: Time.current)
         Ledger::Mapping.create!(ledger: event.ledger, ledger_item: moved_money, on_primary_ledger: true)
-        moved_money.update_columns(status: "declined", amount_cents: 500)
+        moved_money.update_columns(status: "declined", amount_cents: 500, ct_count: 1)
 
         no_money_moved = create(:ledger_item, custom_memo: "Declined with no amount", datetime: Time.current)
         Ledger::Mapping.create!(ledger: event.ledger, ledger_item: no_money_moved, on_primary_ledger: true)
-        no_money_moved.update_columns(status: "declined", amount_cents: 0)
+        no_money_moved.update_columns(status: "declined", amount_cents: 0, ct_count: 1)
 
         get(:ledger, params: { event_id: event.slug })
 

--- a/spec/controllers/ledgers_controller_spec.rb
+++ b/spec/controllers/ledgers_controller_spec.rb
@@ -32,7 +32,12 @@ RSpec.describe LedgersController, type: :controller do
 
       let(:item) { create(:ledger_item) }
 
-      before { create(:ledger_mapping, :on_primary, ledger:, ledger_item: item) }
+      before do
+        create(:ledger_mapping, :on_primary, ledger:, ledger_item: item)
+        # Pin ct_count so this item (which has no real CTs) isn't filtered out
+        # as empty (see Ledger::Query#execute).
+        item.update_columns(ct_count: 1)
+      end
 
       it "renders the shift-click-to-rename widget with the memo as alt text" do
         get :show, params: { id: ledger.to_param }

--- a/spec/models/ledger/query_spec.rb
+++ b/spec/models/ledger/query_spec.rb
@@ -29,8 +29,9 @@ RSpec.describe Ledger::Query, type: :model do
     Ledger::Mapping.create(ledger: test_ledger, ledger_item: item, on_primary_ledger: true)
     # refresh! (triggered on create and on mapping) recomputes memo and
     # amount_cents from canonical transactions, which these items don't have.
-    # Pin the intended values, bypassing callbacks.
-    item.update_columns(**attrs)
+    # Pin the intended values, bypassing callbacks. Also pin ct_count to 1 so
+    # these items don't get filtered out as empty (see Ledger::Query#execute).
+    item.update_columns(ct_count: 1, **attrs)
     item
   end
 
@@ -470,7 +471,7 @@ RSpec.describe Ledger::Query, type: :model do
     def create_other_ledger_item(**attrs)
       item = create(:ledger_item, **attrs)
       Ledger::Mapping.create(ledger: other_ledger, ledger_item: item, on_primary_ledger: true)
-      item.update_columns(**attrs)
+      item.update_columns(ct_count: 1, **attrs)
       item
     end
 
@@ -549,6 +550,34 @@ RSpec.describe Ledger::Query, type: :model do
 
       # item_a (amount=0) + all items except item_f (gamma payment)
       expect(result.pluck(:id)).to match_array(ids_of(item_a, item_b, item_c, item_d, item_e, item_g))
+    end
+  end
+
+  describe "empty items" do
+    it "excludes items with no CTs and no CPTs" do
+      empty_item = create_mapped_item(amount_cents: 100, memo: "empty item", datetime: Date.new(2024, 1, 4))
+      empty_item.update_columns(ct_count: 0, cpt_count: 0)
+
+      result = execute_query({ amount_cents: 100 })
+
+      expect(result.pluck(:id)).to match_array(ids_of(item_b, item_g))
+      expect(result.pluck(:id)).not_to include(empty_item.id)
+    end
+
+    it "includes items with a CT but no CPTs" do
+      item_b.update_columns(ct_count: 1, cpt_count: 0)
+
+      result = execute_query({ amount_cents: 100 })
+
+      expect(result.pluck(:id)).to include(item_b.id)
+    end
+
+    it "includes items with a CPT but no CTs" do
+      item_b.update_columns(ct_count: 0, cpt_count: 1)
+
+      result = execute_query({ amount_cents: 100 })
+
+      expect(result.pluck(:id)).to include(item_b.id)
     end
   end
 end


### PR DESCRIPTION
## Summary of the problem
A `Ledger::Item` with nothing real behind it (no CTs, no CPTs) can still surface in a ledger view — e.g. one that has a mapping or linked object but somehow no CTs/CPTs (an anomaly that's flagged rather than removed, see `Ledger::Item#cleanup_if_empty!` in #14715).

## Describe your changes
`Ledger::Query#execute` now excludes any item with `ct_count == 0` and `cpt_count == 0`, so nothing empty ever shows up in a ledger view regardless of why it ended up that way.

Updates existing specs that built ledger items without real CTs/CPTs (pinning fields like `amount_cents`/`status` via `update_columns`) to also pin `ct_count` so they aren't swept up by the new filter, and adds dedicated coverage for the filter itself in `spec/models/ledger/query_spec.rb`.

Split out of #14715 so this can merge independently first.
