### PR TITLE
[Payment] Fix copying receipts to the payout

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -86,7 +86,7 @@ class Payment < ApplicationRecord
     end
   end
 
-  after_create do
+  after_create_commit do
     if legal_entity&.payable? && legal_entity.default_payout_method.present?
       create_payment_attempt!
     elsif legal_entity&.payable?

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -97,12 +97,6 @@ class Receipt < ApplicationRecord
   after_commit(on: [:create, :update]) { CardLocking::ReceiptResolution.on_receipt_upsert(self) }
   after_commit(on: :destroy) { CardLocking::ReceiptResolution.on_receipt_destroy(self) }
 
-  after_create_commit do
-    if receiptable.is_a?(Payment) && receiptable.current_attempt&.payout.present?
-      Receipt.reupload(old_receiptable: receiptable, new_receiptable: receiptable.current_attempt.payout.local_hcb_code)
-    end
-  end
-
   validate :has_owner
 
   enum :upload_method, {

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -97,6 +97,12 @@ class Receipt < ApplicationRecord
   after_commit(on: [:create, :update]) { CardLocking::ReceiptResolution.on_receipt_upsert(self) }
   after_commit(on: :destroy) { CardLocking::ReceiptResolution.on_receipt_destroy(self) }
 
+  after_create_commit do
+    if receiptable.is_a?(Payment) && receiptable.current_attempt&.payout.present?
+      Receipt.reupload(old_receiptable: receiptable, new_receiptable: receiptable.current_attempt.payout.local_hcb_code)
+    end
+  end
+
   validate :has_owner
 
   enum :upload_method, {


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Receipts were not being properly copied from the payment to the payout, since this was only happening in a callback when payments were created, but the receipt is uploaded and attached to the payment after the payment is created.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Run the payment callback after commit (in PaymentsController#create, the receipt is created in the same transaction as the payment creation).

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

