### PR TITLE
Guard ReceiptService::Extract against a deleted receipt mid-flight

### DIFF
--- a/app/services/receipt_service/extract.rb
+++ b/app/services/receipt_service/extract.rb
@@ -70,6 +70,13 @@ module ReceiptService
 
       return if extracted.nil?
 
+      # the OpenAI request above can take a while; the receipt (or its file)
+      # may have been deleted in the meantime, e.g. the user removed it from
+      # the receipt bin. re-check freshness before persisting to avoid a
+      # RecordInvalid on the "file can't be blank" validation.
+      @receipt = Receipt.find_by(id: @receipt.id)
+      return if @receipt.nil? || !@receipt.file.attached?
+
       extracted[:textual_content] = @receipt.textual_content
 
       data = OpenStruct.new(extracted) # Protection against missing keys

--- a/spec/services/receipt_service/extract_spec.rb
+++ b/spec/services/receipt_service/extract_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReceiptService::Extract do
+  def build_receipt(**attributes)
+    user = create(:user)
+    Receipt.new(upload_method: :api, user:, textual_content: "some receipt text", **attributes).tap do |receipt|
+      receipt.file.attach(
+        io: StringIO.new(File.binread(Rails.root.join("spec/fixtures/files/receipt.png"))),
+        filename: "receipt.png",
+        content_type: "image/png"
+      )
+      receipt.save!
+    end
+  end
+
+  let(:extracted_data) do
+    {
+      transaction_memo: "☕ Coffee from Cafe",
+      total_amount_cents: 500,
+      currency: "usd"
+    }
+  end
+
+  let(:ai_response_body) do
+    {
+      choices: [
+        {
+          message: {
+            content: extracted_data.to_json
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  before do
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 200, body: ai_response_body, headers: { "Content-Type" => "application/json" })
+  end
+
+  it "persists the extracted data onto the receipt" do
+    receipt = build_receipt
+
+    described_class.new(receipt:).run!
+
+    receipt.reload
+    expect(receipt.data_extracted?).to be(true)
+    expect(receipt.suggested_memo).to eq("☕ Coffee from Cafe")
+  end
+
+  # The OpenAI request above is slow enough that a user can delete the
+  # receipt (or its file) from under the job while it's in flight. Before the
+  # fix, the final `@receipt.update!` would re-validate `attached: true`
+  # against the now-gone attachment and raise ActiveRecord::RecordInvalid
+  # ("File can't be blank") instead of just no-oping.
+  it "does not raise when the receipt is deleted while the extraction request is in flight" do
+    receipt = build_receipt
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return do |_request|
+        # simulate a separate request (e.g. the user deleting the receipt from
+        # the UI) racing the job, rather than mutating the job's own in-memory
+        # object directly
+        Receipt.find(receipt.id).destroy!
+        { status: 200, body: ai_response_body, headers: { "Content-Type" => "application/json" } }
+      end
+
+    expect { described_class.new(receipt:).run! }.not_to raise_error
+    expect(Receipt.exists?(receipt.id)).to be(false)
+  end
+end


### PR DESCRIPTION
## Problem

```
ActiveRecord::RecordInvalid: Validation failed: File can't be blank
app/services/receipt_service/extract.rb:77 in ReceiptService::Extract#run!
app/services/receipt_service/suggest.rb:16 in ReceiptService::Suggest#run!
app/jobs/receipt/suggest_pairings_job.rb:13 in Receipt::SuggestPairingsJob#perform
```

`ReceiptService::Extract#run!` makes a slow synchronous call to OpenAI before persisting the extracted fields via `@receipt.update!`. If the receipt (or its file) is deleted while that request is in flight — e.g. the user removes it from the receipt bin while `Receipt::SuggestPairingsJob` is still processing it — the final `update!` re-runs `validates :file, attached: true` against the now-gone attachment and raises `ActiveRecord::RecordInvalid` instead of just no-oping, crashing the job.

## Fix

Re-check that the receipt still exists and still has a file attached right before persisting extraction results, bailing out quietly if not — matching the existing early-return style already used elsewhere in this method (rate limiting, missing textual content, unparseable AI response).

## Test

Added `spec/services/receipt_service/extract_spec.rb`:
- happy path: extracted data is persisted onto the receipt
- regression: deleting the receipt (from a separate in-memory object, simulating a concurrent request) while the OpenAI request is in flight no longer raises. Verified this test reproduces the exact reported `RecordInvalid: File can't be blank` when run against the code before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)