### PR TITLE
[Check deposits] Identify the missing Column parameter

### DIFF
--- a/app/jobs/process_column_check_deposit_job.rb
+++ b/app/jobs/process_column_check_deposit_job.rb
@@ -3,6 +3,7 @@
 class ProcessColumnCheckDepositJob < ApplicationJob
   class UnconfidentError < StandardError; end
   class ApiError < StandardError; end
+  class MissingParameterError < StandardError; end
 
   def perform(check_deposit:, validate: true)
     return if check_deposit.column_id.present? || check_deposit.increase_id.present?
@@ -27,16 +28,26 @@ class ProcessColumnCheckDepositJob < ApplicationJob
     end
 
     event = check_deposit.event
-    account_number_id = (event.column_account_number || event.create_column_account_number)&.column_id
+    account_number = event.column_account_number || event.create_column_account_number
 
-    column_check_deposit = ColumnService.post("/transfers/checks/deposit", bank_account_id: ColumnService::Accounts::FS_MAIN,
-                                                                           account_number_id:,
-                                                                           deposited_amount: check_deposit.amount_cents,
-                                                                           currency_code: "USD",
-                                                                           micr_line: front["micr_line"],
-                                                                           image_front: front["image_front"],
-                                                                           image_back: back["image_back"],
-                                                                           idempotency_key: "check_deposit_#{check_deposit.id}")
+    params = {
+      bank_account_id: ColumnService::Accounts::FS_MAIN,
+      account_number_id: account_number&.column_id,
+      deposited_amount: check_deposit.amount_cents,
+      currency_code: "USD",
+      micr_line: front["micr_line"],
+      image_front: front["image_front"],
+      image_back: back["image_back"]
+    }
+
+    # Column responds to a missing parameter with a generic "The request is
+    # missing a required parameter." Name the parameters ourselves so the error
+    # is actionable — `account_number_id` in particular is silently nil when
+    # `create_column_account_number` fails its validations.
+    missing = params.select { |_, value| value.blank? }.keys
+    raise MissingParameterError, missing_parameter_message(missing, account_number) if missing.any?
+
+    column_check_deposit = ColumnService.post("/transfers/checks/deposit", **params, idempotency_key: "check_deposit_#{check_deposit.id}")
 
     check_deposit.update!(column_id: column_check_deposit["id"], status: :submitted)
 
@@ -44,10 +55,37 @@ class ProcessColumnCheckDepositJob < ApplicationJob
 
     check_deposit
 
-  rescue Faraday::Error, ProcessColumnCheckDepositJob::UnconfidentError => e
+  rescue Faraday::Error, UnconfidentError, MissingParameterError => e
     check_deposit.update!(status: :manual_submission_required)
     Rails.error.unexpected "Check deposit ##{check_deposit.id} needs to be manually submitted to Column."
-    raise ApiError, e.response_body["message"] if e.is_a?(Faraday::Error)
+
+    case e
+    when Faraday::Error then raise ApiError, column_error_message(e)
+    when MissingParameterError then raise
+    end
+  end
+
+  private
+
+  def missing_parameter_message(missing, account_number)
+    message = "missing #{missing.to_sentence} for the Column check deposit"
+    errors = account_number&.errors&.full_messages
+
+    return message if errors.blank?
+
+    "#{message} (Column account number is invalid: #{errors.to_sentence})"
+  end
+
+  # `Faraday::Error#response` is nil for transport-level failures (timeouts,
+  # connection resets), and Column doesn't always respond with a JSON body, so
+  # fall back to Faraday's own message rather than blowing up with a
+  # `NoMethodError` that hides the real failure.
+  def column_error_message(error)
+    body = error.response_body
+    message = (body.is_a?(Hash) ? body["message"] : body).presence || error.message
+    url_path = error.response&.dig(:request, :url_path)
+
+    url_path ? "#{message} (#{url_path})" : message
   end
 
 end


### PR DESCRIPTION
## The error

```
ProcessColumnCheckDepositJob::ApiError: The request is missing a required parameter.
app/jobs/process_column_check_deposit_job.rb:50 in ProcessColumnCheckDepositJob#perform
```

Line 50 is just the re-raise site — it wrapped `e.response_body["message"]` from a Column 400. `"The request is missing a required parameter."` is Column's generic response, and we discarded both **which** endpoint failed and **which** parameter was nil, so the report was untriageable.

## Likely root cause

Three of the seven params sent to `/transfers/checks/deposit` can be nil without anything upstream complaining. The most likely culprit:

```ruby
account_number_id = (event.column_account_number || event.create_column_account_number)&.column_id
```

`create_column_account_number` is the `has_one` builder — it returns the record **even when the save fails validation**, so `&.` doesn't protect us. `Column::AccountNumber` assigns `column_id` in a `before_create`, which never runs on a failed save, so a validation failure (`event_is_not_demo_mode`, the `event` uniqueness check, or `validates_uniqueness_of :account_number_bidx` — which runs against a still-nil bidx, since the blind index isn't computed until `account_number` is assigned in that same `before_create`) sends `account_number_id: nil` to Column.

`micr_line` / `image_front` / `image_back` are the other two candidates, reachable when the job is re-run with `validate: false`.

## Changes

- **Name the missing parameter.** Request params are built into a hash; any blank value raises `MissingParameterError` listing the offending keys before we call Column. When the account number is at fault, its validation errors are included in the message.
- **Identify the failing endpoint.** `ApiError` now appends `e.response[:request][:url_path]`, so the message reads `The request is missing a required parameter. (/transfers/checks/deposit)` — distinguishing the deposit call from the two image uploads, which use a separate Faraday connection with no AppSignal instrumentation.
- **Fix a masking bug.** `e.response_body["message"]` raised `NoMethodError` for transport failures (`Faraday::ConnectionFailed`, `TimeoutError`), where `response` is nil, and for non-JSON error bodies. It now falls back to Faraday's own message.

`MissingParameterError` still marks the deposit `manual_submission_required`, then re-raises so the job fails loudly rather than silently like `UnconfidentError`.

## Not included

- **No spec.** There are no job specs of this shape in the repo, and covering this needs ActiveStorage plus three stubbed Column endpoints — bigger scope than the fix.
- **The shared pattern is untouched.** The same `(x || create_x)&.column_id` bug exists in `ach_transfer.rb:218`, `ach_transfer.rb:247`, `wire.rb:199` and `increase_check.rb:371`. The real cure is probably making `Column::AccountNumber` creation raise on invalid rather than each caller guarding — happy to do that in a follow-up.

Rubocop passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)