### PR TITLE
Report filesystem inode usage to AppSignal

### DIFF
--- a/app/lib/disk_inode_usage_probe.rb
+++ b/app/lib/disk_inode_usage_probe.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Reports filesystem inode usage, as a percentage, to AppSignal.
+#
+# AppSignal's built-in host metrics only cover disk usage in bytes. A
+# filesystem can exhaust its inode table while it still has plenty of free
+# space, which makes it invisible to the disk_usage metric. This probe reports
+# `disk_inode_usage` so it can be alerted on the same way.
+#
+# Registered as a minutely probe in config/initializers/appsignal_inode_probe.rb.
+class DiskInodeUsageProbe
+  METRIC_NAME = "disk_inode_usage"
+
+  # -i reports inodes rather than blocks, -P forces the portable one-line-per-
+  # filesystem format, and -l limits output to local filesystems so that an
+  # unresponsive network mount cannot stall the probe thread.
+  DF_COMMAND = "df -iPl"
+
+  def initialize(hostname: Socket.gethostname, df: -> { `#{DF_COMMAND}` })
+    @hostname = hostname
+    @df = df
+  end
+
+  def call
+    parse(@df.call).each do |mountpoint, percent|
+      Appsignal.set_gauge(METRIC_NAME, percent, hostname: @hostname, mountpoint:)
+    end
+  end
+
+  private
+
+  def parse(output)
+    # Columns are: Filesystem, Inodes, IUsed, IFree, IUse%, Mounted on. The
+    # mount point is taken as the rest of the line because it may contain
+    # spaces.
+    output.to_s.lines.drop(1).filter_map do |line|
+      fields = line.split(" ", 6)
+      next if fields.length < 6
+
+      # Filesystems that do not track inodes, such as an EFI partition, report
+      # "-" here instead of a percentage.
+      percent = fields[4][/\A(\d+)%\z/, 1]
+      next if percent.nil?
+
+      [fields[5].strip, percent.to_i]
+    end
+  end
+
+end

--- a/config/initializers/appsignal_inode_probe.rb
+++ b/config/initializers/appsignal_inode_probe.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# AppSignal's host metrics only report disk usage in bytes, so a filesystem
+# that runs out of inodes while bytes-free still looks healthy goes unnoticed.
+# DiskInodeUsageProbe reports that separately, once a minute per host.
+#
+# The probe only runs once AppSignal starts its minutely probe thread, so this
+# registration is inert in environments where AppSignal is inactive.
+Appsignal::Probes.register :disk_inode_usage, -> { DiskInodeUsageProbe.new.call }

--- a/spec/app/lib/disk_inode_usage_probe_spec.rb
+++ b/spec/app/lib/disk_inode_usage_probe_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DiskInodeUsageProbe do
+  # Format of `df -iPl` on the production hosts.
+  let(:df_output) do
+    <<~DF
+      Filesystem      Inodes   IUsed  IFree IUse% Mounted on
+      tmpfs           992153     755 991398    1% /run
+      /dev/sda1      2427136 2427134      2  100% /
+      /dev/sda15           0       0      0     - /boot/efi
+    DF
+  end
+
+  def probe(output, hostname: "server-jobs-1")
+    described_class.new(hostname:, df: -> { output })
+  end
+
+  before do
+    allow(Appsignal).to receive(:set_gauge)
+  end
+
+  it "reports the inode percentage tagged with the host and mount point" do
+    probe(df_output).call
+
+    expect(Appsignal).to have_received(:set_gauge)
+      .with("disk_inode_usage", 1, { hostname: "server-jobs-1", mountpoint: "/run" })
+  end
+
+  it "reports 100 percent for a filesystem whose inode table is exhausted" do
+    probe(df_output).call
+
+    expect(Appsignal).to have_received(:set_gauge)
+      .with("disk_inode_usage", 100, { hostname: "server-jobs-1", mountpoint: "/" })
+  end
+
+  it "skips filesystems that do not track inodes" do
+    probe(df_output).call
+
+    expect(Appsignal).not_to have_received(:set_gauge)
+      .with(anything, anything, hash_including(mountpoint: "/boot/efi"))
+  end
+
+  it "keeps mount points that contain spaces intact" do
+    output = <<~DF
+      Filesystem      Inodes   IUsed  IFree IUse% Mounted on
+      /dev/sdb1       100000    5000  95000    5% /mnt/my backup
+    DF
+
+    probe(output).call
+
+    expect(Appsignal).to have_received(:set_gauge)
+      .with("disk_inode_usage", 5, { hostname: "server-jobs-1", mountpoint: "/mnt/my backup" })
+  end
+
+  it "reports nothing when df returns no filesystems" do
+    probe("").call
+
+    expect(Appsignal).not_to have_received(:set_gauge)
+  end
+end


### PR DESCRIPTION
## Summary of the problem

AppSignal's host metrics only cover disk usage in bytes. A filesystem can exhaust its **inode** table while still reporting plenty of free space, so it stays invisible to the `disk_usage` metric and to any alert built on it.

That makes for a confusing failure: writes start failing with `No space left on device` while `df -h` still shows the disk as comfortably healthy. Filling an inode table doesn't take anything exotic, just a directory that accumulates a very large number of small files over time. We had a deploy fail this way, and no threshold on the existing metric could have caught it.

## Describe your changes

Adds `DiskInodeUsageProbe`, registered as an AppSignal minutely probe, reporting a `disk_inode_usage` gauge per mount point tagged with `hostname` and `mountpoint`. That mirrors how `disk_usage` is already tagged, so an alert can be set up the same way.

A few details worth calling out:

- `df -iPl` is used rather than plain `df -i`. `-P` forces the portable one line per filesystem format, and `-l` limits output to local filesystems so an unresponsive network mount cannot stall the probe thread. The gem logs an error if probes take longer than 60 seconds.
- Filesystems that do not track inodes, such as an EFI partition, report `-` instead of a percentage. Those are skipped rather than parsed as `0`.
- Mount points can contain spaces, so the mount point is taken as the remainder of the line.
- `df` is injected through the constructor, so the spec covers the parsing without shelling out.

This is inert until AppSignal starts its minutely probe thread, so it does nothing in environments where AppSignal is inactive. The gem also wraps each probe call in a rescue that logs rather than raises.

The alert itself is configured in AppSignal and is not part of this PR. It will be set up once the metric is confirmed reporting.