### PR TITLE
Remove double US from event helper message

### DIFF
--- a/app/views/events/perks/_event_helper.html.erb
+++ b/app/views/events/perks/_event_helper.html.erb
@@ -41,7 +41,7 @@
 
   <section class="card__banner card__darker secondary border-top">
     <p class="my0">
-      The Event Helper can only provide policies for 🇺🇸 US events.
+      The Event Helper can only provide policies for US events.
     </p>
   </section>
 </div>


### PR DESCRIPTION
## Summary of the problem
Right now, under the Event Helper Perk, there is a typo saying that The Event Helper can only provide policies for 🇺🇸 US events. 




## Describe your changes
This pull request takes out the first us as it is rather misleading.



<img width="945" height="463" alt="image" src="https://github.com/user-attachments/assets/995af8e6-d100-468d-9dca-24574f61f203" />


