### PR TITLE
[Admin] Export all filtered users in CSV, fix Locked checkbox styling

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -219,11 +219,12 @@ class AdminController < Admin::BaseController
 
     @count = relation.count
 
-    @users = relation.page(@page).per(@per).order(created_at: :desc)
+    @users = relation.order(created_at: :desc)
     @referral_programs = Referral::Program.all
 
     respond_to do |format|
       format.html do
+        @users = @users.page(@page).per(@per)
       end
       format.csv { render csv: @users.includes(:stripe_cards, :emburse_cards) }
     end

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -9,9 +9,10 @@
   <div class="flex gap-2 items-center mt-2">
     <%= form.select :access_level, User.access_levels.keys.map { |level| [level.humanize, level] }, { include_blank: "All user types", selected: @access_level } %>
     <%= form.select :referral_program_id, @referral_programs.map { |program| [program.name, program.id] }, { include_blank: "No referral filter", selected: @referral_program_id } %>
-    <label class="flex items-center gap-1">
-      <%= form.check_box :locked, checked: @locked %> Locked
-    </label>
+    <div class="field field--checkbox mb0">
+      <%= form.label :locked, "Locked" %>
+      <%= form.check_box :locked, checked: @locked %>
+    </div>
   </div>
 
   <div class="flex items-center mt-2 gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
- The CSV export button on `/admin/users` only exported the current page (100 records) instead of every user matching the applied filters. Fixed by mirroring the pattern already used on the admin organizations (events) page: keep `@users` as the full filtered/ordered relation and paginate it only inside the `format.html` block, so `format.csv` sees the unpaginated relation.
- Fixed the "Locked" checkbox on the same page rendering with its label text wrapped one character per line. `admin.scss` sets a bare `label { display: block }` in unlayered CSS, which always wins the cascade over Tailwind's `.flex` utility (declared inside `@layer utilities`) regardless of specificity — so `class="flex items-center gap-1"` on the label never actually applied. Swapped to the existing `.field.field--checkbox` pattern used elsewhere in the app.

## Test plan
- [ ] Visit `/admin/users`, apply a filter that matches >100 users, click Export, confirm the CSV contains all matching records rather than just 100.
- [ ] Visit `/admin/users` and confirm the "Locked" checkbox + label render inline in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)