### PR TITLE
[Dependencies] Bump blazer, faraday, and mail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "local_time" # client-side timestamp converter for cache-safe rendering
 gem "countries"
 gem "country_select", "~> 8.0"
 
-gem "faraday" # web requests
+gem "faraday", "~> 1.10.6" # web requests
 
 gem "stripe", "11.7.0"
 gem "plaid", "~> 44.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,12 +184,11 @@ GEM
     bigdecimal (4.1.2)
     bindata (2.5.1)
     bindex (0.8.1)
-    blazer (3.3.0)
-      activerecord (>= 7.1)
-      chartkick (>= 5)
+    blazer (3.5.1)
+      activerecord (>= 7.2)
       csv
-      railties (>= 7.1)
-      safely_block (>= 0.4)
+      railties (>= 7.2)
+      safely_block (>= 1)
     blind_index (2.7.0)
       activesupport (>= 7.1)
       argon2-kdf (>= 0.2)
@@ -214,7 +213,6 @@ GEM
       glib2 (= 4.3.6)
     cbor (0.5.10.1)
     cgi (0.5.2)
-    chartkick (5.1.5)
     childprocess (5.1.0)
       logger (~> 1.5)
     chronic (0.10.2)
@@ -318,7 +316,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    faraday (1.10.4)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -340,7 +338,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     ffi (1.17.0)
     fiddle (1.1.8)
     flipper (1.3.5)
@@ -522,7 +520,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -808,7 +806,7 @@ GEM
       logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
-    safely_block (0.5.0)
+    safely_block (1.0.0)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
     sanitize (6.0.2)
@@ -1003,7 +1001,7 @@ DEPENDENCIES
   eu_central_bank
   factory_bot_rails
   faker
-  faraday
+  faraday (~> 1.10.6)
   flipper
   flipper-active_record
   flipper-active_support_cache_store


### PR DESCRIPTION
Routine dependency maintenance.

| gem | from | to |
| --- | --- | --- |
| blazer | 3.3.0 | 3.5.1 |
| faraday | 1.10.4 | 1.10.6 |
| mail | 2.9.0 | 2.9.1 |

Faraday is pinned to the 1.x series because the app uses Faraday 1 builder APIs (`c.authorization`, `Faraday.default_adapter` inside connection blocks) across roughly fifteen call sites. Moving to 2.x is a separate migration.

### Transitive changes

- `safely_block` 0.5.0 → 1.0.0, blazer 3.5's new floor. Its 1.0 release only drops support for appsignal < 3, `ddtrace`, `sentry-raven`, and Ruby < 3.3; we're on appsignal 4.9.1 and Ruby 3.4.9, and the `safely { }` API used in `TransactionEngine::Nightly` is unchanged.
- `chartkick` leaves the lockfile. Blazer 3.5 no longer depends on the gem because it vendors chartkick as a JavaScript asset instead; its charts still render, and nothing in the app uses chartkick directly.
- `faraday-retry` 1.0.3 → 1.0.4, which only adds Ruby 4 support.

### Notes on the blazer jump

- The install migration template is byte-identical to 3.3.0, so there's no schema change and nothing to migrate.
- `lib/blazer/engine.rb` is byte-identical too, so no config keys or Sprockets precompile entries change.
- `Blazer.run_checks(schedule:)` keeps its signature, so `BlazerChecksJob` is unaffected.
- 3.4 raised the floors to Ruby 3.3 / Rails 7.2; we're on 3.4.9 and Rails 8.1.

### Testing

- App boots and the Blazer engine mounts; all 1085 routes resolve.
- `spec/mailboxes` passes, as do the HTTP-exercising specs (`turnstile_service`, `donations_turnstile`, `wires_controller`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)