### PR TITLE
[Errors] Don't re-negotiate format in the Rack::Timeout handler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,13 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionView::MissingTemplate, with: :not_found
 
-  rescue_from Rack::Timeout::RequestTimeoutException do
+  rescue_from Rack::Timeout::RequestTimeoutException do |exception|
+    # Rack::Timeout raises wherever the request happens to be, which can be
+    # after a response has already been rendered or after another `respond_to`
+    # has negotiated a format. Calling `respond_to` again in that case raises
+    # `ActionController::RespondToMismatchError`, masking the actual timeout.
+    raise exception if performed? || response.media_type.present?
+
     respond_to do |format|
       format.html { render "errors/timeout" }
       format.all { render plain: "This request timed out, sorry." }


### PR DESCRIPTION
## Problem

Sentry is reporting `ActionController::RespondToMismatchError` on `POST /receipts` (`ReceiptsController#create`), pointing at `app/controllers/application_controller.rb:66` — the `respond_to` inside `rescue_from Rack::Timeout::RequestTimeoutException`.

The receipt upload isn't the thing that's broken; the timeout handler is masking the real error:

1. A Turbo receipt upload posts to `/receipts`. The `ensure` block in `ReceiptsController#create` calls `respond_to` and negotiates `turbo_stream`, which sets `response.content_type` to `text/vnd.turbo-stream.html` **before** running the format block.
2. Rendering the streams is slow (`generate_streams` re-renders the transaction row, suggested pairings, receipt list, …) and Rack::Timeout's 30s `service_timeout` fires mid-render.
3. The rescue handler calls `respond_to` a second time. Its collector only offers `html` and `all`, so it negotiates `text/html`, which conflicts with the already-set turbo-stream media type — and Rails raises `RespondToMismatchError`.

So every timed-out non-HTML request gets reported as a confusing `RespondToMismatchError` instead of the timeout it actually was.

## Fix

Bail out of the handler when the response has already been started, and let the timeout propagate as itself:

```ruby
raise exception if performed? || response.media_type.present?
```

- `performed?` covers "already fully rendered".
- `response.media_type.present?` covers the receipts case, where a format was negotiated but the render was still in flight.

## Follow-ups (not in this PR)

- **The underlying slowness.** `POST /receipts` is genuinely exceeding 30s. `generate_streams` does a lot of partial rendering per upload, and both `set_event` and `on_transaction_page?` call `Rails.application.routes.recognize_path(request.referrer)` — `on_transaction_page?` repeatedly, with no memoization.
- **The status code.** `errors/timeout` currently renders `200`; `503` would be more accurate, but changing it affects existing monitoring.