### PR TITLE
[Donation] Show the donor behind an in-person donation

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -349,6 +349,17 @@ class Donation < ApplicationRecord
     "https://t0.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://#{URI::Parser.new.escape(referrer_domain)}&size=256"
   end
 
+  # Whether there's a donor for the ledger's author column to show. A donation
+  # collected in person with tap to pay only has one if the donor left an email
+  # address to build an avatar from — anyone else in that column would be the
+  # organizer who collected it, reading as if they made the payment.
+  def showable_donor?
+    return false if anonymous?
+    return email.present? if in_person?
+
+    true
+  end
+
   def avatar(size = 128)
     gravatar_url(email, name, email&.sum || rand(1000), size) unless anonymous?
   end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -349,15 +349,11 @@ class Donation < ApplicationRecord
     "https://t0.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://#{URI::Parser.new.escape(referrer_domain)}&size=256"
   end
 
-  # Whether there's a donor for the ledger's author column to show. A donation
-  # collected in person with tap to pay only has one if the donor left an email
-  # address to build an avatar from — anyone else in that column would be the
-  # organizer who collected it, reading as if they made the payment.
+  # Whether the ledger's author column has a donor to show. One collected in
+  # person with tap to pay only does if the donor left an email to build an
+  # avatar from; the organizer who collected it is never shown there.
   def showable_donor?
-    return false if anonymous?
-    return email.present? if in_person?
-
-    true
+    !anonymous? && (!in_person? || email.present?)
   end
 
   def avatar(size = 128)

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -765,11 +765,22 @@ class HcbCode < ApplicationRecord
     return stripe_cardholder&.user if stripe_card?
     return reimbursement_expense_payout&.expense&.report&.user if reimbursement_expense_payout?
     return paypal_transfer&.user if paypal_transfer?
-    return donation&.collected_by if donation? && donation&.in_person?
     return wise_transfer&.user if wise_transfer?
   end
 
+  # A donation an organizer collected with tap to pay, rather than one the
+  # donor made online themselves.
+  def in_person_donation?
+    donation? && donation.in_person?
+  end
+
   def fallback_avatar
+    # An in-person donation is collected by an organizer tapping their phone,
+    # but the money is the donor's. Nobody at the organization belongs in the
+    # author column, and we don't have the donor to put there instead, so it
+    # stays empty.
+    return nil if in_person_donation?
+
     return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && !donation.anonymous?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
 
@@ -778,7 +789,7 @@ class HcbCode < ApplicationRecord
 
   def author_name
     return author&.name if author&.name.present?
-    return donation.name if donation? && !donation.anonymous?
+    return donation.name if donation? && !donation.anonymous? && !in_person_donation?
     return invoice.sponsor.name if invoice?
 
     nil

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -774,12 +774,20 @@ class HcbCode < ApplicationRecord
     donation? && donation.in_person?
   end
 
+  # The donor who paid for an in-person donation, when there's an email address
+  # to build an avatar from. Nil when they donated anonymously or gave none,
+  # which leaves the author column empty rather than falling back to anyone at
+  # the organization: the money is the donor's, and the collector's face there
+  # would read as if they made the payment.
+  def donor
+    return nil unless in_person_donation?
+    return nil if donation.anonymous? || donation.email.blank?
+
+    donation
+  end
+
   def fallback_avatar
-    # An in-person donation is collected by an organizer tapping their phone,
-    # but the money is the donor's. Nobody at the organization belongs in the
-    # author column, and we don't have the donor to put there instead, so it
-    # stays empty.
-    return nil if in_person_donation?
+    return nil if in_person_donation? && donor.nil?
 
     return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && !donation.anonymous?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
@@ -789,7 +797,8 @@ class HcbCode < ApplicationRecord
 
   def author_name
     return author&.name if author&.name.present?
-    return donation.name if donation? && !donation.anonymous? && !in_person_donation?
+    return nil if in_person_donation? && donor.nil?
+    return donation.name if donation? && !donation.anonymous?
     return invoice.sponsor.name if invoice?
 
     nil

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -769,7 +769,7 @@ class HcbCode < ApplicationRecord
   end
 
   def fallback_avatar
-    return donation.avatar(48) if donation? && donation.showable_donor?
+    return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && donation.showable_donor?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
 
     nil

--- a/app/models/hcb_code.rb
+++ b/app/models/hcb_code.rb
@@ -768,28 +768,8 @@ class HcbCode < ApplicationRecord
     return wise_transfer&.user if wise_transfer?
   end
 
