### PR TITLE
[v3] Use new transaction engine (via special request header)

### DIFF
--- a/app/api/api/entities/activity.rb
+++ b/app/api/api/entities/activity.rb
@@ -18,13 +18,15 @@ module Api
       end
 
       expose_associated Transaction do |activity, options|
-        if activity.trackable.try(:hcb_code).is_a?(HcbCode)
-          return activity.trackable.try(:hcb_code)
-        elsif activity.trackable.try(:hcb_code)
-          HcbCode.find_by_hcb_code(activity.trackable.try(:hcb_code))
-        elsif (cpt_hcb_code = activity.trackable.try(:canonical_pending_transaction)&.try(:local_hcb_code))
-          cpt_hcb_code
-        end
+        hcb_code = if activity.trackable.try(:hcb_code).is_a?(HcbCode)
+                     activity.trackable.try(:hcb_code)
+                   elsif activity.trackable.try(:hcb_code)
+                     HcbCode.find_by_hcb_code(activity.trackable.try(:hcb_code))
+                   else
+                     activity.trackable.try(:canonical_pending_transaction)&.try(:local_hcb_code)
+                   end
+
+        Models::LedgerTransaction.resolve(hcb_code, options) if hcb_code
       end
 
     end

--- a/app/api/api/entities/linked_object_base.rb
+++ b/app/api/api/entities/linked_object_base.rb
@@ -7,7 +7,7 @@ module Api
 
       when_expanded do
         expose :memo do |obj, options|
-          obj.local_hcb_code.memo
+          Models::LedgerTransaction.resolve(obj, options).memo
         end
       end
 
@@ -16,7 +16,7 @@ module Api
         # they will belong to the same Organization as the one associated below
         # (in this Linked Object)
 
-        obj.local_hcb_code
+        Models::LedgerTransaction.resolve(obj, options)
       end
 
       expose_associated Organization, hide: [API_LINKED_OBJECT_TYPE, Transaction] do |obj, options|

--- a/app/api/api/entities/transaction.rb
+++ b/app/api/api/entities/transaction.rb
@@ -19,6 +19,9 @@ module Api
       ].freeze
 
       when_expanded do
+        expose :ledger_item_id, documentation: { type: "string" } do |hcb_code, options|
+          hcb_code.ledger_item&.public_id
+        end
         expose :amount_cents, documentation: { type: "integer" } do |hcb_code, options|
           org = options[:org]
 
