### PR TITLE
Fix race condition creating duplicate tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,8 +8,16 @@ class TagsController < ApplicationController
   def create
     authorize @event, policy_class: TagPolicy
 
-    tag = Tag.where(label: params[:label].strip, event: @event)
-    tag = tag.create_with(color: params[:color], emoji: params[:emoji]).first_or_create
+    label = params[:label].strip
+    tag = Tag.where(label: label, event: @event).first_or_initialize(color: params[:color], emoji: params[:emoji])
+    tag.save unless tag.persisted?
+
+    if !tag.persisted? && tag.errors.of_kind?(:label, :taken)
+      # Another request created this same tag concurrently (e.g. a double
+      # submit) between our lookup above and our attempted create. Use the
+      # tag it created instead of carrying forward an invalid record.
+      tag = Tag.find_by(label: label, event: @event) || tag
+    end
 
     if params[:hcb_code_id]
       hcb_code = HcbCode.find(params[:hcb_code_id])

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -39,5 +39,34 @@ RSpec.describe TagsController do
 
       expect(hcb_code.reload.tags).to be_empty
     end
+
+    it "recovers when the same tag is created concurrently (e.g. a double submit)" do
+      hcb_code = hcb_code_belonging_to(event)
+      concurrent_tag = nil
+      handled = false
+
+      # Simulate another request winning the race and creating the same tag
+      # in between this request's initial lookup (which finds nothing) and
+      # its own attempted create (whose uniqueness validation then fails).
+      allow_any_instance_of(Tag).to receive(:save).and_wrap_original do |original_save, *args, &block|
+        tag = original_save.receiver
+
+        if !handled && tag.new_record? && tag.label == "Snacks"
+          handled = true
+          concurrent_tag = Tag.create!(label: "Snacks", event:, color: "blue", emoji: "🎉")
+          tag.errors.add(:label, :taken)
+          false
+        else
+          original_save.call(*args, &block)
+        end
+      end
+
+      expect {
+        post(:create, params: { event_id: event.slug, label: "Snacks", color: "muted", emoji: "🍕", hcb_code_id: hcb_code.hashid })
+      }.not_to raise_error
+
+      expect(event.tags.sole).to eq(concurrent_tag)
+      expect(hcb_code.reload.tags).to include(concurrent_tag)
+    end
   end
 end


### PR DESCRIPTION
## Problem

`TagsController#create` was hitting a crash reported as:

```
ActiveRecord::RecordInvalid: Validation failed: Label has already been taken
app/controllers/tags_controller.rb:25 in block in TagsController#create
app/controllers/tags_controller.rb:24 in TagsController#create
```

`Tag.where(...).first_or_create` has a check-then-act race: if two requests try to create the same tag (same `label` + `event`) close together — e.g. a double submit — the first one commits, and the second's uniqueness validation then sees it and fails with "Label has already been taken". Since `first_or_create` (no bang) doesn't raise, it silently returned an **unsaved, invalid** `Tag`.

That invalid object then reached `hcb_code.tags << tag` — appending an unpersisted record to a `has_many :through` association forces Rails to save it, and *that's* where `ActiveRecord::RecordInvalid` actually got raised, matching the stack trace (inside the `suppress` block, which only guards `RecordNotUnique`, not `RecordInvalid`).

The `tags` table also has no DB-level unique index (only `index_tags_on_event_id`), so there's no constraint-level backstop — this is purely an app-validation race.

## Fix

After a failed create, detect the "taken" validation error specifically and re-fetch the row the concurrent request just created, instead of carrying forward the invalid record.

## Testing

Added a regression test that simulates the race (stubs `Tag#save` to insert a concurrent duplicate mid-save). Verified it reproduces the exact original crash when the fix is reverted, and passes with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)