### PR TITLE
[PermissionsOverview] Fix flaky event_graph ordering

### DIFF
--- a/app/models/user/permissions_overview.rb
+++ b/app/models/user/permissions_overview.rb
@@ -83,7 +83,7 @@ class User
           active_events.joins("JOIN event_graph ON events.id = event_graph.parent_id")
         )
 
-        (ancestors + descendants).index_by(&:id)
+        (ancestors + descendants).sort_by(&:id).index_by(&:id)
       end
     end
 


### PR DESCRIPTION
## Summary
Fixes a flaky spec: `User::PermissionsOverview#event_graph correctly handles multiple trees` (`spec/models/user/permissions_overview_spec.rb:68`) intermittently failed with the two trees returned in swapped order.

## Root cause
`events_by_id` was built via:
```ruby
(ancestors + descendants).index_by(&:id)
```
`ancestors` and `descendants` come from raw recursive SQL queries with no `ORDER BY`, so Postgres doesn't guarantee row order. Since `events_by_id.values` backs both the root-event list in `event_graph` and sibling ordering via `events_by_parent_id`, the resulting tree/sibling order could vary nondeterministically between runs.

## Fix
Sort by `id` (creation order) before indexing, so ordering is deterministic:
```ruby
(ancestors + descendants).sort_by(&:id).index_by(&:id)
```

## Testing
Ran the spec with several seeds, including the originally-failing seed (2793), 3x each — all green:
```
bundle exec rspec spec/models/user/permissions_overview_spec.rb --seed 2793
5 examples, 0 failures
```