### PR TITLE
Remove dead "latest from HCB announcement" dashboard block

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -218,22 +218,6 @@
 
     <%= render "static_pages/index/teenager_raffle" %>
 
-    <%# Latest HCB announcement %>
-    <% if @latest_hcb_announcement %>
-      <div class="flex flex-row w-full justify-between items-center">
-        <h2 class="heading h2 leading-[1.5] my-2 mt-4 mr-auto py-2 px-4 ml-0 pl-0 border-none">
-          The latest from HCB
-        </h2>
-        <%= link_to event_announcement_overview_path(Event.find(EventMappingEngine::EventIds::HACK_CLUB_BANK)), class: "muted", target: :_blank do %>
-          View all announcements
-          <%= inline_icon "external", size: 18, class: "ml-1 align-text-top", style: "transform: scale(1.2)" %>
-        <% end %>
-      </div>
-      <div class="mb-4 text-left w-full self-stretch">
-        <%= render partial: "announcements/announcement_card", locals: { announcement: @latest_hcb_announcement } %>
-      </div>
-    <% end %>
-
     <%= render "static_pages/index/explore" %>
   <% end %>
 


### PR DESCRIPTION
## Summary
- Removes the "The latest from HCB" announcement section from the dashboard ([app/views/static_pages/index.html.erb](app/views/static_pages/index.html.erb))
- `@latest_hcb_announcement` is never assigned anywhere in the codebase (confirmed via search), so this block was always dead — it never rendered.

## Test plan
- Confirmed no controller sets `@latest_hcb_announcement`
- Loaded the dashboard locally to confirm layout still renders correctly without the block

🤖 Generated with [Claude Code](https://claude.com/claude-code)