### PR TITLE
[Wise] Remove dead `WiseTransfersController#edit` action

### DIFF
--- a/app/controllers/wise_transfers_controller.rb
+++ b/app/controllers/wise_transfers_controller.rb
@@ -58,11 +58,6 @@ class WiseTransfersController < ApplicationController
     redirect_to wise_transfer_process_admin_path(@wise_transfer), flash: { error: e.message }
   end
 
-  def edit
-    authorize @wise_transfer
-    @event = @wise_transfer.event
-  end
-
   def update
     authorize @wise_transfer
     @event = @wise_transfer.event

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -505,7 +505,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :wise_transfers, only: [:show, :edit, :update] do
+  resources :wise_transfers, only: [:show, :update] do
     member do
       post "approve"
       post "reject"


### PR DESCRIPTION
## Summary of the problem

Fixes #14886.

`WiseTransfersController#edit` calls `authorize @wise_transfer`, but `edit` was never in the `set_wise_transfer` `before_action` list. `@wise_transfer` is therefore `nil`, and `authorize nil` raises `Pundit::NotDefinedError` (`unable to find policy 'NilClassPolicy' for nil`). `ApplicationController` only rescues `Pundit::NotAuthorizedError`, and `NotDefinedError` is a sibling of it under `Pundit::Error` rather than a subclass — so nothing catches it and `GET /wise_transfers/:id/edit` 500s for any signed-in user.

Not a security issue: it fails closed, raising before the policy check and before any record is loaded or rendered.

## Describe your changes

Removed the `edit` action from the controller and dropped `:edit` from `resources :wise_transfers`, rather than repairing it — the action is dead code:

- **It could never have rendered.** There is no `app/views/wise_transfers/edit.html.erb`, and `git log --all --diff-filter=A -- 'app/views/wise_transfers/edit*'` is empty — the template has never existed on any ref.
- **Nothing links to it.** `edit_wise_transfer_path`/`_url` has zero occurrences anywhere in the repo (including `app/assets/builds/bundle.js`), and `git log --all -S"edit_wise_transfer"` returns no commits. No `polymorphic_path(..., action: :edit)`, no `link_to [:edit, ...]`, no dynamically built helper either.
- **The real editing UI is elsewhere.** `app/views/admin/wise_transfer_process.html.erb` edits inline, and its forms pass an explicit `url: wise_transfer_path(@wise_transfer), method: :patch` (lines 187 and 204), so they hit `update` directly and never depend on the `edit` route.
- **It was dead on arrival.** Both `def edit` and the incomplete `before_action` list date to the original Wise PR (#11168, `3fd965acd`). The action was copy-paste residue from the wires flow, which *is* complete (`app/views/wires/edit.html.erb`, plus the "Edit wire" button at `admin/wire_process.html.erb:119`); the Wise equivalent was never finished.

### One correction to the issue text

#14886 says adding `:edit` to the `before_action` list would turn the 500 into a 404, because `ActionView::MissingTemplate` is rescued. That isn't right. In Rails 8.1 an implicit render with no template on a GET/HTML/non-XHR request raises `ActionController::MissingExactTemplate < ActionController::UnknownFormat < ActionControllerError` — unrelated to `ActionView::MissingTemplate < ActionViewError`, so `ApplicationController`'s `rescue_from` does not match it. `ActionDispatch::ExceptionWrapper` maps `UnknownFormat` to `:not_acceptable`, so the one-line fix would have produced a **406**, not a 404. Either way it argues for removal.

## Verification

- `bin/rails routes -c wise_transfers` — only the `edit` row is gone. `show`, `update` (PATCH + PUT), `approve`, `reject`, `mark_sent`, `mark_failed`, `generate_quote`, and the event-nested `new`/`create` all still resolve.
- `Rails.application.routes.recognize_path("/wise_transfers/1/edit", method: :get)` now raises `ActionController::RoutingError` — a clean 404. Notably it does *not* fall through to the root-mounted `resources :events, path: "/"`, so the URL doesn't silently become an org lookup.
- `bin/rails zeitwerk:check` → `All is good!`
- `bundle exec rubocop` on both files → no offenses. `bundle exec brakeman -q` → 0 warnings.
- No policy change needed: `WiseTransferPolicy` never defined `edit?` (it inherited `ApplicationPolicy#edit?` → `update?`), so nothing is orphaned. `after_action :verify_authorized` still holds — every remaining routed action calls `authorize`.

## Follow-up worth considering (not in this PR)

Only three of the ~20 params `wise_transfer_params` permits are editable from the admin process page — `wise_recipient_id`, `usd_amount`, and `wise_id` (via `mark_sent`). Recipient name, email, address, and the bank-detail accessors are display-only, whereas wires have a full admin edit form. That gap predates this PR and isn't caused by it — and it matters less for Wise than for wires, since HCB executes wires programmatically from the stored fields while Wise transfers are keyed into wise.com by hand — but if the parity is wanted, it's a new route + `before_action` entry + template, which this removal doesn't foreclose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
