### PR TITLE
[Ledger] Settle a Stripe capture in the transaction that creates it

### DIFF
--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -147,12 +147,24 @@ class CanonicalTransaction < ApplicationRecord
   end
 
   after_create :write_hcb_code
+
+  # Settle in the transaction that creates this transaction, not after it
+  # commits. A CanonicalTransaction that is visible without the
+  # CanonicalPendingSettledMapping recording what it settles leaves its
+  # CanonicalPendingTransaction looking unsettled, and
+  # Ledger::Item#calculate_amount_cents then counts the authorization and the
+  # capture, doubling the item's amount (and the ledger's balance) for as long
+  # as that window is open. Creating both atomically closes it.
+  after_create do
+    PendingEventMappingEngine::Settle::Single::Stripe.new(canonical_transaction: self).run if likely_stripe_card_transaction?
+  end
+
   after_create_commit :write_system_event
+  # Event mapping stays outside the creating transaction: it raises for a card
+  # HCB doesn't know about, and that must not roll back the import of the
+  # transaction itself.
   after_create_commit do
-    if likely_stripe_card_transaction?
-      PendingEventMappingEngine::Settle::Single::Stripe.new(canonical_transaction: self).run
-      EventMappingEngine::Map::Single::Stripe.new(canonical_transaction: self).run
-    end
+    EventMappingEngine::Map::Single::Stripe.new(canonical_transaction: self).run if likely_stripe_card_transaction?
   end
 
   def smart_memo

--- a/app/services/canonical_pending_transaction_service/settle.rb
+++ b/app/services/canonical_pending_transaction_service/settle.rb
@@ -22,20 +22,33 @@ module CanonicalPendingTransactionService
         sync_transaction_category!
       end
 
-      if @canonical_transaction.amount_cents < 0 && @canonical_pending_transaction.raw_pending_stripe_transaction && (@canonical_pending_transaction.amount_cents != @canonical_transaction.amount_cents)
-        CanonicalPendingTransactionMailer.with(
-          canonical_pending_transaction_id: @canonical_pending_transaction.id,
-          canonical_transaction_id: @canonical_transaction.id,
-        ).notify_settled.deliver_later
-
-        spending_control = @canonical_transaction.stripe_card.active_spending_control
-        if spending_control.present?
-          SpendingControlService.check_low_balance(spending_control, @canonical_transaction.local_hcb_code)
-        end
-      end
+      # The caller may be mid-transaction — a Stripe capture settles inside the
+      # transaction that creates its CanonicalTransaction — and ActiveJob does
+      # not defer enqueues to commit (enqueue_after_transaction_commit is
+      # false), so hold these until the mapping is durable: the mailer reads
+      # the records back in another process, and a low-balance check run
+      # against uncommitted state would read a balance without the capture in
+      # it. Runs immediately when there is no surrounding transaction.
+      ActiveRecord.after_all_transactions_commit { notify_settled! }
     end
 
     private
+
+    def notify_settled!
+      return unless @canonical_transaction.amount_cents < 0
+      return unless @canonical_pending_transaction.raw_pending_stripe_transaction
+      return if @canonical_pending_transaction.amount_cents == @canonical_transaction.amount_cents
+
+      CanonicalPendingTransactionMailer.with(
+        canonical_pending_transaction_id: @canonical_pending_transaction.id,
+        canonical_transaction_id: @canonical_transaction.id,
+      ).notify_settled.deliver_later
+
+      spending_control = @canonical_transaction.stripe_card.active_spending_control
+      if spending_control.present?
+        SpendingControlService.check_low_balance(spending_control, @canonical_transaction.local_hcb_code)
+      end
+    end
 
     def sync_transaction_category!
       return unless @canonical_transaction.category.nil?

--- a/spec/services/canonical_pending_transaction_service/settle_spec.rb
+++ b/spec/services/canonical_pending_transaction_service/settle_spec.rb
@@ -80,4 +80,27 @@ RSpec.describe CanonicalPendingTransactionService::Settle do
       end
     end
   end
