### PR TITLE
[Receipts] Give pending charges their own group in the receipt inbox

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -122,9 +122,14 @@ class MyController < ApplicationController
 
     hcb_codes_missing_receipt =
       if @grouping == "due_date"
-        # Soonest deadline first; charges with no deadline sort last, newest first.
+        # Soonest deadline first, then charges still pending, then charges that
+        # never had a deadline; both undated groups newest first.
         hcb_codes_missing_receipt.sort_by do |hcb_code|
-          hcb_code.receipt_due_at ? [0, hcb_code.receipt_due_at.to_i] : [1, -hcb_code.created_at.to_i]
+          if hcb_code.receipt_due_at
+            [0, hcb_code.receipt_due_at.to_i]
+          else
+            [hcb_code.canonical_transactions.empty? ? 1 : 2, -hcb_code.created_at.to_i]
+          end
         end
       else
         hcb_codes_missing_receipt.sort_by(&:created_at).reverse

--- a/app/helpers/receipts_helper.rb
+++ b/app/helpers/receipts_helper.rb
@@ -2,12 +2,16 @@
 
 module ReceiptsHelper
   # Buckets a charge that is missing a receipt by when its receipt is due:
-  # a single :overdue bucket, then one bucket per calendar day, then :none for
-  # charges that never had a deadline (cardholders outside enforcement).
+  # a single :overdue bucket, then one bucket per calendar day, then :pending
+  # for charges that haven't settled yet, then :none for charges that never had
+  # a deadline (cardholders outside enforcement).
   def receipt_due_group(hcb_code, now: Time.current)
     due_at = hcb_code.receipt_due_at
 
-    return :none if due_at.nil?
+    # A pending charge has no deadline because its clock only starts once it
+    # settles. That makes it the newest thing on the page, not the oldest, so it
+    # gets its own bucket rather than sitting with the undated long tail.
+    return hcb_code.canonical_transactions.empty? ? :pending : :none if due_at.nil?
     return :overdue if due_at <= now
 
     due_at.to_date
@@ -16,6 +20,7 @@ module ReceiptsHelper
   def receipt_due_group_label(group, now: Time.current)
     case group
     when :overdue then "Overdue"
+    when :pending then "Pending transactions"
     when :none then "Older receipts"
     else
       case (group - now.to_date).to_i
@@ -30,6 +35,7 @@ module ReceiptsHelper
   def receipt_due_group_urgency(group, now: Time.current)
     case group
     when :overdue then :overdue
+    when :pending then :pending
     when :none then :none
     else (group - now.to_date).to_i <= 1 ? :soon : :later
     end

--- a/spec/helpers/receipts_helper_spec.rb
+++ b/spec/helpers/receipts_helper_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe ReceiptsHelper, type: :helper do
   let(:now) { Time.zone.parse("2026-08-06 14:00:00") }
 
-  def charge(due_at)
-    instance_double(HcbCode, receipt_due_at: due_at)
+  def charge(due_at, settled: true)
+    instance_double(HcbCode, receipt_due_at: due_at, canonical_transactions: settled ? [instance_double(CanonicalTransaction)] : [])
   end
 
   describe "#receipt_due_group" do
@@ -24,8 +24,12 @@ RSpec.describe ReceiptsHelper, type: :helper do
       expect(helper.receipt_due_group(charge(now + 3.days), now:)).to eq((now + 3.days).to_date)
     end
 
-    it "gives charges with no deadline their own bucket rather than inventing a date" do
+    it "gives settled charges with no deadline their own bucket rather than inventing a date" do
       expect(helper.receipt_due_group(charge(nil), now:)).to eq(:none)
+    end
+
+    it "separates charges that haven't settled yet from the undated long tail" do
+      expect(helper.receipt_due_group(charge(nil, settled: false), now:)).to eq(:pending)
     end
 
     it "buckets two charges due the same day together even at different times" do
@@ -37,8 +41,9 @@ RSpec.describe ReceiptsHelper, type: :helper do
   end
 
   describe "#receipt_due_group_label" do
-    it "names the two buckets that aren't dates" do
+    it "names the buckets that aren't dates" do
       expect(helper.receipt_due_group_label(:overdue, now:)).to eq("Overdue")
+      expect(helper.receipt_due_group_label(:pending, now:)).to eq("Pending transactions")
       expect(helper.receipt_due_group_label(:none, now:)).to eq("Older receipts")
     end
 
@@ -61,6 +66,7 @@ RSpec.describe ReceiptsHelper, type: :helper do
       expect(helper.receipt_due_group_urgency(now.to_date, now:)).to eq(:soon)
       expect(helper.receipt_due_group_urgency(now.to_date + 1, now:)).to eq(:soon)
       expect(helper.receipt_due_group_urgency(now.to_date + 2, now:)).to eq(:later)
+      expect(helper.receipt_due_group_urgency(:pending, now:)).to eq(:pending)
       expect(helper.receipt_due_group_urgency(:none, now:)).to eq(:none)
     end
   end
@@ -70,11 +76,12 @@ RSpec.describe ReceiptsHelper, type: :helper do
       expect(helper.receipt_due_group_style(:overdue, now:)).to include(icon_class: "error", badge_class: "bg-error")
       expect(helper.receipt_due_group_style(now.to_date, now:)).to include(icon_class: "muted", badge_class: "bg-warning")
       expect(helper.receipt_due_group_style(now.to_date + 5, now:)).to include(icon_class: "muted", badge_class: "bg-muted")
+      expect(helper.receipt_due_group_style(:pending, now:)).to include(icon_class: "muted", badge_class: "bg-muted")
       expect(helper.receipt_due_group_style(:none, now:)).to include(icon_class: "muted", badge_class: "bg-muted")
     end
 
     it "names icons that actually exist" do
-      groups = [:overdue, :none, now.to_date, now.to_date + 5]
+      groups = [:overdue, :pending, :none, now.to_date, now.to_date + 5]
 
       groups.each do |group|
         icon = helper.receipt_due_group_style(group, now:)[:icon]


### PR DESCRIPTION
## Summary of the problem

A pending card charge has no `receipt_due_at`, so `materialize_card_locking!` leaves the column nil. `receipt_due_group` mapped every nil deadline to `:none`, and `:none` renders as **"Older receipts"** behind a collapsed disclosure. Thus, pending transactions on the page were filed under "Older Transactions".
<img width="2036" height="972" alt="image" src="https://github.com/user-attachments/assets/96830d9d-ba1e-4f82-a49b-1d689b2090b4" />


## Describe your changes

Unsettled charges now get their own bucket instead of falling into the undated long tail:

- `receipt_due_group` returns `:pending` when there's no deadline and the charge hasn't settled. (Settled-but-undated charges, i.e. cardholders outside the rollout, still return `:none`.)
- The new group is labelled **"Pending transactions"** and gets its own `:pending` urgency, which falls through to the existing neutral clock/muted style.
- The inbox sorts so sections come out dated → pending → older receipts, with both undated groups newest first.
