### PR TITLE
[Wires] Use P0802 as the India reimbursement purpose code

### DIFF
--- a/app/models/concerns/has_wire_recipient.rb
+++ b/app/models/concerns/has_wire_recipient.rb
@@ -163,7 +163,7 @@ module HasWireRecipient
         fields << LEGAL_TYPE_FIELD
         fields << { type: :text_field, key: "phone", label: "Phone number associated with account" }
         fields << { type: :text_field, key: "local_bank_code", label: "Local bank code", description: "11-character IFSC codes" }
-        fields << { type: :text_area, key: "purpose_code", label: "Purpose code", description: "A 5-character purpose of payment code, beginning with 'P'.", refer_to: "https://cdn.hackclub.com/019ecca2-62ce-75c8-a16a-40e2d557434e/ASAP840212FL.pdf", reimbursement_default: "S1099" }
+        fields << { type: :text_area, key: "purpose_code", label: "Purpose code", description: "A 5-character purpose of payment code, beginning with 'P'.", refer_to: "https://cdn.hackclub.com/019ecca2-62ce-75c8-a16a-40e2d557434e/ASAP840212FL.pdf", reimbursement_default: "P0802" }
       when "JO"
         fields << { type: :text_area, key: "remittance_info", label: "Remittance information", description: "Payment purpose must be clearly identified" }
         fields << { type: :text_area, key: "purpose_code", label: "Purpose code", description: "A 4-digit purpose of payment code.", refer_to: "https://www.cbj.gov.jo/EchoBusv3.0/SystemAssets/PDFs/1%D8%A7%D9%84%D8%BA%D8%B1%D8%B6%20%D9%85%D9%86%20%D8%A7%D9%84%D8%AA%D8%AD%D9%88%D9%8A%D9%84%D8%A7%D8%AA%200%D8%A7%D9%84%D9%85%D8%A7%D9%84%D9%8A%D8%A9-20191029.pdf" }
@@ -227,9 +227,9 @@ module HasWireRecipient
         "PK": "9675",
         "AE": "TTS",
         "CN": "SRV",
-        "IN": "S1099",
+        "IN": "P0802",
         "KG": "55501000"
-      }[country] || "ICCP"
+      }[country&.to_sym] || "ICCP"
     end
 
     def self.payment_purpose_code_for(country)
@@ -240,7 +240,7 @@ module HasWireRecipient
     def self.reimbursement_remittance_info_for(country)
       {
         "PK": "Reimbursement of expenses made for a nonprofit. Recipient is a volunteer.",
-      }[country] || "Reimbursement of expenses made for a nonprofit."
+      }[country&.to_sym] || "Reimbursement of expenses made for a nonprofit."
     end
 
     def self.payment_remittance_info_for(country)


### PR DESCRIPTION
## Summary of the problem

Closes #14712.

Reimbursement wires to India were going out with the purpose code `ICCP`. Ops requested a change to  `P0802`.

The underlying cause is broader than India. `recipient_country` is a Rails enum over an integer column, so it returns the **string** `"IN"` — but `Wire.reimbursement_purpose_code_for` looked the country up in a **symbol**-keyed hash (`"IN": "S1099"`). Every lookup missed, so *no* country-specific purpose code has ever applied; they all fell through to the `"ICCP"` default. `reimbursement_remittance_info_for` has the same bug, which is also why Pakistan never got its volunteer-specific remittance text.

Fxing the lookup means the mappings for CO, KZ, MY, PK, AE, CN, and KG start taking effect too, where previously all of them silently sent `ICCP`. That's the intended behavior, but it is a live change to those corridors, not just India's.


## Describe your changes

All in `app/models/concerns/has_wire_recipient.rb`:

- Key both hash lookups off `country&.to_sym`, so the per-country mappings actually apply. `&.` because these methods are called with a `recipient_country` that may be nil, in which case the lookup should fall through to the default rather than raise. This matches how the rest of the file already guards the same conversion (`bank_country && IBAN_FORMATS[bank_country.to_sym]`).
- Change India's reimbursement purpose code from `S1099` to `P0802`. `S1099` didn't satisfy the field's own "5-character purpose of payment code, beginning with 'P'" rule, and `P0802` isn't in the `RESTRICTED_PURPOSE_CODES["IN"]` list this file already validates against.
- Update the India form field's `reimbursement_default` to `P0802` to stay in sync with the mapping.
