### PR TITLE
[Reimbursements] Count capped drafts at their maximum in the org totals

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -870,7 +870,7 @@ class EventsController < ApplicationController
 
   def reimbursements
     authorize @event
-    @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:amount_cents)
+    @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:committed_amount_cents)
     @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed.where.not(currency: "USD")).sum(&:amount_cents)
     @total += Money.from_cents(@event.reimbursement_reports.pending.where.not(currency: "USD").sum(&:cached_wise_transfer_quote_amount)).cents
     @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -872,7 +872,12 @@ class EventsController < ApplicationController
     authorize @event
     @total = @event.reimbursement_reports.to_calculate_total.where(currency: "USD").includes(:payout_holding).sum(&:committed_amount_cents)
     @total += Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed.where.not(currency: "USD")).sum(&:amount_cents)
-    @total += Money.from_cents(@event.reimbursement_reports.pending.where.not(currency: "USD").sum(&:cached_wise_transfer_quote_amount)).cents
+    # A capped draft is worth its maximum, which is already in USD cents and is
+    # what ops check the transfer against at approval. Everything else non-USD
+    # is valued at its Wise quote.
+    capped_drafts, quoted = @event.reimbursement_reports.pending.where.not(currency: "USD").partition(&:committed_to_maximum?)
+    @total += capped_drafts.sum(&:committed_amount_cents)
+    @total += Money.from_cents(quoted.sum(&:cached_wise_transfer_quote_amount)).cents
     @reimbursed = Reimbursement::PayoutHolding.where(reimbursement_reports_id: @event.reimbursement_reports.reimbursed).sum(&:amount_cents)
     @pending = @total - @reimbursed
 

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -283,21 +283,32 @@ module Reimbursement
       expenses.approved.to_sum.sum(:amount_cents)
     end
 
-    # How much of the event's balance this report has a claim on.
+    # A draft's expenses are whatever the reimbursee has typed in so far, so an
+    # organizer-set maximum is the only figure that means anything until the
+    # report is submitted.
+    def committed_to_maximum?
+      draft? && maximum_amount_cents.present?
+    end
+
+    # How much of the event's balance this report has a claim on, in USD cents.
     #
-    # Matches `amount_cents` everywhere except a draft carrying an
-    # organizer-set maximum. A draft's expenses are whatever the reimbursee has
-    # typed in so far, which says nothing about what they will eventually
-    # claim — an untouched report reads as $0 and one filled past its maximum
-    # reads above what could ever be paid out. The maximum is the figure the
-    # organizers actually committed to, so that is what the event is on the
-    # hook for until the report is submitted.
+    # Matches `amount_cents` everywhere except a draft carrying a maximum. An
+    # untouched report reads as $0 there, and one filled past its maximum reads
+    # above what could ever be paid out, so neither number describes what the
+    # event is on the hook for — the maximum does.
+    #
+    # This applies to non-USD reports too. `amount_to_reimburse_cents` and
+    # `exceeds_maximum_amount?` only enforce maximums on USD reports, but
+    # `Reimbursement::ReportsController` checks the Wise total against the
+    # maximum before approving a transfer, so ops enforce it either way.
+    # `maximum_amount_cents` is denominated in USD, which is what that check
+    # compares against.
     #
     # Deliberately separate from `amount_cents`: that one gates
     # `exceeds_maximum_amount?` and is what the reimbursee is shown as their
     # requested amount, and neither should move.
     def committed_amount_cents
-      return maximum_amount_cents if draft? && maximum_amount_cents && currency == "USD"
+      return maximum_amount_cents if committed_to_maximum?
 
       amount_cents
     end

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -283,6 +283,25 @@ module Reimbursement
       expenses.approved.to_sum.sum(:amount_cents)
     end
 
+    # How much of the event's balance this report has a claim on.
+    #
+    # Matches `amount_cents` everywhere except a draft carrying an
+    # organizer-set maximum. A draft's expenses are whatever the reimbursee has
+    # typed in so far, which says nothing about what they will eventually
+    # claim — an untouched report reads as $0 and one filled past its maximum
+    # reads above what could ever be paid out. The maximum is the figure the
+    # organizers actually committed to, so that is what the event is on the
+    # hook for until the report is submitted.
+    #
+    # Deliberately separate from `amount_cents`: that one gates
+    # `exceeds_maximum_amount?` and is what the reimbursee is shown as their
+    # requested amount, and neither should move.
+    def committed_amount_cents
+      return maximum_amount_cents if draft? && maximum_amount_cents && currency == "USD"
+
+      amount_cents
+    end
+
     def fees_charged_cents
       expenses.approved.where(type: Reimbursement::Expense::Fee.name).sum(:amount_cents)
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -768,4 +768,59 @@ RSpec.describe EventsController do
     end
   end
 
