### PR TITLE
[Comment::Reaction] Fix crash when re-adding a removed reaction

### DIFF
--- a/app/models/comment/reaction.rb
+++ b/app/models/comment/reaction.rb
@@ -27,12 +27,15 @@
 class Comment
   class Reaction < ApplicationRecord
     acts_as_paranoid
+    validates_as_paranoid
 
     belongs_to :comment
     belongs_to :reactor, class_name: "User"
 
     validates :emoji, presence: true
-    validates :emoji, uniqueness: { scope: [:reactor_id, :comment_id], message: "has already been used for this comment" }
+    # Reactions are soft-deleted when un-reacted, so the uniqueness check has to
+    # ignore deleted rows -- otherwise re-adding a removed reaction raises.
+    validates_uniqueness_of_without_deleted :emoji, scope: [:reactor_id, :comment_id], message: "has already been used for this comment"
 
     EMOJIS = %w[👍 👎 😄 🎉 😔 ❤️ 🚀 👀 💀].freeze
 

--- a/spec/models/comment/reaction_spec.rb
+++ b/spec/models/comment/reaction_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comment::Reaction, type: :model do
+  let(:event) { create(:event) }
+  let(:comment) { create(:comment, commentable: event) }
+  let(:reactor) { create(:user) }
+
+  describe "emoji uniqueness" do
+    it "rejects a duplicate reaction from the same user" do
+      described_class.create!(comment:, reactor:, emoji: "👍")
+
+      duplicate = described_class.new(comment:, reactor:, emoji: "👍")
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:emoji]).to include("has already been used for this comment")
+    end
+
+    it "allows re-reacting after the reaction was soft-deleted" do
+      described_class.create!(comment:, reactor:, emoji: "👍").destroy!
+
+      expect(described_class.new(comment:, reactor:, emoji: "👍")).to be_valid
+    end
+
+    it "allows the same emoji from a different user" do
+      described_class.create!(comment:, reactor:, emoji: "👍")
+
+      expect(described_class.new(comment:, reactor: create(:user), emoji: "👍")).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Problem

```
ActiveRecord::RecordInvalid: Validation failed: Emoji has already been used for this comment
app/controllers/comment/reactions_controller.rb:14 in Comment::ReactionsController#react
```

`Comment::Reaction` is `acts_as_paranoid`, so un-reacting soft-deletes the row rather than removing it.

[`#react`](app/controllers/comment/reactions_controller.rb#L9) looks the existing reaction up through the paranoid default scope, which excludes deleted rows:

```ruby
existing_reaction = Comment::Reaction.find_by(reactor: current_user, comment: @comment, emoji: params[:emoji])
```

But Rails' `UniquenessValidator` builds its query from `klass.unscoped` ([`build_relation`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/validations/uniqueness.rb)), so it *does* see the soft-deleted row.

So the ordinary path of **react 👍 → un-react → react 👍 again** finds no live reaction, falls through to `create!`, and gets rejected by the uniqueness validation on the tombstone — a 500 for the user.

## Fix

Use `acts_as_paranoid`'s `validates_uniqueness_of_without_deleted`, which adds the paranoid scope back to the validator's relation. This matches how `Event#slug`, `GSuite#domain`, `EmburseTransaction#emburse_id` and `Donation::Goal#event_id` already handle uniqueness on soft-deleted models.

`validates_as_paranoid` is required to make that class method available on the model.

## Testing

Added `spec/models/comment/reaction_spec.rb`. The "allows re-reacting after the reaction was soft-deleted" example fails on `main` with the exact production error and passes with this change; the other two examples pin the behaviour the validation is actually there for (duplicate live reaction rejected, same emoji from a different user allowed).

```
3 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)