### PR TITLE
Fail closed in AdminConstraint/AuditorConstraint on cookie decryption errors

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -194,7 +194,11 @@ class LoginsController < ApplicationController
           begin
             route = Rails.application.routes.recognize_path(return_path)
             return_path = root_path if route[:controller] == "logins"
-          rescue ActionController::RoutingError
+          rescue ActionController::RoutingError, NoMethodError
+            # `recognize_path` builds a synthetic request that bypasses the
+            # normal middleware stack, so routes guarded by constraints that
+            # depend on middleware-populated request state (e.g. cookie
+            # decryption keys) can raise here. Fall back to root_path.
             return_path = root_path
           end
         end

--- a/lib/admin_constraint.rb
+++ b/lib/admin_constraint.rb
@@ -15,6 +15,13 @@ class AdminConstraint
     end
 
     false
+  rescue NoMethodError
+    # `request.cookie_jar` can be backed by a request that never went through
+    # the ActionDispatch::Cookies middleware (e.g. a synthetic request built by
+    # `ActionDispatch::Routing::RouteSet#recognize_path`), in which case
+    # `request.key_generator` is nil and cookie decryption blows up. Fail
+    # closed (deny access) rather than raising a 500.
+    false
   end
 
 end

--- a/lib/auditor_constraint.rb
+++ b/lib/auditor_constraint.rb
@@ -15,6 +15,13 @@ class AuditorConstraint
     end
 
     false
+  rescue NoMethodError
+    # `request.cookie_jar` can be backed by a request that never went through
+    # the ActionDispatch::Cookies middleware (e.g. a synthetic request built by
+    # `ActionDispatch::Routing::RouteSet#recognize_path`), in which case
+    # `request.key_generator` is nil and cookie decryption blows up. Fail
+    # closed (deny access) rather than raising a 500.
+    false
   end
 
 end

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe LoginsController do
         # to some unrelated wildcard route (unlike e.g. "/console", which also
         # matches the catch-all `events#show` route).
         login = create(:login, user:, state: { return_to: "/schema/foo/bar" })
-        webauthn_credential = create_webauthn_credential(user:)
+        create_webauthn_credential(user:)
 
         webauthn_challenge = generate_webauthn_challenge(user:)
         session[:webauthn_challenge] = webauthn_challenge

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -145,6 +145,41 @@ RSpec.describe LoginsController do
       end
     end
 
+    context "when return_to points at a route guarded by a constraint that reads cookies" do
+      it "signs the user in and redirects to root instead of raising" do
+        user = create(:user, phone_number: "+18556254225")
+        # No route other than the AuditorConstraint-guarded `/schema` mount
+        # matches this path, so route recognition can't silently fall through
+        # to some unrelated wildcard route (unlike e.g. "/console", which also
+        # matches the catch-all `events#show` route).
+        login = create(:login, user:, state: { return_to: "/schema/foo/bar" })
+        webauthn_credential = create_webauthn_credential(user:)
+
+        webauthn_challenge = generate_webauthn_challenge(user:)
+        session[:webauthn_challenge] = webauthn_challenge
+
+        credential = get_webauthn_credential(challenge: webauthn_challenge)
+
+        post(
+          :complete,
+          params: {
+            id: login.hashid,
+            method: "webauthn",
+            credential: JSON.dump(credential)
+          }
+        )
+
+        # Regression test: `return_to` is user-controlled and reaches
+        # `Rails.application.routes.recognize_path`, which evaluates route
+        # constraints (AuditorConstraint/AdminConstraint) against a synthetic
+        # request that bypasses the cookies middleware. That used to raise
+        # `NoMethodError: undefined method 'generate_key' for nil` instead of
+        # completing the login.
+        expect(response).to redirect_to(root_path)
+        expect(login.reload).to be_complete
+      end
+    end
+
     context "login_code" do
       context "email" do
         it "rejects invalid login codes" do

--- a/spec/lib/admin_constraint_spec.rb
+++ b/spec/lib/admin_constraint_spec.rb
@@ -86,5 +86,18 @@ RSpec.describe AdminConstraint do
         expect(described_class.matches?(request)).to eq(false)
       end
     end
+
+    context "when the request's cookie jar can't be decrypted (e.g. a synthetic request built by " \
+            "ActionDispatch::Routing::RouteSet#recognize_path, which bypasses the cookies middleware)" do
+      let(:request) { instance_double("ActionDispatch::Request") }
+
+      before do
+        allow(request).to receive(:cookie_jar).and_raise(NoMethodError, "undefined method 'generate_key' for nil")
+      end
+
+      it "returns false instead of raising" do
+        expect(described_class.matches?(request)).to eq(false)
+      end
+    end
   end
 end

--- a/spec/lib/auditor_constraint_spec.rb
+++ b/spec/lib/auditor_constraint_spec.rb
@@ -96,5 +96,18 @@ RSpec.describe AuditorConstraint do
         expect(described_class.matches?(request)).to eq(false)
       end
     end
+
+    context "when the request's cookie jar can't be decrypted (e.g. a synthetic request built by " \
+            "ActionDispatch::Routing::RouteSet#recognize_path, which bypasses the cookies middleware)" do
+      let(:request) { instance_double("ActionDispatch::Request") }
+
+      before do
+        allow(request).to receive(:cookie_jar).and_raise(NoMethodError, "undefined method 'generate_key' for nil")
+      end
+
+      it "returns false instead of raising" do
+        expect(described_class.matches?(request)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Bug

Any user could trigger a 500 on login completion by logging in with a
`return_to` param pointing at a path guarded by `AdminConstraint` or
`AuditorConstraint` (e.g. `?return_to=/schema/foo/bar`):

```
NoMethodError: undefined method 'generate_key' for nil
lib/auditor_constraint.rb:8 in AuditorConstraint.matches?
app/controllers/logins_controller.rb:195 in LoginsController#complete
app/middleware/set_current_request_ip.rb:11 in SetCurrentRequestIp#call
```

## Root cause

- `return_to` is user-controlled (`params[:return_to]` → `Login#state`, only
  sanitized by `url_from`, which still permits any in-app path).
- On login completion, `LoginsController#complete` calls
  `Rails.application.routes.recognize_path(return_path)` just to check
  whether it resolves to the `logins` controller (to avoid a redirect loop).
- `recognize_path` builds a **synthetic request** (`Rack::MockRequest.env_for`)
  that never passes through the `ActionDispatch::Cookies` middleware, so
  `request.key_generator` is `nil` on it.
- `/console`, `/blazer`, `/schema` (and `/sidekiq`, `/maintenance_tasks`,
  `/flipper`, `/pghero` via the identical `AdminConstraint` bug) are mounted
  behind route constraints that call `request.cookie_jar.encrypted[...]`.
  Building that encrypted jar unconditionally calls
  `request.key_generator.generate_key(...)` — `nil.generate_key` raises the
  above.

## Fix

- `AdminConstraint`/`AuditorConstraint`: rescue the `NoMethodError` and fail
  closed (deny access), which is the correct behavior for an access-control
  constraint regardless of call site.
- `LoginsController#complete`: broaden the existing `rescue
  ActionController::RoutingError` to also catch `NoMethodError`, as
  defense-in-depth for the same class of failure.
- Added regression specs that reproduce the exact crash (verified they fail
  with the original error/stack trace without the fix, and pass with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)