+  describe "#reimbursements" do
+    render_views
+
+    let(:event) { create(:event) }
+
+    # The statset renders each figure as a `.stat__label` / `.stat__value` pair,
+    # so pull the value out by its label rather than matching loose text.
+    def stat_value(body, label)
+      stat = Nokogiri::HTML5(body).css(".stat").find { |node| node.css(".stat__label").text.strip == label }
+      stat&.css(".stat__value")&.text&.strip
+    end
+
+    before { sign_in_organizer_of(event) }
+
+    it "counts a draft with a maximum at its maximum, not at what has been filed" do
+      report = create(:reimbursement_report, user: create(:user), event:, aasm_state: :draft, maximum_amount_cents: 50_000)
+      create(:reimbursement_expense, report:, value: 80.00, aasm_state: :pending)
+
+      get(:reimbursements, params: { event_id: event.slug })
+
+      expect(response).to have_http_status(:ok)
+      expect(stat_value(response.body, "Total")).to eq(money(50_000))
+      expect(stat_value(response.body, "Pending")).to eq(money(50_000))
+    end
+
+    it "counts an untouched draft with a maximum at its maximum" do
+      create(:reimbursement_report, user: create(:user), event:, aasm_state: :draft, maximum_amount_cents: 50_000)
+
+      get(:reimbursements, params: { event_id: event.slug })
+
+      expect(stat_value(response.body, "Total")).to eq(money(50_000))
+      expect(stat_value(response.body, "Pending")).to eq(money(50_000))
+    end
+
+    it "leaves a draft without a maximum on the expenses filed" do
+      report = create(:reimbursement_report, user: create(:user), event:, aasm_state: :draft)
+      create(:reimbursement_expense, report:, value: 80.00, aasm_state: :pending)
+
+      get(:reimbursements, params: { event_id: event.slug })
+
+      expect(stat_value(response.body, "Total")).to eq(money(8_000))
+      expect(stat_value(response.body, "Pending")).to eq(money(8_000))
+    end
+
+    it "leaves a submitted report with a maximum on the expenses filed" do
+      report = create(:reimbursement_report, user: create(:user), event:, aasm_state: :submitted, maximum_amount_cents: 50_000)
+      create(:reimbursement_expense, report:, value: 50.00, aasm_state: :pending)
+
+      get(:reimbursements, params: { event_id: event.slug })
+
+      expect(stat_value(response.body, "Total")).to eq(money(5_000))
+      expect(stat_value(response.body, "Pending")).to eq(money(5_000))
+    end
+  end
+
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -812,6 +812,18 @@ RSpec.describe EventsController do
       expect(stat_value(response.body, "Pending")).to eq(money(8_000))
     end
 
+    it "counts a non-USD draft with a maximum at its maximum, without a Wise quote" do
+      report = create(:reimbursement_report, user: create(:user), event:, aasm_state: :draft, currency: "EUR", maximum_amount_cents: 50_000)
+      create(:reimbursement_expense, report:, value: 80.00, aasm_state: :pending)
+
+      expect_any_instance_of(Reimbursement::Report).not_to receive(:cached_wise_transfer_quote_amount)
+
+      get(:reimbursements, params: { event_id: event.slug })
+
+      expect(stat_value(response.body, "Total")).to eq(money(50_000))
+      expect(stat_value(response.body, "Pending")).to eq(money(50_000))
+    end
+
     it "leaves a submitted report with a maximum on the expenses filed" do
       report = create(:reimbursement_report, user: create(:user), event:, aasm_state: :submitted, maximum_amount_cents: 50_000)
       create(:reimbursement_expense, report:, value: 50.00, aasm_state: :pending)

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -137,13 +137,14 @@ RSpec.describe Reimbursement::Report, type: :model do
         expect(report).to be_exceeds_maximum_amount
       end
 
