### PR TITLE
Fix Kaminari "Current page was incalculable" crash from ?per=0

### DIFF
--- a/app/controllers/admin/check_deposits_controller.rb
+++ b/app/controllers/admin/check_deposits_controller.rb
@@ -9,7 +9,7 @@ module Admin
 
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
       @check_deposits = CheckDeposit.page(@page).per(@per).order(Arel.sql("column_id IS NULL AND increase_id IS NULL DESC, created_at DESC"))
     end
 

--- a/app/controllers/admin/column_statements_controller.rb
+++ b/app/controllers/admin/column_statements_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class ColumnStatementsController < AdminController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
       @statements = Column::Statement.includes(:file_attachment).page(@page).per(@per).order(created_at: :desc)
     end
 

--- a/app/controllers/admin/ledger_audits/tasks_controller.rb
+++ b/app/controllers/admin/ledger_audits/tasks_controller.rb
@@ -4,7 +4,7 @@ module Admin
   module LedgerAudits
     class TasksController < AdminController
       def index
-        @tasks = Admin::LedgerAudit::Task.flagged.page(params[:page]).per(params[:per] || 25)
+        @tasks = Admin::LedgerAudit::Task.flagged.page(params[:page]).per(safe_per(25))
       end
 
       def show

--- a/app/controllers/admin/ledger_audits_controller.rb
+++ b/app/controllers/admin/ledger_audits_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class LedgerAuditsController < AdminController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
 
       @ledger_audits = Admin::LedgerAudit.all.order(created_at: :desc).includes(:admin_ledger_audit_tasks).where.not(admin_ledger_audit_tasks: { id: nil }).page(@page).per(@per)
     end

--- a/app/controllers/admin/legal_entities_controller.rb
+++ b/app/controllers/admin/legal_entities_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class LegalEntitiesController < Admin::BaseController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
 
       relation = LegalEntity.includes(:users, :managing_event, :latest_tax_form)
 

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class PaymentsController < Admin::BaseController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
 
       relation = Payment.includes(:payee, :event)
 

--- a/app/controllers/admin/payroll_positions_controller.rb
+++ b/app/controllers/admin/payroll_positions_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class PayrollPositionsController < Admin::BaseController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
 
       relation = Payroll::Position.includes(:payee, :event)
 

--- a/app/controllers/admin/tax_forms_controller.rb
+++ b/app/controllers/admin/tax_forms_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class TaxFormsController < Admin::BaseController
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
 
       relation = Tax::Form.includes(:legal_entity)
 

--- a/app/controllers/admin/w9s_controller.rb
+++ b/app/controllers/admin/w9s_controller.rb
@@ -9,7 +9,7 @@ module Admin
 
     def index
       @page = params[:page] || 1
-      @per = params[:per] || 20
+      @per = safe_per(20)
       @w9s = W9.all.order(signed_at: :desc).page(@page).per(@per)
     end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -61,7 +61,7 @@ class AdminController < Admin::BaseController
 
   def events
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @csv_export = params[:format] == "csv"
 
     @events = filtered_events
@@ -172,7 +172,7 @@ class AdminController < Admin::BaseController
 
   def bank_fees
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @event_id = params[:event_id].presence
 
     if @event_id
@@ -191,7 +191,7 @@ class AdminController < Admin::BaseController
 
   def users
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @q = params[:q].presence
     @access_level = params[:access_level]
     @event_id = params[:event_id].presence
@@ -232,7 +232,7 @@ class AdminController < Admin::BaseController
 
   def stripe_cards
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
 
     @q = params[:q].presence
 
@@ -252,7 +252,7 @@ class AdminController < Admin::BaseController
 
   def raw_transactions
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @unique_bank_identifier = params[:unique_bank_identifier].presence
 
     relation = RawCsvTransaction
@@ -281,7 +281,7 @@ class AdminController < Admin::BaseController
 
   def raw_intrafi_transactions
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
 
     @count = RawIntrafiTransaction.count
     @imported = flash[:imported_transactions] || []
@@ -332,7 +332,7 @@ class AdminController < Admin::BaseController
 
   def ledger
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @q = params[:q].presence
     @amount = params[:amount].presence
     @unmapped = params[:unmapped] != "0"
