### PR TITLE
[Turbo] Replace UJS method: links with turbo_method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ plugins:
   - rubocop-rails
 require:
   - ./lib/rubocop/cop/hcb/turbo_confirm
+  - ./lib/rubocop/cop/hcb/turbo_method
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/app/views/admin/contracts.html.erb
+++ b/app/views/admin/contracts.html.erb
@@ -72,9 +72,9 @@
         </td>
         <td class="text-nowrap">
           <% contract.parties.not_hcb.pending.order(role: :desc).each do |party| %>
-            <%= link_to "Resend to #{party.role}", resend_contract_party_path(party), method: :post %><br>
+            <%= link_to "Resend to #{party.role}", resend_contract_party_path(party), data: { turbo_method: :post } %><br>
           <% end %>
-          <%= link_to "Void", void_contract_path(contract), method: :post if contract.pending? || contract.sent? %>
+          <%= link_to "Void", void_contract_path(contract), data: { turbo_method: :post } if contract.pending? || contract.sent? %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/employees.html.erb
+++ b/app/views/admin/employees.html.erb
@@ -35,7 +35,7 @@
               <%= form.submit "Onboard" %>
             <% end %>
           <% end %>
-          <%= link_to "Mark terminated", employee_terminate_path(employee), method: :post if employee.onboarded? %>
+          <%= link_to "Mark terminated", employee_terminate_path(employee), data: { turbo_method: :post } if employee.onboarded? %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/ledger_audits/tasks/show.html.erb
+++ b/app/views/admin/ledger_audits/tasks/show.html.erb
@@ -118,8 +118,8 @@
 </div>
 
 <div class="action_row">
-  <%= link_to "Looks good! 🌈 ✨", admin_ledger_audits_task_reviewed_path(@task), class: "btn", method: :post %>
-  <%= link_to "Looks fishy... 🐡", admin_ledger_audits_task_flagged_path(@task), class: "btn bg-error", method: :post %>
+  <%= link_to "Looks good! 🌈 ✨", admin_ledger_audits_task_reviewed_path(@task), class: "btn", data: { turbo_method: :post } %>
+  <%= link_to "Looks fishy... 🐡", admin_ledger_audits_task_flagged_path(@task), class: "btn bg-error", data: { turbo_method: :post } %>
 </div>
 
 <div style="max-width: 600px; margin-left: auto; margin-right: auto;" class="mt4">

--- a/app/views/admin/wise_transfer_process.html.erb
+++ b/app/views/admin/wise_transfer_process.html.erb
@@ -281,7 +281,7 @@
   <div class="flex flex-row items-start justify-start gap-4">
     <span class="-m-[2px] w-7 h-7 flex-shrink-0 rounded-full flex items-center justify-center text-xs font-bold border-2 border-solid border-smoke">1</span>
     <p class="m-0">
-      <%= link_to "Approve & assign yourself", approve_wise_transfer_path(@wise_transfer), method: :post %> to this Wise transfer to prevent double-processing.
+      <%= link_to "Approve & assign yourself", approve_wise_transfer_path(@wise_transfer), data: { turbo_method: :post } %> to this Wise transfer to prevent double-processing.
     </p>
   </div>
   <div class="flex flex-row items-start justify-start gap-4">

--- a/app/views/application/_user_menu.html.erb
+++ b/app/views/application/_user_menu.html.erb
@@ -20,7 +20,7 @@
             <%= inline_icon "settings", style: "width:30px;height:30px;margin-left:-5px;margin-right:-2px" %>
             Settings
           <% end %>
-          <%= link_to logout_users_path, method: :delete do %>
+          <%= link_to logout_users_path, data: { turbo_method: :delete } do %>
             <%= inline_icon "door-leave", size: 23 %>
             Sign out
           <% end %>
@@ -39,11 +39,11 @@
         <div data-controller="dark-mode-toggle" class="menu__content menu__content--compact menu__content--2 p-2 mt-2 h5" data-menu-target="content" style="z-index: 999;">
           <%= render partial: "application/theme_toggle" %>
           <p class="muted font-medium h5 pl-2 p-1 m0">Account</p>
-          <%= link_to verify_email_first_index_path, method: :post do %>
+          <%= link_to verify_email_first_index_path, data: { turbo_method: :post } do %>
             <%= inline_icon "email-exclamation", style: "width:30px;height:30px;margin-left:-5px;margin-right:-2px" %>
             Verify your email
           <% end %>
-          <%= link_to sign_out_first_index_path, method: :delete do %>
+          <%= link_to sign_out_first_index_path, data: { turbo_method: :delete } do %>
             <%= inline_icon "door-leave", size: 23 %>
             Sign out
           <% end %>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -2,10 +2,10 @@
 <p>
 <% if @account.should_sync? %>
   <%= status_badge "success" %>Enabled.
-  <%= link_to "Pause syncing.", bank_account_path(@account, bank_account: { should_sync: false }), remote: true, method: :patch %>
+  <%= link_to "Pause syncing.", bank_account_path(@account, bank_account: { should_sync: false }), data: { turbo_method: :patch } %>
 <% else %>
   <%= status_badge "muted" %>Paused.
-  <%= link_to "Enable syncing.", bank_account_path(@account, bank_account: { should_sync: true }), remote: true, method: :patch %>
+  <%= link_to "Enable syncing.", bank_account_path(@account, bank_account: { should_sync: true }), data: { turbo_method: :patch } %>
 <% end %>
 </p>
 <div class="statset mt2 mb2">

--- a/app/views/card_grants/actions/_disable_pre_authorization.html.erb
+++ b/app/views/card_grants/actions/_disable_pre_authorization.html.erb
@@ -8,7 +8,8 @@
                                  "You don't have permission to perform this action"
                                end %>
 <%= link_to disable_pre_authorization_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
-            method: :post,
+            data: { turbo_method: :post },
+
             class: "btn btn--list-item",
             disabled: !policy(card_grant).disable_pre_authorization? do %>
   <%= inline_icon "pre-authorization", size: 20 %>

--- a/app/views/card_grants/actions/_toggle_one_time_use.html.erb
+++ b/app/views/card_grants/actions/_toggle_one_time_use.html.erb
@@ -12,7 +12,8 @@
                     "You don't have permission to perform this action"
                   end %>
 <%= link_to toggle_one_time_use_event_card_grant_path(id: card_grant.hashid, event_id: @event.slug),
-            method: :post,
+            data: { turbo_method: :post },
+
             class: "btn btn--list-item",
             disabled: !policy(card_grant).toggle_one_time_use? do %>
   <%= inline_icon "private", size: 20 %>

--- a/app/views/disbursements/show.html.erb
+++ b/app/views/disbursements/show.html.erb
@@ -118,7 +118,7 @@
     <% if @disbursement.pending? %>
       <% admin_tool("mt2") do %>
         <%= link_to "Mark fulfilled", disbursement_mark_fulfilled_path(@disbursement), data: { turbo_method: :post, turbo_confirm: "WOAH THERE! This will prevent HCB from auto-fulfilling this disbursement. I hope you know what you're doing!" }, class: "btn bg-success" %>
