### PR TITLE
Add contractors as an event plan feature

### DIFF
--- a/app/models/event/plan.rb
+++ b/app/models/event/plan.rb
@@ -75,7 +75,7 @@ class Event
 
     def self.available_features
       # this must contain every HCB feature that we want enable / disable with plans.
-      %w[cards invoices donations account_number check_deposits transfers promotions google_workspace documentation reimbursements card_grants unrestricted_disbursements front_disbursements]
+      %w[cards invoices donations account_number check_deposits transfers contractors promotions google_workspace documentation reimbursements card_grants unrestricted_disbursements front_disbursements]
     end
 
     self.available_features.each do |feature|

--- a/app/models/event/plan/spend_only.rb
+++ b/app/models/event/plan/spend_only.rb
@@ -36,7 +36,7 @@ class Event
       end
 
       def features
-        %w[cards transfers promotions google_workspace documentation reimbursements]
+        %w[cards transfers contractors promotions google_workspace documentation reimbursements]
       end
 
     end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -177,7 +177,7 @@ class EventPolicy < ApplicationPolicy
     # The contractors list is visible in transparency mode (public events),
     # but only shows status/name/period/purpose to the public. Sensitive
     # details (email, rate, totals, invoices) are gated by contractor_details?.
-    Flipper.enabled?(:payments_contractors_refresh_2026_06_26, record) && show? && record.plan.transfers_enabled?
+    Flipper.enabled?(:payments_contractors_refresh_2026_06_26, record) && show? && record.plan.transfers_enabled? && record.plan.contractors_enabled?
   end
 
   def contractor_details?


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Need a feature so that we can turn it on/off per event plans, like transfers.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add feature. Note that the policy still also checks the flipper flag - this will be removed when contractors and payments are rolled out.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

