### PR TITLE
[Hashid] Add where_hashid and where_public_id for batch lookups

### DIFF
--- a/app/models/concerns/public_identifiable.rb
+++ b/app/models/concerns/public_identifiable.rb
@@ -18,13 +18,9 @@ module PublicIdentifiable
     end
 
     def find_by_public_id(id)
-      return nil unless id.is_a? String
+      hash = hashid_from_public_id(id)
+      return nil if hash.nil?
 
-      prefix = id.split("_").first.to_s.downcase
-      hash = id.split("_").last
-      return nil unless prefix == self.get_public_id_prefix
-
-      # ex. 'org_h1izp'
       find_by_hashid(hash)
     end
 
@@ -35,10 +31,35 @@ module PublicIdentifiable
       obj
     end
 
+    # Batch counterpart to `find_by_public_id`, for loading many records in one
+    # query rather than one query per public id. Ids that aren't prefixed for
+    # this model are dropped.
+    #
+    # Inherits `where_hashid`'s contract: unordered, de-duplicated, unknown ids
+    # silently omitted, and the relation is not scoped to an owner. See it for
+    # the batch size limit.
+    def where_public_id(ids)
+      ids = [ids] unless ids.is_a?(Array)
+
+      where_hashid(ids.filter_map { |id| hashid_from_public_id(id) })
+    end
+
     def get_public_id_prefix
       return self.public_id_prefix.to_s.downcase if self.public_id_prefix.present?
 
       raise NotImplementedError, "The #{self.class.name} model includes PublicIdentifiable module, but set_public_id_prefix hasn't been called."
+    end
+
+    private
+
+    # ex. 'org_h1izp' => 'h1izp'. nil unless the id is prefixed for this model.
+    def hashid_from_public_id(id)
+      return nil unless id.is_a? String
+
+      parts = id.split("_")
+      return nil unless parts.first.to_s.downcase == self.get_public_id_prefix
+
+      parts.last
     end
   end
 end

--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -1,5 +1,55 @@
 # frozen_string_literal: true
 
+# Batch lookup by hashid, alongside the gem's single-record `find_by_hashid`.
+#
+# This lives on the gem's `ClassMethods` rather than on `ApplicationRecord`
+# because hashid-rails ships no railtie: models opt in with `include
+# Hashid::Rails`. Extending `ClassMethods` reaches exactly those models, plus
+# their relations and `has_many` associations, which the gem extends too.
+module HashidQueryable
+  # A signed hashid for a bigint id is at most 15 characters. Hashids decodes in
+  # time quadratic to input length (16k characters is ~1.5s of CPU), so reject
+  # over-long strings before decoding rather than after.
+  MAX_HASHID_LENGTH = 32
+
+  # Unbounded batch lookup is a table-dump primitive, and decode cost is linear
+  # in the count. Raise rather than truncate: a caller that silently drops the
+  # tail of a bulk action is worse than one that fails loudly.
+  MAX_HASHID_BATCH = 1_000
+
+  # Batch counterpart to `find_by_hashid`, for loading many records in one query
+  # rather than one query per hashid.
+  #
+  # This is a set lookup, not a `map`: the result is unordered, de-duplicated,
+  # and silently omits hashids that don't resolve. It is not a drop-in for
+  # `find_by_hashid!` — callers that must reject an unknown id have to compare
+  # counts themselves.
+  #
+  # The relation is NOT scoped to an owner. Scope it (`event.payees
+  # .where_hashid(...)`) or `policy_scope` it before exposing the records.
+  #
+  # Input is assumed to be user-supplied: anything that isn't a hashid this
+  # model can decode is dropped, so a wholly invalid list matches nothing rather
+  # than everything. Raw database ids are dropped too; callers must pass hashids.
+  def where_hashid(hashids)
+    # Deliberately not `Array.wrap`: it calls `to_ary`, so passing a relation by
+    # mistake would load the whole table before discarding it.
+    candidates = (hashids.is_a?(Array) ? hashids : [hashids]).grep(String)
+    # `hashid_decode` rescues only `Hashids::InputError`, so invalid UTF-8 would
+    # otherwise escape as `ArgumentError` from `String#tr`.
+    candidates = candidates.select { |hashid| hashid.length <= MAX_HASHID_LENGTH && hashid.valid_encoding? }
+
+    if candidates.size > MAX_HASHID_BATCH
+      raise ArgumentError, "too many hashids (#{candidates.size} > #{MAX_HASHID_BATCH})"
+    end
+
+    # `uniq` because Postgres estimates row count from the IN list's length, not
+    # its distinct count: repeating one id 50k times flips the primary key index
+    # scan to a sequential scan.
+    where(id: decode_id(candidates).compact.uniq)
+  end
+end
+
 ActiveSupport.on_load(:active_record) do
   Hashid::Rails::ClassMethods.module_eval do
     def hashid_configuration