@@ -387,7 +387,7 @@ class AdminController < Admin::BaseController
 
   def ledger_items
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @amount = params[:amount].presence
     @q = params[:q].presence
     @unmapped = params[:unmapped] != "0"
@@ -435,7 +435,7 @@ class AdminController < Admin::BaseController
 
   def pending_ledger
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @q = params[:q].presence
     @unsettled = params[:unsettled] == "1" ? true : nil
     @event_id = params[:event_id].presence
@@ -477,7 +477,7 @@ class AdminController < Admin::BaseController
 
   def ach
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @pending = params[:pending] == "1" ? true : nil
     @start_date = params[:start_date].presence
@@ -538,7 +538,7 @@ class AdminController < Admin::BaseController
 
   def reimbursements
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @pending = params[:pending] == "1" ? true : nil
     @failed = params[:failed] == "1" ? true : nil
@@ -580,7 +580,7 @@ class AdminController < Admin::BaseController
 
   def stripe_card_personalization_designs
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @pending = params[:pending] == "1"
     @unlisted = params[:unlisted] == "1"
@@ -703,7 +703,7 @@ class AdminController < Admin::BaseController
 
   def checks
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @in_transit = params[:in_transit] == "1" ? true : nil
     @start_date = params[:start_date].presence
@@ -762,7 +762,7 @@ class AdminController < Admin::BaseController
 
   def increase_checks
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @exclude_reimbursements = params[:exclude_reimbursements] == "1" ? true : nil
 
     relation = IncreaseCheck.all
@@ -782,7 +782,7 @@ class AdminController < Admin::BaseController
 
   def paypal_transfers
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @event = Event.find_by(id: params[:event_id]) if params[:event_id].present?
 
@@ -806,7 +806,7 @@ class AdminController < Admin::BaseController
 
   def wires
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @start_date = params[:start_date].presence
     @end_date = params[:end_date].presence
@@ -844,7 +844,7 @@ class AdminController < Admin::BaseController
 
   def wise_transfers
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @event_id = params[:event_id].presence
     @status = WiseTransfer.aasm.states.collect(&:name).include?(params[:status]&.to_sym) ? params[:status] : nil
@@ -893,7 +893,7 @@ class AdminController < Admin::BaseController
 
   def applications
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @include_archived = params[:include_archived] == "1" ? true : nil
 
@@ -910,7 +910,7 @@ class AdminController < Admin::BaseController
 
   def donations
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @ip_address = params[:ip_address].presence
     @user_agent = params[:user_agent].presence
@@ -968,13 +968,13 @@ class AdminController < Admin::BaseController
 
     relation = relation.where(event_id: @event_id) if @event_id
 
-    @donations = relation.page(params[:page]).per(params[:per] || 20).order(created_at: :desc)
+    @donations = relation.page(params[:page]).per(safe_per(20)).order(created_at: :desc)
 
   end
 
   def fee_revenues
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
 
     # Pending fees that haven't been converted to FeeRevenue yet
     # Pre-calculate fee balances to avoid calling fee_balance_v2_cents multiple times per event
@@ -993,7 +993,7 @@ class AdminController < Admin::BaseController
 
   def disbursements
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @reviewing = params[:reviewing] == "1" ? true : nil
     @pending = params[:pending] == "1" ? true : nil
@@ -1053,7 +1053,7 @@ class AdminController < Admin::BaseController
   def hcb_codes
     @params = params.permit(:page, :per, :q, :has_receipt, :start_date, :end_date)
     @page = @params[:page] || 1
-    @per = @params[:per] || 20
+    @per = safe_per(20)
     @q = @params[:q].presence
     @has_receipt = @params[:has_receipt]
     @start_date = @params[:start_date]
@@ -1092,7 +1092,7 @@ class AdminController < Admin::BaseController
 
   def invoices
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @number = params[:number].presence
     @open = params[:open] == "1" ? true : nil
@@ -1157,7 +1157,7 @@ class AdminController < Admin::BaseController
 
   def sponsors
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
 
     @event_id = params[:event_id].presence
@@ -1179,7 +1179,7 @@ class AdminController < Admin::BaseController
 
   def google_workspaces
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @needs_ops_review = params[:needs_ops_review] == "1" ? true : nil
     @configuring = params[:configuring] == "1" ? true : nil
