### PR TITLE
[Discord] Rescue NoPermission when resolving a channel

### DIFF
--- a/app/controllers/discord_controller.rb
+++ b/app/controllers/discord_controller.rb
@@ -85,7 +85,7 @@ class DiscordController < ApplicationController
     @channel_id = Discord.verify_signed(@signed_channel_id, purpose: :link_server)
 
     @guild = Discord::Bot.bot.server(@guild_id)
-    @channel = Discord::Bot.bot.channel(@channel_id)
+    @channel = resolve_discord_channel(@channel_id)
 
     redirect_to_discord_bot_install_link if @guild.nil? || @channel.nil?
   end
@@ -98,7 +98,7 @@ class DiscordController < ApplicationController
     @channel_id = Discord.verify_signed(params[:signed_channel_id], purpose: :link_server)
 
     @guild = Discord::Bot.bot.server(@guild_id)
-    @channel = Discord::Bot.bot.channel(@channel_id)
+    @channel = resolve_discord_channel(@channel_id)
 
     return redirect_to_discord_bot_install_link if @guild.nil? || @channel.nil?
 
@@ -187,6 +187,15 @@ class DiscordController < ApplicationController
 
   def redirect_to_discord_bot_install_link
     redirect_to Discord::Bot.install_link, allow_other_host: true
+  end
+
+  # `Discordrb::Bot#channel` raises `NoPermission` (rather than returning `nil`, like
+  # `Discordrb::Bot#server` does) when the bot can no longer see the channel — e.g. it was
+  # kicked from the server, or lost the `VIEW_CHANNEL` permission after the link was generated.
+  def resolve_discord_channel(channel_id)
+    Discord::Bot.bot.channel(channel_id)
+  rescue Discordrb::Errors::NoPermission
+    nil
   end
 
 end


### PR DESCRIPTION
## Problem

```
Discordrb::Errors::NoPermission: The bot doesn't have the required permission to do this!
app/controllers/discord_controller.rb:88 in DiscordController#setup
```

`DiscordController#setup` calls `Discord::Bot.bot.channel(@channel_id)` with no rescue anywhere in the action.

`Discordrb::Bot#channel` (from the `discordrb` gem's `Cache` module) only rescues `Discordrb::Errors::UnknownChannel` and returns `nil` on that — it does **not** rescue `Discordrb::Errors::NoPermission`. This is inconsistent with its sibling `Discordrb::Bot#server`, which explicitly rescues `NoPermission` and returns `nil`.

So whenever the bot can no longer see the channel a signed `/setup` link points at — e.g. it was kicked from the server, the channel was made private, or a role/permission change revoked `VIEW_CHANNEL` after the link was generated — `channel()` raises instead of returning `nil`, and that propagated straight through the uncaught action to a 500.

`create_server_link`, the other caller of `.channel(`, wasn't actually crashing (it has a blanket `rescue => e` that happens to catch `NoPermission` since it's a `RuntimeError` subclass), but it mislabeled this expected condition as an "unexpected exception" in error reporting.

## Fix

Added a `resolve_discord_channel` private helper that mirrors discordrb's own `server()` behavior — treats `NoPermission` as "not found" and returns `nil` — and used it in both `#setup` and `#create_server_link`. This routes the failure into the existing `redirect_to_discord_bot_install_link if @guild.nil? || @channel.nil?` path (prompting the user to reinstall/reauthorize the bot) instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)