### PR TITLE
[ApiToken] Remove ignored refresh_token column

### DIFF
--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -50,8 +50,6 @@ class ApiToken < ApplicationRecord
   blind_index :token
   blind_index :refresh_token
 
-  self.ignored_columns += ["refresh_token"]
-
   belongs_to :user
 
   def self.generate(options = {})


### PR DESCRIPTION
## Summary of the problem

The plaintext `refresh_token` column was dropped from `api_tokens` as part of the Lockbox migration for encrypting refresh tokens (#13538). The `self.ignored_columns += ["refresh_token"]` line was only needed while that column still existed, so it's now dead code.

## Describe your changes

Removes the `ignored_columns` declaration from `ApiToken`. The schema confirms only `refresh_token_bidx` and `refresh_token_ciphertext` remain, so nothing needs to be ignored anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)