### PR TITLE
[Donation] Remove icon for in-person donations

### DIFF
--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -765,11 +765,22 @@ class HcbCode < ApplicationRecord
     return stripe_cardholder&.user if stripe_card?
     return reimbursement_expense_payout&.expense&.report&.user if reimbursement_expense_payout?
     return paypal_transfer&.user if paypal_transfer?
-    return donation&.collected_by if donation? && donation&.in_person?
     return wise_transfer&.user if wise_transfer?
   end
 
+  # A donation an organizer collected with tap to pay, rather than one the
+  # donor made online themselves.
+  def in_person_donation?
+    donation? && donation.in_person?
+  end
+
   def fallback_avatar
+    # An in-person donation is collected by an organizer tapping their phone,
+    # but the money is the donor's. Nobody at the organization belongs in the
+    # author column, and we don't have the donor to put there instead, so it
+    # stays empty.
+    return nil if in_person_donation?
+
     return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && !donation.anonymous?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
 
@@ -778,7 +789,7 @@ class HcbCode < ApplicationRecord
 
   def author_name
     return author&.name if author&.name.present?
-    return donation.name if donation? && !donation.anonymous?
+    return donation.name if donation? && !donation.anonymous? && !in_person_donation?
     return invoice.sponsor.name if invoice?
 
     nil

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -768,19 +768,7 @@ class HcbCode < ApplicationRecord
     return wise_transfer&.user if wise_transfer?
   end
 
-  # A donation an organizer collected with tap to pay, rather than one the
-  # donor made online themselves.
-  def in_person_donation?
-    donation? && donation.in_person?
-  end
-
   def fallback_avatar
-    # An in-person donation is collected by an organizer tapping their phone,
-    # but the money is the donor's. Nobody at the organization belongs in the
-    # author column, and we don't have the donor to put there instead, so it
-    # stays empty.
-    return nil if in_person_donation?
-
     return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && !donation.anonymous?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
 
@@ -789,7 +777,7 @@ class HcbCode < ApplicationRecord
 
   def author_name
     return author&.name if author&.name.present?
-    return donation.name if donation? && !donation.anonymous? && !in_person_donation?
+    return donation.name if donation? && !donation.anonymous?
     return invoice.sponsor.name if invoice?
 
     nil

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -363,8 +363,6 @@ class Ledger
         linked_object&.expense&.report&.user
       when "PaypalTransfer"
         linked_object&.user
-      when "Donation"
-        linked_object&.collected_by if linked_object&.in_person?
       when "Wire"
         linked_object&.user
       when "WiseTransfer"

--- a/app/tasks/maintenance/clear_donation_ledger_item_authors_task.rb
+++ b/app/tasks/maintenance/clear_donation_ledger_item_authors_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # One-time cleanup: `ledger_items.author_id` is a cached column, only
+  # recomputed when an item is refreshed. In-person donations used to be
+  # attributed to the organizer who collected them, which read as if that
+  # organizer had made the payment. Donations no longer have an author, so
+  # clear the ones already stored instead of waiting for each item to be
+  # touched. Run once after deploying.
+  class ClearDonationLedgerItemAuthorsTask < MaintenanceTasks::Task
+    def collection
+      Ledger::Item.where(linked_object_type: "Donation").where.not(author_id: nil)
+    end
+
+    def process(ledger_item)
+      ledger_item.update!(author_id: nil)
+    end
+
+  end
+end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -373,4 +373,32 @@ RSpec.describe HcbCode, type: :model do
       end
     end
   end
+
+  describe "donation authorship" do
+    include DonationSupport
+
+    before { stub_donation_payment_intent_creation }
+
+    let(:collector) { create(:user) }
+
+    it "does not attribute an in-person donation to the organizer who collected it" do
+      donation = create(:donation, in_person: true, collected_by: collector)
+
+      expect(donation.local_hcb_code.author).to be_nil
+    end
+
+    it "leaves the author column empty for an in-person donation" do
+      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace")
+
+      expect(donation.local_hcb_code.fallback_avatar).to be_nil
+      expect(donation.local_hcb_code.author_name).to be_nil
+    end
+
+    it "keeps the donor's gravatar on a donation made online" do
+      donation = create(:donation, name: "Ada Lovelace", email: "ada@example.com")
+
+      expect(donation.local_hcb_code.fallback_avatar).to start_with("https://gravatar.com/avatar/")
+      expect(donation.local_hcb_code.author_name).to eq("Ada Lovelace")
+    end
+  end
 end

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -444,4 +444,23 @@ RSpec.describe Ledger::Item, type: :model do
       end
     end
   end
+
+  describe "#author" do
+    it "is nobody for an in-person donation, which the donor paid rather than the organizer who collected it" do
+      stub_donation_payment_intent_creation
+      donation = create(:donation, in_person: true, collected_by: create(:user))
+
+      item = Ledger::Item.new(
+        amount_cents: 1000,
+        memo: "Initial",
+        datetime: Time.current,
+        linked_object: donation
+      )
+      item.save(validate: false)
+
+      item.refresh!
+
+      expect(item.reload.author).to be_nil
+    end
+  end
 end

--- a/spec/tasks/maintenance/clear_donation_ledger_item_authors_task_spec.rb
+++ b/spec/tasks/maintenance/clear_donation_ledger_item_authors_task_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::ClearDonationLedgerItemAuthorsTask do
+  include DonationSupport
+
+  before { stub_donation_payment_intent_creation }
+
+  # `refresh!` no longer computes an author for a donation, so a stale
+  # author_id has to be written directly to stand in for what the pre-change
+  # code cached.
+  def donation_item(author: nil)
+    donation = create(:donation, in_person: true, collected_by: create(:user))
+    item = Ledger::Item.new(
+      amount_cents: 1000,
+      memo: "Donation",
+      datetime: Time.current,
+      linked_object: donation
+    )
+    item.save(validate: false)
+    item.update_columns(author_id: author&.id)
+    item
+  end
+
+  it "clears the collecting organizer cached on an in-person donation" do
+    item = donation_item(author: create(:user))
+
+    described_class.new.process(item)
+
+    expect(item.reload.author).to be_nil
+  end
+
+  it "collects only the donations that still have an author" do
+    stale = donation_item(author: create(:user))
+    already_cleared = donation_item
+
+    expect(described_class.new.collection).to include(stale)
+    expect(described_class.new.collection).not_to include(already_cleared)
+  end
+end


### PR DESCRIPTION
When an organizer collects a donation with tap to pay in HCB Mobile, the ledger's author column showed that organizer's avatar. It reads as if they spent or sent the money themselves, which is the opposite of what happened: the money is the donor's.

Drop the author on in-person donations in both ledger engines, and the name and gravatar the author column falls back to along with it, so the column is simply empty the way it is for any other transaction with nobody at the organization behind it.

`ledger_items.author_id` is a cached column, so the migration clears the ones already stored rather than waiting for each item to be refreshed.