### PR TITLE
[OrganizerPositionInvite::Link] Add max expiry for 3 months

### DIFF
--- a/app/models/organizer_position_invite/link.rb
+++ b/app/models/organizer_position_invite/link.rb
@@ -31,10 +31,13 @@ class OrganizerPositionInvite
     hashid_config salt: ""
 
     DEFAULT_EXPIRATION = 30.days
+    MAX_EXPIRATION = 3.months
 
     belongs_to :event
     belongs_to :creator, class_name: "User"
     belongs_to :deactivator, class_name: "User", optional: true
+
+    validate :expiration_within_limit, on: :create
 
     has_many :requests, class_name: "OrganizerPositionInvite::Request", foreign_key: "organizer_position_invite_link_id", inverse_of: :link, dependent: :destroy
 
@@ -56,6 +59,16 @@ class OrganizerPositionInvite
       return false if deactivated?
 
       update(deactivated_at: Time.now, deactivator: user)
+    end
+
+    private
+
+    def expiration_within_limit
+      return if expires_in.blank?
+
+      if expires_in.seconds.from_now > MAX_EXPIRATION.from_now
+        errors.add(:base, "Expiration date cannot be greater than 3 months from now")
+      end
     end
 
   end

--- a/app/views/organizer_position_invite/links/_form.html.erb
+++ b/app/views/organizer_position_invite/links/_form.html.erb
@@ -12,7 +12,7 @@
     <%= form_with(url: event_invite_links_path(event_id: event.slug), data: { turbo_frame: "invite_links_section" }) do |form| %>
       <div class="field">
         <%= form.label :expires_at, "Expires on" %>
-        <%= form.date_field :expires_on, class: "!max-w-full w-full", value: OrganizerPositionInvite::Link::DEFAULT_EXPIRATION.from_now.strftime("%Y-%m-%d") %>
+        <%= form.date_field :expires_on, class: "!max-w-full w-full", value: OrganizerPositionInvite::Link::DEFAULT_EXPIRATION.from_now.strftime("%Y-%m-%d"), max: OrganizerPositionInvite::Link::MAX_EXPIRATION.from_now.strftime("%Y-%m-%d") %>
       </div>
       <button data-action="click->menu#close" class="btn -mt-1 w-full" onclick="this.closest('form').requestSubmit();">
         Continue


### PR DESCRIPTION
## Summary of the problem

From #14871 
> Right now, organizers can configure an expiration for OrganizerPositionInvite::Link. But we don't limit what the expiration is. In theory, someone could set it for 99999 years from now.
>
> When creating an invite link, let's limit the expiration to 3 months from now

## Describe your changes

This PR simply adds a validation in the backend + the frontend to verify that no organizer position invite links can be created unless the expiry date is less than or equal to 3 months from the date of creation. The fix is backwards-compatible so existing invite links will work as intended, and only new invite links will be validated.