### PR TITLE
Point retired CDN asset URLs at /rescue (1 link)

### DIFF
--- a/dev-docs/research/aws-s3-vs-hetzner.md
+++ b/dev-docs/research/aws-s3-vs-hetzner.md
@@ -877,7 +877,7 @@ result in:
       environment variables.
 3. Run benchmarks for Hetzner and AWS S3
    ```sh
-   export AWS_PROFILE=hetzner && ./s3-benchmark -region=hel1 -endpoint=https://hel1.your-objectstorage.com -upload-csv=data
+   export AWS_PROFILE=hetzner && ./s3-benchmark -region=hel1 -endpoint=https://cdn.hackclub.com/rescue?url=https://hel1.your-objectstorage.com -upload-csv=data
    ```
    ```sh
    export AWS_PROFILE=aws && ./s3-benchmark -region=us-east-2 -upload-csv=data


### PR DESCRIPTION
Points **1 retired-CDN asset references** across **1 files** at the current CDN's lookup endpoint, `cdn.hackclub.com/rescue?url=<original>`.

The old Vercel and Hetzner origins are being retired. `/rescue` resolves an original URL to wherever that file now lives on the v4 CDN, so wrapping the existing URL keeps these assets loading without moving any bytes or re-uploading anything.

```diff
- ![screenshot](https://cloud-abc123-hack-club-bot.vercel.app/0image.png)
+ ![screenshot](https://cdn.hackclub.com/rescue?url=https://cloud-abc123-hack-club-bot.vercel.app/0image.png)
```

### Scope

- 1 references rewritten across 1 files.
- 68 references were **already** wrapped in `/rescue` and are left exactly as they were.
- Text references only — no image bytes, no filenames, no uploads, no layout changes.
- Every change is a pure URL-for-URL substitution, verified programmatically: masking the rewritten spans in both the original and the result yields byte-identical documents, so no surrounding markup was touched.
- Original URLs are preserved verbatim inside the `url=` parameter, so this is fully reversible and nothing is lost.