-        <%= link_to "Reject", disbursement_reject_path(@disbursement), method: :post, class: "btn bg-error" %>
+        <%= link_to "Reject", disbursement_reject_path(@disbursement), data: { turbo_method: :post }, class: "btn bg-error" %>
       <% end %>
     <% end %>
   </section>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -7,7 +7,7 @@
   <div class="banner banner--archived mt3">
     <span class="bold block mb1">This document was archived by <%= user_mention @document.archived_by %> on <%= format_date @document.archived_at %>.</span>
     <span class="block">It will display under the Archived section<span class="xs-hide"> on the Documents page</span>.</span>
-    <span>You can <%= link_to "unarchive it", document_toggle_path(@document), method: :post %>.</span>
+    <span>You can <%= link_to "unarchive it", document_toggle_path(@document), data: { turbo_method: :post } %>.</span>
   </div>
 <% end %>
 

--- a/app/views/donations/_logo.html.erb
+++ b/app/views/donations/_logo.html.erb
@@ -13,7 +13,7 @@
                 <% end %>
             <% end %>
 
-            <%= link_to event_remove_logo_path(@event), method: :post do %>
+            <%= link_to event_remove_logo_path(@event), data: { turbo_method: :post } do %>
                 <div
                     role="button"
                     class="donations-logo-edit-btn donations-logo-edit-btn--left pointer select-none tooltipped tooltipped--e line-height-0 absolute rounded-full flex items-center justify-center embedded-display-none"

--- a/app/views/emburse_card_requests/index.html.erb
+++ b/app/views/emburse_card_requests/index.html.erb
@@ -26,7 +26,7 @@
         <% if emburse_card_request.under_review? %>
           <td><%= link_to "Show", emburse_card_request %></td>
           <td><%= link_to "Edit", edit_emburse_card_request_path(emburse_card_request) %></td>
-          <td><%= link_to "Reject", emburse_card_request_reject_path(emburse_card_request), method: :post %></td>
+          <td><%= link_to "Reject", emburse_card_request_reject_path(emburse_card_request), data: { turbo_method: :post } %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/employees/show.html.erb
+++ b/app/views/employees/show.html.erb
@@ -12,12 +12,12 @@
       <% end %>
     <% end %>
     <% if policy(@employee).destroy? %>
-      <%= link_to @employee, class: "btn bg-error", method: :delete do %>
+      <%= link_to @employee, class: "btn bg-error", data: { turbo_method: :delete } do %>
         <%= inline_icon "delete" %>
         Delete
       <% end %>
     <% elsif policy(@employee).terminate? && @employee.may_mark_terminated? %>
-      <%= link_to employee_terminate_path(@employee), class: "btn bg-error", method: :post do %>
+      <%= link_to employee_terminate_path(@employee), class: "btn bg-error", data: { turbo_method: :post } do %>
         <%= inline_icon "member-remove" %>
         Terminate
       <% end %>

--- a/app/views/event/applications/submission.html.erb
+++ b/app/views/event/applications/submission.html.erb
@@ -106,7 +106,7 @@
       <% admin_tool do %>
         <% disabled = @application.teen_led? && pending_parties.any? %>
         <p class="<%= "tooltipped" if disabled %> my-0" aria-label="<%= "The contract is still pending on the #{pending_parties.to_sentence}" if disabled %>">
-          <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", method: :post, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: %>
+          <%= link_to "Approve", admin_approve_application_path(@application), class: "btn bg-success tooltipped tooltipped--w", data: { turbo_method: :post }, "aria-label": "Approve this application#{" and continue to the contract" if @application.teen_led?}", disabled: %>
         </p>
       <% end %>
     <% elsif @application.approved? && @application.event.nil? && @application.contract.present? %>

--- a/app/views/events/_card_grant_actions.html.erb
+++ b/app/views/events/_card_grant_actions.html.erb
@@ -9,11 +9,11 @@
       <%= inline_icon "card", size: 20 %> View transactions
     <% end if card_grant.stripe_card.present? %>
     <% if card_grant.active? && card_grant.stripe_card&.active? && policy(card_grant.stripe_card).freeze? %>
-      <%= link_to freeze_stripe_card_path(card_grant.stripe_card), method: :post do %>
+      <%= link_to freeze_stripe_card_path(card_grant.stripe_card), data: { turbo_method: :post } do %>
       <%= inline_icon "freeze", size: 20 %> Freeze card
       <% end %>
     <% elsif card_grant.active? && card_grant.stripe_card&.frozen? && policy(card_grant.stripe_card).defrost? %>
-      <%= link_to defrost_stripe_card_path(card_grant.stripe_card), method: :post do %>
+      <%= link_to defrost_stripe_card_path(card_grant.stripe_card), data: { turbo_method: :post } do %>
         <%= inline_icon "freeze", size: 20 %> Defrost
       <% end %>
     <% end %>

--- a/app/views/events/_heading.html.erb
+++ b/app/views/events/_heading.html.erb
@@ -14,12 +14,12 @@
   <div class="flex items-center gap-2">
     <% if show_ledger_toggle && signed_in? %>
       <% if new_ledger_active %>
-        <%= link_to event_toggle_new_ledger_path(event, enabled: false), method: :post, class: "btn flex items-center" do %>
+        <%= link_to event_toggle_new_ledger_path(event, enabled: false), data: { turbo_method: :post }, class: "btn flex items-center" do %>
           <%= inline_icon "back" %>
           Go back to the classic ledger
         <% end %>
       <% else %>
-        <%= link_to event_toggle_new_ledger_path(event, enabled: true), method: :post, class: "btn flex items-center" do %>
+        <%= link_to event_toggle_new_ledger_path(event, enabled: true), data: { turbo_method: :post }, class: "btn flex items-center" do %>
           <%= inline_icon "wand-stars" %>
           Try the new ledger
         <% end %>

--- a/app/views/events/landing/_header.html.erb
+++ b/app/views/events/landing/_header.html.erb
@@ -16,7 +16,7 @@
         <% end %>
       <% end %>
       <% if @has_header_image %>
-        <%= link_to event_remove_header_image_path(@event), method: :post, data: { turbo_confirm: "Are you sure you want to remove this image?", turbo_confirm_danger: true } do %>
+        <%= link_to event_remove_header_image_path(@event), data: { turbo_method: :post, turbo_confirm: "Are you sure you want to remove this image?", turbo_confirm_danger: true } do %>
           <div
             role="button"
             class="muted pointer ml1 select-none tooltipped tooltipped--e line-height-0"

--- a/app/views/events/settings/_admin.html.erb
+++ b/app/views/events/settings/_admin.html.erb
@@ -40,8 +40,7 @@
     <% admin_tool "p-3" do %>
       <%= link_to (event.hidden? ? "Un-hide project" : "Hide project"),
                   event_toggle_hidden_path(event),
