### PR TITLE
[IncreaseCheck] Remove ignored_columns for dropped reissued_for_id

### DIFF
--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -46,7 +46,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class IncreaseCheck < ApplicationRecord
-  self.ignored_columns += ["reissued_for_id"]
   # [@garyhtou] `IncreaseCheck` superseded `Check` starting March 2023.
   # On January 2024, we switched check printing & mailing services from
   # Increase to Column. This model, although still named `IncreaseCheck`, now


### PR DESCRIPTION
## Summary
- `reissued_for_id` was dropped from `increase_checks` in `db/migrate/20260626120100_remove_reissued_for_id_from_increase_checks.rb` (already applied — the column is absent from `db/schema.rb` and the schema version is later than that migration).
- The `self.ignored_columns += ["reissued_for_id"]` line in `IncreaseCheck` is now dead weight; removing it.

No other references to `reissued_for_id` exist in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)