@@ -99,8 +102,7 @@ module Api
         [
           {
             entity: Entities::CardCharge,
-            # Convert the HcbCode to it's equivalent CardCharge.
-            hcb_method: ->(hcb_code) { Models::CardCharge.find(hcb_code.id) },
+            hcb_method: ->(hcb_code) { Models::CardCharge.find_by(id: hcb_code.local_hcb_code&.id) },
           },
           {
             entity: Entities::AchTransfer,

--- a/app/api/api/models/ledger_transaction.rb
+++ b/app/api/api/models/ledger_transaction.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Api
+  module Models
+    # Presents a Ledger::Item through the interface that Api::Entities::Transaction
+    # (and, via LinkedObjectBase, every linked object entity) expects from an
+    # HcbCode. This lets the v3 serializers run on the new transaction engine
+    # without forking them into a parallel set of entities.
+    #
+    # Only the methods those entities actually call are defined here; everything
+    # else falls through to the Ledger::Item.
+    class LedgerTransaction < SimpleDelegator
+      HEADER = "X-HCB-Transaction-Engine"
+      LEDGER = "ledger"
+      ENV_KEY = "HTTP_#{HEADER.upcase.tr("-", "_")}".freeze
+
+      # Ledger::Item#linked_object_type mapped onto the symbols HcbCode#type
+      # returns. StripeServiceFee, FeeRevenue and Reimbursement::PayoutHolding
+      # have no HcbCode#type branch, so they stay unmapped (nil) to match.
+      TYPES = {
+        "Invoice"                      => :invoice,
+        "Donation"                     => :donation,
+        "AchTransfer"                  => :ach,
+        "Check"                        => :check,
+        "IncreaseCheck"                => :check,
+        "CardCharge"                   => :card_charge,
+        "Wire"                         => :wire,
+        "WiseTransfer"                 => :wise_transfer,
+        "PaypalTransfer"               => :paypal_transfer,
+        "CheckDeposit"                 => :check_deposit,
+        "BankFee"                      => :bank_fee,
+        "Reimbursement::ExpensePayout" => :reimbursement_expense_payout,
+        "Disbursement::Outgoing"       => :disbursement,
+        "Disbursement::Incoming"       => :disbursement,
+        nil                            => :unknown
+      }.freeze
+
+      # The linked object each HcbCode-style reader resolves to. A ledger item
+      # holds exactly one, so a reader returns nil unless the type matches —
+      # mirroring HcbCode, where e.g. #check is nil for an IncreaseCheck.
+      READERS = {
+        ach_transfer: "AchTransfer",
+        check: "Check",
+        increase_check: "IncreaseCheck",
+        donation: "Donation",
+        invoice: "Invoice",
+        wire: "Wire",
+        wise_transfer: "WiseTransfer",
+        paypal_transfer: "PaypalTransfer",
+        check_deposit: "CheckDeposit",
+        bank_fee: "BankFee",
+        reimbursement_expense_payout: "Reimbursement::ExpensePayout",
+        outgoing_disbursement: "Disbursement::Outgoing",
+        incoming_disbursement: "Disbursement::Incoming"
+      }.freeze
+
+      READERS.each do |name, type|
+        define_method(name) { linked_object_type == type ? linked_object : nil }
+        define_method(:"#{name}?") { linked_object_type == type }
+      end
+
+      def self.requested?(request)
+        request.get_header(ENV_KEY).to_s.casecmp?(LEDGER)
+      end
+
+      # The object to serialize as a linked object's transaction: its ledger item
+      # when the request asked for the ledger engine, otherwise the HcbCode.
+      # Disbursements have no single ledger item (there is one per side), so they
+      # always fall back.
+      def self.resolve(linked_object, options = {})
+        item = linked_object.try(:ledger_item) if options[:ledger]
+
+        item ? new(item) : linked_object.local_hcb_code
+      end
+
+      # v3 ids stay HcbCode-derived; the ledger item's id is exposed separately
+      # as `ledger_item_id`.
+      def public_id = hcb_code&.public_id
+
+      def local_hcb_code = hcb_code
+
+      # Api::Entities::Transaction exposes this as `ledger_item_id`.
+      def ledger_item = __getobj__
+
+      def event = primary_ledger&.event
+
+      # HcbCode#date is a Date; ledger items carry a full timestamp.
+      def date = datetime&.to_date
+
+      # HcbCode#memo accepts an `event:` kwarg but never reads it.
+      def memo(event: nil) = __getobj__.memo
+
+      def not_admin_only_comments_count = not_admin_only_comment_count
+
+      def type
+        return :card_grant if special_appearance&.key == "card_grant"
+
+        TYPES[linked_object_type]
+      end
+
+    end
+  end
+end

--- a/app/api/api/models/ledger_transaction.rb
+++ b/app/api/api/models/ledger_transaction.rb
@@ -14,9 +14,6 @@ module Api
       LEDGER = "ledger"
       ENV_KEY = "HTTP_#{HEADER.upcase.tr("-", "_")}".freeze
 
-      # Ledger::Item#linked_object_type mapped onto the symbols HcbCode#type
-      # returns. StripeServiceFee, FeeRevenue and Reimbursement::PayoutHolding
-      # have no HcbCode#type branch, so they stay unmapped (nil) to match.
       TYPES = {
         "Invoice"                      => :invoice,
         "Donation"                     => :donation,
@@ -35,9 +32,6 @@ module Api
         nil                            => :unknown
       }.freeze
 
-      # The linked object each HcbCode-style reader resolves to. A ledger item
-      # holds exactly one, so a reader returns nil unless the type matches —
-      # mirroring HcbCode, where e.g. #check is nil for an IncreaseCheck.
       READERS = {
         ach_transfer: "AchTransfer",
         check: "Check",
@@ -63,10 +57,6 @@ module Api
         request.get_header(ENV_KEY).to_s.casecmp?(LEDGER)
       end
 
-      # The object to serialize as a linked object's transaction: its ledger item
-      # when the request asked for the ledger engine, otherwise the HcbCode.
-      # Disbursements have no single ledger item (there is one per side), so they
-      # always fall back.
       def self.resolve(linked_object, options = {})
         item = linked_object.try(:ledger_item) if options[:ledger]
 
@@ -84,10 +74,8 @@ module Api
 
       def event = primary_ledger&.event
 
-      # HcbCode#date is a Date; ledger items carry a full timestamp.
       def date = datetime&.to_date
 
-      # HcbCode#memo accepts an `event:` kwarg but never reads it.
       def memo(event: nil) = __getobj__.memo
 
       def not_admin_only_comments_count = not_admin_only_comment_count

--- a/app/api/api/v3.rb
+++ b/app/api/api/v3.rb
@@ -52,10 +52,26 @@ module Api
         error!({ message: "Organization not found." }, 404)
       end
 
+      def ledger_items(query = {})
+        ::Ledger::Query.new(
+          "$and" => [
+            query,
+            { "$or" => [
+              { amount_cents: { "$ne" => 0 } },
+              { status: { "$in" => %w[settled pending reversed] } }
+            ]
+}
+          ]
+        ).execute(ledgers: [org.ledger])
+                       .preload(:canonical_transactions, :canonical_pending_transactions, :receipts, :tags, primary_ledger: :event)
+      end
+
       def transactions
-        # TODO: this can be optimized
         @transactions ||=
-          begin
+          if ledger_engine?
+            paginate(ledger_items).map { |item| Models::LedgerTransaction.new(item) }
+          else
+            # TODO: this can be optimized
             pending = PendingTransactionEngine::PendingTransaction::All.new(event_id: org.id).run
             settled = TransactionGroupingEngine::Transaction::All.new(event_id: org.id).run
 
@@ -65,13 +81,20 @@ module Api
       end
 
       def transaction
-        public_id_resource!(:@transaction, :transaction_id, HcbCode, "Transaction not found.")
+        public_id_resource!(:@transaction, :transaction_id, HcbCode, "Transaction not found.").tap do |hcb_code|
+          error!({ message: "Transaction not found." }, 404) if ledger_engine? && hcb_code.event.nil?
+        end
       end
 
       def card_charges
-        # TODO: this can be optimized
         @card_charges ||=
-          begin
+          if ledger_engine?
+            items = paginate(ledger_items(linked_object_type: { "$eq" => "CardCharge" }))
+            charges = Models::CardCharge.where(id: items.filter_map { |item| item.hcb_code&.id }).index_by(&:id)
+
+            items.filter_map { |item| charges[item.hcb_code&.id] }
+          else
+            # TODO: this can be optimized
             pending = PendingTransactionEngine::PendingTransaction::All.new(event_id: org.id).run
             settled = TransactionGroupingEngine::Transaction::All.new(event_id: org.id).run
 
@@ -184,8 +207,15 @@ module Api
       def type_expansion(expand: [], hide: [])
         {
           expand: (params[:expand] || []) + expand,
-          hide: (params[:hide] || []) + hide
+          hide: (params[:hide] || []) + hide,
+          ledger: ledger_engine?
         }
+      end
+
+      def ledger_engine?
+        return @ledger_engine if defined?(@ledger_engine)
+
+        @ledger_engine = Models::LedgerTransaction.requested?(request)
       end
 
       params :expand do
@@ -882,7 +912,8 @@ module Api
       route_param :transaction_id do
         get do
           Pundit.authorize(nil, [:api, transaction], :show?)
-          present transaction, with: Api::Entities::Transaction, **type_expansion(expand: %w[transaction])
+          options = type_expansion(expand: %w[transaction])
+          present Models::LedgerTransaction.resolve(transaction, options), with: Api::Entities::Transaction, **options
         end
       end
     end

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -48,6 +48,9 @@ class Ledger
     pg_search_scope :search_memo, against: [:memo], ranked_by: "ledger_items.datetime"
 
     include Hashid::Rails
+    include PublicIdentifiable
+    set_public_id_prefix :lit
+
     has_paper_trail
 
     include Commentable

--- a/spec/api/models/ledger_transaction_spec.rb
+++ b/spec/api/models/ledger_transaction_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::Models::LedgerTransaction do
+  let(:event) { create(:event) }
+  let(:item) { create(:ledger_item, datetime: Time.zone.parse("2026-08-27 14:30:00")) }
+  let(:transaction) { described_class.new(item) }
+
+  before do
+    Ledger::Mapping.create!(ledger: event.ledger, ledger_item: item, on_primary_ledger: true)
+  end
+
+  describe ".requested?" do
+    def request_for(headers) = ActionDispatch::Request.new(headers)
+
+    it "is true for the ledger header" do
+      expect(described_class.requested?(request_for(described_class::ENV_KEY => "ledger"))).to be true
+    end
+
+    it "is case insensitive" do
+      expect(described_class.requested?(request_for(described_class::ENV_KEY => "Ledger"))).to be true
+    end
+
+    it "is false without the header" do
+      expect(described_class.requested?(request_for({}))).to be false
+    end
+
+    it "is false for any other value" do
+      expect(described_class.requested?(request_for(described_class::ENV_KEY => "hcb_code"))).to be false
+    end
+  end
+
+  describe ".resolve" do
+    # AchTransfer validates the event has the funds to cover it.
+    let(:funded_event) { create(:event, :with_positive_balance) }
+    let(:ach_transfer) { create(:ach_transfer, event: funded_event) }
+
+    it "returns the HcbCode when the ledger engine was not requested" do
+      expect(described_class.resolve(ach_transfer, ledger: false)).to eq(ach_transfer.local_hcb_code)
+    end
+
+    it "returns the HcbCode for a linked object with no ledger item" do
+      allow(ach_transfer).to receive(:ledger_item).and_return(nil)
+
+      expect(described_class.resolve(ach_transfer, ledger: true)).to eq(ach_transfer.local_hcb_code)
+    end
+
+    # An AchTransfer builds a canonical pending transaction, which builds and
+    # links its own ledger item.
+    it "wraps the linked object's ledger item" do
+      resolved = described_class.resolve(ach_transfer, ledger: true)
+
+      expect(resolved).to be_a(described_class)
+      expect(resolved.ledger_item).to eq(ach_transfer.ledger_item)
+    end
+
+    # A disbursement has one ledger item per side, so there is no single item to
+    # resolve to and it must fall back rather than pick one arbitrarily.
+    it "falls back for an object with no ledger_item association" do
+      disbursement = create(:disbursement, event:, source_event: create(:event))
+
+      expect(described_class.resolve(disbursement, ledger: true)).to eq(disbursement.local_hcb_code)
+    end
+  end
+
+  describe "#type" do
+    # Every linked_object_type the ledger records, mapped onto what HcbCode#type
+    # returns for the same transaction. Api::Entities::Transaction renames these
+    # again for the public payload.
+    {
+      "Invoice"                      => :invoice,
+      "Donation"                     => :donation,
+      "AchTransfer"                  => :ach,
+      "Check"                        => :check,
+      "IncreaseCheck"                => :check,
+      "CardCharge"                   => :card_charge,
+      "Wire"                         => :wire,
+      "WiseTransfer"                 => :wise_transfer,
+      "PaypalTransfer"               => :paypal_transfer,
+      "CheckDeposit"                 => :check_deposit,
+      "BankFee"                      => :bank_fee,
+      "Reimbursement::ExpensePayout" => :reimbursement_expense_payout,
+      "Disbursement::Outgoing"       => :disbursement,
+      "Disbursement::Incoming"       => :disbursement,
+      nil                            => :unknown
+    }.each do |linked_object_type, expected|
+      it "maps #{linked_object_type.inspect} to #{expected.inspect}" do
+        item.update_columns(linked_object_type:)
+
+        expect(transaction.type).to eq(expected)
+      end
+    end
+
+    # HcbCode#type has no branch for these, so it returns nil and the payload
+    # carries a null `type`. Matching that keeps the two engines in agreement.
+    ["StripeServiceFee", "FeeRevenue", "Reimbursement::PayoutHolding"].each do |linked_object_type|
+      it "leaves #{linked_object_type} unmapped, as HcbCode#type does" do
+        item.update_columns(linked_object_type:)
+
+        expect(transaction.type).to be_nil
+      end
+    end
+
+    it "reports a card grant, which the ledger records as an outgoing disbursement" do
+      item.update_columns(linked_object_type: "Disbursement::Outgoing")
+      allow(item).to receive(:special_appearance).and_return(instance_double(Ledger::Item::SpecialAppearance, key: "card_grant"))
+
+      expect(transaction.type).to eq(:card_grant)
+    end
+  end
+
+  describe "linked object readers" do
+    it "returns the linked object under its matching reader" do
+      ach_transfer = create(:ach_transfer, event: create(:event, :with_positive_balance))
+      item.update!(linked_object: ach_transfer)
+
+      expect(transaction.ach_transfer?).to be true
+      expect(transaction.ach_transfer).to eq(ach_transfer)
+    end
+
+    it "returns nil from every other reader" do
+      item.update_columns(linked_object_type: "AchTransfer")
+
+      expect(transaction.donation?).to be false
+      expect(transaction.donation).to be_nil
+      expect(transaction.check).to be_nil
+    end
+
+    # HcbCode#check is nil for an IncreaseCheck even though HcbCode#type is
+    # :check for both, so Api::Entities::Transaction renders an empty `check`.
+    it "keeps IncreaseCheck out of the check reader, as HcbCode does" do
+      item.update_columns(linked_object_type: "IncreaseCheck")
+
+      expect(transaction.type).to eq(:check)
+      expect(transaction.check).to be_nil
+      expect(transaction.increase_check?).to be true
+    end
+  end
+
+  describe "identity and attributes" do
+    it "keeps the HcbCode's public id and exposes the ledger item separately" do
+      hcb_code = create(:hcb_code, ledger_item: item)
+
+      expect(transaction.public_id).to eq(hcb_code.public_id)
+      expect(transaction.public_id).to start_with("txn_")
+      expect(transaction.ledger_item.public_id).to start_with("lit_")
+      expect(transaction.local_hcb_code).to eq(hcb_code)
+    end
+
+    it "reports a Date, matching HcbCode#date" do
+      expect(transaction.date).to eq(Date.new(2026, 8, 27))
+    end
+
+    it "resolves the event through the primary ledger" do
+      expect(transaction.event).to eq(event)
+    end
+
+    it "accepts and ignores the event kwarg on memo, as HcbCode#memo does" do
+      expect(transaction.memo(event:)).to eq(item.memo)
+    end
+  end
+end

--- a/spec/requests/api/v3/transactions_spec.rb
+++ b/spec/requests/api/v3/transactions_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The v3 API had no coverage before the ledger rewrite. The assertion that
+# matters most is parity: without the header the legacy transaction engines run,
+# with it Ledger::Query does, and the payloads must agree.
+RSpec.describe "Api::V3 transactions", type: :request do
+  let(:event) { create(:event, is_public: true) }
+  let(:ledger_header) { { Api::Models::LedgerTransaction::HEADER => Api::Models::LedgerTransaction::LEDGER } }
+
+  # One fixture visible to both engines: the canonical event mapping is what the
+  # legacy engines read, and CanonicalTransaction#assign_ledger_item builds the
+  # Ledger::Item. Ledger::Mapper derives the ledger from raw transaction sources
+  # (Column, Stripe, linked objects), which a plaid-backed fixture has none of,
+  # so map it explicitly the way Ledger::Query's own spec does.
+  #
+  # `date` is today so the CT's date and the ledger item's datetime agree —
+  # in production `backfill_ledger_item_datetime_task` aligns them.
+  def create_transaction(amount_cents: -1234, memo: "Test transaction")
+    ct = create(:canonical_transaction, amount_cents:, memo:, date: Date.current)
+    create(:canonical_event_mapping, event:, canonical_transaction: ct)
+    hcb_code = ct.reload.local_hcb_code
+
+    Ledger::Mapping.create!(ledger: event.ledger, ledger_item: hcb_code.ledger_item, on_primary_ledger: true)
+
+    hcb_code
+  end
+
+  def get_transactions(headers: {})
+    get "/api/v3/organizations/#{event.slug}/transactions", params: { expand: "transaction" }, headers: headers
+    response
+  end
+
+  def by_id(body) = body.index_by { |txn| txn["id"] }
+
+  before { create_transaction }
+
+  describe "GET /organizations/:id/transactions" do
+    it "returns the same payload from both engines" do
+      legacy = by_id(get_transactions.parsed_body)
+      ledger = by_id(get_transactions(headers: ledger_header).parsed_body)
+
+      expect(ledger.keys).to match_array(legacy.keys)
+      expect(ledger).to eq(legacy)
+    end
+
+    it "returns the same pagination headers from both engines" do
+      headers = ->(res) { res.headers.slice("X-Total", "X-Total-Pages", "X-Per-Page", "X-Page") }
+
+      legacy = headers.call(get_transactions)
+
+      expect(headers.call(get_transactions(headers: ledger_header))).to eq(legacy)
+      expect(legacy["X-Total"].to_i).to eq(1)
+    end
+
+    it "exposes the ledger item's public id alongside the HcbCode-derived id" do
+      txn = get_transactions(headers: ledger_header).parsed_body.first
+      item = Ledger::Item.find_by_public_id(txn["ledger_item_id"])
+
+      expect(txn["id"]).to start_with("txn_")
+      expect(txn["ledger_item_id"]).to start_with("lit_")
+      expect(item.hcb_code.public_id).to eq(txn["id"])
+    end
+
+    it "runs Ledger::Query instead of the legacy engines when the header is sent" do
+      expect(TransactionGroupingEngine::Transaction::All).not_to receive(:new)
+      expect(PendingTransactionEngine::PendingTransaction::All).not_to receive(:new)
+
+      expect(get_transactions(headers: ledger_header)).to have_http_status(:ok)
+    end
+
+    it "does not run Ledger::Query without the header" do
+      expect(Ledger::Query).not_to receive(:new)
+
+      expect(get_transactions).to have_http_status(:ok)
+    end
+
+    it "ignores an unrecognised header value" do
+      expect(Ledger::Query).not_to receive(:new)
+
+      expect(get_transactions(headers: { Api::Models::LedgerTransaction::HEADER => "hcb_code" })).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /transactions/:id" do
+    it "returns the same payload from both engines" do
+      id = get_transactions.parsed_body.first["id"]
+
+      get "/api/v3/transactions/#{id}", params: { expand: "transaction" }
+      legacy = response.parsed_body
+
+      get "/api/v3/transactions/#{id}", params: { expand: "transaction" }, headers: ledger_header
+
+      expect(response.parsed_body).to eq(legacy)
+    end
+
+    it "404s on the ledger engine for a transaction with no event" do
+      hcb_code = create(:hcb_code)
+
+      get "/api/v3/transactions/#{hcb_code.public_id}", headers: ledger_header
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
We need to migrate over to the new txn engine


## Describe your changes
If a user add the header `X-HCB-Transaction-Engine: ledger` then the v3 will use the new txn engine for this which should return exactly the same response body as the old but with a new `ledger_item_id` for the associated Ledger Item. it still returns the HcbCode ID as well 


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