@@ -1520,14 +1520,14 @@ class AdminController < Admin::BaseController
 
   def hq_receipts
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @users = User.where(id: Event.omitted.includes(:users).flat_map(&:users).map(&:id)).page(@page).per(@per).order(created_at: :desc)
 
   end
 
   def account_numbers
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @event_id = params[:event_id].presence
     @account_number_type = params[:account_number_type].presence # default/nil = show all, 1 = deposit only, 2 = spend + deposit
@@ -1567,7 +1567,7 @@ class AdminController < Admin::BaseController
 
   def emails
     @page = params[:page] || 1
-    @per = params[:per] || 100
+    @per = safe_per(100)
     @q = params[:q].presence
     @user_id = params[:user_id]
     @to = params[:to].presence
@@ -1624,7 +1624,7 @@ class AdminController < Admin::BaseController
 
   def employees
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @employees = Employee.all.includes(:event, :entity).page(@page).per(@per).order(
       Arel.sql("aasm_state = 'onboarding' DESC"),
       "employees.created_at desc"
@@ -1633,7 +1633,7 @@ class AdminController < Admin::BaseController
 
   def employee_payments
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @payments = Employee::Payment.all.page(@page).per(@per)
   end
 
@@ -1660,7 +1660,7 @@ class AdminController < Admin::BaseController
 
   def contracts
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
     @q = params[:q].presence
     @type = params[:type].presence
     @status = params[:status].presence

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,12 +102,6 @@ class ApplicationController < ActionController::Base
     current_user if auditor_signed_in?
   end
 
-  # Safely computes a per-page value for Kaminari pagination from a
-  # user-controlled param. Guards against `?per=0`, `?per=-5`, `?per=abc`,
-  # or `?per=` producing a per-page of 0, which Kaminari accepts silently
-  # via `.per(0)` but then blows up with
-  # `Kaminari::ZeroPerPageOperation: Current page was incalculable. Perhaps you called .per(0)?`
-  # the moment the view calls `.current_page`, `.total_pages`, or renders `paginate`.
   def safe_per(default, max: 200)
     (params[:per] || default).to_i.clamp(1, max)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,6 +102,17 @@ class ApplicationController < ActionController::Base
     current_user if auditor_signed_in?
   end
 
+  # Safely computes a per-page value for Kaminari pagination from a
+  # user-controlled param. Guards against `?per=0`, `?per=-5`, `?per=abc`,
+  # or `?per=` producing a per-page of 0, which Kaminari accepts silently
+  # via `.per(0)` but then blows up with
+  # `Kaminari::ZeroPerPageOperation: Current page was incalculable. Perhaps you called .per(0)?`
+  # the moment the view calls `.current_page`, `.total_pages`, or renders `paginate`.
+  def safe_per(default, max: 200)
+    (params[:per] || default).to_i.clamp(1, max)
+  end
+  helper_method :safe_per
+
   private
 
   def redirect_to_onboarding

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -22,7 +22,7 @@ class CardGrantsController < ApplicationController
     params[:q] ||= params[:search]
 
     card_grants_page = (params[:page] || 1).to_i
-    card_grants_per_page = (params[:per] || 20).to_i
+    card_grants_per_page = safe_per(20)
 
     @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger, :reimbursement_report).order(created_at: :desc)
     @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?
@@ -38,7 +38,7 @@ class CardGrantsController < ApplicationController
     set_ledger_filters
     return if performed?
 
-    @per = params[:per] || 25
+    @per = safe_per(25)
     @table_only = true
     if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
       @ledger = @event.ledger
@@ -222,7 +222,7 @@ class CardGrantsController < ApplicationController
     @hcb_codes = @card_grant.visible_hcb_codes
 
     if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
-      @per = params[:per] || 25
+      @per = safe_per(25)
       @table_only = true
       @ledger = @card_grant.ledger
       @items = Ledger::Query.new({}).execute(ledgers: [@card_grant.ledger]).page(params[:page]).per(@per)
@@ -246,7 +246,7 @@ class CardGrantsController < ApplicationController
     @card = @card_grant.stripe_card
     @hcb_codes = @card&.local_hcb_codes
 
