### PR TITLE
Add flipper groups for event plans

### DIFF
--- a/app/lib/flipper_groups.rb
+++ b/app/lib/flipper_groups.rb
@@ -71,6 +71,10 @@ module FlipperGroups
     in_set?(actor, Event, hq_event_ids)
   end
 
+  def event_in_plan?(actor, plan)
+    in_set?(actor, Event, plan_event_ids(plan))
+  end
+
   def in_set?(actor, klass, ids)
     actor.is_a?(klass) && ids.include?(actor.id)
   end
@@ -103,6 +107,12 @@ module FlipperGroups
 
         [event.id] + event.descendant_ids
       }.uniq.to_set
+    end
+  end
+
+  def plan_event_ids(plan)
+    fetch_id_set("flipper_groups/plan_event_ids/#{plan.name.demodulize.underscore}") do
+      Event.joins(:plan).where({ plan: { type: plan.name } }).pluck(:id).to_set
     end
   end
 

--- a/config/initializers/flipper_groups.rb
+++ b/config/initializers/flipper_groups.rb
@@ -6,7 +6,7 @@
 # Group blocks receive the actor wrapped in Flipper::Types::Actor, whose is_a? is
 # not delegated to the wrapped object, so we unwrap with `actor.actor` and let
 # FlipperGroups guard the type. Groups are only evaluated when a check passes an
-# actor; user groups match User actors and hq_descendant_organizations matches
+# actor; user groups match User actors and hq_descendant_organizations / organization_plan_ matches
 # Event actors.
 Flipper.register(:hcb_team)                    { |actor, _context| FlipperGroups.hcb_team?(actor.actor) }
 Flipper.register(:hcb_engineers)               { |actor, _context| FlipperGroups.hcb_engineer?(actor.actor) }
@@ -14,3 +14,14 @@ Flipper.register(:hackclub_emails)             { |actor, _context| FlipperGroups
 Flipper.register(:admins_and_auditors)         { |actor, _context| FlipperGroups.admin_or_auditor?(actor.actor) }
 Flipper.register(:hq_descendant_users)         { |actor, _context| FlipperGroups.hq_descendant_user?(actor.actor) }
 Flipper.register(:hq_descendant_organizations) { |actor, _context| FlipperGroups.hq_descendant_organization?(actor.actor) }
+
+# Event::Plan.available_plans Event and the Plan subclasses to be loaded first
+Rails.application.config.to_prepare do
+  Rails.autoloaders.main.eager_load_dir(Rails.root.join("app/models/event/plan").to_s)
+
+  Event::Plan.available_plans.each do |plan|
+    Flipper.register("organization_plan_#{plan.name.demodulize.underscore}".to_sym) do |actor, _context|
+      FlipperGroups.event_in_plan?(actor.actor, plan)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Useful to flip on beta features for certain plans before fully rolling them out - sort of like hq_descendant_organizations, but for any plan.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Automatically add Flipper groups for each event plan. Note that this is not inclusive of descendants - enabling for the Standard plan will not enable the feature for events that have plans that inherit from Standard, since you can manually add those plans to the feature yourself if desired.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