-                  method: :put,
-                  "data-confirm": "Do you really want to #{event.hidden? ? "un-hide" : "hide"} #{event.name}?",
+                  data: { turbo_method: :put, turbo_confirm: "Do you really want to #{event.hidden? ? "un-hide" : "hide"} #{event.name}?" },
                   class: "btn bg-success mb2",
                   disabled: disabled if event.persisted? %>
 
@@ -95,7 +94,7 @@
 
       <div class="field">
         <%= form.label :point_of_contact_id, capture { %>
-          Point of Contact <%= link_to "(Me!)", event_claim_point_of_contact_path(event), method: :post %>
+          Point of Contact <%= link_to "(Me!)", event_claim_point_of_contact_path(event), data: { turbo_method: :post } %>
         <% } %>
         <%= form.collection_select :point_of_contact_id, User.admin.or(User.where(id: event.point_of_contact_id)).order(:email), :id, :email, {}, { disabled: } %>
         <% if event.point_of_contact_history.any? %>
@@ -207,9 +206,9 @@
     <% admin_tool "p-3" do %>
       <h3 id="admin_fees" class="mb2 mt1">Wire minimum exemption</h3>
       <% if Flipper.enabled?(:exempt_from_wire_minimum, event) %>
-        <%= link_to "Disable", disable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-accent", data: { turbo_method: :post }, disabled: %>
+        <%= link_to "Disable", disable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), class: "btn bg-accent", data: { turbo_method: :post }, disabled: %>
       <% else %>
-        <%= link_to "Enable", enable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), method: :post, class: "btn bg-info", disabled: %>
+        <%= link_to "Enable", enable_feature_path(feature: :exempt_from_wire_minimum, event_id: event.id), data: { turbo_method: :post }, class: "btn bg-info", disabled: %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/events/settings/_details.html.erb
+++ b/app/views/events/settings/_details.html.erb
@@ -31,7 +31,7 @@
             </div>
             <% if event.background_image.attached? %>
               <div class="menu__divider"></div>
-              <%= link_to "Remove background image", event_remove_background_image_path(event), method: :post, style: "padding: 0.25rem 0.5rem" %>
+              <%= link_to "Remove background image", event_remove_background_image_path(event), data: { turbo_method: :post }, style: "padding: 0.25rem 0.5rem" %>
             <% end %>
           </div>
         </div>
@@ -63,7 +63,7 @@
               </div>
               <% if event.logo.attached? %>
                 <div class="menu__divider"></div>
-                <%= link_to "Remove logo", event_remove_logo_path(event), method: :post, style: "padding: 0.25rem 0.5rem", disabled: %>
+                <%= link_to "Remove logo", event_remove_logo_path(event), data: { turbo_method: :post }, style: "padding: 0.25rem 0.5rem", disabled: %>
               <% end %>
             </div>
           </div>

--- a/app/views/events/settings/_donation_tiers.html.erb
+++ b/app/views/events/settings/_donation_tiers.html.erb
@@ -62,7 +62,7 @@
 
                 <div class="flex flex-col gap-1">
                   <%= pop_icon_to "drag-indicator", "javascript:void(0)", class: "draggable-handle cursor-move" %>
-                  <%= pop_icon_to "delete", event_donation_tiers_path(event, tier), method: :delete, data: { turbo_confirm: "Are you sure?", turbo_confirm_danger: true } %>
+                  <%= pop_icon_to "delete", event_donation_tiers_path(event, tier), data: { turbo_method: :delete, turbo_confirm: "Are you sure?", turbo_confirm_danger: true } %>
                 </div>
               </div>
             <% end %>

--- a/app/views/events/settings/_tags.html.erb
+++ b/app/views/events/settings/_tags.html.erb
@@ -86,7 +86,8 @@
         </div>
         <%= pop_icon_to "delete",
           event_tag_path(event, tag.id),
-          method: :delete,
+          data: { turbo_method: :delete },
+
           icon_size: 26,
           class: "tooltipped tooltipped--w h-8 w-8",
           style: "background: #ec375020; color: #ec3750",

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -84,7 +84,7 @@
       <div class="relative card my-3 text-center sm:text-left flex items-center flex-col sm:flex-row gap-5">
         <div class="flex-1">
           <p class="my-0 text-lg font-[700]">Schedule an onboarding call</p>
-          <p class="my-0 text-md max-w-2xl">If you would like, you can schedule a call with a member of the HCB team to learn more about the platform, or <%= link_to "hide this message", hide_onboarding_message_event_path(@event), method: :post %>.</p>
+          <p class="my-0 text-md max-w-2xl">If you would like, you can schedule a call with a member of the HCB team to learn more about the platform, or <%= link_to "hide this message", hide_onboarding_message_event_path(@event), data: { turbo_method: :post } %>.</p>
         </div>
         <% if (scheduling_link = @event.onboarding_scheduling_link).present? %>
           <%= link_to scheduling_link, class: "btn" do %>

--- a/app/views/features/_preview.html.erb
+++ b/app/views/features/_preview.html.erb
@@ -42,7 +42,7 @@
     <% if local_assigns[:footer].present? %>
       <section class="card__banner card__darker secondary border-top mt-4">
         <p class="m-0">
-          <%= sanitize(local_assigns[:footer], attributes: %w(href data-turbo-action)) %>
+          <%= sanitize(local_assigns[:footer], attributes: %w(href data-turbo-action data-turbo-method)) %>
         </p>
       </section>
     <% end %>

--- a/app/views/g_suite_accounts/_panel.html.erb
+++ b/app/views/g_suite_accounts/_panel.html.erb
@@ -37,19 +37,16 @@
                 <% if account.accepted? && organizer_signed_in? %>
                   <%= link_to "Reset password",
                       g_suite_account_reset_password_path(account.id),
-                      method: :put,
-                      class: ("disabled" unless policy(account).reset_password?),
-                      'data-confirm': "Reset the account password for #{account.address}? We’ll email a new password to the backup email." %>
+                      data: { turbo_method: :put, turbo_confirm: "Reset the account password for #{account.address}? We’ll email a new password to the backup email." },
+                      class: ("disabled" unless policy(account).reset_password?) %>
                   <%= link_to (account.suspended? ? "Re-activate" : "Suspend"),
                       g_suite_account_toggle_suspension_path(account.id),
-                      method: :put,
-                      class: ("disabled" unless policy(account).toggle_suspension?),
-                      'data-confirm': "Do you really want to #{account.suspended? ? 're-activate' : 'suspend'} #{account.address}?" %>
+                      data: { turbo_method: :put, turbo_confirm: "Do you really want to #{account.suspended? ? 're-activate' : 'suspend'} #{account.address}?" },
+                      class: ("disabled" unless policy(account).toggle_suspension?) %>
                 <% end %>
                 <%= link_to "Delete",
                   account,
