### PR TITLE
Swap Team/Balance columns in sub-organizations table

### DIFF
--- a/app/views/events/_sub_organization_row.html.erb
+++ b/app/views/events/_sub_organization_row.html.erb
@@ -63,19 +63,19 @@
       <% end %>
     <% end %>
   </td>
-  <td class="tabular-nums">
-    <%= turbo_frame_tag "event_balance_#{event.public_id}",
-                        src: event_async_balance_path(event),
-                        loading: :lazy,
-                        data: { controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" } do %>
-      <span class="muted">—</span>
-    <% end %>
-  </td>
   <td>
     <span class="sub-organization-row__count tabular-nums">
       <%= inline_icon "people-2", size: 18, class: "muted", 'aria-label': "Team members" %>
       <%= row[:organizer_count] %>
     </span>
     <%= link_to "", event, class: "stretched-link", "aria-label": event.name %>
+  </td>
+  <td class="tabular-nums text-right">
+    <%= turbo_frame_tag "event_balance_#{event.public_id}",
+                        src: event_async_balance_path(event, symbol: "true"),
+                        loading: :lazy,
+                        data: { controller: "cached-frame", action: "turbo:frame-render->cached-frame#cache" } do %>
+      <span class="muted">—</span>
+    <% end %>
   </td>
 </tr>

--- a/app/views/events/sub_organizations.html.erb
+++ b/app/views/events/sub_organizations.html.erb
@@ -64,8 +64,8 @@
             <tr>
               <th>Organization</th>
               <th>Tags</th>
-              <th>Balance</th>
               <th>Team</th>
+              <th class="text-right">Balance</th>
             </tr>
           </thead>
           <tbody id="sub_organizations">


### PR DESCRIPTION
## Summary
- Swapped the order of the **Team** and **Balance** columns in the sub-organizations table (Team now comes before Balance)
- Right-aligned the Balance column and added a `$` prefix to the displayed amount

## Test plan
- Visited an organization's Sub-organizations page (list view) and confirmed the column order and formatting look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)