### PR TITLE
[CT / CPT] Remove safely do from `assign_ledger_item`

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -475,13 +475,11 @@ class CanonicalPendingTransaction < ApplicationRecord
   private
 
   def assign_ledger_item
-    safely do
-      reload_local_hcb_code
-      ActiveRecord::Base.transaction do
-        li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
-        update!(ledger_item: li)
-        li.map!
-      end
+    reload_local_hcb_code
+    ActiveRecord::Base.transaction do
+      li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      update!(ledger_item: li)
+      li.map!
     end
   end
 

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -485,17 +485,15 @@ class CanonicalTransaction < ApplicationRecord
   private
 
   def assign_ledger_item
-    safely do
-      reload_local_hcb_code
-      ActiveRecord::Base.transaction do
-        if calculated_ledger_item != local_hcb_code.ledger_item
-          Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
-        end
-
-        li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
-        update!(ledger_item: li)
-        li.map!
+    reload_local_hcb_code
+    ActiveRecord::Base.transaction do
+      if calculated_ledger_item != local_hcb_code.ledger_item
+        Rails.error.unexpected("CanonicalTransaction #{id} has calculated a different ledger item from its local_hcb_code. (#{calculated_ledger_item&.id} vs. #{local_hcb_code.ledger_item&.id})")
       end
+
+      li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime: created_at, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
+      update!(ledger_item: li)
+      li.map!
     end
   end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
We want this to raise because CTs and CPTs are being made without ledger items.


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Remove safely do.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