-    @per = params[:per] || 25
+    @per = safe_per(25)
     @table_only = true
     @ledger = @card_grant.ledger
     @items = @card_grant.ledger.items.order(datetime: :desc, created_at: :desc, id: :desc).page(params[:page]).per(@per)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -141,7 +141,7 @@ class DocumentsController < ApplicationController
 
   def set_document
     @page = params[:page] || 1
-    @per = params[:per] || 20
+    @per = safe_per(20)
 
     @document = Document.friendly.find(params[:id] || params[:document_id])
     @downloads = @document.downloads.page(@page).per(@per)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -223,7 +223,7 @@ class EventsController < ApplicationController
     @pending_transactions = type_results[:pending_transactions]
 
     page = (params[:page] || 1).to_i
-    per_page = (params[:per] || TRANSACTIONS_PER_PAGE).to_i.clamp(1, 200)
+    per_page = safe_per(TRANSACTIONS_PER_PAGE)
 
     @transactions = Kaminari.paginate_array(@all_transactions).page(page).per(per_page)
     TransactionGroupingEngine::Transaction::AssociationPreloader.new(transactions: @transactions, event: @event).run!
@@ -303,7 +303,7 @@ class EventsController < ApplicationController
     elsif @filter
       @all_positions = @all_positions.where(role: @filter)
     end
-    @positions = Kaminari.paginate_array(@all_positions).page(params[:page]).per(params[:per] || (@view == "list" ? 20 : 10))
+    @positions = Kaminari.paginate_array(@all_positions).page(params[:page]).per(safe_per(@view == "list" ? 20 : 10))
 
     if @event.parent
       # `ancestor_organizer_positions` covers this organization as well as its
@@ -520,7 +520,7 @@ class EventsController < ApplicationController
     authorize @event
 
     page = (params[:page] || 1).to_i
-    per_page = (params[:per] || 18).to_i
+    per_page = safe_per(18)
 
     display_cards = [
       @user_stripe_cards.active,
@@ -576,12 +576,12 @@ class EventsController < ApplicationController
         @ledger_items = @ledger.items
                                .where(id: column_transactions.select(:ledger_item_id), linked_object_type: nil)
                                .order(created_at: :desc)
-                               .page((params[:page] || 1).to_i).per(params[:per] || 25)
+                               .page((params[:page] || 1).to_i).per(safe_per(25))
       else
         @transactions = column_transactions.where("hcb_code ilike 'HCB-#{::TransactionGroupingEngine::Calculate::HcbCode::UNKNOWN_CODE}%'")
                                            .order(created_at: :desc)
         page = (params[:page] || 1).to_i
-        @transactions = @transactions.page(page).per(params[:per] || 25)
+        @transactions = @transactions.page(page).per(safe_per(25))
       end
 
       # We only want to show this callout if there were transfers from before https://github.com/hackclub/hcb/pull/13684 was merged
@@ -657,7 +657,7 @@ class EventsController < ApplicationController
     relation = relation.search_name(params[:q]) if params[:q].present?
 
     page = (params[:page] || 1).to_i
-    per_page = (params[:per] || DONATIONS_PER_PAGE).to_i
+    per_page = safe_per(DONATIONS_PER_PAGE)
 
     @all_donations = relation.order(created_at: :desc)
 
@@ -756,7 +756,7 @@ class EventsController < ApplicationController
       all_transfers = [@payments]
     end
 
-    @transfers = Kaminari.paginate_array(all_transfers.flatten.sort_by { |o| o.created_at }.reverse!).page(params[:page]).per(params[:per] || 100)
+    @transfers = Kaminari.paginate_array(all_transfers.flatten.sort_by { |o| o.created_at }.reverse!).page(params[:page]).per(safe_per(100))
 
     @filter_options = transfer_filter_options
     helpers.validate_filter_options(@filter_options, params)
@@ -846,7 +846,7 @@ class EventsController < ApplicationController
       all_transfers = [@paypal_transfers]
     end
 
-    @transfers = Kaminari.paginate_array(all_transfers.flatten.sort_by { |o| o.created_at }.reverse!).page(params[:page]).per(params[:per] || 100)
+    @transfers = Kaminari.paginate_array(all_transfers.flatten.sort_by { |o| o.created_at }.reverse!).page(params[:page]).per(safe_per(100))
 
     @filter_options = transfer_filter_options
     helpers.validate_filter_options(@filter_options, params)
@@ -887,7 +887,7 @@ class EventsController < ApplicationController
     @reports = @reports.search(params[:q]) if params[:q].present?
     @reports = @reports.where("reimbursement_reports.created_at <= ?", params[:created_before]) if params[:created_before].present?
     @reports = @reports.where("reimbursement_reports.created_at >= ?", params[:created_after]) if params[:created_after].present?
-    @reports = @reports.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 25)
+    @reports = @reports.order(created_at: :desc).page(params[:page] || 1).per(safe_per(25))
 
     @filter_options = [
       { key: "status", label: "Status", type: "select", options: %w[draft review_required pending reimbursed rejected] },
@@ -944,7 +944,7 @@ class EventsController < ApplicationController
           @rows = sub_organization_table_rows(search: @search)
         else
           sub_organizations = filtered_sub_organizations
-          @sub_organizations = sub_organizations.not_hidden.page(params[:page]).per(params[:per] || 24)
+          @sub_organizations = sub_organizations.not_hidden.page(params[:page]).per(safe_per(24))
           @hidden_sub_organizations = sub_organizations.hidden.to_a
         end
       end
@@ -1312,7 +1312,7 @@ class EventsController < ApplicationController
 
   def ledger
     authorize @event
-    @per = (params[:per] || 100).to_i.clamp(1, 200)
+    @per = safe_per(100)
 
     @items = ledger_query.execute(ledgers: @ledgers)
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -59,7 +59,7 @@ class InvoicesController < ApplicationController
       relation,
       INVOICE_COLUMNS,
       sort: [params[:sort], params[:direction]]
-    ).includes(:sponsor).page(params[:page]).per(params[:per] || 25)
+    ).includes(:sponsor).page(params[:page]).per(safe_per(25))
 
     @sponsor = Sponsor.new(event: @event)
     @invoice = Invoice.new(sponsor: @sponsor, event: @event)

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -143,7 +143,7 @@ class MyController < ApplicationController
     end
 
     @hcb_codes = Kaminari.paginate_array(hcb_codes_missing_receipt)