+
+  context "when a capture is settled from inside the transaction that creates it" do
+    let(:canonical_pending_transaction) { create(:canonical_pending_transaction, amount_cents: -1000) }
+    let(:canonical_transaction) { create(:canonical_transaction, amount_cents: -400) }
+
+    # notify_settled reads both records back in another process, so it must not
+    # be enqueued against a transaction that may still roll back.
+    it "holds the settled notification until the transaction commits" do
+      allow(canonical_pending_transaction).to receive(:raw_pending_stripe_transaction).and_return(create(:raw_pending_stripe_transaction))
+      allow(canonical_transaction).to receive(:stripe_card).and_return(create(:stripe_card, :with_stripe_id))
+
+      clear_enqueued_jobs
+
+      ActiveRecord::Base.transaction do
+        service.run!
+
+        expect(CanonicalPendingSettledMapping.count).to eq(1)
+        expect(enqueued_jobs).to be_empty
+      end
+
+      expect(enqueued_jobs).not_to be_empty
+    end
+  end
 end

--- a/spec/services/pending_event_mapping_engine/settle/single/stripe_spec.rb
+++ b/spec/services/pending_event_mapping_engine/settle/single/stripe_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PendingEventMappingEngine::Settle::Single::Stripe do
+  let(:event) { create(:event) }
+  let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:) }
+  let(:authorization_id) { "iauth_settle_single" }
+  let(:amount_cents) { -1000 }
+
+  # The authorization, as the issuing webhook imports it.
+  def import_authorization!
+    raw = create(:raw_pending_stripe_transaction, amount_cents:, date_posted: Date.current, stripe_transaction_id: authorization_id)
+    raw.update!(stripe_transaction: raw.stripe_transaction.merge("card" => { "id" => stripe_card.stripe_id }))
+    cpt = PendingTransactionEngine::CanonicalPendingTransactionService::ImportSingle::Stripe.new(raw_pending_stripe_transaction: raw).run
+    PendingEventMappingEngine::Map::Single::Stripe.new(canonical_pending_transaction: cpt).run
+    cpt.reload
+  end
+
+  # The capture, as TransactionEngine::CanonicalTransactionService::Import imports it.
+  def import_capture!
+    raw = create(:raw_stripe_transaction, amount_cents:, stripe_authorization_id: authorization_id, stripe_card:, date_posted: Date.current)
+    raw.update!(stripe_transaction: raw.stripe_transaction.merge("authorization" => authorization_id))
+    hashed = create(:hashed_transaction, raw_stripe_transaction: raw, date: Date.current)
+
+    CanonicalTransaction.create!(
+      date: hashed.date,
+      memo: raw.memo,
+      amount_cents: raw.amount_cents,
+      canonical_hashed_mappings: [CanonicalHashedMapping.new(hashed_transaction: hashed)],
+      transaction_source: raw
+    )
+  end
+
+  # Every amount_cents value written to ledger_items while the block runs.
+  def ledger_amounts_written(&)
+    amounts = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next unless payload[:sql].match?(/(UPDATE|INSERT INTO) "ledger_items"/)
+
+      payload[:binds].to_a.each { |bind| amounts << bind.value if bind.name == "amount_cents" }
+    end
+
+    yield
+
+    amounts
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  it "settles the authorization against the capture" do
+    cpt = import_authorization!
+
+    ct = import_capture!
+
+    expect(ct.reload.canonical_pending_transaction).to eq(cpt)
+    expect(cpt.reload).to be_settled
+  end
+
+  # The ledger item counts every unsettled outgoing CPT plus every CT, so a
+  # capture that is visible before its settled mapping doubles the item's
+  # amount and the org's balance.
+  it "never persists an amount that counts both the authorization and the capture" do
+    cpt = import_authorization!
+    ledger_item = cpt.ledger_item
+
+    amounts = ledger_amounts_written { import_capture! }
+
+    expect(amounts).not_to include(amount_cents * 2)
+    expect(ledger_item.reload.amount_cents).to eq(amount_cents)
+    expect(ledger_item.status).to eq("settled")
+    expect(event.ledger.balance_cents).to eq(amount_cents)
+  end
+
+  it "creates the settled mapping in the same transaction as the capture" do
+    import_authorization!
+    allow(CanonicalPendingSettledMapping).to receive(:create!).and_raise(ActiveRecord::StatementInvalid.new("settle failed"))
+    already_imported = CanonicalTransaction.count
+
+    expect { import_capture! }.to raise_error(ActiveRecord::StatementInvalid)
+    expect(CanonicalTransaction.count).to eq(already_imported)
+  end
+
+  context "when the capture arrives before the authorization has been imported" do
+    it "leaves the capture unsettled for the nightly sweep" do
+      ct = import_capture!
+      expect(ct.reload.canonical_pending_settled_mapping).to be_nil
+
+      cpt = import_authorization!
+      PendingEventMappingEngine::Settle::Stripe.new.run
+
+      expect(ct.reload.canonical_pending_transaction).to eq(cpt)
+      expect(ct.ledger_item.reload.amount_cents).to eq(amount_cents)
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`Ledger::Item#calculate_amount_cents` sums every CT on the item **plus** every `outgoing.unsettled` CPT. A `CanonicalTransaction` that is visible without the `CanonicalPendingSettledMapping` recording what it settles leaves its `CanonicalPendingTransaction` looking unsettled, so the authorization and the capture both count. `Ledger#balance_cents` reads that cached column, so the org's balance is wrong for as long as the window is open.

