### PR TITLE
docs: fix typo enviroment -> environment

### DIFF
--- a/dev-docs/development.md
+++ b/dev-docs/development.md
@@ -184,7 +184,7 @@ We've transitioned to using development keys and seed data in development, but h
 
 - Use a `DOPPLER_TOKEN` with development access, this can be generated [here](https://dashboard.doppler.com/workplace/2818669764d639172564/projects/hcb/configs/development/access).
 
-- Override the `LOCKBOX`, `ACTIVE_RECORD__ENCRYPTION__DETERMINISTIC_KEY`, `ACTIVE_RECORD__ENCRYPTION__KEY_DERIVATION_SALT`, and `ACTIVE_RECORD__ENCRYPTION__PRIMARY_KEY` secrets by defining them in `.env.development`. Use the values from the [`production` enviroment in Doppler](https://dashboard.doppler.com/workplace/2818669764d639172564/projects/hcb/configs/production).
+- Override the `LOCKBOX`, `ACTIVE_RECORD__ENCRYPTION__DETERMINISTIC_KEY`, `ACTIVE_RECORD__ENCRYPTION__KEY_DERIVATION_SALT`, and `ACTIVE_RECORD__ENCRYPTION__PRIMARY_KEY` secrets by defining them in `.env.development`. Use the values from the [`production` environment in Doppler](https://dashboard.doppler.com/workplace/2818669764d639172564/projects/hcb/configs/production).
 
 - Run the [docker_setup.sh](https://github.com/hackclub/hcb/docker_setup.sh) script to set up a local environment with Docker. The script will use a dump of our production database from Heroku.
 

--- a/dev-docs/production/migrations/sidekiq-redis.md
+++ b/dev-docs/production/migrations/sidekiq-redis.md
@@ -14,5 +14,5 @@ Here are the steps to do the migration:
     ```
     
     If migrating from Heroku, you'll need to add `--source-insecure --no-ttl` [(context)](https://stackoverflow.com/questions/65042551/ssl-certification-verify-failed-on-heroku-redis/). Read more on [redis.github.io](https://redis.github.io/riot/#_replication).
-5) Change `REDIS_URL` in your enviroment variables.
+5) Change `REDIS_URL` in your environment variables.
 6) Turn off maintenance mode, enable Sidekiq and verify the queue has migrated!


### PR DESCRIPTION
Typo fix in two dev docs:

- `dev-docs/development.md:187` — `enviroment` → `environment`
- `dev-docs/production/migrations/sidekiq-redis.md:17` — `enviroment` → `environment`

Docs only.