-  # A donation an organizer collected with tap to pay, rather than one the
-  # donor made online themselves.
-  def in_person_donation?
-    donation? && donation.in_person?
-  end
-
-  # The donor who paid for an in-person donation, when there's an email address
-  # to build an avatar from. Nil when they donated anonymously or gave none,
-  # which leaves the author column empty rather than falling back to anyone at
-  # the organization: the money is the donor's, and the collector's face there
-  # would read as if they made the payment.
-  def donor
-    return nil unless in_person_donation?
-    return nil if donation.anonymous? || donation.email.blank?
-
-    donation
-  end
-
   def fallback_avatar
-    return nil if in_person_donation? && donor.nil?
-
-    return gravatar_url(donation.email, donation.name, donation.email.to_i, 48) if donation? && !donation.anonymous?
+    return donation.avatar(48) if donation? && donation.showable_donor?
     return gravatar_url(invoice.sponsor.contact_email, invoice.sponsor.name, invoice.sponsor.contact_email.to_i, 48) if invoice?
 
     nil
@@ -797,8 +777,7 @@ class HcbCode < ApplicationRecord
 
   def author_name
     return author&.name if author&.name.present?
-    return nil if in_person_donation? && donor.nil?
-    return donation.name if donation? && !donation.anonymous?
+    return donation.name if donation? && donation.showable_donor?
     return invoice.sponsor.name if invoice?
 
     nil

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -363,8 +363,6 @@ class Ledger
         linked_object&.expense&.report&.user
       when "PaypalTransfer"
         linked_object&.user
-      when "Donation"
-        linked_object&.collected_by if linked_object&.in_person?
       when "Wire"
         linked_object&.user
       when "WiseTransfer"

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -126,6 +126,16 @@ class Ledger
       end
     end
 
+    # The author column falls back to whoever is behind an item with no
+    # organizer to attribute it to — the donor, or an invoice's sponsor.
+    def fallback_avatar
+      hcb_code&.fallback_avatar
+    end
+
+    def author_name
+      author&.name.presence || hcb_code&.author_name
+    end
+
     # Substring identifiers (case-insensitive) in the memo that indicate an
     # account-verification micro-deposit. Most use "ACCTVERIFY"; a few companies
     # use other variants. Mirrors CanonicalTransaction#likely_account_verification_related?.

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -130,24 +130,18 @@ class Ledger
     # The author column falls back to whoever is behind an item with no
     # organizer to attribute it to — the donor, or an invoice's sponsor.
     def fallback_avatar
-      case linked_object_type
-      when "Donation"
-        linked_object.avatar(48) if linked_object.showable_donor?
-      when "Invoice"
-        sponsor = linked_object.sponsor
-        gravatar_url(sponsor.contact_email, sponsor.name, sponsor.contact_email.to_i, 48)
-      end
+      return gravatar_url(linked_object.email, linked_object.name, linked_object.email.to_i, 48) if showable_donation?
+      return gravatar_url(linked_object.sponsor.contact_email, linked_object.sponsor.name, linked_object.sponsor.contact_email.to_i, 48) if linked_object_type == "Invoice"
+
+      nil
     end
 
     def author_name
       return author.name if author&.name.present?
+      return linked_object.name if showable_donation?
+      return linked_object.sponsor.name if linked_object_type == "Invoice"
 
-      case linked_object_type
-      when "Donation"
-        linked_object.name if linked_object.showable_donor?
-      when "Invoice"
-        linked_object.sponsor.name
-      end
+      nil
     end
 
     # Substring identifiers (case-insensitive) in the memo that indicate an
@@ -367,6 +361,10 @@ class Ledger
       end
 
       amount_cents
+    end
+
+    def showable_donation?
+      linked_object_type == "Donation" && linked_object&.showable_donor?
     end
 
     def calculate_author

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -52,6 +52,7 @@ class Ledger
 
     include Commentable
     include Receiptable
+    include UsersHelper
 
     has_one :hcb_code, class_name: "HcbCode", required: false, foreign_key: "ledger_item_id", inverse_of: :ledger_item
     has_one :personal_transaction, required: false, foreign_key: "ledger_item_id", inverse_of: :ledger_item
@@ -129,11 +130,24 @@ class Ledger
     # The author column falls back to whoever is behind an item with no
     # organizer to attribute it to — the donor, or an invoice's sponsor.
     def fallback_avatar
-      hcb_code&.fallback_avatar
+      case linked_object_type
+      when "Donation"
+        linked_object.avatar(48) if linked_object.showable_donor?
+      when "Invoice"
+        sponsor = linked_object.sponsor
+        gravatar_url(sponsor.contact_email, sponsor.name, sponsor.contact_email.to_i, 48)
+      end
     end
 
     def author_name
