### PR TITLE
[v4][Organization] Expose Plan information

### DIFF
--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -15,6 +15,7 @@ object_shape(json, event, object_name: "organization") do
   json.transparent event.is_public?
   json.fee_percentage event.revenue_fee.to_f
   json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
+  json.card_grants_enabled event.plan.card_grants_enabled?
 
   if expand?(:balance_cents)
     json.balance_cents event.balance_available
@@ -32,7 +33,6 @@ object_shape(json, event, object_name: "organization") do
     json.swift_bic_code event.bic_code
   end
 
-  # TODO: Remove users field once migration to /api/v4/organizer_positions is done
   if expand?(:users)
     json.users event.organizer_positions.includes(:user).order(created_at: :desc) do |op|
       json.partial! "api/v4/users/user", user: op.user, show_email: shares_org_with?(op.user)

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -15,7 +15,14 @@ object_shape(json, event, object_name: "organization") do
   json.transparent event.is_public?
   json.fee_percentage event.revenue_fee.to_f
   json.background_image event.background_image.attached? ? Rails.application.routes.url_helpers.url_for(event.background_image) : nil
-  json.card_grants_enabled event.plan.card_grants_enabled?
+
+  if expand?(:plan)
+    json.plan do
+      json.name event.plan.label
+      json.fee_percentage event.revenue_fee.to_f
+      json.features event.plan.features
+    end
+  end
 
   if expand?(:balance_cents)
     json.balance_cents event.balance_available

--- a/app/views/api/v4/events/_event.json.jbuilder
+++ b/app/views/api/v4/events/_event.json.jbuilder
@@ -33,6 +33,7 @@ object_shape(json, event, object_name: "organization") do
     json.swift_bic_code event.bic_code
   end
 
+  # TODO: Remove users field once migration to /api/v4/organizer_positions is done
   if expand?(:users)
     json.users event.organizer_positions.includes(:user).order(created_at: :desc) do |op|
       json.partial! "api/v4/users/user", user: op.user, show_email: shares_org_with?(op.user)

--- a/dev-docs/v4-api/standards.md
+++ b/dev-docs/v4-api/standards.md
@@ -356,6 +356,7 @@ Check each endpoint's documentation for its supported expansions. Common ones in
 | `organization`      | transactions, cards, card grants         |
 | `user`              | cards, card grants                       |
 | `balance_cents`     | organizations                            |
+| `plan`              | organizations                            |
 | `account_number`    | organizations (requires permission)      |
 | `users`             | organizations                            |
 | `total_spent_cents` | cards                                    |

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Api::V4::CardGrantsController do
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => nil,
         "transparent"                       => true,
-        "created_at"                        => event.created_at.iso8601(3),
-        "card_grants_enabled"               => true
+        "card_grants_enabled"               => true,
+        "created_at"                        => event.created_at.iso8601(3)
       }
 
       expect(response.parsed_body).to eq(

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Api::V4::CardGrantsController do
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => nil,
         "transparent"                       => true,
-        "card_grants_enabled"               => true,
         "created_at"                        => event.created_at.iso8601(3)
       }
 

--- a/spec/controllers/api/v4/card_grants_controller_spec.rb
+++ b/spec/controllers/api/v4/card_grants_controller_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Api::V4::CardGrantsController do
         "playground_mode"                   => false,
         "playground_mode_meeting_requested" => nil,
         "transparent"                       => true,
-        "created_at"                        => event.created_at.iso8601(3)
+        "created_at"                        => event.created_at.iso8601(3),
+        "card_grants_enabled"               => true
       }
 
       expect(response.parsed_body).to eq(


### PR DESCRIPTION
## Summary of the problem
For mobile, we don't know if card grants are enabled on an org so we can't conditionally show the card grant transfer view


## Describe your changes
Add field


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

