### PR TITLE
[Stripe Issuing] Run TopupStripeJob on a schedule instead of per-webhook

### DIFF
--- a/app/jobs/topup_stripe_job.rb
+++ b/app/jobs/topup_stripe_job.rb
@@ -3,7 +3,7 @@
 class TopupStripeJob < ApplicationJob
   queue_as :default
 
-  # This job runs hourly on a schedule (see `config/schedule.yml`).
+  # This job runs twice a day on a schedule (see `config/schedule.yml`).
   #
   # It used to be enqueued from every Stripe issuing authorization webhook,
   # which meant a burst of card activity ran many copies of it concurrently.

--- a/app/jobs/topup_stripe_job.rb
+++ b/app/jobs/topup_stripe_job.rb
@@ -3,6 +3,14 @@
 class TopupStripeJob < ApplicationJob
   queue_as :default
 
+  # This job runs hourly on a schedule (see `config/schedule.yml`).
+  #
+  # It used to be enqueued from every Stripe issuing authorization webhook,
+  # which meant a burst of card activity ran many copies of it concurrently.
+  # Each copy read the balance and the list of pending top-ups before any of
+  # them had created one, so they all computed the same amount and each
+  # created a duplicate top-up.
+
   # Don't retry jobs w/ balance anomalies, reattempt at next run
   discard_on(Errors::StripeIssuingBalanceAnomaly) do |job, error|
     Rails.error.report error

--- a/app/jobs/topup_stripe_job.rb
+++ b/app/jobs/topup_stripe_job.rb
@@ -3,14 +3,6 @@
 class TopupStripeJob < ApplicationJob
   queue_as :default
 
-  # This job runs twice a day on a schedule (see `config/schedule.yml`).
-  #
-  # It used to be enqueued from every Stripe issuing authorization webhook,
-  # which meant a burst of card activity ran many copies of it concurrently.
-  # Each copy read the balance and the list of pending top-ups before any of
-  # them had created one, so they all computed the same amount and each
-  # created a duplicate top-up.
-
   # Don't retry jobs w/ balance anomalies, reattempt at next run
   discard_on(Errors::StripeIssuingBalanceAnomaly) do |job, error|
     Rails.error.report error

--- a/app/services/stripe_authorization_service/create_from_webhook.rb
+++ b/app/services/stripe_authorization_service/create_from_webhook.rb
@@ -61,8 +61,6 @@ module StripeAuthorizationService
           end
         end
       end
-
-      TopupStripeJob.perform_later
     end
 
   end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -230,6 +230,10 @@ stripe_missed_webhooks_job:
   cron: "0/5 * * * *" # run every 5 minutes
   class: "StripeMissedWebhooksJob"
 
+topup_stripe_job:
+  cron: "15 * * * *" # run every 1 hour
+  class: "TopupStripeJob"
+
 events_sync_to_airtable_job:
   cron: "0 0 * * *" # run every 1 day
   class: "Event::SyncToAirtableJob"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -231,7 +231,7 @@ stripe_missed_webhooks_job:
   class: "StripeMissedWebhooksJob"
 
 topup_stripe_job:
-  cron: "15 * * * *" # run every 1 hour
+  cron: "15 */12 * * *" # run twice a day
   class: "TopupStripeJob"
 
 events_sync_to_airtable_job:


### PR DESCRIPTION
## Problem

A few days ago we sent Stripe 5 top-ups for the same amount at the same time.

`TopupStripeJob` was enqueued from **every** Stripe issuing authorization webhook (`StripeAuthorizationService::CreateFromWebhook`), approved or declined. Production runs Sidekiq at `RAILS_MAX_THREADS=10` per worker, so a burst of card activity started many copies of the job within milliseconds of each other.

The job is a check-then-act sequence with nothing serializing it:

1. read the issuing balance
2. sum *pending* top-ups (`enroute_sum` — the only thing that stops a double top-up)
3. page through every pending authorization (`auto_paging_each`, seconds of network I/O)
4. create a top-up for the difference

Step 2 only protects us if a concurrent job's write in step 4 has already landed. Step 3 makes that window wide, so all the concurrent copies finished reading before any of them wrote — same stale balance, same empty `enroute_sum`, same computed amount, five identical top-ups.

The balance anomaly guard didn't catch it either: it only inspects `available`, and duplicate top-ups sit in `pending` for ~5 business days, so it stays quiet until the money actually lands.

## Change

Schedule the job twice a day (`15 */12 * * *`) in `config/schedule.yml` and drop the per-webhook enqueue.

- A single scheduled run can't race itself.
- The existing `enroute_sum` subtraction already accounts for in-flight top-ups, so each run correctly sees what the previous one sent.
- Runs at `:15` past the hour to stay off the top-of-hour pile-up.

## Trade-off

Top-up timing goes from "within a minute of card activity" to "within 12 hours." That's well inside tolerance — the buffer is $250k against a $95k max week (~$13.6k/day), and top-ups take ~5 business days to become available anyway, so replenishment latency on this order isn't meaningful against a two-week buffer.

One incidental benefit of the longer interval: the job no-ops below a $5k top-up amount, so at a 12-hour cadence each run has accrued enough spend to clear that threshold, rather than frequently doing a full round of Stripe API paging just to bail out.

## Testing

- `bundle exec rubocop` clean on both changed Ruby files
- `config/schedule.yml` parses; entry loads as `{"cron" => "15 */12 * * *", "class" => "TopupStripeJob"}`
- No existing specs reference `TopupStripeJob` or `CreateFromWebhook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
