### PR TITLE
Fix flaky where_hashid ordering spec

### DIFF
--- a/spec/initializers/hashid_spec.rb
+++ b/spec/initializers/hashid_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe HashidQueryable do
     end
 
     it "does not preserve the order of the given hashids" do
-      # This is a set lookup; callers needing input order must re-sort themselves.
-      expect(User.where_hashid(hashids.reverse).map(&:id)).to eq(users.map(&:id).sort)
+      # This is a set lookup: the query has no ORDER BY of its own, so callers
+      # needing an order have to ask for one, as this expectation does.
+      expect(User.where_hashid(hashids.reverse).order(:id).map(&:id)).to eq(users.map(&:id).sort)
     end
 
     describe "input this model cannot decode" do

--- a/spec/initializers/hashid_spec.rb
+++ b/spec/initializers/hashid_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe HashidQueryable do
     end
 
     it "does not preserve the order of the given hashids" do
-      # This is a set lookup: the query has no ORDER BY of its own, so callers
-      # needing an order have to ask for one, as this expectation does.
       expect(User.where_hashid(hashids.reverse).order(:id).map(&:id)).to eq(users.map(&:id).sort)
     end
 


### PR DESCRIPTION
## Problem

`HashidQueryable.where_hashid does not preserve the order of the given hashids` fails intermittently in CI:

```
expected: [80, 81, 82]
     got: [82, 80, 81]
```

`where_hashid` builds `where(id: [...])` with no `ORDER BY`, so Postgres is free to return the rows in whatever order the plan produces. The spec asserted one particular unordered result, so it passed most of the time and failed whenever the plan or physical row layout differed.

## Fix

Order the relation explicitly, so the comparison is deterministic:

```ruby
expect(User.where_hashid(hashids.reverse).order(:id).map(&:id)).to eq(users.map(&:id).sort)
```

The input is still reversed, so the spec keeps documenting that input order isn't preserved.

## Testing

`bundle exec rspec spec/initializers/hashid_spec.rb` — 25 examples, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