-                  method: :delete,
-                  'data-confirm': "Deleting #{account.address} is *permanent, irreversible, and does not back up any data*. Are you sure you want to continue?" if policy(account).destroy? %>
+                  data: { turbo_method: :delete, turbo_confirm: "Deleting #{account.address} is *permanent, irreversible, and does not back up any data*. Are you sure you want to continue?", turbo_confirm_danger: true } if policy(account).destroy? %>
               </div>
             </action>
           </div>

--- a/app/views/g_suites/_panel.html.erb
+++ b/app/views/g_suites/_panel.html.erb
@@ -210,7 +210,7 @@
             <% end %>
           <% end %>
           <% if @g_suite.configuring? || @g_suite.verification_error? %>
-            <%= link_to @g_suite.verification_error? ? "Retry Verification" : "Verify", event_g_suite_verify_path(event_id: @event.slug), method: :put, class: "btn" %>
+            <%= link_to @g_suite.verification_error? ? "Retry Verification" : "Verify", event_g_suite_verify_path(event_id: @event.slug), data: { turbo_method: :put }, class: "btn" %>
           <% end %>
           <% if @g_suite.verifying? %>
             <span class="h4 ml0 pending badge">Verifying…</span>

--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -152,7 +152,7 @@
 
       <br>
 
-      <span class="mt-2 block">If this transaction was intentional, double check the card details and try again. If you don't recognize this transaction, <%= link_to "freeze your card", stripe_card_url(hcb_code.stripe_card), method: :post %>.</span>
+      <span class="mt-2 block">If this transaction was intentional, double check the card details and try again. If you don't recognize this transaction, <%= link_to "freeze your card", stripe_card_url(hcb_code.stripe_card), data: { turbo_method: :post } %>.</span>
     <% elsif hcb_decline_reason != :inadequate_balance %>
       Try again, or contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
 

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -22,7 +22,7 @@
     <% if @hcb_code.stripe_card? || @hcb_code.stripe_force_capture? %>
       <% admin_tool("mt1 p-3") do %>
         ☎️ moshi moshi?
-        <%= link_to "Click to get an SMS (to #{current_user.phone_number}) of the notification", send_sms_receipt_hcb_code_path(@hcb_code), method: :post %>
+        <%= link_to "Click to get an SMS (to #{current_user.phone_number}) of the notification", send_sms_receipt_hcb_code_path(@hcb_code), data: { turbo_method: :post } %>
       <% end %>
     <% end %>
     <%= render "receipts/list_v2", hcb_code: @hcb_code, frame: @frame, transaction_show_receipt_button: @transaction_show_receipt_button, transaction_show_author_img: @transaction_show_author_img %>

--- a/app/views/hcb_codes/transaction_types/_invoice.html.erb
+++ b/app/views/hcb_codes/transaction_types/_invoice.html.erb
@@ -38,7 +38,7 @@
   <div class="banner banner--archived mt3">
     <span class="bold block mb1">This invoice was archived by <%= user_mention @invoice.archived_by %> on <%= format_date @invoice.archived_at %>.</span>
     <span class="block">It will only display in the Archived tab<span class="xs-hide"> on the Invoices page</span>.</span>
-    <span>You can <%= link_to "un-archive it", invoice_unarchive_path(@invoice), method: :post %>.</span>
+    <span>You can <%= link_to "un-archive it", invoice_unarchive_path(@invoice), data: { turbo_method: :post } %>.</span>
   </div>
 <% end %>
 
@@ -185,7 +185,7 @@
       <%= link_to (@invoice.archived? ? "Un-archive" : "Archive"),
         (@invoice.archived? ? invoice_unarchive_path(@invoice) : invoice_archive_path(@invoice)),
         disabled: !organizer_signed_in?,
-        method: :post,
+        data: { turbo_method: :post },
         class: "btn bg-muted" %>
     <% end %>
     <%= link_to organizer_signed_in? ? invoice_hosted_path(@invoice.hashid) : root_path,

--- a/app/views/hcb_codes/transaction_types/_stripe_card.html.erb
+++ b/app/views/hcb_codes/transaction_types/_stripe_card.html.erb
@@ -4,7 +4,7 @@
 
 <% admin_tool("mt1") do %>
   <%= link_to "View on Stripe", @hcb_code.stripe_card? ? @hcb_code.stripe_auth_dashboard_url : @hcb_code.stripe_txn_dashboard_url, class: "btn bg-accent" %>
-  <%= link_to "Flag transaction", admin_ledger_audits_tasks_path(hcb_code: @hcb_code.id), method: :post, class: "btn bg-error" %>
+  <%= link_to "Flag transaction", admin_ledger_audits_tasks_path(hcb_code: @hcb_code.id), data: { turbo_method: :post }, class: "btn bg-error" %>
 <% end %>
 
 <% @hcb_code.canonical_pending_transactions.each do |pt| %>

--- a/app/views/logins/_badge.html.erb
+++ b/app/views/logins/_badge.html.erb
@@ -4,7 +4,7 @@
     <%= user_mention user, class: "badge bg-muted pl-1 m-0 tooltipped tooltipped--e", aria_label: "Switch account" %>
   <% end %>
   <% if signed_in? %>
-    <%= link_to(logout_users_path, method: :delete, class: "mb-2") { mention } %>
+    <%= link_to(logout_users_path, data: { turbo_method: :delete }, class: "mb-2") { mention } %>
   <% else %>
     <%= link_to(auth_users_path, class: "mb-2") { mention } %>
   <% end %>

--- a/app/views/logins/choose_login_preference.html.erb
+++ b/app/views/logins/choose_login_preference.html.erb
@@ -57,7 +57,7 @@
     <%= form.hidden_field :email, value: @email, data: { "webauthn-auth-target" => "loginEmailInput" } %>
 
     <div class="flex flex-row justify-between items-center my-4">
-      <%= link_to "Cancel", logout_users_path, method: :delete, class: "no-underline block" %>
+      <%= link_to "Cancel", logout_users_path, data: { turbo_method: :delete }, class: "no-underline block" %>
       <%= form.submit "Continue", data: { "webauthn-auth-target" => "continueButton", "form-disable-target" => "submitButton" } %>
     </div>
 

--- a/app/views/organizer_position/spending/controls/index.html.erb
+++ b/app/views/organizer_position/spending/controls/index.html.erb
@@ -55,7 +55,7 @@
 <% if @organizer_position.member? %>
   <% spending_controls_callout_footer = capture do %>
     <% if @active_control %>
-      <% control_disable_button = link_to new_event_organizer_position_spending_control_path(@event, @organizer_position), class: "btn btn-small bg-error tooltipped tooltipped--e", disabled: !policy(@provisional_control).destroy?, method: :delete do %>
+      <% control_disable_button = link_to new_event_organizer_position_spending_control_path(@event, @organizer_position), class: "btn btn-small bg-error tooltipped tooltipped--e", disabled: !policy(@provisional_control).destroy?, data: { turbo_method: :delete } do %>
         Disable controls for <%= @organizer_position.user.first_name %>
       <% end %>
 
