### PR TITLE
[Forms] Remove duplicate input focus styling

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -29,7 +29,7 @@ textarea {
   width: 100%;
   max-width: 24rem;
 
-  &:not(.transaction *):focus-within {
+  &:not(.transaction *, .input input):focus-within {
     border-color: map-get($palette, info);
     box-shadow: 0 0 0 3px rgba(map-get($palette, info), 0.25);
   }


### PR DESCRIPTION
Before 
<img width="936" height="110" alt="image" src="https://github.com/user-attachments/assets/2b053d26-9d7b-42d9-a708-3c5237264226" />


After
<img width="1030" height="142" alt="image" src="https://github.com/user-attachments/assets/da17f3e3-552d-43ec-8b51-c4538d18d3f9" />
