### PR TITLE
[Hashid] Parse public id prefixes strictly

### DIFF
--- a/app/models/concerns/public_identifiable.rb
+++ b/app/models/concerns/public_identifiable.rb
@@ -53,13 +53,18 @@ module PublicIdentifiable
     private
 
     # ex. 'org_h1izp' => 'h1izp'. nil unless the id is prefixed for this model.
+    #
+    # A public id always has exactly one underscore: no prefix contains one, and
+    # the hashid alphabet is alphanumeric. Anything else is malformed, so reject
+    # it rather than picking a segment out of the middle.
     def hashid_from_public_id(id)
       return nil unless id.is_a? String
 
-      parts = id.split("_")
-      return nil unless parts.first.to_s.downcase == self.get_public_id_prefix
+      prefix, hashid, extra = id.split("_", 3)
+      return nil unless extra.nil? && hashid.present?
+      return nil unless prefix.downcase == self.get_public_id_prefix
 
-      parts.last
+      hashid
     end
   end
 end

--- a/spec/models/concerns/public_identifiable_spec.rb
+++ b/spec/models/concerns/public_identifiable_spec.rb
@@ -42,11 +42,23 @@ RSpec.describe PublicIdentifiable do
       expect(User.find_by_public_id(ActionController::Parameters.new(id: users.first.public_id))).to be_nil
     end
 
-    # Characterization of long standing behaviour, not an endorsement: the
-    # parser takes the first and last underscore separated segments, so anything
-    # between them is ignored.
-    it "ignores segments between the prefix and the hashid" do
-      expect(User.find_by_public_id("usr_junk_#{users.first.hashid}")).to eq(users.first)
+    # A public id has exactly one underscore, so these are all malformed even
+    # though they contain a resolvable hashid.
+    it "returns nil for extra segments between the prefix and the hashid" do
+      expect(User.find_by_public_id("usr_junk_#{users.first.hashid}")).to be_nil
+    end
+
+    it "returns nil for a doubled underscore" do
+      expect(User.find_by_public_id("usr__#{users.first.hashid}")).to be_nil
+    end
+
+    it "returns nil for a trailing underscore" do
+      expect(User.find_by_public_id("usr_#{users.first.hashid}_")).to be_nil
+    end
+
+    it "returns nil for a bare prefix" do
+      expect(User.find_by_public_id("usr")).to be_nil
+      expect(User.find_by_public_id("usr_")).to be_nil
     end
   end
 
@@ -110,6 +122,12 @@ RSpec.describe PublicIdentifiable do
 
     it "skips public ids with no prefix" do
       expect(User.where_public_id([users.first.hashid])).to be_empty
+    end
+
+    it "skips malformed public ids that contain a resolvable hashid" do
+      malformed = ["usr_junk_#{users.first.hashid}", "usr__#{users.first.hashid}", "usr_#{users.first.hashid}_"]
+
+      expect(User.where_public_id(malformed)).to be_empty
     end
 
     it "skips ids that are not strings" do


### PR DESCRIPTION
## Summary of the problem

`hashid_from_public_id` split on every underscore and took the first and last segments, so everything in between was ignored:

```ruby
User.find_by_public_id("usr_junk_#{user.hashid}")  # => the user
User.find_by_public_id("usr__#{user.hashid}")      # => the user
User.find_by_public_id("usr_#{user.hashid}_")      # => the user
```

A bare `"usr"` also parsed as prefix `usr` plus hashid `usr`, since `split` returns a single segment that is both first and last.

Nothing exploits this today, but the parser now backs `where_public_id` as well as `find_by_public_id`, so it takes user supplied input on both a single and a batch path. A prefix check that can be padded past isn't really checking the prefix.

## Describe your changes

A public id always has exactly one underscore: no prefix contains one, and the hashid alphabet is alphanumeric. So require exactly two segments and reject anything else, instead of picking a segment out of the middle.

```ruby
prefix, hashid, extra = id.split("_", 3)
return nil unless extra.nil? && hashid.present?
return nil unless prefix.downcase == self.get_public_id_prefix
```

## Why this shouldn't change any real behaviour

- **No generated public id changes meaning.** Checked every `PublicIdentifiable` model (34 of them) across a spread of ids: every generated public id has exactly one underscore, and the old and new parsers agree on all of them. Prefixes are underscore free and no model overrides the hashid alphabet, so this holds by construction rather than by sampling.
- **The bare prefix case already returned nil.** No model's prefix decodes to a valid id, so `"usr"` resolved to `find_by_hashid("usr")` and then to nil. Strict parsing reaches nil sooner; the result is the same.
- **Nothing in the app builds a malformed id.** The org chart tree keys, the hardcoded recipient lists in the mailers, and the comment reply address (`comments+cmt_<hashid>@`) are all well formed. The one place a public id is embedded in a larger string, the `"#{public_id}_reversed"` idempotency key, is sent to an external API and never parsed back.
- **Slug and friendly id fallbacks get better, not worse.** Call sites like `Event.find_by_public_id(params[:id]) || Event.find_by!(slug: params[:id])` now reach the fallback instead of being shadowed by a malformed match that happened to decode.

The only inputs whose behaviour changes are malformed ones, which is the point.

Specs cover each newly rejected shape. 385 examples pass across the controller, request, and integration specs, which is where the ~50 `find_by_public_id` call sites live.
