### PR TITLE
[Card Charge] Add instructions to email hcb@ when declined due to required Stripe cardholder verification

### DIFF
--- a/app/views/hcb_codes/_decline_reason.html.erb
+++ b/app/views/hcb_codes/_decline_reason.html.erb
@@ -99,7 +99,9 @@
       <% end %>
     <% elsif stripe_decline_reason == :card_expired %>
       Try again using a different card.
-    <% elsif stripe_decline_reason.in? %i[cardholder_verification_required insufficient_funds] %>
+    <% elsif stripe_decline_reason == :cardholder_verification_required %>
+      This could be a persistent issue affecting many of your transactions. Please email a photo of your ID and your full name to <%= mail_to "hcb@hackclub.com" %> so we can complete cardholder verification.
+    <% elsif stripe_decline_reason == :insufficient_funds %>
       This could be a persistent issue affecting many of your transactions. Please contact the HCB team at <%= mail_to "hcb@hackclub.com" %>.
     <% elsif stripe_decline_reason == :insecure_authorization_method %>
       <% auth_method = pt&.raw_pending_stripe_transaction&.stripe_transaction&.[]("authorization_method") %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14820


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Card charges declined because of Stripe cardholder verification now also ask the user to email their ID and full name to hcb@hackclub.com


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="577" height="298" alt="Screenshot 2026-09-02 at 22 24 15" src="https://github.com/user-attachments/assets/c1ac433f-db9b-44ec-916a-1e2273aa0cfc" />
