### PR TITLE
[ReceiptablePolicy] Fix crash uploading/linking receipts on Ledger::Item

### DIFF
--- a/app/policies/receiptable_policy.rb
+++ b/app/policies/receiptable_policy.rb
@@ -20,9 +20,19 @@ class ReceiptablePolicy < ApplicationPolicy
   private
 
   def present_in_events?
-    # Assumption: Receiptable has an association to Event
-    events = (record.try(:events) || [record.event]).compact
-    events.any? { |event| OrganizerPosition.role_at_least?(user, event, :member) }
+    return false if record.nil?
+
+    # Ledger::Item deliberately has no generic `event`/`events` method (it can be
+    # mapped onto more than one ledger), so look up its event the same way
+    # Ledger::ItemPolicy#rename? does instead of assuming a single association.
+    events =
+      if record.is_a?(::Ledger::Item)
+        [record.primary_ledger&.event]
+      else
+        record.try(:events) || [record.event]
+      end
+
+    events.compact.any? { |event| OrganizerPosition.role_at_least?(user, event, :member) }
   end
 
 end

--- a/spec/policies/receiptable_policy_spec.rb
+++ b/spec/policies/receiptable_policy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReceiptablePolicy, type: :policy do
+  describe "#upload?" do
+    context "when the record is a Ledger::Item" do
+      let(:ledger_item) { create(:ledger_item, :with_primary_ledger) }
+      let(:event) { ledger_item.primary_ledger.event }
+
+      it "authorizes a member of the item's primary ledger event" do
+        organizer_position = create(:organizer_position, event:)
+
+        expect(described_class.new(organizer_position.user, ledger_item).upload?).to be(true)
+      end
+
+      it "does not authorize an unrelated user" do
+        expect(described_class.new(create(:user), ledger_item).upload?).to be_falsey
+      end
+
+      it "does not raise for an unmapped item with no primary ledger" do
+        unmapped_item = create(:ledger_item)
+
+        expect { described_class.new(create(:user), unmapped_item).upload? }.not_to raise_error
+        expect(described_class.new(create(:user), unmapped_item).upload?).to be_falsey
+      end
+    end
+
+    context "when the record is nil" do
+      it "does not raise and is not authorized" do
+        expect { described_class.new(create(:user), nil).upload? }.not_to raise_error
+        expect(described_class.new(create(:user), nil).upload?).to be_falsey
+      end
+    end
+  end
+
+  describe "#link_modal?" do
+    it "does not raise when the record is nil" do
+      expect { described_class.new(create(:user), nil).link_modal? }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Two production errors from `ReceiptablePolicy#present_in_events?`:

```
ActionView::Template::Error: undefined method 'event' for an instance of Ledger::Item
app/policies/receiptable_policy.rb:24 in ReceiptablePolicy#present_in_events?
```

```
NoMethodError: undefined method 'event' for nil
app/policies/receiptable_policy.rb:24 in ReceiptablePolicy#present_in_events?
```

## Cause

`present_in_events?` assumed every receiptable exposes `.events`/`.event`, which is true for `HcbCode`, `CanonicalTransaction`, etc. — but `Ledger::Item` deliberately has no generic `event`/`events` method (it can be mapped onto more than one ledger). `Ledger::Item` is already a valid receiptable type (see `ReceiptsController::RECEIPTABLE_TYPE_MAP`), so calling `.event` on it raised.

The second trace is the same method with `record` itself `nil` (e.g. an unresolvable `receiptable_type`/`receiptable_id`), which also wasn't guarded.

## Fix

- Added a `record.nil?` guard that returns `false` instead of raising.
- Added a `Ledger::Item` branch that resolves the event via `primary_ledger&.event`, matching the pattern already used in `Ledger::ItemPolicy#rename?`.

## Testing

Added `spec/policies/receiptable_policy_spec.rb` covering: a `Ledger::Item` owned by an authorized organizer, an unrelated user, an unmapped item (no primary ledger), and a `nil` record. Also verified the existing `spec/policies/hcb_code_policy_spec.rb` (which exercises `ReceiptablePolicy` too) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)