### PR TITLE
Fix nil ledger items crash on account number creation

### DIFF
--- a/app/controllers/column/account_number_controller.rb
+++ b/app/controllers/column/account_number_controller.rb
@@ -10,6 +10,11 @@ module Column
         column_account_number = authorize @event.build_column_account_number
         column_account_number.save!
 
+        if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
+          @ledger = @event.ledger
+          @ledger_items = @ledger.items.none.page(1)
+        end
+
         @animated = true
         render "events/account_number", status: :unprocessable_content
       else


### PR DESCRIPTION
## Problem

Creating a new Column account number (`Column::AccountNumberController#create`) crashed with:

```
ActionView::Template::Error: private method 'load' called for nil
app/views/ledgers/_ledger.html.erb:45
app/views/ledgers/_ledger.html.erb:3
app/views/events/account_number.html.erb:61
app/controllers/column/account_number_controller.rb:14 in Column::AccountNumberController#create
```

`create` renders `events/account_number` directly after creating the account number, but unlike `EventsController#account_number` (the action that normally backs that view), it never set `@ledger`/`@ledger_items` when the `new_ledger_everywhere_2026_07_13` flipper is enabled. The view then passed `items: nil` into `ledgers/_ledger`, which calls `items.load.any?` and blew up on `nil`.

## Fix

Set `@ledger` and `@ledger_items` (an empty, correctly paginated relation, since the account number was just created and has no items yet) in `create` when the flipper is enabled, mirroring `EventsController#account_number`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)