-      # Maximums are only enforced on USD reports, so they are not applied to
-      # anything else here either.
-      it "falls back to the expenses filed on a non-USD report" do
+      # `exceeds_maximum_amount?` skips non-USD reports, but ops check the Wise
+      # total against the maximum before approving the transfer, so it binds
+      # here too. `maximum_amount_cents` is denominated in USD.
+      it "reports the maximum on a non-USD report" do
         report = report_with_expense(:draft, 8_000, maximum_amount_cents: 50_000, expense_state: :pending)
         report.update!(currency: "EUR")
 
-        expect(report.committed_amount_cents).to eq(8_000)
+        expect(report.committed_amount_cents).to eq(50_000)
       end
     end
 

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -97,4 +97,77 @@ RSpec.describe Reimbursement::Report, type: :model do
       end
     end
   end
+
+  describe "#committed_amount_cents" do
+    let(:event) { create(:event) }
+    let(:user) { create(:user) }
+
+    def report_with_expense(aasm_state, cents, maximum_amount_cents: nil, expense_state: :approved)
+      report = create(:reimbursement_report, user:, event:, aasm_state:, maximum_amount_cents:)
+      create(:reimbursement_expense, report:, value: cents / 100.0, aasm_state: expense_state) if cents.positive?
+      report
+    end
+
+    context "when the report is a draft with a maximum" do
+      it "reports the maximum even though nothing has been filed" do
+        report = report_with_expense(:draft, 0, maximum_amount_cents: 50_000)
+
+        expect(report.amount_cents).to eq(0)
+        expect(report.committed_amount_cents).to eq(50_000)
+      end
+
+      it "reports the maximum rather than the expenses filed under it" do
+        report = report_with_expense(:draft, 8_000, maximum_amount_cents: 50_000, expense_state: :pending)
+
+        expect(report.committed_amount_cents).to eq(50_000)
+      end
+
+      # `submit` is guarded on `!exceeds_maximum_amount?`, so an over-maximum
+      # report is a state reports sit in rather than pass through.
+      it "reports the maximum rather than expenses filed above it" do
+        report = report_with_expense(:draft, 70_000, maximum_amount_cents: 50_000, expense_state: :pending)
+
+        expect(report.amount_cents).to eq(70_000)
+        expect(report.committed_amount_cents).to eq(50_000)
+      end
+
+      it "leaves `exceeds_maximum_amount?` reading the filed expenses" do
+        report = report_with_expense(:draft, 70_000, maximum_amount_cents: 50_000, expense_state: :pending)
+
+        expect(report).to be_exceeds_maximum_amount
+      end
+
+      # Maximums are only enforced on USD reports, so they are not applied to
+      # anything else here either.
+      it "falls back to the expenses filed on a non-USD report" do
+        report = report_with_expense(:draft, 8_000, maximum_amount_cents: 50_000, expense_state: :pending)
+        report.update!(currency: "EUR")
+
+        expect(report.committed_amount_cents).to eq(8_000)
+      end
+    end
+
+    context "when the report has no maximum" do
+      it "matches the expenses filed on a draft" do
+        report = report_with_expense(:draft, 8_000, expense_state: :pending)
+
+        expect(report.committed_amount_cents).to eq(report.amount_cents)
+        expect(report.committed_amount_cents).to eq(8_000)
+      end
+    end
+
+    context "when the report is past draft" do
+      it "matches `amount_cents` once submitted, maximum or not" do
+        report = report_with_expense(:submitted, 5_000, maximum_amount_cents: 50_000, expense_state: :pending)
+
+        expect(report.committed_amount_cents).to eq(5_000)
+      end
+
+      it "matches `amount_cents` once reimbursement has been requested" do
+        report = report_with_expense(:reimbursement_requested, 10_000, maximum_amount_cents: 50_000)
+
+        expect(report.committed_amount_cents).to eq(10_000)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary of the problem

#14793 - YSWSs need a better way to see reimbursements that haven't affected the balance yet. The main category we are missing are blank reports with a cap (converted grant cards).

### How each report contributes

Maximum is $500 where present. Rows this PR changes are <ins>underlined</ins>.