@@ -67,7 +67,7 @@
         </div>
       <% end %>
     <% else %>
-      <% control_enable_button = link_to event_organizer_position_spending_controls_path(@event, @organizer_position), class: "btn btn-small bg-info tooltipped tooltipped--e", disabled: !policy(@provisional_control).new?, method: :post do %>
+      <% control_enable_button = link_to event_organizer_position_spending_controls_path(@event, @organizer_position), class: "btn btn-small bg-info tooltipped tooltipped--e", disabled: !policy(@provisional_control).new?, data: { turbo_method: :post } do %>
         Enable controls for <%= @organizer_position.user.first_name %>
       <% end %>
 

--- a/app/views/organizer_position_deletion_requests/show.html.erb
+++ b/app/views/organizer_position_deletion_requests/show.html.erb
@@ -113,8 +113,8 @@
       <% if @opdr.organizer_position.deleted_at.nil? && (@opdr.under_review? || @opdr.assigned?) %>
         <%= link_to "Delete organizer ⚠️☣☠",
                     organizer_path(@opdr.organizer_position.id),
-                    method: :delete,
                     data: {
+                      turbo_method: :delete,
                       turbo_confirm: "You are about to remove " \
                               "#{@opdr.organizer_position.user.initial_name} " \
                               "from #{@opdr.event.name}. This has PERMANENT " \

--- a/app/views/organizer_position_invite/links/show.html.erb
+++ b/app/views/organizer_position_invite/links/show.html.erb
@@ -18,6 +18,6 @@
   <% end %>
 
   <div class="flex justify-center items-center flex-wrap mt3">
-    <%= link_to "Request to join", requests_path(link_id: @link.hashid), method: :post, class: "btn bg-success h2 m1" %>
+    <%= link_to "Request to join", requests_path(link_id: @link.hashid), data: { turbo_method: :post }, class: "btn bg-success h2 m1" %>
   </div>
 </main>

--- a/app/views/organizer_position_invites/_organizer_position_invite.html.erb
+++ b/app/views/organizer_position_invites/_organizer_position_invite.html.erb
@@ -66,14 +66,16 @@
         <%= pop_icon_to "email",
                         organizer_position_invite_resend_path(organizer_position_invite.id),
                         size: 24,
-                        method: :post,
+                        data: { turbo_method: :post },
+
                         class: "tooltipped tooltipped--w",
                         'aria-label': "Resend this invitation",
                         disabled: !policy(organizer_position_invite).resend? %>
         <%= pop_icon_to "view-close",
                         organizer_position_invite_cancel_path(organizer_position_invite.id),
                         size: 24,
-                        method: :post,
+                        data: { turbo_method: :post },
+
                         class: "error tooltipped tooltipped--w",
                         'aria-label': "Cancel this invitation",
                         disabled: !policy(organizer_position_invite).cancel? %>

--- a/app/views/organizer_position_invites/show.html.erb
+++ b/app/views/organizer_position_invites/show.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 
   <div class="flex justify-center items-center flex-wrap mt-3 gap-2">
-    <%= link_to "Reject", organizer_position_invite_reject_path(@invite), method: :post, class: "btn bg-error" %>
+    <%= link_to "Reject", organizer_position_invite_reject_path(@invite), data: { turbo_method: :post }, class: "btn bg-error" %>
     <% if @invite.contract && !@invite.contract.signed? && !@invite.contract.party(:signee)&.signed? %>
       <% if @invite.contract.party(:signee).present? %>
         <%= link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent" %>
@@ -37,7 +37,7 @@
       <% end %>
     <% else %>
       <% disabled = @invite.contract.present? && !@invite.contract.signed? %>
-      <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
+      <p class="tooltipped my-0" aria-label="<%= "The contract must be signed before you can accept this invite" if disabled %>"><%= link_to "Accept invitation", organizer_position_invite_accept_path(@invite), data: { turbo_method: :post }, class: "btn bg-success #{"pointer-events-none" if disabled}", disabled: %></p>
     <% end %>
   </div>
 </main>

--- a/app/views/receipts/_form_v3.html.erb
+++ b/app/views/receipts/_form_v3.html.erb
@@ -114,7 +114,7 @@
     <% if defined?(receiptable) && (receiptable&.missing_receipt? || (admin_signed_in? && !receiptable&.no_or_lost_receipt?)) %>
       <div class="flex muted justify-end items-center mt1">
         <%= inline_icon "forbidden", size: 20 %>
-        <%= link_to receiptable_mark_no_or_lost_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id, s: local_assigns[:secret]), method: :post do %>
+        <%= link_to receiptable_mark_no_or_lost_path(receiptable_type: receiptable.class, receiptable_id: receiptable.id, s: local_assigns[:secret]), data: { turbo_method: :post } do %>
           <small class="mt0 mb0">
             No/lost receipt?
           </small>

--- a/app/views/receipts/_receipt.html.erb
+++ b/app/views/receipts/_receipt.html.erb
@@ -66,8 +66,7 @@
     <% if defined?(delete_on_hover) && delete_on_hover && policy(receipt).destroy? %>
       <%= pop_icon_to "view-close",
               { controller: "/receipts", action: :destroy, id: receipt.id, popover: local_assigns[:popover] },
-              method: :delete,
-              data: { behavior: "modal_ignore" },
+              data: { turbo_method: :delete, behavior: "modal_ignore" },
               size: 12,
               class: "warning bg-black-important tooltipped tooltipped--w receipt__delete-button",
               style: "position: absolute; top: 4px; right: 4px; z-index: 1;",

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -48,7 +48,7 @@
       <% if report.locked? %>
         <div style="flex-grow: 1;" class="flex sm:justify-start sm:items-center">
           <% if report.reimbursement_requested? && !admin_signed_in? %>
-            <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted w-full sm:w-auto", method: :post do %>
+            <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted w-full sm:w-auto", data: { turbo_method: :post } do %>
               <%= inline_icon "reply" %>
               Mark as draft
               <% button_hint = capture do %>
@@ -56,7 +56,7 @@
               <% end %>
             <% end %>
           <% elsif current_user == report.user && report.submitted? %>
-            <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted w-full sm:w-auto", method: :post do %>
+            <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted w-full sm:w-auto", data: { turbo_method: :post } do %>
               <%= inline_icon "reply" %>
               Mark as draft
               <% button_hint = capture do %>
@@ -77,7 +77,7 @@
 
       <% if policy(report).update_currency? %>
         <div style="flex-grow: 1;" class="flex sm:justify-end">
