### PR TITLE
Fix Pundit crash on invalid hashid in invite links/requests and tax forms

### DIFF
--- a/app/controllers/organizer_position_invite/links_controller.rb
+++ b/app/controllers/organizer_position_invite/links_controller.rb
@@ -91,7 +91,7 @@ class OrganizerPositionInvite
     private
 
     def set_link
-      @link = OrganizerPositionInvite::Link.find_by_hashid(params[:id])
+      @link = OrganizerPositionInvite::Link.find_by_hashid!(params[:id])
     end
 
   end

--- a/app/controllers/organizer_position_invite/requests_controller.rb
+++ b/app/controllers/organizer_position_invite/requests_controller.rb
@@ -51,7 +51,7 @@ class OrganizerPositionInvite
     private
 
     def set_request
-      @request = OrganizerPositionInvite::Request.find_by_hashid(params[:id])
+      @request = OrganizerPositionInvite::Request.find_by_hashid!(params[:id])
     end
 
   end

--- a/app/controllers/tax/forms_controller.rb
+++ b/app/controllers/tax/forms_controller.rb
@@ -21,7 +21,7 @@ module Tax
     end
 
     def create
-      @legal_entity = LegalEntity.find_by_hashid(params[:legal_entity_id])
+      @legal_entity = LegalEntity.find_by_hashid!(params[:legal_entity_id])
       authorize @legal_entity, policy_class: Tax::FormPolicy
 
       if @legal_entity.mismatched_tax_form.present? || @legal_entity.entity_type_mismatched_tax_form.present?


### PR DESCRIPTION
## Problem

`find_by_hashid` returns `nil` instead of raising when a hashid doesn't resolve to a record. In three places that `nil` flowed straight into `authorize` with no guard:

- `OrganizerPositionInvite::LinksController#show` — an invalid/expired invite link ID raised `Pundit::NotDefinedError: unable to find policy NilClassPolicy for nil`, instead of a normal 404.
- `OrganizerPositionInvite::RequestsController#approve` / `#deny` — same bug, same crash, via `set_request`.
- `Tax::FormsController#create` — passes `policy_class:` explicitly, so it doesn't hit the `NilClassPolicy` error, but instead crashes inside `Tax::FormPolicy#create?` with `NoMethodError: undefined method 'users' for nil` when `record` (the legal entity) is nil.

## Fix

Switch all three lookups to `find_by_hashid!`, which raises `ActiveRecord::RecordNotFound` when the ID doesn't resolve. That's handled by Rails' default exception handling into a normal 404, before `authorize` ever runs — matching the dominant convention already used elsewhere in the codebase (`legal_entities_controller.rb`, `card_grants_controller.rb`, `donation/tiers_controller.rb`, etc.).

## Testing

Small, mechanical, low-risk change (non-bang → bang finder) with no behavior change for valid IDs. Recommend manually exercising each affected action with a bogus ID to confirm a 404 instead of a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)