### PR TITLE
[Ledger::Item] Fix false "invoice already exists" when flagging a personal transaction

### DIFF
--- a/app/controllers/ledger/items_controller.rb
+++ b/app/controllers/ledger/items_controller.rb
@@ -82,9 +82,9 @@ class Ledger
         return redirect_to personal_tx.invoice
       end
 
-      if @item.personal_transaction.present?
+      if (existing = @item.reload_personal_transaction)
         flash[:error] = "A repayment invoice already exists for this transaction."
-        redirect_to @item.personal_transaction.invoice
+        redirect_to existing.invoice
       else
         flash[:error] = personal_tx.errors.full_messages.to_sentence
         redirect_to @item.hcb_code

--- a/spec/controllers/ledger/items_controller_spec.rb
+++ b/spec/controllers/ledger/items_controller_spec.rb
@@ -33,6 +33,34 @@ RSpec.describe Ledger::ItemsController, type: :controller do
         expect(response.body).to include("turbo-stream")
       end
     end
+
+    describe "POST #invoice_as_personal_transaction" do
+      before { create(:hcb_code, ledger_item: item) }
+
+      it "reports why the invoice couldn't be created rather than claiming one exists" do
+        post :invoice_as_personal_transaction, params: { item_id: item.hashid }
+
+        expect(flash[:error]).to include("Invoices can only be generated for card charges.")
+        expect(response).to redirect_to(hcb_code_path(item.hcb_code))
+        expect(PersonalTransaction.where(ledger_item: item)).not_to exist
+      end
+
+      context "when a repayment invoice already exists" do
+        it "redirects to the existing invoice" do
+          allow_any_instance_of(Sponsor).to receive(:create_stripe_customer).and_return(true)
+          # Validations are skipped so this stands in for any already-invoiced
+          # item; the branch under test only cares that a row is persisted.
+          existing = PersonalTransaction.new(ledger_item: item, reporter: member_user, invoice: create(:invoice))
+          existing.save!(validate: false)
+
+          post :invoice_as_personal_transaction, params: { item_id: item.hashid }
+
+          expect(flash[:error]).to eq("A repayment invoice already exists for this transaction.")
+          expect(response).to redirect_to(invoice_path(existing.invoice))
+          expect(PersonalTransaction.where(ledger_item: item).count).to eq(1)
+        end
+      end
+    end
   end
 
   context "as a reader (not a member)" do


### PR DESCRIPTION
## Summary of the problem

Flagging a transaction as a personal transaction could fail with a bogus flash — "A repayment invoice already exists for this transaction." — even when no `PersonalTransaction` row existed for the item, and no invoice was created. The request itself 500'd:

```
ActionController::ActionControllerError: Cannot redirect to nil!
app/controllers/ledger/items_controller.rb:87 in Ledger::ItemsController#invoice_as_personal_transaction
```

`PersonalTransaction belongs_to :ledger_item, inverse_of: :personal_transaction` is the inverse of `Ledger::Item has_one :personal_transaction`, so `PersonalTransaction.new(ledger_item: @item, …)` sets `@item.personal_transaction` to the *unsaved* record in memory — no query involved. When the save then failed a validation, the controller's `@item.personal_transaction.present?` check read that cached target and always took the "already exists" branch. `before_create :send_invoice` had never run, so `.invoice` was nil and the redirect raised. The flash was already written to the session, so the stale error surfaced on the user's next page load.

Net effect: the real validation error (e.g. "Invoices can only be generated for card charges.") was never shown, and the action always 500'd for any item that failed validation.

## Describe your changes

Re-read the association from the database on the failure path with `@item.reload_personal_transaction`, which discards the inverse-set target. The happy path is unchanged and does no extra query.

Added two controller specs covering both branches. With the controller change reverted, both fail with the exact production error (`Cannot redirect to nil!`).