-          <%= link_to reimbursement_report_update_currency_path(report), method: :post, class: "btn bg-secondary" do %>
+          <%= link_to reimbursement_report_update_currency_path(report), data: { turbo_method: :post }, class: "btn bg-secondary" do %>
             <%= inline_icon "transactions" %>
             Switch to <%= report.payout_method&.currency %>
           <% end %>
@@ -177,7 +177,7 @@
             <% end %>
           </div>
         <% elsif report.draft? && report.currency != "USD" && report.wise_transfer_may_exceed_balance? && !report.team_review_required? %>
-          <%= link_to reimbursement_report_submit_path(report_id: report.id), class: "btn bg-warning whitespace-nowrap", method: :post, data: { turbo_confirm: "Reports that exceed an organization's balance will be rejected. With current exchange rates, this report exceeds your balance." } do %>
+          <%= link_to reimbursement_report_submit_path(report_id: report.id), class: "btn bg-warning whitespace-nowrap", data: { turbo_method: :post, turbo_confirm: "Reports that exceed an organization's balance will be rejected. With current exchange rates, this report exceeds your balance." } do %>
             <%= inline_icon "send" %>
             Submit & request review
             <% button_hint = capture do %>
@@ -185,7 +185,7 @@
             <% end %>
           <% end %>
         <% elsif report.initial_draft? %>
-          <%= link_to reimbursement_report_submit_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", method: :post do %>
+          <%= link_to reimbursement_report_submit_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", data: { turbo_method: :post } do %>
             <%= inline_icon "send" %>
             Submit & request review
             <% button_hint = capture do %>
@@ -229,7 +229,7 @@
             </div>
           </div>
         <% elsif report.submitted? && policy(report).approve_all_expenses? && report.expenses.approved.none? %>
-          <%= link_to reimbursement_report_approve_all_expenses_path(report), class: "btn bg-success", method: :post do %>
+          <%= link_to reimbursement_report_approve_all_expenses_path(report), class: "btn bg-success", data: { turbo_method: :post } do %>
             <%= inline_icon "thumbsup" %>
             Approve all expenses
           <% end %>
@@ -276,7 +276,7 @@
                   <li>Close this reimbursement report without marking it as reimbursed</li>
                 </ul>
 
-                <%= link_to reimbursement_report_convert_to_wise_transfer_path(report), class: "btn btn-large bg-muted tooltipped tooltipped--n", method: :post, "aria-label": "Don't do this without checking with engineering first!" do %>
+                <%= link_to reimbursement_report_convert_to_wise_transfer_path(report), class: "btn btn-large bg-muted tooltipped tooltipped--n", data: { turbo_method: :post }, "aria-label": "Don't do this without checking with engineering first!" do %>
                   <%= inline_icon "important" %>
                   Alternative: Convert to Wise transfer
                 <% end %>
@@ -348,7 +348,7 @@
                 <% end %>
               </section>
             <% else %>
-              <%= link_to reimbursement_report_admin_approve_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", method: :post, data: { turbo_confirm: } do %>
+              <%= link_to reimbursement_report_admin_approve_path(report_id: report.id), class: "btn bg-info whitespace-nowrap", data: { turbo_method: :post, turbo_confirm: } do %>
                 <%= inline_icon "thumbsup" %>
                 Approve <%= "#{payout_method.human_kind} " if payout_method %>reimbursement
               <% end %>
@@ -359,7 +359,7 @@
     </div>
   <% end %>
   <% if report.rejected? && !member_viewing %>
-    <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted mt2", method: :post do %>
+    <%= link_to reimbursement_report_draft_path(report_id: report.id), class: "btn bg-muted mt2", data: { turbo_method: :post } do %>
       <%= inline_icon "view-reload" %>
       Re-open report for review
     <% end %>

--- a/app/views/static_pages/_suggested_pairings.html.erb
+++ b/app/views/static_pages/_suggested_pairings.html.erb
@@ -69,7 +69,7 @@
         <div class="lg-hide m2"></div>
 
         <div class="flex flex-row justify-end xs-hide sm-hide" style="margin-top: 16px;">
-          <%= link_to ignore_suggested_pairing_path(pairing), method: :post, class: "btn bg-muted tooltipped tooltipped--n", "aria-label": "Ignore suggestion" do %>
+          <%= link_to ignore_suggested_pairing_path(pairing), data: { turbo_method: :post }, class: "btn bg-muted tooltipped tooltipped--n", "aria-label": "Ignore suggestion" do %>
             <%= inline_icon "view-close", size: 32 %>
             <span>Ignore</span>
           <% end %>

--- a/app/views/stripe_cards/actions/_freeze.html.erb
+++ b/app/views/stripe_cards/actions/_freeze.html.erb
@@ -3,7 +3,8 @@
 <% if stripe_card&.stripe_status == 'inactive' %>
   <% defrost_tooltip = "Instantly re-freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>
   <%= link_to defrost_stripe_card_path(stripe_card),
-              method: :post,
+              data: { turbo_method: :post },
+
               class: "btn btn--list-item",
               disabled: !policy(stripe_card).defrost? do %>
     <%= inline_icon "freeze" %>
@@ -15,7 +16,8 @@
 <% elsif stripe_card&.stripe_status == 'active' %>
   <% freeze_tooltip = label.presence || "Instantly freeze #{stripe_card.user == current_user ? "your" : stripe_card.user.possessive_name} card anytime" %>
   <%= link_to freeze_stripe_card_path(stripe_card),
-              method: :post,
+              data: { turbo_method: :post },
+
               class: "btn btn--list-item",
               disabled: !policy(stripe_card).freeze? do %>
     <%= inline_icon "freeze" %>
@@ -26,7 +28,8 @@
   <% end %>
 <% elsif !stripe_card&.canceled? %>
   <%= link_to "#",
-              method: :post,
+              data: { turbo_method: :post },
+
               class: "btn btn--list-item",
               disabled: true do %>
     <%= inline_icon "freeze" %>

--- a/app/views/stripe_cards/show.html.erb
+++ b/app/views/stripe_cards/show.html.erb
@@ -20,9 +20,9 @@
           <%= link_to "View card on Stripe", @card.stripe_dashboard_url, class: "btn btn--list-item" %>
           <%= link_to "View cardholder on Stripe", @card.cardholder.stripe_dashboard_url, class: "btn btn--list-item" %>
           <% if @card.cash_withdrawal_enabled? %>
-            <%= link_to "Disable cash withdrawals", enable_cash_withdrawal_stripe_card_path(@card), method: :post, class: "btn btn--list-item bg-success", disabled: !admin_signed_in? %>
+            <%= link_to "Disable cash withdrawals", enable_cash_withdrawal_stripe_card_path(@card), data: { turbo_method: :post }, class: "btn btn--list-item bg-success", disabled: !admin_signed_in? %>
           <% elsif @card.physical? %>
