### PR TITLE
[Ledger] Fix crash when personal transaction invoicing fails

### DIFF
--- a/app/controllers/ledger/items_controller.rb
+++ b/app/controllers/ledger/items_controller.rb
@@ -82,9 +82,14 @@ class Ledger
         return redirect_to personal_tx.invoice
       end
 
-      if @item.personal_transaction.present?
+      # Deliberately queried rather than read off `@item.personal_transaction`:
+      # building `personal_tx` above populates that association (`inverse_of`)
+      # with the unsaved record, which has no invoice to redirect to.
+      existing = PersonalTransaction.find_by(ledger_item_id: @item.id)
+
+      if existing
         flash[:error] = "A repayment invoice already exists for this transaction."
-        redirect_to @item.personal_transaction.invoice
+        redirect_to existing.invoice
       else
         flash[:error] = personal_tx.errors.full_messages.to_sentence
         redirect_to @item.hcb_code

--- a/spec/controllers/ledger/items_controller_spec.rb
+++ b/spec/controllers/ledger/items_controller_spec.rb
@@ -22,6 +22,23 @@ RSpec.describe Ledger::ItemsController, type: :controller do
       create_session(member_user, verified: true)
     end
 
+    describe "POST #invoice_as_personal_transaction" do
+      # Regression: building the PersonalTransaction populates
+      # `item.personal_transaction` via `inverse_of` with the unsaved record,
+      # which used to be mistaken for an existing invoice and redirected to its
+      # nil invoice ("Cannot redirect to nil!").
+      it "reports the validation error instead of redirecting to a nil invoice" do
+        hcb_code = create(:hcb_code, hcb_code: "HCB-100-#{item.id}", ledger_item: item)
+
+        expect do
+          post :invoice_as_personal_transaction, params: { item_id: item.hashid }
+        end.not_to change(PersonalTransaction, :count)
+
+        expect(response).to redirect_to(hcb_code)
+        expect(flash[:error]).to include("card charges")
+      end
+    end
+
     describe "PATCH #rename" do
       it "updates the memo and responds with a turbo stream" do
         patch :rename, params: { item_id: item.hashid, ledger_item: { memo: "New memo" } }


### PR DESCRIPTION
## Problem

```
ActionController::ActionControllerError: Cannot redirect to nil!
app/controllers/ledger/items_controller.rb:87 in Ledger::ItemsController#invoice_as_personal_transaction
```

`PersonalTransaction`'s `belongs_to :ledger_item` declares `inverse_of: :personal_transaction`, pairing with the `has_one` on `Ledger::Item`. So `PersonalTransaction.new(ledger_item: @item, …)` writes the new object back into `@item.personal_transaction` and marks the association loaded.

Whenever the save failed, the "a repayment invoice already exists" branch therefore matched against that **unsaved** record, whose `invoice` is always `nil` — `send_invoice` is a `before_create` that never ran.

Two bugs fell out of this:

- Validation failures (not a card charge, charge under $1.00) 500'd instead of surfacing `personal_tx.errors`. The `else` branch was unreachable.
- Genuine duplicates also 500'd instead of redirecting to the existing invoice.

The reported `/transactions/9ofnjAw/…` is almost certainly the first case: the meatball menu offers this action on transactions that can't qualify.

## Fix

Look the existing row up from the database rather than reading the polluted association. This also keeps the branch correct for the concurrent-request race, where the uniqueness validation is what fails.

## Testing

Added a controller spec covering the validation-failure path. Verified it reproduces `Cannot redirect to nil!` against the unfixed controller and passes with the fix; the file's 3 examples pass and RuboCop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)