### PR TITLE
Fix NoMethodError crash on GSuiteAccount#rejected?

### DIFF
--- a/app/controllers/g_suite_accounts_controller.rb
+++ b/app/controllers/g_suite_accounts_controller.rb
@@ -108,7 +108,7 @@ class GSuiteAccountsController < ApplicationController
   end
 
   def g_suite_account_params
-    params.require(:g_suite_account).permit(:backup_email, :address, :accepted_at, :rejected_at, :initial_password, :g_suite_id, :first_name, :last_name)
+    params.require(:g_suite_account).permit(:backup_email, :address, :accepted_at, :initial_password, :g_suite_id, :first_name, :last_name)
   end
 
   def full_email_address(address, g_suite)

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -31,8 +31,6 @@ class GSuiteAccount < ApplicationRecord
   has_paper_trail skip: [:initial_password] # ciphertext columns will still be tracked
   has_encrypted :initial_password
 
-  include Rejectable
-
   attr_accessor :skip_gsuite_sync
 
   after_update :attempt_notify_user_of_password_change
@@ -48,7 +46,6 @@ class GSuiteAccount < ApplicationRecord
   normalizes :backup_email, with: ->(backup_email) { backup_email.strip.downcase }
   validates :backup_email, nondisposable: true, on: :create
 
-  validate :status_accepted_or_rejected
   validate :within_quota, on: :create
   validates :address, uniqueness: { scope: :g_suite }
 

--- a/app/views/g_suite_accounts/index.html.erb
+++ b/app/views/g_suite_accounts/index.html.erb
@@ -48,7 +48,7 @@
 
   <tbody>
     <% @g_suite_accounts.each do |g_suite_account| %>
-      <tr class="<%= "shade-yellow" if g_suite_account.under_review? %> <%= "shade-red" if g_suite_account.rejected? %>">
+      <tr class="<%= "shade-yellow" if g_suite_account.under_review? %>">
         <td><%= g_suite_account.address %></td>
         <td><%= g_suite_account.backup_email %></td>
         <td><%= g_suite_account.status.capitalize %></td>


### PR DESCRIPTION
## Problem

`/g_suite_accounts` crashed with:

```
ActionView::Template::Error: undefined local variable or method 'rejected_at' for an instance of GSuiteAccount
app/models/concerns/rejectable.rb:15 in Rejectable#rejected?
app/views/g_suite_accounts/index.html.erb:51
```

## Root cause

The `rejected_at` column was dropped from `g_suite_accounts` back in 2024 (#7924, #7935). That cleanup removed the `rejected?` method override and the "Reject" action, but missed a few leftover references:

- The accounts index view still called `g_suite_account.rejected?` to shade a row red. With the override gone, that fell through to `Rejectable#rejected?` (`rejected_at.present?`), which blew up since the column no longer exists.
- `GSuiteAccount` still `include`d `Rejectable` and validated `status_accepted_or_rejected`, both of which reference `rejected_at`/`canceled_at` — neither column exists on this table, and `accepted?`/`canceled?`/`rejected?` aren't used anywhere else for this model.
- The controller's strong params still permitted `:rejected_at`.

## Fix

Removes all of the above dead code. `accepted_at` (a real column) and the model's own `status`/`under_review?` methods are untouched, so behavior is unchanged apart from no longer crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)