Settling from `after_create_commit` opens that window on every card capture. For card charges it never closed on its own:

1. `CanonicalTransaction`'s `before_create` checks `elsif linked_object.present?` ahead of its `RawPendingStripeTransaction` lookup. A card charge's `linked_object` is a `CardCharge`, which has no `canonical_pending_transaction`, so the branch matches, returns `nil`, and the lookup below it never runs — the capture is inserted with `ledger_item_id = NULL`.
2. So `assign_ledger_item` runs as an earlier `after_create_commit`. Its nested `update!` clears the record's create-transaction state, which makes `transaction_include_any_action?([:create])` false for the rest of the chain — so **every later `after_create_commit` is silently skipped**, the settle among them.

Reproduced end-to-end (authorization → CPT → capture → CT). Importing a single −$10 capture left:

```
CPSM=0  event_mapping=nil  li.amount=-2000  status=pending  balance=-2000
```

The ledger only recovered on the nightly `PendingEventMappingEngine::Settle::Stripe` sweep.

## The fix

Moving the settle to `after_create` writes the mapping in the same transaction as the capture, so no reader can ever see one without the other — and it puts the settle out of reach of the callback-ordering problem above, since `after_create` runs inside the creating transaction, long before any `after_commit`. Verified: the ledger item's amount is never rewritten during import, because it was already correct.

Event mapping stays in `after_create_commit` on purpose — it raises for a card HCB doesn't know about, which must not roll back the import of the transaction itself.

`Settle`'s notifications now wait for the surrounding transaction to commit, via `ActiveRecord.after_all_transactions_commit`. This is a consequence of the move, not a separate change: `enqueue_after_transaction_commit` is `false` here, so `deliver_later` inside the creating transaction can be picked up by a Sidekiq worker before the commit lands, and the mailer reads both records back in another process. A low-balance check run against uncommitted state would also read a balance without the capture in it.

## Verification

4 new specs. Run against `main` first, all 4 fail there — `amounts` contains `-2000`; the CPT never settles; the CT survives a forced mapping failure; the mailer is enqueued mid-transaction — and all pass after.

Ran ~460 specs across the transaction engine, pending transaction engine, ledger, card charge and Stripe suites. The failures that remain are all reproducible on a clean baseline of the same seed (stale rows in a shared test database); zero new.

## Potential follow-up (not in this PR)

The two defects above are separable, and only the second one is fixed here. The `before_create` lookup is still wrong: a card capture is still inserted with `ledger_item_id = NULL` and still goes through `assign_ledger_item`, which still truncates the `after_create_commit` chain. So **card charges still never get realtime event mapping or `write_system_event`** — they wait for the nightly sweep. The `RawPendingStripeTransaction` branch in `before_create` remains dead code.

The mechanism is generic, and it isn't specific to card charges: any nested `update!` or `transaction` inside an `after_commit` callback clears the create-transaction state for the callbacks that follow it. Non-Stripe transactions (Plaid, Column, Increase) and Stripe force captures also reach `assign_ledger_item` and also lose `write_system_event`, and anything added after it in the chain will be dropped too.

Fixing it means either reaching the CPT through the `CardCharge`'s `RawPendingStripeTransaction` in `before_create` so the ledger item is assigned on insert, or reordering the `after_commit` registrations so `assign_ledger_item` runs last, or replacing its nested `update!` with `update_columns`. All three change behaviour for every canonical transaction type — the first turns `write_system_event` and realtime event mapping on for every card charge — so it wants its own PR and its own testing. Worth doing: as it stands it's a landmine for anyone adding an `after_create_commit` to `CanonicalTransaction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