@@ -10,6 +60,10 @@ ActiveSupport.on_load(:active_record) do
       end
     end
   end
+
+  # As of hashid-rails 1.4.1 the gem defines no `where_hashid`; if it ever does,
+  # this include leaves the gem's version winning rather than silently shadowing it.
+  Hashid::Rails::ClassMethods.include(HashidQueryable)
 end
 
 Hashid::Rails.configure do |config|

--- a/spec/initializers/hashid_spec.rb
+++ b/spec/initializers/hashid_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Verifies the hashid extensions added in config/initializers/hashid.rb.
+RSpec.describe HashidQueryable do
+  let!(:users) { create_list(:user, 3) }
+  let(:hashids) { users.map(&:hashid) }
+
+  def user_query_count(&block)
+    count = 0
+    callback = ->(*, payload) { count += 1 if payload[:sql].include?(%("users")) }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    count
+  end
+
+  describe ".where_hashid" do
+    it "returns every record matching the given hashids" do
+      expect(User.where_hashid(hashids)).to match_array(users)
+    end
+
+    it "loads the records in a single query" do
+      count = user_query_count { User.where_hashid(hashids).to_a }
+
+      expect(count).to eq(1)
+    end
+
+    it "accepts a single hashid" do
+      expect(User.where_hashid(users.first.hashid)).to contain_exactly(users.first)
+    end
+
+    it "returns a relation that can be chained further" do
+      expect(User.where_hashid(hashids).where(id: users.first.id)).to contain_exactly(users.first)
+    end
+
+    it "is available on associations" do
+      event = create(:event)
+      payees = create_list(:payee, 2, event:)
+      create(:payee)
+
+      expect(event.payees.where_hashid(payees.map(&:hashid))).to match_array(payees)
+    end
+
+    it "keeps the conditions of the relation it is called on" do
+      event = create(:event)
+      active = create(:payee, event:)
+      archived = create(:payee, event:, archived_at: Time.current)
+
+      expect(event.payees.not_archived.where_hashid([active, archived].map(&:hashid))).to contain_exactly(active)
+    end
+
+    it "matches a record once when its hashid is repeated" do
+      expect(User.where_hashid([users.first.hashid] * 3)).to contain_exactly(users.first)
+    end
+
+    it "does not preserve the order of the given hashids" do
+      # This is a set lookup; callers needing input order must re-sort themselves.
+      expect(User.where_hashid(hashids.reverse).map(&:id)).to eq(users.map(&:id).sort)
+    end
+
+    describe "input this model cannot decode" do
+      it "skips a hashid built from characters outside the alphabet" do
+        expect(User.where_hashid([users.first.hashid, "not-a-real-hashid"])).to contain_exactly(users.first)
+      end
+
+      it "skips a well formed hashid that fails the checksum" do
+        expect(User.where_hashid([users.first.hashid, "zzzzzz"])).to contain_exactly(users.first)
+      end
+
+      it "does not decode another model's hashid" do
+        event = create(:event)
+
+        expect(User.where_hashid([event.hashid])).to be_empty
+      end
+
+      it "returns no records when none of the hashids decode" do
+        expect(User.where_hashid(["zzzzzz"])).to be_empty
+      end
+
+      it "does not compare against a null id for hashids it skips" do
+        sql = User.where_hashid([users.first.hashid, "zzzzzz"]).to_sql
+
+        expect(sql).not_to include("IS NULL")
+      end
+
+      it "skips a hashid that decodes beyond the range of the id column" do
+        expect(User.where_hashid([users.first.hashid, User.encode_id(2**63)])).to contain_exactly(users.first)
+      end
+
+      it "skips a hashid containing invalid UTF-8 rather than raising" do
+        expect(User.where_hashid([(+"b9YtZ\xFF").force_encoding("UTF-8")])).to be_empty
+      end
+    end
+
+    describe "input that is not a hashid at all" do
+      it "returns no records for an empty list" do
+        expect(User.where_hashid([])).to be_empty
+      end
+
+      it "returns no records for a nil list" do
+        expect(User.where_hashid(nil)).to be_empty
+      end
+
+      it "does not accept raw database ids" do
+        expect(User.where_hashid(users.map(&:id))).to be_empty
+      end
+
+      it "does not accept stringified raw database ids" do
+        expect(User.where_hashid(users.map { |user| user.id.to_s })).to be_empty
+      end
+
+      it "does not accept a symbol that stringifies to a hashid" do
+        expect(User.where_hashid([users.first.hashid.to_sym])).to be_empty
+      end
+
+      it "does not accept a params hash in place of a list of hashids" do
+        params = ActionController::Parameters.new(hashid: users.first.hashid)
+
+        expect(User.where_hashid(params)).to be_empty
+      end
+
+      it "does not load a relation passed in place of a list of hashids" do
+        relation = User.all
+
+        expect(User.where_hashid(relation)).to be_empty
+        expect(relation).not_to be_loaded
+      end
+    end
+
+    describe "limits" do
+      # Hashids decodes in time quadratic to input length, so over-long strings
+      # are rejected before they reach the decoder.
+      it "skips hashids longer than the maximum length" do
+        too_long = "a" * (described_class::MAX_HASHID_LENGTH + 1)
+
+        expect(User.where_hashid([users.first.hashid, too_long])).to contain_exactly(users.first)
+      end
+
+      it "accepts a batch at the maximum size" do
+        padded = hashids + ["zzzzzz"] * (described_class::MAX_HASHID_BATCH - hashids.size)
+
+        expect(User.where_hashid(padded)).to match_array(users)
+      end
+
+      it "raises rather than silently truncating a batch over the maximum size" do
+        oversized = ["zzzzzz"] * (described_class::MAX_HASHID_BATCH + 1)
+
+        expect { User.where_hashid(oversized) }.to raise_error(ArgumentError, /too many hashids/)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/public_identifiable_spec.rb
+++ b/spec/models/concerns/public_identifiable_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PublicIdentifiable do
+  let!(:users) { create_list(:user, 3) }
+  let(:public_ids) { users.map(&:public_id) }
+
+  def user_query_count(&block)
+    count = 0
+    callback = ->(*, payload) { count += 1 if payload[:sql].include?(%("users")) }
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    count
+  end
+
+  describe ".find_by_public_id" do
+    it "returns the record for its own public id" do
+      expect(User.find_by_public_id(users.first.public_id)).to eq(users.first)
+    end
+
+    it "matches the prefix case insensitively" do
+      expect(User.find_by_public_id("USR_#{users.first.hashid}")).to eq(users.first)
+    end
+
+    it "returns nil for a hashid prefixed for another model" do
+      expect(User.find_by_public_id("org_#{users.first.hashid}")).to be_nil
+    end
+
+    it "returns nil for a hashid with no prefix" do
+      expect(User.find_by_public_id(users.first.hashid)).to be_nil
+    end
+
+    it "returns nil for a public id this model cannot decode" do
+      expect(User.find_by_public_id("usr_zzzzzz")).to be_nil
+    end
+
+    # `params[:id]` is not always a String: `?id[]=x` yields an Array.
+    it "returns nil rather than raising for an id that is not a string" do
+      expect(User.find_by_public_id(nil)).to be_nil
+      expect(User.find_by_public_id(123)).to be_nil
+      expect(User.find_by_public_id([users.first.public_id])).to be_nil
+      expect(User.find_by_public_id(ActionController::Parameters.new(id: users.first.public_id))).to be_nil
+    end
+
+    # Characterization of long standing behaviour, not an endorsement: the
+    # parser takes the first and last underscore separated segments, so anything
+    # between them is ignored.
+    it "ignores segments between the prefix and the hashid" do
+      expect(User.find_by_public_id("usr_junk_#{users.first.hashid}")).to eq(users.first)
+    end
+  end
+
+  describe ".find_by_public_id!" do
+    it "returns the record for its own public id" do
+      expect(User.find_by_public_id!(users.first.public_id)).to eq(users.first)
+    end
+
+    it "raises RecordNotFound naming the model when nothing matches" do
+      expect { User.find_by_public_id!("usr_zzzzzz") }.to raise_error(ActiveRecord::RecordNotFound) do |error|
+        expect(error.model).to eq("User")
+      end
+    end
+  end
+
+  describe ".where_public_id" do
+    it "returns every record matching the given public ids" do
+      expect(User.where_public_id(public_ids)).to match_array(users)
+    end
+
+    it "loads the records in a single query" do
+      count = user_query_count { User.where_public_id(public_ids).to_a }
+
+      expect(count).to eq(1)
+    end
+
+    it "resolves the same records as find_by_public_id" do
+      expect(public_ids.filter_map { |id| User.find_by_public_id(id) }).to match_array(User.where_public_id(public_ids))
+    end
+
+    it "accepts a single public id" do
+      expect(User.where_public_id(users.first.public_id)).to contain_exactly(users.first)
+    end
+
+    it "matches the prefix case insensitively" do
+      expect(User.where_public_id("USR_#{users.first.hashid}")).to contain_exactly(users.first)
+    end
+
+    it "is available on associations" do
+      event = create(:event)
+      payees = create_list(:payee, 2, event:)
+      create(:payee)
+
+      expect(event.payees.where_public_id(payees.map(&:public_id))).to match_array(payees)
+    end
+
+    it "keeps the conditions of the relation it is called on" do
+      event = create(:event)
+      active = create(:payee, event:)
+      archived = create(:payee, event:, archived_at: Time.current)
+
+      expect(event.payees.not_archived.where_public_id([active, archived].map(&:public_id))).to contain_exactly(active)
+    end
+
+    it "skips a hashid prefixed for another model" do
+      # Prefixed for an Event but decodable as a User, so only the prefix check
+      # can reject it.
+      expect(User.where_public_id([users.first.public_id, "org_#{users.first.hashid}"]))
+        .to contain_exactly(users.first)
+    end
+
+    it "skips public ids with no prefix" do
+      expect(User.where_public_id([users.first.hashid])).to be_empty
+    end
+
+    it "skips ids that are not strings" do
+      mixed = [nil, 123, [users.first.public_id], users.first.public_id]
+
+      expect(User.where_public_id(mixed)).to contain_exactly(users.first)
+    end
+
+    it "returns no records for an empty list" do
+      expect(User.where_public_id([])).to be_empty
+    end
+
+    it "returns no records for a nil list" do
+      expect(User.where_public_id(nil)).to be_empty
+    end
+
+    it "returns no records for a params hash" do
+      params = ActionController::Parameters.new(id: users.first.public_id)
+
+      expect(User.where_public_id(params)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Looking up several records by hashid means one query per id today:

```ruby
Model.where(id: hashids.map { |id| Model.find_by_hashid(id)&.id })
```

Decoding a hashid is pure arithmetic and needs no database round trip, so that whole list can be one query. `find_by_hashid` accepts an array without complaining, but `find_by` is `where(...).take`, so it quietly returns a single arbitrary record rather than a collection.

## Describe your changes

Adds `where_hashid`, the batch counterpart to `find_by_hashid`, and `where_public_id`, the batch counterpart to `find_by_public_id`.

```ruby
User.where_hashid(["abc123", "def456"])
event.payees.not_archived.where_public_id(params[:payee_ids])
```

`where_hashid` lives on the gem's `ClassMethods` rather than on `ApplicationRecord` because hashid-rails ships no railtie: models opt in with `include Hashid::Rails`. Extending `ClassMethods` reaches exactly those models, plus the relations and `has_many` associations the gem extends too. On `ApplicationRecord` it would appear on every model and raise `NoMethodError` on the ones without hashids.

**Both are set lookups, not maps.** The result is unordered, deduplicated, and silently omits ids that don't resolve, so neither is a drop-in replacement for the `find_by_*!` variants. The doc comments say so, and the relation is not scoped to an owner, so callers still need their own scoping or `policy_scope`.

Both are built to take user supplied input directly:

- A wholly invalid list matches nothing rather than everything.
- Raw database ids are rejected; callers must pass hashids.
- Overlong strings are dropped before decoding, since decode cost grows with the square of input length.
- A batch over `MAX_HASHID_BATCH` raises rather than silently truncating what may be a bulk action.
- Decoded ids are deduplicated, because Postgres estimates row count from the length of an `IN` list rather than its distinct count, so a repeated id can push the planner off the primary key index.

`find_by_public_id` behaviour is unchanged. Its prefix parsing moved into a private helper so the batch method can share it, and it picks up the unit specs it never had, including the non-String guard that keeps `?id[]=x` from raising.

No call sites are converted here. The clearest candidate is the `tag_ids` loop in the v4 transactions controller, but it uses `find_by_public_id!` and authorizes per record, so converting it needs its own change to preserve both.

47 new examples; 216 pass across the specs touching these paths.
