### PR TITLE
[Impersonation] Fix exit banner crash when target is unverified

### DIFF
--- a/app/views/application/_banner_container.html.erb
+++ b/app/views/application/_banner_container.html.erb
@@ -7,13 +7,7 @@
       </p>
     </div>
   <% end %>
-  <% if current_session&.impersonated? %>
-    <div class="w-100 px4 bg-white transparency-banner px-4">
-      <p class="h5 medium center py-2 my-0">
-        <%= link_to "← Exit Impersonation", unimpersonate_user_path(current_user&.id, return_to: request.url), data: { turbo_method: :post, turbo_frame: "_top" } %> | You're currently impersonating <%= user_mention User.find(current_user&.id) %><% unless current_user&.verified? %> <span class="badge bg-warning">unverified</span><% end %>
-      </p>
-    </div>
-  <% end %>
+  <%= render "application/impersonation_banner", klass: "px-4" %>
   <% if current_user&.cards_locked? %>
     <div class="w-100 px4 bg-white transparency-banner px-4">
       <p class="h5 medium center py-2 my-0">

--- a/app/views/application/_impersonation_banner.html.erb
+++ b/app/views/application/_impersonation_banner.html.erb
@@ -1,0 +1,14 @@
+<%#
+  Resolve the impersonated user through `allow_unverified: true`: impersonation
+  sessions mirror their target's `verified` flag, so `current_user` is nil
+  whenever an admin impersonates an unverified account and the exit link would
+  otherwise be built with a nil id.
+%>
+<% impersonated_user = current_user(allow_unverified: true) %>
+<% if current_session&.impersonated? && impersonated_user.present? %>
+  <div class="w-100 px4 bg-white transparency-banner <%= local_assigns[:klass] %>">
+    <p class="h5 medium center py-2 my-0">
+      <%= link_to "← Exit Impersonation", unimpersonate_user_path(impersonated_user, return_to: request.url), data: { turbo_method: :post, turbo_frame: "_top" } %> | You're currently impersonating <%= user_mention impersonated_user %><% unless impersonated_user.verified? %> <span class="badge bg-warning">unverified</span><% end %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/application/_impersonation_banner.html.erb
+++ b/app/views/application/_impersonation_banner.html.erb
@@ -1,9 +1,3 @@
-<%#
-  Resolve the impersonated user through `allow_unverified: true`: impersonation
-  sessions mirror their target's `verified` flag, so `current_user` is nil
-  whenever an admin impersonates an unverified account and the exit link would
-  otherwise be built with a nil id.
-%>
 <% impersonated_user = current_user(allow_unverified: true) %>
 <% if current_session&.impersonated? && impersonated_user.present? %>
   <div class="w-100 px4 bg-white transparency-banner <%= local_assigns[:klass] %>">

--- a/app/views/layouts/docs.html.erb
+++ b/app/views/layouts/docs.html.erb
@@ -12,13 +12,7 @@
                         options: @tour&.tourable&.try(:tourable_options) || {},
                         back_to_tour: @back_to_tour %>
 
-    <% if current_session&.impersonated? %>
-      <div class="w-100 px4 bg-white transparency-banner">
-        <p class="h5 medium center py-2 my-0">
-          <%= link_to "← Exit Impersonation", unimpersonate_user_path(current_user&.id, return_to: request.url), data: { turbo_method: :post, turbo_frame: "_top" } %> | You're currently impersonating <%= user_mention User.find(current_user&.id) %><% unless current_user&.verified? %> <span class="badge bg-warning">unverified</span><% end %>
-        </p>
-      </div>
-    <% end %>
+    <%= render "application/impersonation_banner" %>
     <% if @event&.is_public && !organizer_signed_in? && !@no_app_shell && !@no_transparency_header && !@use_user_nav %>
       <div class="w-100 px3 bg-white transparency-banner" data-behavior="hide_iframe">
         <p class="h5 font-medium text-center text-balance py-2 my-0">

--- a/spec/requests/users/impersonation_banner_spec.rb
+++ b/spec/requests/users/impersonation_banner_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "impersonation banner", type: :request do
+  let(:admin) { create(:user, :make_admin) }
+  let(:shadow) { create(:user, verified: false) }
+
+  before do
+    impersonation_session = create(
+      :user_session,
+      user: shadow,
+      verified: false,
+      impersonated_by: admin,
+      expiration_at: 1.hour.from_now,
+    )
+
+    allow_any_instance_of(SessionsHelper)
+      .to receive(:find_current_session)
+      .and_return(impersonation_session)
+  end
+
+  # Impersonation sessions mirror their target's `verified` flag, so
+  # `current_user` is nil while impersonating an unverified account. The banner
+  # used to build the exit link from `current_user&.id`, which blew up with
+  # "No route matches ... id: nil" on every page it rendered on.
+  it "renders the exit link on the docs layout" do
+    get "/branding"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(unimpersonate_user_path(shadow))
+  end
+
+  it "renders the exit link on the application layout" do
+    get "/applications/new"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(unimpersonate_user_path(shadow))
+  end
+end


### PR DESCRIPTION
## Summary of the problem

Two production exceptions, same root cause:

```
ActionView::Template::Error: No route matches {action: "unimpersonate", controller: "users", id: nil, return_to: ".../applications/new"}
  app/views/application/_banner_container.html.erb:13

ActionView::Template::Error: No route matches {action: "unimpersonate", controller: "users", id: nil, return_to: ".../branding"}
  app/views/layouts/docs.html.erb:18
```

`User::Session#user` returns `nil` unless the session is `verified?`, and `impersonate_user` mirrors the target's verified flag onto the session. So while an admin impersonates an **unverified** account, `current_user` is `nil` — and the impersonation banner built its exit link from `current_user&.id`, blowing up on every page it rendered on. The two traces are just the two layouts that carry the banner (`application` and `docs`); the failing paths aren't special. `User.find(current_user&.id)` on the same line would have raised `RecordNotFound` immediately after.

The `unimpersonate` controller action was already hardened for exactly this case (`current_user(allow_unverified: true)`, plus the `signed_in_user` skip) — the views were missed, so the admin hit a 500 instead of an exit link.

## Describe your changes

Extracted the banner into a single partial, `app/views/application/_impersonation_banner.html.erb`, which:

- resolves the target through `current_user(allow_unverified: true)`, and
- passes the record (not a possibly-nil id) to `unimpersonate_user_path`.

The markup was duplicated verbatim in `_banner_container.html.erb` and `layouts/docs.html.erb`, which is why one bug produced two error reports; both now render the shared partial so they can't drift again. The `unverified` badge already present in that markup shows this case was always meant to be supported — it just never had a user to render.

Also added `spec/requests/users/impersonation_banner_spec.rb`, which loads `/branding` and `/applications/new` under an unverified impersonation session. Reverting the view changes reproduces both production errors verbatim (`id: nil`, unmatched constraint `[:id]`); with the fix, both pass alongside the existing `unimpersonate_spec`. erb_lint and rubocop are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
