### PR TITLE
[Login] Add "resend code" button

### DIFF
--- a/app/javascript/controllers/resend_code_controller.js
+++ b/app/javascript/controllers/resend_code_controller.js
@@ -1,0 +1,63 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    seconds: { type: Number, default: 30 },
+  }
+
+  static targets = ['button', 'countdown']
+
+  connect() {
+    this.start()
+  }
+
+  disconnect() {
+    this.stop()
+  }
+
+  sending() {
+    this.showCountdown('Sending...')
+  }
+
+  submitEnd(event) {
+    if (event.detail.fetchResponse?.statusCode === 429) {
+      this.start(this.secondsValue * 2, 'Too many attempts, try again')
+      return
+    }
+    this.start()
+  }
+
+  start(seconds = this.secondsValue, message = null) {
+    this.stop()
+    this.deadline = Date.now() + seconds * 1000
+    this.message = message
+    this.tick()
+    this.interval = setInterval(() => this.tick(), 1000)
+  }
+
+  stop() {
+    if (this.interval) clearInterval(this.interval)
+    this.interval = null
+  }
+
+  tick() {
+    this.remaining = Math.max(0, Math.ceil((this.deadline - Date.now()) / 1000))
+    if (this.remaining <= 0) {
+      this.stop()
+      this.showButton()
+      return
+    }
+    this.showCountdown(`${this.message ?? 'Resend code'} in ${this.remaining}s`)
+  }
+
+  showCountdown(label) {
+    this.countdownTarget.hidden = false
+    this.buttonTarget.hidden = true
+    this.countdownTarget.textContent = label
+  }
+
+  showButton() {
+    this.countdownTarget.hidden = true
+    this.buttonTarget.hidden = false
+  }
+}

--- a/app/javascript/controllers/resend_code_controller.js
+++ b/app/javascript/controllers/resend_code_controller.js
@@ -15,11 +15,13 @@ export default class extends Controller {
     this.stop()
   }
 
