### PR TITLE
[Invoices] Fix voiding an invoice that already has a payment method

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -300,20 +300,25 @@ class Invoice < ApplicationRecord
     self.starting_balance = inv.starting_balance
     self.statement_descriptor = inv.statement_descriptor
     self.status = inv.status
-    if inv&.charge.is_a?(String)
-      self.stripe_charge_id = inv.charge
-    else
-      self.stripe_charge_id = inv&.charge&.id
-      # https://stripe.com/docs/api/charges/object#charge_object-payment_method_details
-      self.payment_method_type = type = inv&.charge&.payment_method_details&.type
-    end
     self.subtotal = inv.subtotal
     self.tax = inv.tax
     # self.tax_percent = inv.tax_percent
     self.total = inv.total
-    return unless self.payment_method_type
 
-    details = inv&.charge&.payment_method_details&.[](self.payment_method_type)
+    charge = inv&.charge
+    # the charge is unexpanded (just an ID) on responses that weren't fetched
+    # through `Partners::Stripe::Invoices::Show`, ex. the response to voiding.
+    if charge.is_a?(String)
+      self.stripe_charge_id = charge
+      return
+    end
+
+    self.stripe_charge_id = charge&.id
+    # https://stripe.com/docs/api/charges/object#charge_object-payment_method_details
+    self.payment_method_type = type = charge&.payment_method_details&.type
+    return unless type
+
+    details = charge.payment_method_details[type]
     return unless details
 
     case type
@@ -394,7 +399,12 @@ class Invoice < ApplicationRecord
   end
 
   def close_stripe_invoice
-    remote_invoice.void_invoice
+    # Stripe rejects voiding an invoice that's already void, which would leave
+    # invoices voided remotely but not locally stuck that way forever.
+    remote_invoice.void_invoice unless remote_invoice.status == "void"
+    # `void_invoice` updates `remote_invoice` in place with an unexpanded
+    # response; drop it so the sync refetches the expanded invoice.
+    @remote_invoice = nil
 
     sync_remote!
   end


### PR DESCRIPTION
## Summary of the problem

Voiding an invoice blows up with `NoMethodError: undefined method 'payment_method_details' for an instance of String` in `Invoice#set_fields_from_stripe_invoice`.

Claude's diagnosis,

> `close_stripe_invoice` calls `remote_invoice.void_invoice`. stripe-ruby's `request_stripe_object` calls `initialize_from` when the response object matches the resource class, so the void response mutates the memoized invoice in place — and that response isn't expanded, so `charge` turns from a `Stripe::Charge` into a bare `"ch_..."` String. The follow-up `sync_remote!` then hits `set_fields_from_stripe_invoice`, where the String branch sets `stripe_charge_id` but skips the `payment_method_type` assignment, so the guard below falls through to the *persisted* column. Any invoice that already had a charge synced (a failed card attempt, an ACH credit transfer) has that column populated, so the guard passes and `payment_method_details` gets called on a String.

Because the void POST already succeeded but the surrounding transaction rolls back, affected invoices end up voided on Stripe while still `open_v2` in HCB, and retrying crashes the same way. This also breaks manually marking an invoice as paid, which runs `MarkVoid` first.

## Describe your changes

- `set_fields_from_stripe_invoice` keys off the `type` derived from the live Stripe object instead of the persisted `payment_method_type`, and returns early on an unexpanded charge. This also fixes a latent bug where `case type` compared an always-nil local in the String branch.
- `close_stripe_invoice` drops the memoized invoice so the sync refetches with the expansions applied.
- `close_stripe_invoice` skips the remote call when Stripe already considers the invoice void, so the invoices currently stuck self-heal on the next void, rather than failing on Stripe's "already void" error.