### PR TITLE
[EmailUpdates] Skip authorization when the token isn't found

### DIFF
--- a/app/controllers/users/email_updates_controller.rb
+++ b/app/controllers/users/email_updates_controller.rb
@@ -15,6 +15,7 @@ module Users
         return redirect_to root_path, flash: { success: "Authorized; please check your new email's inbox (#{@request.replacement}) to verify this change." }
       end
     rescue ActiveRecord::RecordNotFound => e
+      skip_authorization
       flash[:error] = "This authorization token has expired, please request another."
       redirect_to root_path
     rescue ActiveRecord::RecordInvalid => e
@@ -35,6 +36,7 @@ module Users
         return redirect_to root_path, flash: { success: "Verified; please check your old email's inbox (#{@request.original}) to authorize this change." }
       end
     rescue ActiveRecord::RecordNotFound => e
+      skip_authorization
       return redirect_to root_path, flash: { error: "This authorization token has expired, please request another." }
     rescue ActiveRecord::RecordInvalid => e
       return redirect_to root_path, flash: { error: @request.errors.full_messages.to_sentence }

--- a/spec/requests/users/email_updates_spec.rb
+++ b/spec/requests/users/email_updates_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users::EmailUpdatesController", type: :request do
+  let(:user) { create(:user) }
+  let(:user_session) { create(:user_session, user:) }
+
+  before do
+    allow_any_instance_of(SessionsHelper).to receive(:find_current_session).and_return(user_session)
+  end
+
+  describe "GET /email_updates/authorize" do
+    it "redirects with an error for an unknown authorization token" do
+      get authorize_email_updates_path(authorization_token: "does-not-exist")
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("This authorization token has expired, please request another.")
+    end
+  end
+
+  describe "GET /email_updates/verify" do
+    it "redirects with an error for an unknown verification token" do
+      get verify_email_updates_path(verification_token: "does-not-exist")
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("This authorization token has expired, please request another.")
+    end
+  end
+end


### PR DESCRIPTION
Fixes `Pundit::AuthorizationNotPerformedError` in `Users::EmailUpdatesController`.

## Relationship to #14775

#14775 ("Redirect on error in `Users::EmailUpdatesController#verify`") changed `#verify` to rescue `ActiveRecord::RecordNotFound` and redirect to `root_path` instead of letting the exception propagate. That was the right call for the user-facing behaviour, but it exposed a latent problem:

`ApplicationController` enforces Pundit usage with an `after_action :verify_authorized`. An `after_action` doesn't run when an exception propagates out of the action, so while `RecordNotFound` was escaping, `verify_authorized` never fired. Now that the rescue swallows it and the action completes with a normal redirect, the `after_action` does fire — and `authorize` was never reached, because `find_by!` raised first:

```ruby
@request = User::EmailUpdate.active.find_by!(verification_token: params[:verification_token])

authorize @request # ← never reached
```

So a user clicking a stale/expired verification link gets a 500 instead of the intended "this token has expired" flash.

`#authorize_change` has the same hole; its rescue dates back to #11673.

## The fix

Call `skip_authorization` in both `RecordNotFound` rescues, matching the pattern used elsewhere in the app (e.g. `StripeCards::ActivationController`, `Referral::LinksController`).

The `RecordInvalid` rescues deliberately don't get this — `authorize` runs before `update!`, so authorization has already been performed by the time those fire.

## Testing

Added `spec/requests/users/email_updates_spec.rb` covering both actions with an unknown token. Both examples fail with `Pundit::AuthorizationNotPerformedError` on `main` and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)