-  sending() {
+  sending(event) {
+    if (event.target.id !== 'resend-code-form') return
     this.showCountdown('Sending...')
   }
 
   submitEnd(event) {
+    if (event.target.id !== 'resend-code-form') return
     if (event.detail.fetchResponse?.statusCode === 429) {
       this.start(this.secondsValue * 2, 'Too many attempts, try again')
       return
@@ -47,7 +49,7 @@ export default class extends Controller {
       this.showButton()
       return
     }
-    this.showCountdown(`${this.message ?? 'Resend code'} in ${this.remaining}s`)
+    this.showCountdown(`${this.message ?? 'Resend code'} (${this.remaining}s)`)
   }
 
   showCountdown(label) {

--- a/app/views/logins/_resend_code.html.erb
+++ b/app/views/logins/_resend_code.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (path:, seconds:) -%>
+<div class="mt-2" data-controller="resend-code" data-resend-code-seconds-value="<%= seconds %>" data-action="turbo:submit-start->resend-code#sending turbo:submit-end->resend-code#submitEnd">
+  <span class="muted tabular-nums" data-resend-code-target="countdown" hidden></span>
+  <%= button_to "Resend code", path, class: "link-button", data: { "resend-code-target": "button" } %>
+</div>

--- a/app/views/logins/_resend_code.html.erb
+++ b/app/views/logins/_resend_code.html.erb
@@ -1,5 +1,5 @@
-<%# locals: (path:, seconds:) -%>
-<div class="mt-2" data-controller="resend-code" data-resend-code-seconds-value="<%= seconds %>" data-action="turbo:submit-start->resend-code#sending turbo:submit-end->resend-code#submitEnd">
-  <span class="muted tabular-nums" data-resend-code-target="countdown" hidden></span>
-  <%= button_to "Resend code", path, class: "link-button", data: { "resend-code-target": "button" } %>
+<%# locals: (seconds:) -%>
+<div class="absolute inset-y-0 right-2 flex items-center gap-1 h5 muted pointer-events-none" data-controller="resend-code" data-resend-code-seconds-value="<%= seconds %>" data-action="turbo:submit-start@window->resend-code#sending turbo:submit-end@window->resend-code#submitEnd">
+  <span class="bold tabular-nums cursor-not-allowed pointer-events-auto" data-resend-code-target="countdown" hidden></span>
+  <button type="submit" form="resend-code-form" class="!font-bold link-button pointer-events-auto" data-resend-code-target="button">Resend code</button>
 </div>

--- a/app/views/logins/_resend_code_form.html.erb
+++ b/app/views/logins/_resend_code_form.html.erb
@@ -1,0 +1,2 @@
+<%# locals: (path:) -%>
+<%= button_to "Resend code", path, form: { id: "resend-code-form" }, form_class: "hidden" %>

--- a/app/views/logins/email.html.erb
+++ b/app/views/logins/email.html.erb
@@ -64,11 +64,11 @@
         Continue
       </button>
     </div>
-
-    <div class="flex justify-end">
-      <%= render partial: "logins/resend_code", locals: { path: email_login_path(@login), seconds: 30 } %>
-    </div>
   <% end %>
+
+  <div class="flex justify-end">
+    <%= render partial: "logins/resend_code", locals: { path: email_login_path(@login), seconds: 30 } %>
+  </div>
 
   <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/ua-parser-js/dist/ua-parser.min.js" %>
   <%= javascript_include_tag "fingerprint.js" %>

--- a/app/views/logins/email.html.erb
+++ b/app/views/logins/email.html.erb
@@ -23,41 +23,42 @@
   </p>
 
   <%= form_tag complete_login_path(@login), id: "login" do %>
-    <% if Flipper.enabled?(:otp_single_input, @login.user) %>
-      <%= text_field_tag(
-            :login_code,
-            "",
-            class: "otp_code",
-            autocomplete: "one-time-code",
-            required: true,
-            inputmode: "numeric",
-            maxlength: "6",
-            autofocus: true,
-            data: { behavior: "otp_input", "op-ignore": true }
-          ) %>
-    <% else %>
-      <%= text_field_tag(
-            :login_code,
-            "",
-            placeholder: "Enter your login code",
-            class: "!max-w-full w-max",
-            autocomplete: "one-time-code",
-            required: true,
-            autofocus: true,
-            inputmode: "numeric",
-            data: { "op-ignore": true }
-          ) %>
-    <% end %>
+    <div class="relative">
+      <% if Flipper.enabled?(:otp_single_input, @login.user) %>
+        <%= text_field_tag(
+              :login_code,
+              "",
+              class: "otp_code",
+              autocomplete: "one-time-code",
+              required: true,
+              inputmode: "numeric",
+              maxlength: "6",
+              autofocus: true,
+              data: { behavior: "otp_input", "op-ignore": true }
+            ) %>
+      <% else %>
+        <%= text_field_tag(
+              :login_code,
+              "",
+              placeholder: "Enter your login code",
+              class: "!max-w-full w-max pr-32",
+              autocomplete: "one-time-code",
+              required: true,
+              autofocus: true,
+              inputmode: "numeric",
+              data: { "op-ignore": true }
+            ) %>
+      <% end %>
+      <%= render partial: "logins/resend_code", locals: { seconds: 30 } %>
+    </div>
     <%= invisible_captcha :remember_me %>
 
     <%= hidden_field_tag :method, :email %>
     <%= render partial: "logins/fingerprint_info" %>
 
-    <p class="h5 muted"><em>Make sure to check your spam folder</em></p>
-
     <div class="flex flex-row justify-between items-center mt-4 gap-2">
       <% if @login.available_factors.excluding(:email).any? %>
-        <%= link_to "Sign in another way", choose_login_preference_login_path(@login), class: "block mt-0 no-underline" %>
+        <%= link_to "Sign in another way", choose_login_preference_login_path(@login), class: "block mt-0 underline" %>
       <% end %>
 
       <button type="submit" class="gap-2 btn ml-auto">
@@ -66,9 +67,7 @@
     </div>
   <% end %>
 
-  <div class="flex justify-end">
-    <%= render partial: "logins/resend_code", locals: { path: email_login_path(@login), seconds: 30 } %>
-  </div>
+  <%= render partial: "logins/resend_code_form", locals: { path: email_login_path(@login) } %>
 
   <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/ua-parser-js/dist/ua-parser.min.js" %>
   <%= javascript_include_tag "fingerprint.js" %>

--- a/app/views/logins/email.html.erb
+++ b/app/views/logins/email.html.erb
@@ -64,6 +64,10 @@
         Continue
       </button>
     </div>
+
+    <div class="flex justify-end">
+      <%= render partial: "logins/resend_code", locals: { path: email_login_path(@login), seconds: 30 } %>
+    </div>
   <% end %>
 
   <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/ua-parser-js/dist/ua-parser.min.js" %>

--- a/app/views/logins/sms.html.erb
+++ b/app/views/logins/sms.html.erb
@@ -22,31 +22,34 @@
   </p>
 
   <%= form_tag complete_login_path(@login), id: "login" do %>
-    <% if Flipper.enabled?(:otp_single_input, @login.user) %>
-      <%= text_field_tag(
-            :login_code,
-            "",
-            class: "otp_code",
-            autocomplete: "one-time-code",
-            required: true,
-            inputmode: "numeric",
-            maxlength: "6",
-            autofocus: true,
-            data: { behavior: "otp_input", "op-ignore": true }
-          ) %>
-    <% else %>
-      <%= text_field_tag(
-            :login_code,
-            "",
-            placeholder: "Enter your login code",
-            class: "!max-w-full w-max",
-            autocomplete: "one-time-code",
-            required: true,
-            autofocus: true,
-            inputmode: "numeric",
-            data: { "op-ignore": true }
-          ) %>
-    <% end %>
+    <div class="relative">
+      <% if Flipper.enabled?(:otp_single_input, @login.user) %>
+        <%= text_field_tag(
+              :login_code,
+              "",
+              class: "otp_code",
+              autocomplete: "one-time-code",
+              required: true,
+              inputmode: "numeric",
+              maxlength: "6",
+              autofocus: true,
+              data: { behavior: "otp_input", "op-ignore": true }
+            ) %>
+      <% else %>
+        <%= text_field_tag(
+              :login_code,
+              "",
+              placeholder: "Enter your login code",
+              class: "!max-w-full w-max pr-32",
+              autocomplete: "one-time-code",
+              required: true,
+              autofocus: true,
+              inputmode: "numeric",
+              data: { "op-ignore": true }
+            ) %>
+      <% end %>
+      <%= render partial: "logins/resend_code", locals: { seconds: 30 } %>
+    </div>
 
     <%= invisible_captcha :remember_me %>
     <%= hidden_field_tag :method, :sms %>
@@ -54,7 +57,7 @@
 
     <div class="flex flex-row justify-between items-center mt-4 gap-2">
       <% if @login.available_factors.excluding(:sms).any? %>
-        <%= link_to "Sign in another way", choose_login_preference_login_path(@login), class: "block mt-0 no-underline" %>
+        <%= link_to "Sign in another way", choose_login_preference_login_path(@login), class: "block mt-0 underline" %>
       <% end %>
       <button type="submit" class="gap-2 btn ml-auto">
         Continue
@@ -62,9 +65,7 @@
     </div>
   <% end %>
 
-  <div class="flex justify-end">
-    <%= render partial: "logins/resend_code", locals: { path: sms_login_path(@login), seconds: 30 } %>
-  </div>
+  <%= render partial: "logins/resend_code_form", locals: { path: sms_login_path(@login) } %>
 
   <%= render partial: "logins/environment_banner" %>
 </div>

--- a/app/views/logins/sms.html.erb
+++ b/app/views/logins/sms.html.erb
@@ -60,11 +60,11 @@
         Continue
       </button>
     </div>
-
-    <div class="flex justify-end">
-      <%= render partial: "logins/resend_code", locals: { path: sms_login_path(@login), seconds: 30 } %>
-    </div>
   <% end %>
+
+  <div class="flex justify-end">
+    <%= render partial: "logins/resend_code", locals: { path: sms_login_path(@login), seconds: 30 } %>
+  </div>
 
   <%= render partial: "logins/environment_banner" %>
 </div>

--- a/app/views/logins/sms.html.erb
+++ b/app/views/logins/sms.html.erb
@@ -60,7 +60,12 @@
         Continue
       </button>
     </div>
+
+    <div class="flex justify-end">
+      <%= render partial: "logins/resend_code", locals: { path: sms_login_path(@login), seconds: 30 } %>
+    </div>
   <% end %>
+
 
   <%= render partial: "logins/environment_banner" %>
 </div>

--- a/app/views/logins/sms.html.erb
+++ b/app/views/logins/sms.html.erb
@@ -66,7 +66,6 @@
     </div>
   <% end %>
 
-
   <%= render partial: "logins/environment_banner" %>
 </div>
 

--- a/spec/controllers/logins_controller_spec.rb
+++ b/spec/controllers/logins_controller_spec.rb
@@ -67,6 +67,23 @@ RSpec.describe LoginsController do
       expect(response.body).to include("We just sent a login code")
     end
 
+    it "resends the login code when the user requests it" do
+      user = create(:user, email: "text@example.com")
+      login = create(:login, user:)
+
+      expect {
+        post(:email, params: { id: login.hashid })
+      }.to send_email(to: user.email)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Resend code")
+      expect(response.body).to include(email_login_path(login))
+
+      expect {
+        post(:email, params: { id: login.hashid })
+      }.to send_email(to: user.email)
+    end
+
     it "sends an SMS code if the user has opted-in and verified their phone number" do
       user = create(:user, phone_number: "+18556254225")
       # This can't be done through the factory because we have validation logic
@@ -84,6 +101,24 @@ RSpec.describe LoginsController do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("SMS code")
       expect(response.body).to include("We just sent a login code")
+    end
+
+    it "resends the SMS code when the user requests it" do
+      user = create(:user, phone_number: "+18556254225")
+      user.update!(use_sms_auth: true, phone_number_verified: true)
+      login = create(:login, user:)
+
+      verification_service = instance_double(TwilioVerificationService)
+      expect(verification_service).to receive(:send_verification_request).with(user.phone_number).twice
+      expect(TwilioVerificationService).to receive(:new).twice.and_return(verification_service)
+
+      post(:sms, params: { id: login.hashid })
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Resend code")
+
+      post(:sms, params: { id: login.hashid })
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Resend code")
     end
 
     # The UI never offers SMS for an unverified number, so this request only


### PR DESCRIPTION
## Summary of the problem
Fixes #11754


## Describe your changes
Adds a simple "Resend code" button to the login flow, with a timeout of 30s (60s on 429), to both the email and SMS paths.


<img width="457" height="296" alt="image" src="https://github.com/user-attachments/assets/26eea91b-ae0c-4a71-a8a6-449fe9cca6e2" />

