### PR TITLE
[Invoices] Handle invalid sponsor details on the form

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -83,11 +83,9 @@ class InvoicesController < ApplicationController
 
     sponsor_attrs = filtered_params[:sponsor_attributes]
 
-    due_date = Date.parse(filtered_params["due_date"])
-
     @invoice = ::InvoiceService::Create.new(
       event_id: @event.id,
-      due_date:,
+      due_date: parsed_due_date,
       item_description: filtered_params[:item_description],
       item_amount: filtered_params[:item_amount],
       current_user:,
@@ -108,6 +106,15 @@ class InvoicesController < ApplicationController
     redirect_to @invoice
   rescue Pundit::NotAuthorizedError
     raise
+  rescue ActiveRecord::RecordInvalid => e
+    # Bad sponsor or invoice details are a mistake in what was typed, not a bug,
+    # so re-render the form with the validation errors instead of reporting the
+    # exception and sending the organizer back to an empty form.
+    @sponsor = e.record.is_a?(Sponsor) ? e.record : sponsor_from_params
+    @invoice = e.record.is_a?(Invoice) ? e.record : invoice_from_params
+    @invoice.sponsor ||= @sponsor
+
+    render :new, status: :unprocessable_content
   rescue => e
     Rails.error.report(e)
 
@@ -226,6 +233,29 @@ class InvoicesController < ApplicationController
     { key: "amount_due", right: true, display: "Amount" },
   ].freeze
   private_constant :INVOICE_COLUMNS
