### PR TITLE
[Contracts] Fire on_party_signed after commit, not inside the caller's transaction

### DIFF
--- a/app/models/contract/party.rb
+++ b/app/models/contract/party.rb
@@ -51,7 +51,7 @@ class Contract
 
       event :mark_signed do
         transitions from: :pending, to: :signed
-        after do
+        after_commit do
           contract.on_party_signed(self)
         end
 

--- a/spec/models/contract/party_spec.rb
+++ b/spec/models/contract/party_spec.rb
@@ -161,4 +161,32 @@ RSpec.describe Contract::Party, type: :model do
       expect(described_class.for(event:, user: signee)).to be_nil
     end
   end
+
+  describe "#mark_signed" do
+    before do
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+    end
+
+    # DocusealController#webhook wraps the whole party.with_lock { party.mark_signed! }
+    # call in its own outer transaction. If on_party_signed fired from a plain
+    # `after` (rather than `after_commit`), its mailer/reminder job enqueues
+    # would carry a GlobalID for a party row that isn't committed yet - a
+    # background worker could pick the job up and fail to find it
+    # (ActiveJob::DeserializationError) before our transaction ever commits.
+    it "does not notify until the enclosing transaction commits" do
+      invite = create(:organizer_position_invite)
+      contract = Contract::FiscalSponsorship.create!(contractable: invite, include_videos: false)
+      party = contract.parties.create!(user: create(:user), role: :signee)
+
+      signaled = false
+      allow_any_instance_of(Contract).to receive(:on_party_signed) { signaled = true }
+
+      ActiveRecord::Base.transaction do
+        party.with_lock { party.mark_signed! }
+        expect(signaled).to be false
+      end
+
+      expect(signaled).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Production error:

```
ActiveJob::DeserializationError: Error while trying to deserialize arguments: Couldn't find Contract::Party with 'id'="18960"
```

`Contract::Party#mark_signed` fired `contract.on_party_signed` from a plain AASM `after` callback. That method enqueues mailer/reminder jobs carrying the party via GlobalID (`Contract::PartyMailer#notify`, `Contract::Party#schedule_reminders`, etc).

[`DocusealController#webhook`](app/controllers/docuseal_controller.rb) calls `party.mark_signed!` from inside `party.with_lock { ... }`, itself nested in an outer `ActiveRecord::Base.transaction do ... end`. With a plain `after` callback, those jobs get enqueued while that outer transaction is still open — a Sidekiq worker can pick one up and try to deserialize the party before the transaction commits and the row is visible, raising the error above.

This is the same class of race already fixed for `Contract#mark_sent` in #13483; `mark_signed` was missed.

## Fix

Switch `Contract::Party`'s `mark_signed` event to `after_commit`. Confirmed via the `aasm` gem source (backed by `after_commit_everywhere`, already a dependency here) that this works independently of `requires_lock: true` — that flag only controls whether AASM's own internal transaction takes a row lock, unrelated to how `after_commit` hooks into ActiveRecord's transactional callbacks.

Added a regression spec that reproduces the DocuSeal webhook's transaction nesting and asserts `on_party_signed` doesn't fire until the enclosing transaction commits.

## Testing

- `bundle exec rspec spec/models/contract/party_spec.rb` — 17 examples, 0 failures
- `bundle exec rspec spec/models/contract_spec.rb spec/requests/docuseal_webhook_spec.rb` — 4 examples, 0 failures
- `bundle exec rubocop app/models/contract/party.rb spec/models/contract/party_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)