### PR TITLE
[Admin] Restrict `pretend_is_not_admin` to auditors and admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -596,12 +596,6 @@ class UsersController < ApplicationController
       }
     end
 
-    # Pretending not to be an admin is only meaningful for accounts that
-    # actually have the role, and `UserPolicy#toggle_pretend_is_not_admin?`
-    # already limits the toggle to the admin's own account. Without this guard
-    # any user could set the flag on themselves through `#update` and get stuck
-    # with the "you're pretending to not be an admin" banner, since they aren't
-    # authorized to turn it back off.
     if @user == current_user && current_user.admin_override_pretend?
       attributes << :pretend_is_not_admin
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -571,8 +571,6 @@ class UsersController < ApplicationController
       :birthday,
       :profile_picture,
       :seasonal_themes_enabled,
-      # admin
-      :pretend_is_not_admin,
       # security
       :sessions_reported,
       :session_validity_preference,
@@ -596,6 +594,16 @@ class UsersController < ApplicationController
           :stripe_billing_address_country
         ]
       }
+    end
+
+    # Pretending not to be an admin is only meaningful for accounts that
+    # actually have the role, and `UserPolicy#toggle_pretend_is_not_admin?`
+    # already limits the toggle to the admin's own account. Without this guard
+    # any user could set the flag on themselves through `#update` and get stuck
+    # with the "you're pretending to not be an admin" banner, since they aren't
+    # authorized to turn it back off.
+    if @user == current_user && current_user.admin_override_pretend?
+      attributes << :pretend_is_not_admin
     end
 
     if admin_signed_in?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,10 +199,6 @@ class User < ApplicationRecord
 
   before_save :sync_teenager_columns, if: :should_sync_teenager_columns?
 
-  # `pretend_is_not_admin` only makes sense for accounts that hold the role;
-  # left set on a regular user it just pins the "you're pretending to not be an
-  # admin" banner to an account that can't authorize the toggle to remove it.
-  # Clearing it on save also covers admins who are later demoted.
   before_save :clear_pretend_is_not_admin, if: -> { pretend_is_not_admin? && !admin_override_pretend? }
 
   before_create :format_number

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,6 +199,12 @@ class User < ApplicationRecord
 
   before_save :sync_teenager_columns, if: :should_sync_teenager_columns?
 
+  # `pretend_is_not_admin` only makes sense for accounts that hold the role;
+  # left set on a regular user it just pins the "you're pretending to not be an
+  # admin" banner to an account that can't authorize the toggle to remove it.
+  # Clearing it on save also covers admins who are later demoted.
+  before_save :clear_pretend_is_not_admin, if: -> { pretend_is_not_admin? && !admin_override_pretend? }
+
   before_create :format_number
   before_save :on_phone_number_update
   validate :second_factor_present_for_2fa
@@ -839,6 +845,10 @@ class User < ApplicationRecord
   def sync_teenager_columns
     self.teenager = is_teenager?
     self.joined_as_teenager = was_teenager_on_join?
+  end
+
+  def clear_pretend_is_not_admin
+    self.pretend_is_not_admin = false
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -349,6 +349,34 @@ RSpec.describe UsersController do
 
       expect(user.reload.phone_number_verification_bypassed).to eq(false)
     end
+
+    it "does not let a regular user pretend not to be an admin" do
+      user = create(:user)
+      create_session(user, verified: true)
+
+      patch(:update, params: { id: user.id, user: { pretend_is_not_admin: "1" } })
+
+      expect(user.reload.pretend_is_not_admin).to eq(false)
+    end
+
+    it "lets an auditor pretend not to be an admin" do
+      auditor = create(:user, access_level: :auditor)
+      create_session(auditor, verified: true)
+
+      patch(:update, params: { id: auditor.id, user: { pretend_is_not_admin: "1" } })
+
+      expect(auditor.reload.pretend_is_not_admin).to eq(true)
+    end
+
+    it "does not let an admin make another user pretend not to be an admin" do
+      admin_user = create(:user, :make_admin)
+      user = create(:user, access_level: :auditor)
+      create_session(admin_user, verified: true)
+
+      patch(:update, params: { id: user.id, user: { pretend_is_not_admin: "1" } })
+
+      expect(user.reload.pretend_is_not_admin).to eq(false)
+    end
   end
 
   describe "settings access for unverified users" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -332,6 +332,34 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#pretend_is_not_admin" do
+    it "is cleared on save for users without an admin role" do
+      user = create(:user)
+      user.pretend_is_not_admin = true
+
+      user.save!
+
+      expect(user.pretend_is_not_admin).to eq(false)
+      expect(user.reload.pretend_is_not_admin).to eq(false)
+    end
+
+    it "is kept for auditors and admins" do
+      auditor = create(:user, access_level: :auditor, pretend_is_not_admin: true)
+      admin = create(:user, :make_admin, pretend_is_not_admin: true)
+
+      expect(auditor.reload.pretend_is_not_admin).to eq(true)
+      expect(admin.reload.pretend_is_not_admin).to eq(true)
+    end
+
+    it "is cleared when an admin is demoted" do
+      admin = create(:user, :make_admin, pretend_is_not_admin: true)
+
+      admin.update!(access_level: :user)
+
+      expect(admin.reload.pretend_is_not_admin).to eq(false)
+    end
+  end
+
   describe "#use_two_factor_authentication" do
     it "cannot be disabled by admins" do
       user = create(:user, :make_admin, use_two_factor_authentication: true, phone_number: "+18556254225", phone_number_verified: true, use_sms_auth: true)


### PR DESCRIPTION
## What

`pretend_is_not_admin` was listed unconditionally in `UsersController#user_params`, so any user could set it on themselves with a `PATCH /users/:id`. `UserPolicy#update?` is `user.admin? || record == user`, so self-service writes went straight through.

It isn't privilege escalation — `admin?`/`auditor?` still gate on `access_level`, so the flag can only ever subtract — but it's a one-way trap. The flag pins the "You're currently pretending to not be an admin" banner (guarded only by `pretend_is_not_admin?`), and both ways to clear it require `auditor?`/`admin_override_pretend?`: the `toggle_pretend_is_not_admin` policy, and the settings checkbox behind `edit_admin?`. A regular user who set it got a permanent banner they couldn't remove. Same trap catches a real admin who is demoted while pretending.

## Changes

- `user_params` permits the attribute only when `@user == current_user && current_user.admin_override_pretend?`, mirroring `UserPolicy#toggle_pretend_is_not_admin?`. This matches both existing write paths — the sidebar `button_to` in `_logo.html.erb` and the checkbox in `edit_admin.html.erb` are already rendered only for auditors+ on their own account, so no UI changes.
- A `before_save` on `User` clears the flag for accounts without an admin-ish role. Defense in depth for other write paths, and it self-heals the demotion case by clearing on the same save that drops `access_level`.
- Specs for both, including that an admin can't set the flag on someone else.

## Existing data

No migration here — the cleanup is a one-off console run rather than a deploy step:

```ruby
scope = User.where(pretend_is_not_admin: true).where.not(access_level: [:auditor, :admin, :superadmin])
scope.update_all(pretend_is_not_admin: false)
```

Affected rows in prod: https://hcb.hackclub.com/blazer/queries/1346-users-pretending-not-to-be-admin-that-arent-admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
