### PR TITLE
[CI] Add a Bundler Audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,3 +259,14 @@ jobs:
       - uses: ./.github/actions/setup-ruby
       - name: Run Brakeman
         run: bundle exec brakeman -q
+  bundler_audit:
+    name: Bundler Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-ruby
+      # `--update` pulls the latest ruby-advisory-db so a newly published
+      # advisory against an already-locked gem fails CI without needing a
+      # Gemfile.lock change to trigger it.
+      - name: Run Bundler Audit
+        run: bundle exec bundle-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -156,6 +156,7 @@ group :development, :test do
   gem "rubocop-rails", "~> 2.30"
   gem "relaxed-rubocop"
   gem "brakeman" # static security vulnerability scanner
+  gem "bundler-audit", require: false
 
   gem "rspec-rails", "~> 7.1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,9 @@ GEM
     bullet (8.1.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     business_time (0.13.0)
       activesupport (>= 3.2.0)
       tzinfo
@@ -982,6 +985,7 @@ DEPENDENCIES
   brakeman
   browser (~> 6.2)
   bullet
+  bundler-audit
   business_time
   byebug
   chronic


### PR DESCRIPTION
Adds `bundler-audit` and a CI job that checks `Gemfile.lock` against the [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db), sitting alongside the existing Brakeman job.

`--update` pulls the latest advisory database on every run, so a newly published advisory against a gem we already have locked fails CI on its own, without needing a `Gemfile.lock` change to trigger it.

### Testing

`bundle exec bundle-audit check --update` passes locally against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)