-            <%= link_to "Enable cash withdrawals", enable_cash_withdrawal_stripe_card_path(@card), method: :post, class: "btn btn--list-item bg-success", disabled: !admin_signed_in? %>
+            <%= link_to "Enable cash withdrawals", enable_cash_withdrawal_stripe_card_path(@card), data: { turbo_method: :post }, class: "btn btn--list-item bg-success", disabled: !admin_signed_in? %>
           <% end %>
         <% end %>
         <%= render partial: "stripe_cards/actions", locals: { stripe_card: @card } %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -135,7 +135,7 @@
         <span>
           <%= render_money @transaction.fee.amount_cents_as_decimal %> (<%= render_percentage @transaction.fee.event_sponsorship_fee %>)
           <% admin_tool("py0 ml1", "span") do %>
-            <%= link_to "[waive fee]", waive_fee_canonical_transaction_url(@transaction), method: :post if @transaction.fee.amount_cents_as_decimal > 0 %>
+            <%= link_to "[waive fee]", waive_fee_canonical_transaction_url(@transaction), data: { turbo_method: :post } if @transaction.fee.amount_cents_as_decimal > 0 %>
           <% end %>
         </span>
       </p>
@@ -147,7 +147,7 @@
     <% else %>
       <% admin_tool("py0", "p") do %>
         <strong>Fee</strong>
-        <%= link_to "[unwaive fee]", unwaive_fee_canonical_transaction_url(@transaction), method: :post if @transaction.fee&.revenue_waived? %>
+        <%= link_to "[unwaive fee]", unwaive_fee_canonical_transaction_url(@transaction), data: { turbo_method: :post } if @transaction.fee&.revenue_waived? %>
       <% end %>
     <% end %>
   </section>

--- a/app/views/users/_oauth_authorization.html.erb
+++ b/app/views/users/_oauth_authorization.html.erb
@@ -3,7 +3,7 @@
     <span class="bold flex items-center">
       <span><%= authorization.application.name %></span> <span class="badge bg-info ml1">App</span>
     </span>
-    <%= link_to revoke_oauth_application_users_path(authorization.application.id), method: :delete, class: "muted tooltipped tooltipped--w z5", 'aria-label': "Sign out of this app", disabled: do %>
+    <%= link_to revoke_oauth_application_users_path(authorization.application.id), data: { turbo_method: :delete }, class: "muted tooltipped tooltipped--w z5", 'aria-label': "Sign out of this app", disabled: do %>
       <%= inline_icon "door-leave", size: home_action_size %>
     <% end %>
   </span>
@@ -38,7 +38,8 @@
               <td>
                 <% if token.expires_in %>
                   <%= link_to make_authorization_eternal_users_path(id: token.id),
-                              method: :post,
+                              data: { turbo_method: :post },
+
                               class: "btn bg-success py1 px2 h4",
                               disabled: !policy(token).make_eternal? do %>
                     <%= inline_icon "clock", size: home_action_size %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -206,7 +206,7 @@
             <span>
               <% if @user.profile_picture.attached? %>
                 You're currently using an uploaded profile picture.<br>
-                If you'd like to switch back to your Gravatar, <%= link_to "click here", user_delete_profile_picture_path(@user), method: :post %>.
+                If you'd like to switch back to your Gravatar, <%= link_to "click here", user_delete_profile_picture_path(@user), data: { turbo_method: :post } %>.
               <% else %>
                 If you have a <a href="https://gravatar.com" target="_blank">Gravatar</a>, we’ll pull it in here.<br>
                 Or, you can upload a profile picture.<br>

--- a/app/views/users/edit_featurepreviews.html.erb
+++ b/app/views/users/edit_featurepreviews.html.erb
@@ -90,7 +90,7 @@
             fully_shipped: true,
             name: "Receipt Report",
             description: "Opting into this preview will send you a weekly reminder with a list of all your missing receipts.",
-            footer: "Try #{link_to "triggering an email for yourself", trigger_receipt_report_path, method: :post, data: { turbo: false } }!",
+            footer: "Try #{link_to "triggering an email for yourself", trigger_receipt_report_path, data: { turbo_method: :post } }!",
             user: @user
           } %>
 

--- a/app/views/users/edit_security.html.erb
+++ b/app/views/users/edit_security.html.erb
@@ -153,7 +153,7 @@
         <span class="h2 bold">Sessions</span>
         <%= badge_for @all_sessions.count, class: "bg-muted" %>
       </legend>
-      <%= link_to logout_all_user_path(@user), method: :delete,
+      <%= link_to logout_all_user_path(@user), data: { turbo_method: :delete },
               class: "btn bg-error py1 px2 h4", disabled: @sessions.count <= (current_user == @user ? 1 : 0) || disabled do %>
         <%= inline_icon "door-leave", size: home_action_size %>
         Sign out everywhere else

--- a/app/views/users/logout.html.erb
+++ b/app/views/users/logout.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
   <div class="flex justify-between items-center flex-wrap w-full">
-    <%= link_to "Sign out", logout_users_path, method: :delete, class: "block mt-0 no-underline" %>
+    <%= link_to "Sign out", logout_users_path, data: { turbo_method: :delete }, class: "block mt-0 no-underline" %>
 
     <%= ugc_link_to "Continue to HCB", @return_to || root_path, class: "btn bg-info" %>
   </div>

--- a/app/views/webauthn_credentials/_webauthn_credential.html.erb
+++ b/app/views/webauthn_credentials/_webauthn_credential.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </span>
     <%= link_to user_webauthn_credential_path(webauthn_credential.user, webauthn_credential),
-      method: :delete,
+      data: { turbo_method: :delete },
       class: "muted tooltipped tooltipped--w z5",
       'aria-label': "Delete this security key",
       disabled: !policy(webauthn_credential).destroy? do %>

--- a/lib/rubocop/cop/hcb/turbo_method.rb
+++ b/lib/rubocop/cop/hcb/turbo_method.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   # also good — renders a real <form>
       #   button_to "Accept invitation", accept_path, method: :post
       class TurboMethod < Base
-        MSG = "Use `data: { turbo_method: %<verb>s }` instead of `method: %<verb>s`. " \
+        MSG = "Use `data: { turbo_method: %{verb} }` instead of `method: %{verb}`. " \
               "Turbo ignores `data-method`, so this link falls back to a GET and 404s."
 
         LINK_HELPERS = %i[link_to pop_icon_to].freeze