-      author&.name.presence || hcb_code&.author_name
+      return author.name if author&.name.present?
+
+      case linked_object_type
+      when "Donation"
+        linked_object.name if linked_object.showable_donor?
+      when "Invoice"
+        linked_object.sponsor.name
+      end
     end
 
     # Substring identifiers (case-insensitive) in the memo that indicate an

--- a/app/tasks/maintenance/clear_donation_ledger_item_authors_task.rb
+++ b/app/tasks/maintenance/clear_donation_ledger_item_authors_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # One-time cleanup: `ledger_items.author_id` is a cached column, only
+  # recomputed when an item is refreshed. In-person donations used to be
+  # attributed to the organizer who collected them, which read as if that
+  # organizer had made the payment. Donations no longer have an author, so
+  # clear the ones already stored instead of waiting for each item to be
+  # touched. Run once after deploying.
+  class ClearDonationLedgerItemAuthorsTask < MaintenanceTasks::Task
+    def collection
+      Ledger::Item.where(linked_object_type: "Donation").where.not(author_id: nil)
+    end
+
+    def process(ledger_item)
+      ledger_item.update!(author_id: nil)
+    end
+
+  end
+end

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -36,12 +36,15 @@
     </span>
   </td>
   <% if show_author %>
+    <% author_name = item.author_name %>
     <td>
-      <% if item.author.present? %>
-        <div class="flex items-center justify-center tooltipped tooltipped--w" aria-label="<%= item.author.name %>">
+      <div class="flex items-center justify-center <%= "tooltipped tooltipped--w" if author_name %>" aria-label="<%= author_name %>">
+        <% if item.author.present? %>
           <%= avatar_for item.author, class: "align-middle author", cached: true %>
-        </div>
-      <% end %>
+        <% elsif item.fallback_avatar %>
+          <%= image_tag(item.fallback_avatar, loading: "lazy", width: 24, height: 24, class: "rounded-full shrink-none") %>
+        <% end %>
+      </div>
     </td>
   <% end %>
 </tr>

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Donation, type: :model do
     expect(donation).to be_valid
   end
 
+  describe "#showable_donor?" do
+    it "is true for a donation made online" do
+      expect(create(:donation)).to be_showable_donor
+    end
+
+    it "is true for an in-person donation whose donor left an email" do
+      expect(create(:donation, in_person: true, email: "ada@example.com")).to be_showable_donor
+    end
+
+    it "is false for an in-person donation with no email to build an avatar from" do
+      expect(create(:donation, in_person: true, email: nil)).not_to be_showable_donor
+    end
+
+    it "is false for an anonymous donation" do
+      expect(create(:donation, anonymous: true)).not_to be_showable_donor
+    end
+  end
+
   it "sends the correct payment notification for each succeeded donation" do
     event = create(:event)
 

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -373,4 +373,32 @@ RSpec.describe HcbCode, type: :model do
       end
     end
   end
+
+  describe "donation authorship" do
+    include DonationSupport
+
+    before { stub_donation_payment_intent_creation }
+
+    let(:collector) { create(:user) }
+
+    it "does not attribute an in-person donation to the organizer who collected it" do
+      donation = create(:donation, in_person: true, collected_by: collector)
+
+      expect(donation.local_hcb_code.author).to be_nil
+    end
+
+    it "leaves the author column empty for an in-person donation" do
+      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace")
+
+      expect(donation.local_hcb_code.fallback_avatar).to be_nil
+      expect(donation.local_hcb_code.author_name).to be_nil
+    end
+
+    it "keeps the donor's gravatar on a donation made online" do
+      donation = create(:donation, name: "Ada Lovelace", email: "ada@example.com")
+
+      expect(donation.local_hcb_code.fallback_avatar).to start_with("https://gravatar.com/avatar/")
+      expect(donation.local_hcb_code.author_name).to eq("Ada Lovelace")
+    end
+  end
 end

--- a/spec/models/hcb_code_spec.rb
+++ b/spec/models/hcb_code_spec.rb
@@ -387,8 +387,22 @@ RSpec.describe HcbCode, type: :model do
       expect(donation.local_hcb_code.author).to be_nil
     end
 
-    it "leaves the author column empty for an in-person donation" do
-      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace")
+    it "shows the donor who paid for an in-person donation" do
+      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace", email: "ada@example.com")
+
+      expect(donation.local_hcb_code.fallback_avatar).to include(Digest::SHA256.hexdigest("ada@example.com"))
+      expect(donation.local_hcb_code.author_name).to eq("Ada Lovelace")
+    end
+
+    it "leaves the author column empty for an anonymous in-person donor" do
+      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace", email: "ada@example.com", anonymous: true)
+
+      expect(donation.local_hcb_code.fallback_avatar).to be_nil
+      expect(donation.local_hcb_code.author_name).to be_nil
+    end
+
+    it "leaves the author column empty when an in-person donor gave no email" do
+      donation = create(:donation, in_person: true, collected_by: collector, name: "Ada Lovelace", email: nil)
 
       expect(donation.local_hcb_code.fallback_avatar).to be_nil
       expect(donation.local_hcb_code.author_name).to be_nil

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -444,4 +444,23 @@ RSpec.describe Ledger::Item, type: :model do
       end
     end
   end
