### PR TITLE
[Tax::Form] Check get endpoint for TaxBandits form status

### DIFF
--- a/app/models/tax/form.rb
+++ b/app/models/tax/form.rb
@@ -164,7 +164,7 @@ module Tax
         submission_form_type = submission["FormType"]
         form_hash = submission[TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type]]
 
-        form_status_field = form_hash.keys.find { |key| key.end_with?("Status") }
+        form_status_field = "#{submission["FormType"][4..]}Status"
         form_status = form_hash[form_status_field]
         tin_match_status = form_hash["TINMatching"]&.[]("Status")
       else

--- a/app/models/tax/form.rb
+++ b/app/models/tax/form.rb
@@ -151,14 +151,29 @@ module Tax
       # A manually entered form has no certificate at TaxBandits to sync against.
       return unless sent_with_taxbandits?
 
-      response = TaxbanditsService.get_status(public_id)
-
-      if response.present?
-        update!(
-          taxbandits_status: response["FormStatus"].downcase,
-          taxbandits_tin_matching_status: response["TINMatching"]&.[]("Status")&.downcase
-        )
+      form_data = begin
+        remote_taxbandits_submission_form_data
+      rescue
+        nil
       end
+
+      form_status = nil
+      tin_match_status = nil
+
+      if form_data.present?
+        form_status_field = form_data.keys.find { |key| key.end_with?("Status") }
+        form_status = form_data[form_status_field]
+        tin_match_status = form_data["TINMatching"]&.[]("Status")&.downcase
+      else
+        status_response = TaxbanditsService.get_status(public_id)
+        form_status = status_response["FormStatus"].downcase
+        tin_match_status = status_response["TINMatching"]&.[]("Status")&.downcase
+      end
+
+      update!(
+        taxbandits_status: form_status,
+        taxbandits_tin_matching_status: tin_match_status
+      )
     end
 
     # Only the last four digits, and only ever shown to the payee themselves.
@@ -211,6 +226,14 @@ module Tax
       TaxbanditsService.get_submission(public_id)
     end
 
+    def remote_taxbandits_submission_form_data
+      submission = remote_taxbandits_submission
+      return if submission.nil?
+
+      submission_form_type = submission["FormType"]
+      submission.dig(TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type], "FormData")
+    end
+
     def tin_hash_cannot_change
       if tin_hash_changed? && tin_hash_was.present?
         errors.add(:tin_hash, "cannot change once set")
@@ -225,11 +248,7 @@ module Tax
     end
 
     def import_taxbandits_data
-      submission = remote_taxbandits_submission
-      return if submission.nil?
-
-      submission_form_type = submission["FormType"]
-      form_data = submission.dig(TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type], "FormData")
+      form_data = remote_taxbandits_submission_form_data
 
       return if form_data.blank?
 

--- a/app/models/tax/form.rb
+++ b/app/models/tax/form.rb
@@ -151,8 +151,8 @@ module Tax
       # A manually entered form has no certificate at TaxBandits to sync against.
       return unless sent_with_taxbandits?
 
-      form_data = begin
-        remote_taxbandits_submission_form_data
+      submission = begin
+        submission = remote_taxbandits_submission
       rescue
         nil
       end
@@ -160,19 +160,22 @@ module Tax
       form_status = nil
       tin_match_status = nil
 
-      if form_data.present?
-        form_status_field = form_data.keys.find { |key| key.end_with?("Status") }
-        form_status = form_data[form_status_field]
-        tin_match_status = form_data["TINMatching"]&.[]("Status")&.downcase
+      if submission.present?
+        submission_form_type = submission["FormType"]
+        form_hash = submission[TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type]]
+
+        form_status_field = form_hash.keys.find { |key| key.end_with?("Status") }
+        form_status = form_hash[form_status_field]
+        tin_match_status = form_hash["TINMatching"]&.[]("Status")
       else
         status_response = TaxbanditsService.get_status(public_id)
-        form_status = status_response["FormStatus"].downcase
-        tin_match_status = status_response["TINMatching"]&.[]("Status")&.downcase
+        form_status = status_response["FormStatus"]
+        tin_match_status = status_response["TINMatching"]&.[]("Status")
       end
 
       update!(
-        taxbandits_status: form_status,
-        taxbandits_tin_matching_status: tin_match_status
+        taxbandits_status: form_status.downcase,
+        taxbandits_tin_matching_status: tin_match_status&.downcase
       )
     end
 
@@ -226,14 +229,6 @@ module Tax
       TaxbanditsService.get_submission(public_id)
     end
 
-    def remote_taxbandits_submission_form_data
-      submission = remote_taxbandits_submission
-      return if submission.nil?
-
-      submission_form_type = submission["FormType"]
-      submission.dig(TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type], "FormData")
-    end
-
     def tin_hash_cannot_change
       if tin_hash_changed? && tin_hash_was.present?
         errors.add(:tin_hash, "cannot change once set")
@@ -248,7 +243,11 @@ module Tax
     end
 
     def import_taxbandits_data
-      form_data = remote_taxbandits_submission_form_data
+      submission = remote_taxbandits_submission
+      return if submission.nil?
+
+      submission_form_type = submission["FormType"]
+      form_data = submission.dig(TaxbanditsService::TAXBANDITS_FORM_DATA_KEYS[submission_form_type], "FormData")
 
       return if form_data.blank?
 

--- a/app/models/tax/form.rb
+++ b/app/models/tax/form.rb
@@ -152,7 +152,7 @@ module Tax
       return unless sent_with_taxbandits?
 
       submission = begin
-        submission = remote_taxbandits_submission
+        remote_taxbandits_submission
       rescue
         nil
       end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
TaxBandits is slow with updating what their Status endpoint returns to us, but their Get endpoint seems to update faster (and has the information we need anyways). However, the Get endpoint pretends a WhCertificate just doesn't exist if it's not completed yet.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Check the Get endpoint first, and if we don't get a response, check the status endpoint.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

