### PR TITLE
[Card locking] Disable self-suppression by default

### DIFF
--- a/app/views/users/edit_admin.html.erb
+++ b/app/views/users/edit_admin.html.erb
@@ -93,7 +93,7 @@
       <% if @user.card_locking_suppressed? %>
         <p>Card locking is suppressed until <%= format_datetime @user.card_locking_suppressed_until %>.</p>
       <% end %>
-      <% if admin_signed_in? %>
+      <% if admin_signed_in? && (@user != current_user || Flipper.enabled?(:card_locking_self_suppression, current_user)) %>
         <%= form_with url: suppress_card_locking_user_path(@user), method: :post, data: { turbo_frame: "_top" } do |form| %>
           <div class="field">
             <%= form.label :hours, "Suppress card locking for (hours)" %>


### PR DESCRIPTION
Closes #14821.

Admins can still suppress card locking for anyone else. On their own admin page, the "Suppress card locking" form is now hidden unless the `card_locking_self_suppression` Flipper flag is enabled for them. Nothing enables the flag, so it's off for everyone by default and has to be turned on per-actor in the Flipper UI.

The issue named the flag `card-locking-self-suppression`; this uses `card_locking_self_suppression` to match the underscore convention of every other flag in the app.

Note that the gate is in the view only — `UserPolicy#suppress_card_locking?` is unchanged, so a `POST /users/:id/suppress_card_locking` crafted by hand would still go through for an admin acting on themselves. Happy to move it into the policy if we want it enforced server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)