| Report | State | Reimbursed | Pending (Current Behavior) | Pending (New Behavior) |
|---|---|---|---|---|
| Untouched draft, no maximum | `draft` | — | $0 | $0 |
| <ins>Untouched draft, $500 maximum <em>(converted card grant)</em></ins> | <ins><code>draft</code></ins> | <ins>—</ins> | <ins>$0</ins> | <ins>$500</ins> |
| $80 filed, no maximum | `draft` | — | $80 | $80 |
| <ins>$80 filed, $500 maximum</ins> | <ins><code>draft</code></ins> | <ins>—</ins> | <ins>$80</ins> | <ins>$500</ins> |
| <ins>$700 filed, $500 maximum <em>(can't be submitted)</em></ins> | <ins><code>draft</code></ins> | <ins>—</ins> | <ins>$700</ins> | <ins>$500</ins> |
| €100 filed, no maximum | `draft` | — | Wise quote | Wise quote |
| <ins>€100 filed, $500 maximum</ins> | <ins><code>draft</code></ins> | <ins>—</ins> | <ins>Wise quote</ins> | <ins>$500</ins> |
| $50 filed, no maximum | `submitted` | — | $50 | $50 |
| $50 filed, $500 maximum | `submitted` | — | $50 | $50 |
| $50 filed, $30 approved | `submitted` | — | $50 | $50 |
| $100 approved | `reimbursement_requested` | — | $100 | $100 |
| $50 approved by the org, $75 maximum | `reimbursement_requested` | — | $50 | $50 |
| $100, approved for payout | `reimbursement_approved` | — | $100 | $100 |
| $100 paid out | `reimbursed` | $100 | $0 | $0 |
| $100 sent, transfer failed | `reimbursed` | $100 | $0 | $0 |
| $100 rejected | `rejected` | — | $0 | $0 |
| $100 paid, then reversed | `reversed` | — | $100 | $100 |

The maximum applies to non-USD reports as well. `amount_to_reimburse_cents` and
`exceeds_maximum_amount?` skip them, but `Reimbursement::ReportsController`
checks the Wise total including fees against `maximum_amount_cents` before
approving a transfer, with no currency guard — so ops enforce it at process time
either way. `maximum_amount_cents` is denominated in USD, which is what that
check compares against, so it can be used directly. A capped non-USD draft also
stops needing a Wise quote at all.

## Describe your changes

Adds `Reimbursement::Report#committed_amount_cents`: how much of the event's
balance a report has a claim on. It returns the maximum for a **draft with a
maximum set**, and defers to `amount_cents` for everything else. The
reimbursements page's `@total` now sums that instead of `amount_cents`; Pending
follows automatically, since it's derived from Total.

A draft is the only place the substitution makes sense. Once a report is
submitted, the filed expenses *are* the claim, and the submit guard has already
enforced that they're within the maximum — so the maximum adds no information.
Draft is precisely where filed expenses tell you nothing.

Kept deliberately separate from `amount_cents`, which must not move:

- `exceeds_maximum_amount?` is `amount_cents > maximum_amount_cents`. Folding the
  maximum into `amount_cents` would make that always false and stop the submit
  guard blocking over-maximum reports.
- `monetize :amount_cents, as: "amount"` makes it user-facing — the amount column
  in the table, "is requesting $X" on the edit page, "Amount requested" in the
  report summary, the reimbursee's low-balance warning, and the divisor for the
  Wise conversion rate. An untouched $500-maximum draft would start telling the
  reimbursee they were requesting $500.

### Worth knowing

**Pending becomes a ceiling rather than an expectation for capped drafts.** An
org that grants ten $500 maximums expecting ~$200 claims each will see $5,000
where the eventual debit is likely nearer $2,000. For "how much of my balance is
already spoken for", erring high is the safe direction, but it is a real change
in what the number means for orgs that use maximums.

Maximums aren't set by default — they come only from card grant conversion and
from a manager setting one when inviting or editing a report — so this moves the
figure for the orgs that promised someone a number, and leaves everyone else
alone.

### Not addressed here

Found while tracing this, all pre-existing and left for their own PRs:

- `reversed` reports stay inside `to_calculate_total` but drop out of
  `@reimbursed`, so a reversal inflates Pending permanently even though
  `PayoutHolding#reverse!` restores the balance.
- Wise transfer fees are added as `Expense::Fee` rows at approval, which
  `to_sum` excludes, so the eventual debit on a non-USD report exceeds what
  Pending predicted.
- `wise_transfer_quote_amount` rescues to zero, so a Wise outage silently drops
  non-USD reports out of every figure with no indication on the page.
- The status filter's "Pending" option maps to `reimbursement_requested` alone,
  which is a narrower set than the Pending stat above it.



