### PR TITLE
[Event::Configuration] Fix monthly-announcement email race with after_update_commit

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -81,6 +81,11 @@ class EventMailer < ApplicationMailer
 
   def monthly_announcements_enabled
     @monthly_announcement = @event.announcements.monthly_for(Date.today).last
+    if @monthly_announcement.nil?
+      Rails.logger.error("EventMailer#monthly_announcements_enabled: no monthly announcement found for event #{@event.id}; skipping email")
+      return
+    end
+
     @scheduled_for = Date.today.next_month.beginning_of_month
     @warning_date = @scheduled_for - 7.days
 

--- a/app/models/event/configuration.rb
+++ b/app/models/event/configuration.rb
@@ -34,7 +34,7 @@ class Event
     validates :event, uniqueness: true
 
     after_save :create_or_destroy_monthly_announcement
-    after_update if: :generate_monthly_announcement_previously_changed? do
+    after_update_commit if: :generate_monthly_announcement_previously_changed? do
       version = self.versions.where_object_changes(generate_monthly_announcement:).last
       whodunnit = version&.whodunnit.present? ? User.find(version.whodunnit) : User.system_user
       if generate_monthly_announcement


### PR DESCRIPTION
## Problem

Enabling monthly announcements for an org would sometimes error out with:

```
ActionView::Template::Error: No route matches {action: "show", controller: "announcements", id: nil}, possible unmatched constraints: [:id]
app/views/event_mailer/monthly_announcements_enabled.html.erb:11
app/mailers/event_mailer.rb:87 in EventMailer#monthly_announcements_enabled
```

## Root cause

In `Event::Configuration`:

```ruby
after_save :create_or_destroy_monthly_announcement
after_update if: :generate_monthly_announcement_previously_changed? do
  ...
  EventMailer.with(event:, whodunnit:).monthly_announcements_enabled.deliver_later
  ...
end
```

Rails' callback order for an update is `before_update → after_update → after_save → after_commit` — `after_update` fires **before** `after_save`. So the mailer job was being enqueued before `create_or_destroy_monthly_announcement` (an `after_save` callback) had a chance to create the `Announcement` row.

Since mail delivery is asynchronous, the mailer's job could run before the `Announcement` existed — or before the transaction that created it had even committed — leaving `EventMailer#monthly_announcements_enabled`'s `@monthly_announcement` `nil`, which then blew up trying to build `announcement_url(nil)`.

## Fix

Switch the mailer trigger to `after_update_commit` (shorthand for `after_commit on: :update`), so it only fires once the entire transaction — including the `Announcement` creation — has committed. This guarantees the record exists and is visible to the async job by the time it runs, regardless of queue adapter timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)