### PR TITLE
[Filter Bar] Fix capitalization of selected filter chips

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -431,6 +431,17 @@ module EventsHelper
     end
   end
 
+  # Resolves an applied filter value to the label shown for it in the filter
+  # dropdown. Both the dropdown and the chips use this so they can't disagree
+  # about how a value is spelled.
+  def filter_option_label(filter_option, value)
+    labels = Array(filter_option[:options]).to_h do |option|
+      option.is_a?(Array) ? [option.last.to_s, option.first] : [option.to_s, option.humanize]
+    end
+
+    labels[value.to_s] || value.to_s.humanize
+  end
+
   def validate_filter_options(filter_options, params)
     filter_options.each do |opt|
       case opt[:type]

--- a/app/views/events/filters/_bar.html.erb
+++ b/app/views/events/filters/_bar.html.erb
@@ -11,7 +11,7 @@
     <% filters.each do |filter| %>
       <% if params[filter[:key]] %>
         <div class="badge badge-large bg-muted">
-          <%= params[filter[:key]].humanize %>
+          <%= filter_option_label(filter, params[filter[:key]]) %>
           <%= link_to upsert_query_params(filter[:key] => nil),
                       class: "flex items-center",
                       data: { turbo_prefetch: "false" } do %>

--- a/app/views/events/filters/_menu.html.erb
+++ b/app/views/events/filters/_menu.html.erb
@@ -39,8 +39,8 @@
               <p class="p-1 text-center">No <%= filter[:label].pluralize %> found</p>
             <% end %>
             <% filter[:options].each do |option| %>
-              <% label, value = option.is_a?(Array) ? option : [option.humanize, option] %>
-              <%= link_to label,
+              <% value = option.is_a?(Array) ? option.last : option %>
+              <%= link_to filter_option_label(filter, value),
                           upsert_query_params(filter[:key] => value, page: 1),
                           class: "menu__action !border-none #{'menu__action--active' if params[filter[:key]] == value.to_s}" %>
             <% end %>

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventsHelper, type: :helper do
+  describe "#filter_option_label" do
+    # The filter dropdown and the chip that shows what you picked both resolve a
+    # value through this, so they can't disagree about how a value is spelled.
+    let(:transfer_type) do
+      {
+        key: "transfer_type",
+        label: "Type",
+        type: "select",
+        options: [["ACH", "ach"], ["HCB transfer", "hcb_transfer"], ["PayPal", "paypal"]]
+      }
+    end
+    let(:status) { { key: "status", label: "Status", type: "select", options: %w[deposited in_transit canceled] } }
+
+    it "uses the label an option was declared with" do
+      expect(helper.filter_option_label(transfer_type, "hcb_transfer")).to eq("HCB transfer")
+      expect(helper.filter_option_label(transfer_type, "paypal")).to eq("PayPal")
+    end
+
+    it "humanizes options declared without a label" do
+      expect(helper.filter_option_label(status, "in_transit")).to eq("In transit")
+    end
+
+    it "humanizes a value that isn't one of the options" do
+      expect(helper.filter_option_label(transfer_type, "wire_transfer")).to eq("Wire transfer")
+      expect(helper.filter_option_label({ key_base: "created", type: "date_range" }, "canceled")).to eq("Canceled")
+    end
+  end
+end


### PR DESCRIPTION
Closes #13940

## Problem

Filter chips rendered the raw param through `.humanize`, so a value whose dropdown option declares an explicit label came back out of the chip mis-capitalized — "HCB transfer" in the dropdown, "Hcb transfer" in the chip.

## Fix

There's now one shared way to resolve a filter value to its display label, `EventsHelper#filter_option_label`, and both the dropdown option and the chip go through it — so they can't drift apart again.

An option declared as `["HCB transfer", "hcb_transfer"]` uses its label; a bare `"in_transit"` still humanizes as before. A value that isn't in the option list (or a filter with no options) falls back to `.humanize`, matching today's behavior.

This deliberately doesn't extend the hardcoded `.gsub("Ach", "ACH").gsub("Hcb", "HCB")` chain in the older ledger filter; replacing that one is left as a follow-up, as the issue suggests.

## Testing

- Added `spec/helpers/events_helper_spec.rb` covering labelled options, bare options, and the fallback — 3 examples, 0 failures.
- Repro from the issue: an org's Transfers page filtered by Type → HCB transfer now shows "HCB transfer" on the chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)