### PR TITLE
[Admin] Restrict `/ach_transfers/:id` to auditor

### DIFF
--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -14,8 +14,7 @@ class AchTransferPolicy < ApplicationPolicy
   end
 
   def show?
-    # Semantically, this should be admin_or_manager?, right?
-    is_public? || user_who_can_transfer?
+    user&.auditor?
   end
 
   def view_account_routing_numbers?

--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -63,8 +63,4 @@ class AchTransferPolicy < ApplicationPolicy
     user&.admin? || OrganizerPosition.role_at_least?(user, record.event, :manager)
   end
 
-  def is_public?
-    record.event.is_public?
-  end
-
 end

--- a/spec/controllers/ach_transfers_controller_spec.rb
+++ b/spec/controllers/ach_transfers_controller_spec.rb
@@ -6,10 +6,14 @@ describe AchTransfersController do
   include SessionSupport
 
   describe "show" do
-    it "redirects to hcb code" do
+    it "redirects to hcb code only if user is an auditor or admin" do
+      user = create(:user, :make_auditor)
       event = create(:event)
       create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
       ach_transfer = create(:ach_transfer, event:)
+
+      create_session(user, verified: true)
+
       get :show, params: { id: ach_transfer.id }
       expect(response).to redirect_to(hcb_code_path(ach_transfer.local_hcb_code.hashid))
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

We shouldn't expose internal ids for transfers.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

Only auditors can access this endpoint. 

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

