### PR TITLE
[CanonicalTransaction] Fix duplicate short_code on assign_ledger_item

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -489,11 +489,11 @@ class CanonicalTransaction < ApplicationRecord
     safely do
       reload_local_hcb_code
       ActiveRecord::Base.transaction do
-        if calculated_ledger_item != local_hcb_code.ledger_item
+        if calculated_ledger_item.present? && calculated_ledger_item != local_hcb_code.ledger_item
           Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
         end
 
-        li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+        li = local_hcb_code.ledger_item || calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
         update!(ledger_item: li)
         li.map!
       end

--- a/spec/models/canonical_transaction_spec.rb
+++ b/spec/models/canonical_transaction_spec.rb
@@ -69,4 +69,23 @@ RSpec.describe CanonicalTransaction, type: :model do
       expect(canonical_transaction.local_hcb_code).to be_present
     end
   end
+
+  describe "#assign_ledger_item" do
+    it "reuses the local hcb_code's existing ledger item instead of creating a duplicate" do
+      hcb_code = create(:hcb_code)
+      ledger_item = create(:ledger_item, short_code: hcb_code.short_code)
+      hcb_code.update!(ledger_item:)
+
+      # Simulate a second canonical transaction settling onto an hcb_code that
+      # already has a ledger item, via a linked_object type not covered by
+      # `linked_object_v2` (e.g. a BankFee/Disbursement/Donation leg) - so
+      # `calculated_ledger_item` can't find it and would otherwise attempt to
+      # create a second `Ledger::Item` with the same (unique) short_code.
+      canonical_transaction.update_column(:hcb_code, hcb_code.hcb_code)
+      canonical_transaction.reload_local_hcb_code
+
+      expect { canonical_transaction.send(:assign_ledger_item) }.to_not change(Ledger::Item, :count)
+      expect(canonical_transaction.reload.ledger_item).to eq(ledger_item)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Production was hitting:

```
ActiveRecord::RecordNotUnique: [safely] PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_ledger_items_on_short_code"
DETAIL:  Key (short_code)=(?) already exists.

app/models/canonical_transaction.rb:496 in block (2 levels) in CanonicalTransaction#assign_ledger_item
```

`CanonicalTransaction#assign_ledger_item` only checked `calculated_ledger_item` (resolved via the CT's own memo-parsed `short_code`, or `linked_object_v2` — a narrow type list: `AchTransfer`/`Wire`/`CheckDeposit`/`IncreaseCheck`/`CardCharge`) before creating a new `Ledger::Item`. For an `hcb_code` grouping multiple `CanonicalTransaction`s through the broader `linked_object` path (`BankFee`, `Donation`, `Disbursement`, `Check`, `FeeRevenue`, reimbursement payouts), the first sibling CT creates the `Ledger::Item` fine, but the next one's `calculated_ledger_item` comes back `nil` even though `local_hcb_code.ledger_item` already exists — so it redundantly calls `create_ledger_item!` with the already-taken `short_code`.

This is a regression from #14231 (Jul 9), which swapped the previously-safe `local_hcb_code.ledger_item || create_ledger_item!(...)` (from #13643) for `calculated_ledger_item || create_ledger_item!(...)`. `CanonicalPendingTransaction#assign_ledger_item` still has the correct pattern.

In production, `safely` swallows the resulting `RecordNotUnique` (reports to Appsignal, doesn't re-raise outside dev/test) — so the nightly job doesn't crash, but the affected `CanonicalTransaction` is left permanently without a `ledger_item_id`, since `assign_ledger_item` only runs once via `after_create_commit unless: -> { ledger_item.present? }`.

## Fix

- Prioritize `local_hcb_code.ledger_item` over `calculated_ledger_item` when resolving which `Ledger::Item` to attach, matching `CanonicalPendingTransaction`'s existing safe pattern.
- Narrow the adjacent `Rails.error.unexpected` divergence check to only fire when `calculated_ledger_item` resolves to a different, non-nil item (a real conflict) rather than merely being `nil` while `local_hcb_code.ledger_item` is already present. That nil-vs-present case is an expected gap given `calculated_ledger_item`'s narrower type coverage, not a bug — and left unnarrowed, the check raises before ever reaching the fix in dev/test (Rails re-raises "unexpected" errors when debug mode is on, which it is by default there), and would otherwise generate a false-positive Appsignal report on every occurrence in prod.

## Testing

Added a regression spec verifying `assign_ledger_item` reuses an already-existing `local_hcb_code.ledger_item` instead of attempting a duplicate create. Confirmed it fails with the original code (raising the exact same divergence error reported in production) and passes with the fix.

Out of scope for this PR: a backfill for `CanonicalTransaction`s already left orphaned by this bug in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)