### PR TITLE
[Admin::LedgerAudit::Task] Add ledger_item_id

### DIFF
--- a/app/models/admin/ledger_audit/task.rb
+++ b/app/models/admin/ledger_audit/task.rb
@@ -10,18 +10,21 @@
 #  updated_at            :datetime         not null
 #  admin_ledger_audit_id :bigint
 #  hcb_code_id           :bigint
+#  ledger_item_id        :bigint
 #  reviewer_id           :bigint
 #
 # Indexes
 #
 #  index_admin_ledger_audit_tasks_on_admin_ledger_audit_id  (admin_ledger_audit_id)
 #  index_admin_ledger_audit_tasks_on_hcb_code_id            (hcb_code_id)
+#  index_admin_ledger_audit_tasks_on_ledger_item_id         (ledger_item_id)
 #  index_admin_ledger_audit_tasks_on_reviewer_id            (reviewer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (admin_ledger_audit_id => admin_ledger_audits.id)
 #  fk_rails_...  (hcb_code_id => hcb_codes.id)
+#  fk_rails_...  (ledger_item_id => ledger_items.id)
 #  fk_rails_...  (reviewer_id => users.id)
 #
 
@@ -29,11 +32,24 @@ module Admin
   class LedgerAudit
     class Task < ApplicationRecord
       belongs_to :admin_ledger_audit, class_name: "Admin::LedgerAudit", optional: true
-      belongs_to :hcb_code
+      belongs_to :hcb_code, optional: true
+      belongs_to :ledger_item, class_name: "Ledger::Item", optional: true, inverse_of: :admin_ledger_audit_tasks
       belongs_to :reviewer, class_name: "User", optional: true
       scope :pending, -> { where("status = ?", "pending") }
       scope :flagged, -> { where("status = ?", "flagged") }
 
+      before_create :fill_in_counterparty
+
+      private
+
+      # TODO: fully migrate to ledger item
+      def fill_in_counterparty
+        if hcb_code.nil? && ledger_item.present?
+          self.hcb_code = ledger_item.hcb_code
+        elsif ledger_item.nil? && hcb_code.present?
+          self.ledger_item = hcb_code.ledger_item
+        end
+      end
 
     end
 

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -55,6 +55,7 @@ class Ledger
 
     has_one :hcb_code, class_name: "HcbCode", required: false, foreign_key: "ledger_item_id", inverse_of: :ledger_item
     has_one :personal_transaction, required: false, foreign_key: "ledger_item_id", inverse_of: :ledger_item
+    has_many :admin_ledger_audit_tasks, class_name: "Admin::LedgerAudit::Task", foreign_key: "ledger_item_id", inverse_of: :ledger_item
     belongs_to :linked_object, polymorphic: true, optional: true, inverse_of: :ledger_item
     belongs_to :author, class_name: "User", optional: true
 

--- a/app/tasks/maintenance/backfill_admin_ledger_audit_task_counterparties_task.rb
+++ b/app/tasks/maintenance/backfill_admin_ledger_audit_task_counterparties_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # One-time backfill: derives ledger_item_id from hcb_code_id on existing
+  # Admin::LedgerAudit::Task records (all created before ledger_item_id
+  # existed), mirroring the before_create callback added alongside the
+  # column.
+  class BackfillAdminLedgerAuditTaskCounterpartiesTask < MaintenanceTasks::Task
+    def collection
+      Admin::LedgerAudit::Task.where(ledger_item_id: nil)
+    end
+
+    def process(task)
+      return if task.hcb_code.blank?
+
+      task.update!(ledger_item_id: task.hcb_code.ledger_item_id)
+    end
+
+  end
+end

--- a/app/tasks/maintenance/backfill_admin_ledger_audit_task_counterparties_task.rb
+++ b/app/tasks/maintenance/backfill_admin_ledger_audit_task_counterparties_task.rb
@@ -11,7 +11,7 @@ module Maintenance
     end
 
     def process(task)
-      return if task.hcb_code.blank?
+      return if task.hcb_code_id.nil?
 
       task.update!(ledger_item_id: task.hcb_code.ledger_item_id)
     end

--- a/db/migrate/20260827120000_add_ledger_item_id_to_admin_ledger_audit_tasks.rb
+++ b/db/migrate/20260827120000_add_ledger_item_id_to_admin_ledger_audit_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddLedgerItemIdToAdminLedgerAuditTasks < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :admin_ledger_audit_tasks, :ledger_item, index: { algorithm: :concurrently }
+
+    add_foreign_key :admin_ledger_audit_tasks, :ledger_items, validate: false
+
+    validate_foreign_key :admin_ledger_audit_tasks, :ledger_items
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_003730) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -120,11 +120,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_003730) do
     t.bigint "admin_ledger_audit_id"
     t.datetime "created_at", null: false
     t.bigint "hcb_code_id"
+    t.bigint "ledger_item_id"
     t.bigint "reviewer_id"
     t.string "status", default: "pending"
     t.datetime "updated_at", null: false
     t.index ["admin_ledger_audit_id"], name: "index_admin_ledger_audit_tasks_on_admin_ledger_audit_id"
     t.index ["hcb_code_id"], name: "index_admin_ledger_audit_tasks_on_hcb_code_id"
+    t.index ["ledger_item_id"], name: "index_admin_ledger_audit_tasks_on_ledger_item_id"
     t.index ["reviewer_id"], name: "index_admin_ledger_audit_tasks_on_reviewer_id"
   end
 
@@ -3051,6 +3053,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_003730) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_ledger_audit_tasks", "admin_ledger_audits"
   add_foreign_key "admin_ledger_audit_tasks", "hcb_codes"
+  add_foreign_key "admin_ledger_audit_tasks", "ledger_items"
   add_foreign_key "admin_ledger_audit_tasks", "users", column: "reviewer_id"
   add_foreign_key "announcement_blocks", "announcements"
   add_foreign_key "announcements", "events"


### PR DESCRIPTION
## What

Adds `ledger_item_id` to `admin_ledger_audit_tasks`, alongside the existing `hcb_code_id`.

## Changes

- **Migration**: adds a nullable `ledger_item_id` reference (concurrent index, FK added unvalidated then validated - the standard `strong_migrations`-safe pattern for this repo).
- **Model**: `hcb_code` is now optional (was required); new optional `belongs_to :ledger_item`. A `before_create` callback fills in whichever side is missing, bridging through the existing `HcbCode <-> Ledger::Item` association: only `ledger_item` given → derives `hcb_code` from `ledger_item.hcb_code`; only `hcb_code` given → derives `ledger_item` from `hcb_code.ledger_item`.
- **Association**: `Ledger::Item` gains `has_many :admin_ledger_audit_tasks` (a ledger item can have more than one task across different audits).
- **Backfill**: `Maintenance::BackfillAdminLedgerAuditTaskCounterpartiesTask` fills in `ledger_item_id` on existing rows (all created before the column existed, so they all have `hcb_code_id` set already).

## Testing

Verified manually against the dev DB inside rolled-back transactions: the `before_create` callback fills in the correct counterparty in both directions, and the backfill task correctly derives `ledger_item_id` from `hcb_code_id` on a simulated legacy row. Migration reverses and re-applies cleanly. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)