+
+  # A blank or malformed date would otherwise raise out of `Date.parse`; leaving
+  # it nil lets Invoice's presence validation report it on the form instead.
+  def parsed_due_date
+    Date.parse(filtered_params[:due_date].to_s)
+  rescue Date::Error
+    nil
+  end
+
+  # Rebuilds the submitted sponsor/invoice so a failed create can re-render the
+  # form with everything the organizer already filled in.
+  def sponsor_from_params
+    @event.sponsors.new(filtered_params[:sponsor_attributes])
+  end
+
+  def invoice_from_params
+    Invoice.new(
+      event: @event,
+      item_description: filtered_params[:item_description],
+      item_amount: Monetize.parse(filtered_params[:item_amount])&.cents,
+      due_date: parsed_due_date
+    )
+  end
 
   def filtered_params
     params.require(:invoice).permit(

--- a/app/javascript/controllers/invoice_form_controller.js
+++ b/app/javascript/controllers/invoice_form_controller.js
@@ -12,6 +12,8 @@ export default class extends Controller {
     'secondTab',
   ]
 
+  static values = { invalid: Boolean }
+
   static fields = [
     'name',
     'contact_email',
@@ -25,9 +27,13 @@ export default class extends Controller {
   ]
 
   connect() {
+    // `invalidValue` means the server re-rendered a rejected submission, so the
+    // fields hold what was typed: show them for correction and don't clear them.
     if (this.selectSponsorTarget.disabled) {
       this.continueButtonTarget.disabled = false
-      this.showNewSponsorCard()
+      this.showNewSponsorCard(!this.invalidValue)
+    } else if (this.invalidValue) {
+      this.showNewSponsorCard(false)
     }
 
     this.sponsorFormTarget.addEventListener(

--- a/app/views/invoices/_form.html.erb
+++ b/app/views/invoices/_form.html.erb
@@ -1,9 +1,10 @@
+<% invalid_submission = sponsor.errors.any? || invoice.errors.any? %>
 <% if @event.demo_mode? %>
   <div class="muted mt-6">
     Once your organization is activated, you'll be able to create and send invoices
   </div>
 <% else %>
-  <%= form_with(model: invoice, url: event_invoices_path(@event), local: true, data: { controller: "invoice-form" }, html: { "x-data" => "{ amount: null }" }) do |form| %>
+  <%= form_with(model: invoice, url: event_invoices_path(@event), local: true, data: { controller: "invoice-form", invoice_form_invalid_value: invalid_submission }, html: { "x-data" => "{ amount: null }" }) do |form| %>
     <div data-controller="tabs" data-tabs-default-tab-value="sponsor">
       <div class="flex mb-4 gap-5">
         <div
@@ -38,15 +39,16 @@
             id="invoice_sponsor_id"
             class="max-w-full"
             <%= "disabled hidden" if @event.sponsors.empty? %>>
-            <option value="default" selected disabled>Select…</option>
-            <option value="">+⠀New sponsor…</option>
-            <% @event.sponsors.select(:id, :name, :contact_email, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country).each do |sponsor| %>
-              <option value="<%= sponsor.id %>" data-json="<%= sponsor.to_json %>"><%= sponsor.name %></option>
+            <option value="default" <%= "selected" unless invalid_submission %> disabled>Select…</option>
+            <option value="" <%= "selected" if invalid_submission && sponsor.id.blank? %>>+⠀New sponsor…</option>
+            <% @event.sponsors.select(:id, :name, :contact_email, :address_line1, :address_line2, :address_city, :address_state, :address_postal_code, :address_country).each do |option_sponsor| %>
+              <option value="<%= option_sponsor.id %>" data-json="<%= option_sponsor.to_json %>" <%= "selected" if invalid_submission && sponsor.id == option_sponsor.id %>><%= option_sponsor.name %></option>
             <% end %>
           </select>
         </div>
         <details
           id="sponsor-collapsible"
+          <%= "open" if invalid_submission %>
           data-invoice-form-target="sponsorCollapsible">
           <summary class="list-none select-none flex !hidden items-center bg-gray-100 hover:bg-gray-200 active:bg-gray-300 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:active:bg-neutral-600 transition-colors px-7 p-4" data-invoice-form-target="sponsorPreview">
             <div class="flex flex-col">
@@ -55,7 +57,7 @@
             </div>
             <span class="muted ml-auto">Edit</span>
           </summary>
-          <%= form.fields_for :sponsor_attributes do |form| %>
+          <%= form.fields_for :sponsor_attributes, sponsor do |form| %>
             <div data-invoice-form-target="sponsorForm">
               <p id="sponsor-warning" class="flex items-center info leading-[1.25]" hidden>
                 <%= inline_icon "important", size: 32, class: "mr1" %>
@@ -70,7 +72,9 @@
               <div class="field">
                 <%= form.label :contact_email, "Contact email" %>
                 <span class="muted mb-2 block text-sm">Email you'll send this invoice to</span>
-                <%= form.email_field :contact_email, placeholder: "peter.gregory@ravigacapital.com", required: true, disabled: @event.demo_mode? %>
+                <%= form.email_field :contact_email, placeholder: "peter.gregory@ravigacapital.com", required: true, disabled: @event.demo_mode?,
+                                      pattern: "[^@\\s]+@[^@\\s]+\\.[A-Za-z][A-Za-z0-9-]*",
+                                      title: "Include the full domain, e.g. peter.gregory@ravigacapital.com" %>
               </div>
               <%= form.label :address_line1, "Street address" %>
               <div class="flex gap-2">
@@ -144,7 +148,7 @@
         </div>
         <div class="field">
           <%= form.label :due_date %>
-          <%= form.date_field :due_date, min: 3.days.from_now, value: 30.days.from_now, class: "!max-w-full", disabled: @event.demo_mode? %>
+          <%= form.date_field :due_date, min: 3.days.from_now, value: invoice.due_date || 30.days.from_now, class: "!max-w-full", disabled: @event.demo_mode? %>
         </div>
         <div class="actions tooltipped tooltipped--n inline-block" aria-label="Your invoice will immediately be emailed to the sponsor">
           <%= form.submit "Send invoice now", disabled: !organizer_signed_in? || @event.demo_mode? %>

--- a/spec/controllers/invoices_controller_spec.rb
+++ b/spec/controllers/invoices_controller_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe InvoicesController do
+  include SessionSupport
+
+  render_views
+
+  # The invoice form partial is shared between the full page and the modal on
+  # the index, so render both.
+  describe "the invoice form" do
+    let(:user) { create(:user) }
+    let(:event) { create(:event, organizers: [user]) }
+
+    before { create_session(user, verified: true) }
+
+    it "renders on the new page" do
+      get :new, params: { event_id: event.friendly_id }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders in the index modal" do
+      get :index, params: { event_id: event.friendly_id }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "create" do
+    let(:user) { create(:user) }
+    let(:event) { create(:event, organizers: [user]) }
+
+    let(:valid_params) do
+      {
+        event_id: event.friendly_id,
+        invoice: {
+          due_date: 30.days.from_now.to_date.to_s,
+          item_description: "Silver Sponsorship",
+          item_amount: "500.00",
+          sponsor_attributes: {
+            name: "Raviga Capital",
+            contact_email: "peter.gregory@ravigacapital.com",
+            address_line1: "1 Letterman Drive",
+            address_city: "San Francisco",
+            address_state: "CA",
+            address_postal_code: "94129",
+            address_country: "US"
+          }
+        }
+      }
+    end
+
+    before { create_session(user, verified: true) }
+
+    # `type="email"` lets `peter.gregory@ravigacapital` through, but Sponsor's
+    # server-side validation requires a TLD.
+    context "when the sponsor's email is invalid" do
+      let(:params) do
+        valid_params.deep_merge(
+          invoice: { sponsor_attributes: { contact_email: "peter.gregory@ravigacapital" } }
+        )
+      end
+
+      it "re-renders the form with the error instead of reporting it" do
+        expect(Rails.error).not_to receive(:report)
+        expect(StripeService::Customer).not_to receive(:create)
+
+        expect { post :create, params: params }.not_to change(Sponsor, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Contact email does not appear to be a valid email address")
+      end
+
+      it "keeps what was already filled in" do
+        post :create, params: params
+
+        expect(response.body).to include('value="peter.gregory@ravigacapital"')
+        expect(response.body).to include('value="Raviga Capital"')
+        expect(response.body).to include('value="San Francisco"')
+        expect(response.body).to include('value="Silver Sponsorship"')
+        expect(response.body).to include('value="500.0"')
+      end
+    end
+
+    context "when the due date is blank" do
+      it "re-renders the form rather than raising out of Date.parse" do
+        expect(Rails.error).not_to receive(:report)
+        allow_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+
+        post :create, params: valid_params.deep_merge(invoice: { due_date: "" })
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Due date can&#39;t be blank")
+      end
+    end
+
+    context "when the amount is below the $1 minimum" do
+      it "re-renders the form with the error and the sponsor's details" do
+        expect(Rails.error).not_to receive(:report)
+        allow_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+
+        post :create, params: valid_params.deep_merge(invoice: { item_amount: "0.50" })
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Item amount must be at least $1")
+        expect(response.body).to include('value="Raviga Capital"')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary of the problem

We're getting untriaged error reports like this one from `POST /:org/invoices`:

```
ActiveRecord::RecordInvalid: Validation failed: Contact email does not appear to be a valid email address
app/services/invoice_service/create.rb:136 in InvoiceService::Create#sponsor
app/controllers/invoices_controller.rb:104 in InvoicesController#create
```

`validates_email_format_of` on `Sponsor` requires a dotted domain with a letter-initial TLD. A browser's `type="email"` does **not** — it happily accepts `peter.gregory@ravigacapital`. So a missing-TLD typo sails past the client-side check *and* past the `checkValidity()` gate on the "Continue" button, then raises out of `Sponsor#create!`.

The catch-all `rescue` in `InvoicesController#create` then does two unhelpful things: it files the typo as an untriaged error via `Rails.error.report`, and it redirects to a **blank** form. The organizer loses the entire invoice they'd filled in and just sees the raw `ActiveRecord` message in a flash.

## Describe your changes

**Prevention.** Added a `pattern` to the contact email field requiring a real TLD, so the typo is caught at step 1 with a native browser message and never reaches the server.

**Graceful handling.** `ActiveRecord::RecordInvalid` is now rescued separately: it re-renders `:new` with `422` and the validation errors, and is no longer reported as an exception. Bad input isn't a bug. The form already had `form_errors` slots wired up that nothing ever populated.

**Preserving what was typed.** Three separate things were dropping it, so all three needed fixing:
- `fields_for :sponsor_attributes` had no object bound, so nothing could prefill
- the sponsor card renders collapsed *and* with a hidden `<summary>`, so it's invisible until JS opens it — now marked `open` server-side
- `connect()` called `clearValues()` whenever an event had no sponsors yet, which is exactly the case after a rolled-back sponsor create — it now skips the clear via an `invalid` Stimulus value

The submitted `due_date` is also kept instead of always resetting to 30 days out.

**Blank due dates.** `Date.parse("")` was raising into that same reporting path (`TypeError`/`Date::Error` surfaced to the user as `no implicit conversion of nil into String`). Parsing is now tolerant, and Invoice's presence validation reports "Due date can't be blank" on the form.

Added `spec/controllers/invoices_controller_spec.rb` covering the invalid email, blank due date, and below-minimum amount paths, plus rendering of the shared form partial in both the full page and the index modal.

### Two things worth flagging for review

- The `pattern` is marginally stricter than the server for IPv4-literal domains (`a@1.2.3.4`), which the gem permits. I judged that a non-issue for sponsor billing emails, but it is a deliberate narrowing.
- A pre-existing wart I left alone: `Sponsor#create_stripe_customer` is a `before_create` hook, so when an invoice-level validation fails *after* a valid sponsor, the DB rolls back but the Stripe customer is orphaned. Fixing that means restructuring the service's transaction, which felt out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