-                         .page(params[:page]).per(params[:per] || 15)
+                         .page(params[:page]).per(safe_per(15))
 
     if @grouping == "due_date"
       # @hcb_codes is already in due date order, so group_by preserves it.
@@ -220,7 +220,7 @@ class MyController < ApplicationController
     @payments = @payments.where(aasm_state: %w[pending_legal_entity under_review sent]) if params[:status] == "in_transit"
     @payments = @payments.where(aasm_state: "successful") if params[:status] == "deposited"
     @payments = @payments.where(aasm_state: "rejected") if params[:status] == "canceled"
-    @payments = @payments.page(params[:page] || 1).per(params[:per] || 10)
+    @payments = @payments.page(params[:page] || 1).per(safe_per(10))
 
     @filter_options = [
       { key: "status", label: "Status", type: "select", options: %w[deposited in_transit canceled] }

--- a/app/controllers/stripe_cards_controller.rb
+++ b/app/controllers/stripe_cards_controller.rb
@@ -81,12 +81,12 @@ class StripeCardsController < ApplicationController
 
     @hcb_codes = @card.local_hcb_codes
                       .includes(canonical_pending_transactions: [:raw_pending_stripe_transaction], canonical_transactions: :transaction_source)
-                      .page(params[:page]).per(params[:per] || 25)
+                      .page(params[:page]).per(safe_per(25))
 
     if Flipper.enabled?(:new_ledger_everywhere_2026_07_13, current_user)
       # Grant cards (viewable here by auditors) keep their charges on the card
       # grant's ledger rather than the event's.
-      @per = params[:per] || 25
+      @per = safe_per(25)
       @table_only = true
       @ledger = @card.card_grant&.ledger || @event.ledger
       # TODO: Swap this out for Ledger::Query once Stripe cards have their own non-primary ledgers

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -276,43 +276,43 @@ class UsersController < ApplicationController
   def admin_details_ach_transfers
     authorize @user
 
-    @ach_transfers = @user.ach_transfers.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @ach_transfers = @user.ach_transfers.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_check_deposits
     authorize @user
 
-    @check_deposits = @user.check_deposits.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @check_deposits = @user.check_deposits.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_disbursements
     authorize @user
 
-    @disbursements = @user.disbursements.order(created_at: :desc).includes([:destination_event]).page(params[:page] || 1).per(params[:per] || 10)
+    @disbursements = @user.disbursements.order(created_at: :desc).includes([:destination_event]).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_emburse_cards
     authorize @user
 
-    @emburse_cards = @user.emburse_cards.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @emburse_cards = @user.emburse_cards.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_increase_checks
     authorize @user
 
-    @increase_checks = @user.increase_checks.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @increase_checks = @user.increase_checks.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_invoices
     authorize @user
 
-    @invoices = @user.invoices.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @invoices = @user.invoices.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_lob_checks
     authorize @user
 
-    @lob_checks = @user.checks.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @lob_checks = @user.checks.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_missing_receipts
@@ -322,7 +322,7 @@ class UsersController < ApplicationController
     @hcb_codes_missing_receipts = @user.transactions_missing_receipt
                                        .order(created_at: :desc)
                                        .includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
-                                       .page(params[:page] || 1).per(params[:per] || 10)
+                                       .page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_reimbursement_reports
@@ -331,13 +331,13 @@ class UsersController < ApplicationController
     @reimbursement_reports = @user.reimbursement_reports
                                   .order(created_at: :desc)
                                   .includes([:event, :payout_holding])
-                                  .page(params[:page] || 1).per(params[:per] || 10)
+                                  .page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_stripe_cards
     authorize @user
 
-    @stripe_cards = @user.stripe_cards.order(created_at: :desc).page(params[:page] || 1).per(params[:per] || 10)
+    @stripe_cards = @user.stripe_cards.order(created_at: :desc).page(params[:page] || 1).per(safe_per(10))
   end
 
   def admin_details_stripe_transactions
@@ -349,12 +349,12 @@ class UsersController < ApplicationController
                                   .includes(:canonical_transactions, :canonical_pending_transactions, :linked_object)
                                   .where(linked_object_type: "CardCharge")
                                   .order(datetime: :desc, created_at: :desc, id: :desc)
-                                  .page(params[:page] || 1).per(params[:per] || 10)
+                                  .page(params[:page] || 1).per(safe_per(10))
     else
       @stripe_transactions = HcbCode.where(id: @user.stripe_cards.flat_map { |sc| sc.local_hcb_codes.pluck(:id) })
                                     .order(created_at: :desc)
                                     .includes([:canonical_transactions, :event, :receipts, :subledger, :tags])
-                                    .page(params[:page] || 1).per(params[:per] || 10)
+                                    .page(params[:page] || 1).per(safe_per(10))
     end
   end
 


### PR DESCRIPTION
## Problem

`ActionView::Template::Error: Current page was incalculable. Perhaps you called .per(0)?` was reported on `events/donation_overview.html.erb:40`.

Root cause: Kaminari's `.per(n)` coerces its argument via `.to_i`; when that lands on `0` (`?per=0`, `?per=-5`, `?per=abc`, or `?per=`), any subsequent call to `.current_page`, `.total_pages`, `.out_of_range?`, or the `paginate` view helper divides by that zero limit and raises the error above.

Auditing the app turned up ~70 call sites with the same unclamped shape (`params[:per]` fed straight into `.per(...)`), spanning `events_controller.rb`, `card_grants_controller.rb`, `stripe_cards_controller.rb`, `my_controller.rb`, `invoices_controller.rb`, `documents_controller.rb`, `users_controller.rb` (11 `admin_details_*` actions), `admin_controller.rb` (30 actions), and 9 more `admin/*_controller.rb` files.

## Fix

Added `ApplicationController#safe_per(default, max: 200)`:

```ruby
def safe_per(default, max: 200)
  (params[:per] || default).to_i.clamp(1, max)
end
helper_method :safe_per
```

and replaced every unclamped `params[:per]` → `.per(...)` call site with it, so `per` is always coerced to an integer and floored at 1.

## Testing

- `ruby -c` clean on all 18 touched files
- `rubocop` reports zero offenses on the diff
- Grep confirms no `params[:per]` reaches `.per(...)`/`@per =` anywhere in `app/controllers/` outside the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)