### PR TITLE
[Payments] Fix attribution when paying contractors

### DIFF
--- a/app/models/ach_transfer.rb
+++ b/app/models/ach_transfer.rb
@@ -79,7 +79,7 @@ class AchTransfer < ApplicationRecord
   pg_search_scope :search_recipient, against: [:recipient_name], using: { tsearch: { prefix: true, dictionary: "english" } }, ranked_by: "ach_transfers.created_at"
 
   include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  tracked owner: proc { |controller, record| record.creator || controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
   has_one :ledger_item, class_name: "Ledger::Item", as: :linked_object
   belongs_to :creator, class_name: "User", optional: true

--- a/app/models/increase_check.rb
+++ b/app/models/increase_check.rb
@@ -61,7 +61,7 @@ class IncreaseCheck < ApplicationRecord
   pg_search_scope :search_recipient, against: [:recipient_name, :memo], using: { tsearch: { prefix: true, dictionary: "english" } }, ranked_by: "increase_checks.created_at"
 
   include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  tracked owner: proc { |controller, record| record.user || controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
   include Hashid::Rails
   hashid_config salt: ""

--- a/app/models/wire.rb
+++ b/app/models/wire.rb
@@ -85,7 +85,7 @@ class Wire < ApplicationRecord
 
 
   include PublicActivity::Model
-  tracked owner: proc{ |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  tracked owner: proc { |controller, record| record.user || controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
   after_create do
     create_canonical_pending_transaction!(

--- a/app/models/wise_transfer.rb
+++ b/app/models/wise_transfer.rb
@@ -78,7 +78,7 @@ class WiseTransfer < ApplicationRecord
   validates :quoted_usd_amount_cents, numericality: { greater_than_or_equal_to: 0, message: "must be positive" }, allow_nil: true
 
   include PublicActivity::Model
-  tracked owner: proc { |controller, record| controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
+  tracked owner: proc { |controller, record| record.user || controller&.current_user }, event_id: proc { |controller, record| record.event.id }, only: [:create]
 
   WISE_ID_FORMAT = /\A\d+\z/
   before_validation(:normalize_wise_id)

--- a/spec/models/ach_transfer_spec.rb
+++ b/spec/models/ach_transfer_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe AchTransfer, type: :model do
     end
   end
 
+  describe "public activity" do
+    it "attributes creation to the transfer creator when no controller is present" do
+      creator = create(:user)
+
+      transfer = PublicActivity.with_tracking do
+        create(:ach_transfer, event:, creator:)
+      end
+
+      activity = PublicActivity::Activity.find_by!(trackable: transfer, key: "ach_transfer.create")
+      expect(activity.owner).to eq(creator)
+    end
+  end
+
   describe "invoiced_at validation" do
     it "allows invoiced_at to be nil" do
       ach_transfer = build(:ach_transfer, event:, invoiced_at: nil)


### PR DESCRIPTION
Generated ACH, check, wire, and Wise transfers now use the payment’s original creator rather than the user who triggers contractor onboarding. This includes some simple regression coverage