### PR TITLE
Redirect on error in Users::EmailUpdatesController#verify

### DIFF
--- a/app/controllers/users/email_updates_controller.rb
+++ b/app/controllers/users/email_updates_controller.rb
@@ -36,8 +36,10 @@ module Users
       end
     rescue ActiveRecord::RecordNotFound => e
       flash[:error] = "This authorization token has expired, please request another."
+      redirect_to root_path
     rescue ActiveRecord::RecordInvalid => e
       flash[:error] = @request.errors.full_messages.to_sentence
+      redirect_to root_path
     end
 
   end

--- a/app/controllers/users/email_updates_controller.rb
+++ b/app/controllers/users/email_updates_controller.rb
@@ -35,11 +35,9 @@ module Users
         return redirect_to root_path, flash: { success: "Verified; please check your old email's inbox (#{@request.original}) to authorize this change." }
       end
     rescue ActiveRecord::RecordNotFound => e
-      flash[:error] = "This authorization token has expired, please request another."
-      redirect_to root_path
+      return redirect_to root_path, flash: { error: "This authorization token has expired, please request another." }
     rescue ActiveRecord::RecordInvalid => e
-      flash[:error] = @request.errors.full_messages.to_sentence
-      redirect_to root_path
+      return redirect_to root_path, flash: { error: @request.errors.full_messages.to_sentence }
     end
 
   end


### PR DESCRIPTION
## Summary
Fixes a production error:

```
ActionController::MissingExactTemplate: Users::EmailUpdatesController#verify is missing a template for request formats: text/html
```

In `verify`, the `rescue` blocks for `ActiveRecord::RecordNotFound` and `ActiveRecord::RecordInvalid` set a flash message but never called `redirect_to` or `render`. When either exception fires (e.g. an expired or already-used verification token — plausible from stale email links or double-clicked links), the action falls through to Rails' implicit view rendering, which looks for `verify.html.erb`. That template doesn't exist, since the action is only ever meant to redirect, so it raises `ActionController::MissingExactTemplate`.

The sibling action `authorize_change` had this exact bug and was already fixed by adding `redirect_to root_path` to both rescue blocks, but that fix was never mirrored onto `verify`. This PR applies the same fix to `verify` for consistency.

## Test plan
- [x] Confirmed the fix exactly mirrors the existing, already-shipped pattern in `authorize_change` in the same controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)