### PR TITLE
[Applications] Complete HCB application reminder email has off-center button

### DIFF
--- a/app/views/event/application_mailer/incomplete.html.erb
+++ b/app/views/event/application_mailer/incomplete.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </p>
 
-<%= link_to "Continue your application →", application_url(@application), style: "display: inline-block; background-color: #74B3E7; color: #121519 !important; font-size: 16px; font-weight: 600; line-height: 20px; padding: 8px 16px; border-radius: 6px; margin: 12px 0; text-decoration: none; text-align: center;" %>
+<%= link_to "Continue your application →", application_url(@application), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-block; font-size: 1rem; font-weight: 600; letter-spacing: 0; line-height: 20px; overflow: hidden; padding: 8px 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;" %>
 
 <p>If you have any questions, we're here to help! Just reply to this email or reach out to <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %>.</p>
 

--- a/app/views/event/application_mailer/incomplete.html.erb
+++ b/app/views/event/application_mailer/incomplete.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </p>
 
-<%= link_to "Continue your application →", application_url(@application), style: "border: 0; border-radius: 6px; box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.125); cursor: pointer; display: inline-flex; font-size: 1rem; font-weight: 600; justify-content: center; align-items: center; height: 36px; letter-spacing: 0; overflow: hidden; padding: 0 1rem; position: relative; text-align: center; text-decoration: none; user-select: none; min-height: 36px; background-color: #74B3E7; color: #121519 !important; margin: 12px 0px;" %>
+<%= link_to "Continue your application →", application_url(@application), style: "display: inline-block; background-color: #74B3E7; color: #121519 !important; font-size: 16px; font-weight: 600; line-height: 20px; padding: 8px 16px; border-radius: 6px; margin: 12px 0; text-decoration: none; text-align: center;" %>
 
 <p>If you have any questions, we're here to help! Just reply to this email or reach out to <%= link_to "hcb@hackclub.com", "mailto:hcb@hackclub.com" %>.</p>
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14878 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Gmail doesn’t really support flexbox on links, so the old button (inline-flex + a fixed height) couldn’t center the text. Switching it to a plain inline-block link with padding made it render correctly.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
After the fix:
<img width="586" height="121" alt="Screenshot 2026-09-04 at 11 47 19" src="https://github.com/user-attachments/assets/206f8021-09a0-45a1-9dac-9c097f3f22f3" />
Before:
<img width="586" height="121" alt="Screenshot 2026-09-04 at 11 38 57" src="https://github.com/user-attachments/assets/ab494cc4-9933-4ecf-9bf3-28200968c8b5" />
