### PR TITLE
[Admin] Handle non-JSON responses in hackathons_task_size

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1813,12 +1813,16 @@ class AdminController < Admin::BaseController
   end
 
   def hackathons_task_size
-    hackathons = Faraday
-                 .new(ssl: { verify: false }, request: { open_timeout: 5, timeout: 8 }) { |c| c.response :json }
-                 .get("https://dash.hackathons.hackclub.com/api/v1/stats/hackathons")
-                 .body
+    client = Faraday.new(ssl: { verify: false }, request: { open_timeout: 5, timeout: 8 }) do |c|
+      c.response :json
+      c.response :raise_error
+    end
 
-    hackathons.dig("status", "pending", "meta", "count")
+    hackathons = client.get("https://dash.hackathons.hackclub.com/api/v1/stats/hackathons").body
+
+    raise TypeError, "unexpected response: #{hackathons.inspect.truncate(200)}" unless hackathons.is_a?(Hash)
+
+    hackathons.dig("status", "pending", "meta", "count") || 0
   rescue => e
     Rails.error.report(e)
     9999


### PR DESCRIPTION
## Problem

The ops task-size dashboard was reporting:

```
NoMethodError: undefined method 'dig' for an instance of String
app/controllers/admin_controller.rb:1821 in AdminController#hackathons_task_size
```

The Faraday stack in `hackathons_task_size` only had `c.response :json`. That middleware parses the body **only** when the response's content-type is JSON, so when `dash.hackathons.hackclub.com` returned something else (a Cloudflare/error HTML page, a 5xx, a redirect), `.body` came back as a `String` and `String#dig` raised.

This was already inside `rescue => e`, so the admin page didn't 500 — the trace is what `Rails.error.report` shipped, and the task size fell back to `9999`. The endpoint is healthy right now, so this is intermittent upstream flakiness surfacing as a misleading error.

## Change

Rewritten to match the sibling `pending_identity_vault_verifications_task_size`:

- Add `c.response :raise_error`, so an HTTP error surfaces as a `Faraday::Error` naming the status instead of a `NoMethodError` further down.
- Guard the body with `is_a?(Hash)`, raising a `TypeError` that includes a truncated inspect of what actually came back — future reports will say what upstream returned.
- `|| 0` on the `dig`, so an upstream shape change yields `0` rather than `nil` flowing into task-size arithmetic.

Behaviour on success is unchanged; all failure paths still land in the existing rescue and return `9999`.

## Note

That client still passes `ssl: { verify: false }`. The host's cert verifies fine (`curl` verify result `0`), so the flag looks like a leftover — left alone here to keep this focused, happy to drop it in a follow-up.

## Testing

- `bundle exec rubocop app/controllers/admin_controller.rb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)