--- a/lib/rubocop/cop/hcb/turbo_method.rb
+++ b/lib/rubocop/cop/hcb/turbo_method.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Hcb
+      # `link_to ..., method: :post` is Rails-UJS syntax: it renders a plain
+      # `<a data-method="post">`. Turbo has no `data-method` support, so the
+      # browser follows the link as a GET, the POST-only route doesn't match,
+      # and the user gets a bare 404 with nothing logged as an app error.
+      #
+      # `button_to` and the `form_*` helpers are fine — they emit a real form.
+      #
+      #   # bad
+      #   link_to "Accept invitation", accept_path, method: :post
+      #
+      #   # good
+      #   link_to "Accept invitation", accept_path, data: { turbo_method: :post }
+      #
+      #   # also good — renders a real <form>
+      #   button_to "Accept invitation", accept_path, method: :post
+      class TurboMethod < Base
+        MSG = "Use `data: { turbo_method: %<verb>s }` instead of `method: %<verb>s`. " \
+              "Turbo ignores `data-method`, so this link falls back to a GET and 404s."
+
+        LINK_HELPERS = %i[link_to pop_icon_to].freeze
+        VERBS = %i[post put patch delete].freeze
+
+        def on_send(node)
+          return unless LINK_HELPERS.include?(node.method_name)
+
+          options = node.last_argument
+          return unless options.respond_to?(:hash_type?) && options.hash_type?
+
+          method_pair = options.pairs.find { |pair| symbol_key?(pair, :method) && verb?(pair.value) }
+          return unless method_pair
+
+          add_offense(method_pair, message: format(MSG, verb: method_pair.value.source))
+        end
+
+        private
+
+        def symbol_key?(node, key)
+          node.key.sym_type? && node.key.value == key
+        end
+
+        def verb?(node)
+          node.sym_type? && VERBS.include?(node.value)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/rubocop/cop/hcb/turbo_method_spec.rb
+++ b/spec/lib/rubocop/cop/hcb/turbo_method_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rubocop"
+require Rails.root.join("lib/rubocop/cop/hcb/turbo_method")
+
+RSpec.describe RuboCop::Cop::Hcb::TurboMethod do
+  let(:config) { RuboCop::Config.new("Hcb/TurboMethod" => { "Enabled" => true }) }
+  let(:team) { RuboCop::Cop::Team.new([described_class.new(config)], config) }
+
+  def investigate(source)
+    processed_source = RuboCop::ProcessedSource.new(source, RUBY_VERSION.to_f, "app/views/example.html.erb")
+
+    team.investigate(processed_source).offenses
+  end
+
+  it "registers an offense for link_to with a UJS method" do
+    offenses = investigate(<<~RUBY)
+      link_to "Accept invitation", organizer_position_invite_accept_path(@invite), method: :post
+    RUBY
+
+    expect(offenses.map(&:message)).to eq(
+      ["Use `data: { turbo_method: :post }` instead of `method: :post`. " \
+       "Turbo ignores `data-method`, so this link falls back to a GET and 404s."]
+    )
+  end
+
+  it "registers an offense for pop_icon_to with a UJS method" do
+    offenses = investigate(<<~RUBY)
+      pop_icon_to "delete", event_tag_path(event, tag.id), method: :delete
+    RUBY
+
+    expect(offenses.count).to eq(1)
+  end
+
+  it "registers an offense when the link already has a data hash" do
+    offenses = investigate(<<~RUBY)
+      link_to reimbursement_report_submit_path(report_id: report.id), method: :post, data: { turbo_confirm: "Sure?" }
+    RUBY
+
+    expect(offenses.count).to eq(1)
+  end
+
+  it "registers an offense for each of the non-GET verbs" do
+    offenses = investigate(<<~RUBY)
+      link_to "a", path, method: :post
+      link_to "b", path, method: :put
+      link_to "c", path, method: :patch
+      link_to "d", path, method: :delete
+    RUBY
+
+    expect(offenses.count).to eq(4)
+  end
+
+  it "allows turbo_method" do
+    offenses = investigate(<<~RUBY)
+      link_to "Accept invitation", organizer_position_invite_accept_path(@invite), data: { turbo_method: :post }
+    RUBY
+
+    expect(offenses).to be_empty
+  end
+
+  it "allows button_to, which renders a real form" do
+    offenses = investigate(<<~RUBY)
+      button_to "Cancel donation", cancel_recurring_donation_path(@donation), method: :post
+    RUBY
+
+    expect(offenses).to be_empty
+  end
+
+  it "allows the form helpers" do
+    offenses = investigate(<<~RUBY)
+      form_with url: link_receipts_path, method: :post
+      form_for model, url: url, method: :post
+      form_tag path, method: :patch
+    RUBY
+
+    expect(offenses).to be_empty
+  end
+
+  it "ignores a `method` key inside a url hash rather than the options" do
+    offenses = investigate(<<~RUBY)
+      link_to "Show", { controller: "/receipts", action: :show, method: :post }, class: "btn"
+    RUBY
+
+    expect(offenses).to be_empty
+  end
+
+  it "ignores a plain GET link" do
+    offenses = investigate(<<~RUBY)
+      link_to "View pending contract", contract_party_path(@invite.contract.party(:signee)), class: "btn bg-accent"
+    RUBY
+
+    expect(offenses).to be_empty
+  end
+end

--- a/spec/services/pending_event_mapping_engine/anomaly_detection/bad_settled_mapping_spec.rb
+++ b/spec/services/pending_event_mapping_engine/anomaly_detection/bad_settled_mapping_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe PendingEventMappingEngine::AnomalyDetection::BadSettledMapping do
     # Known regression: CanonicalTransaction#assign_ledger_item's divergence
     # check (canonical_transaction.rb:493) raises via Rails.error.unexpected
     # when calculated_ledger_item doesn't match local_hcb_code.ledger_item.
-    it(skip: "known CanonicalTransaction#assign_ledger_item ledger-item divergence regression") { is_expected.to eq(true) }
+    it "flags the bad mapping", skip: "known CanonicalTransaction#assign_ledger_item ledger-item divergence regression" do
+      is_expected.to eq(true)
+    end
   end
 
   context "when the canonical transaction predates the pending transaction" do


### PR DESCRIPTION
## Summary of the problem
Certain buttons 404 for some people and not others, acting as GETs instead of POSTs, with nothing logged as an application error.

Claude Diagnosis:

`link_to ..., method: :post` is Rails-UJS syntax — it renders a plain `<a href="..." data-method="post">`. Turbo has no `data-method` support, so nothing in the main JS bundle handles these links. The only thing that does is `jquery_ujs`, which ships in a separate legacy sprockets bundle (`app/views/layouts/_head.html.erb:11`), distinct from the webpack bundle carrying Turbo on the next line. Unhandled, the browser does what an `<a>` normally does — an ordinary GET — the POST-only route doesn't match, and the user gets a bare `ActionController::RoutingError`. It surfaces as a 404 and never as an application error, which is why it went unnoticed.

That leaves these links depending on a second, independently-failing bundle, and on which of two competing `document` click handlers (Turbo Drive vs `jquery_ujs`) happens to be registered first. Every other action in the app goes through Turbo.

## Describe your changes
Switched every UJS-style link to `data: { turbo_method: ... }`, which is already the convention nearly everywhere else in the app — 74 links across 49 view files. `button_to` and the `form_*` helpers were left alone; they emit a real form and were never affected.

To stop this coming back, added a `Hcb/TurboMethod` cop alongside the existing `Hcb/TurboConfirm`, so erb_lint catches it over views in CI.
