### PR TITLE
[Admin] Add locked filter to users list

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -196,7 +196,8 @@ class AdminController < Admin::BaseController
     @access_level = params[:access_level]
     @event_id = params[:event_id].presence
     @referral_program_id = params[:referral_program_id].presence
-    @params = params.permit(:page, :per, :q, :access_level, :event_id, :referral_program_id)
+    @locked = ActiveModel::Type::Boolean.new.cast(params[:locked])
+    @params = params.permit(:page, :per, :q, :access_level, :event_id, :referral_program_id, :locked)
 
     if @event_id
       @event = Event.find(@event_id)
@@ -214,6 +215,7 @@ class AdminController < Admin::BaseController
 
     relation = relation.search_name(@q) if @q
     relation = relation.where(access_level: @access_level) if @access_level.present?
+    relation = relation.where.not(locked_at: nil) if @locked
 
     @count = relation.count
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -196,7 +196,7 @@ class AdminController < Admin::BaseController
     @access_level = params[:access_level]
     @event_id = params[:event_id].presence
     @referral_program_id = params[:referral_program_id].presence
-    @locked = ActiveModel::Type::Boolean.new.cast(params[:locked])
+    @locked = params[:locked] == "1"
     @params = params.permit(:page, :per, :q, :access_level, :event_id, :referral_program_id, :locked)
 
     if @event_id

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -9,6 +9,9 @@
   <div class="flex gap-2 items-center mt-2">
     <%= form.select :access_level, User.access_levels.keys.map { |level| [level.humanize, level] }, { include_blank: "All user types", selected: @access_level } %>
     <%= form.select :referral_program_id, @referral_programs.map { |program| [program.name, program.id] }, { include_blank: "No referral filter", selected: @referral_program_id } %>
+    <label class="flex items-center gap-1">
+      <%= form.check_box :locked, checked: @locked %> Locked
+    </label>
   </div>
 
   <div class="flex items-center mt-2 gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
Adds a checkbox to the admin users page to filter for users that are locked (`locked_at` present).

## Test plan
- Visit `/admin/users`, check the "Locked" checkbox, submit, and confirm only locked users are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)