+
+  describe "#author" do
+    it "is nobody for an in-person donation, which the donor paid rather than the organizer who collected it" do
+      stub_donation_payment_intent_creation
+      donation = create(:donation, in_person: true, collected_by: create(:user))
+
+      item = Ledger::Item.new(
+        amount_cents: 1000,
+        memo: "Initial",
+        datetime: Time.current,
+        linked_object: donation
+      )
+      item.save(validate: false)
+
+      item.refresh!
+
+      expect(item.reload.author).to be_nil
+    end
+  end
 end

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -445,6 +445,42 @@ RSpec.describe Ledger::Item, type: :model do
     end
   end
 
+  describe "the author column fallback" do
+    def donation_item(donation)
+      item = Ledger::Item.new(
+        amount_cents: donation.amount,
+        memo: "Donation",
+        datetime: Time.current,
+        linked_object: donation
+      )
+      item.save(validate: false)
+      item
+    end
+
+    it "shows the donor behind an in-person donation, reading its own linked object" do
+      stub_donation_payment_intent_creation
+      donation = create(:donation, in_person: true, collected_by: create(:user), name: "Ada Lovelace", email: "ada@example.com")
+
+      item = donation_item(donation)
+
+      # The item has no HcbCode of its own, so this can only come from the
+      # linked donation.
+      expect(item.hcb_code).to be_nil
+      expect(item.fallback_avatar).to eq(donation.avatar(48))
+      expect(item.author_name).to eq("Ada Lovelace")
+    end
+
+    it "stays empty when an in-person donor gave no email" do
+      stub_donation_payment_intent_creation
+      donation = create(:donation, in_person: true, collected_by: create(:user), name: "Ada Lovelace", email: nil)
+
+      item = donation_item(donation)
+
+      expect(item.fallback_avatar).to be_nil
+      expect(item.author_name).to be_nil
+    end
+  end
+
   describe "#author" do
     it "is nobody for an in-person donation, which the donor paid rather than the organizer who collected it" do
       stub_donation_payment_intent_creation

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe Ledger::Item, type: :model do
       # The item has no HcbCode of its own, so this can only come from the
       # linked donation.
       expect(item.hcb_code).to be_nil
-      expect(item.fallback_avatar).to eq(donation.avatar(48))
+      expect(item.fallback_avatar).to include(Digest::SHA256.hexdigest("ada@example.com"))
       expect(item.author_name).to eq("Ada Lovelace")
     end
 

--- a/spec/tasks/maintenance/clear_donation_ledger_item_authors_task_spec.rb
+++ b/spec/tasks/maintenance/clear_donation_ledger_item_authors_task_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Maintenance::ClearDonationLedgerItemAuthorsTask do
+  include DonationSupport
+
+  before { stub_donation_payment_intent_creation }
+
+  # `refresh!` no longer computes an author for a donation, so a stale
+  # author_id has to be written directly to stand in for what the pre-change
+  # code cached.
+  def donation_item(author: nil)
+    donation = create(:donation, in_person: true, collected_by: create(:user))
+    item = Ledger::Item.new(
+      amount_cents: 1000,
+      memo: "Donation",
+      datetime: Time.current,
+      linked_object: donation
+    )
+    item.save(validate: false)
+    item.update_columns(author_id: author&.id)
+    item
+  end
+
+  it "clears the collecting organizer cached on an in-person donation" do
+    item = donation_item(author: create(:user))
+
+    described_class.new.process(item)
+
+    expect(item.reload.author).to be_nil
+  end
+
+  it "collects only the donations that still have an author" do
+    stale = donation_item(author: create(:user))
+    already_cleared = donation_item
+
+    expect(described_class.new.collection).to include(stale)
+    expect(described_class.new.collection).not_to include(already_cleared)
+  end
+end


### PR DESCRIPTION
Now that the collecting organizer is gone from the author column, fill the space with the person who actually paid: the Gravatar and name for the email address they gave at the point of sale. Donations that were anonymous, or where no address was collected, keep the empty column rather than falling back to anyone at the organization.

The new ledger had no fallback avatar at all, so donations and invoices showed an empty cell there. It now renders the same fallback and tooltip as the legacy transactions table.

## Testing

`bundle exec rspec spec/models/hcb_code_spec.rb spec/models/ledger/item_spec.rb`