### PR TITLE
[Admin] Pagination popup does not close when new option is selected

### DIFF
--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -100,10 +100,17 @@ export default class extends Controller {
         $(e.target).closest('.menu__content').length
       )
         return
+    }
 
-      this.content && this.content.remove()
-    } else {
-      this.content && this.content.remove()
+    if (this.content) {
+      const content = this.content
+      if (e?.type == 'click') {
+        // let turbo resolve the target frame before removing the link
+        content.style.display = 'none'
+        setTimeout(() => content.remove(), 0)
+      } else {
+        content.remove()
+      }
     }
 
     this.toggleTarget.setAttribute('aria-expanded', false)

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -30,6 +30,11 @@ export default class extends Controller {
 
   disconnect() {
     this.cleanup && this.cleanup()
+    // remove cloned popup so it doesn't outlive turbo frame updates.
+    this.content && this.content.remove()
+    this.content = undefined
+    this.cleanup = undefined
+    this.isOpen = false
     document.removeEventListener('hcb:close-menus', this._closeMenusHandler)
   }
 

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -26,7 +26,7 @@
                         url_for((request.query_parameters || {}).merge("per" => n, "page" => 1, only_path: true)),
                         class: "menu__action #{'menu__action--active' if n == per_page}",
                         aria: { current: n == per_page ? "true" : nil },
-                        data: { turbo_frame: request.headers["Turbo-Frame"].presence } %>
+                        data: { turbo_frame: request.headers["Turbo-Frame"].presence, action: "menu#close" } %>
           <% end %>
         </div>
       </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -331,13 +331,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "9d0250d9ac9f2db54434d7a0a1fe5c34aa4edc236cd92def76d77b6bec2a7b44",
+      "fingerprint": "f6e465cc77fa185d0d6cf2b23ce0e1bb2ea2e8857360fe89c41f0e6bca3d6d74",
       "check_name": "LinkToHref",
       "message": "Unsafe parameter value in `link_to` href",
       "file": "app/views/kaminari/_paginator.html.erb",
-      "line": 24,
+      "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"#{n} per page\", url_for((request.query_parameters or {}).merge(\"per\" => n, \"page\" => 1, :only_path => true)), :class => (\"menu__action #{\"menu__action--active\" if (n == per_page)}\"), :aria => ({ :current => ((n == per_page) ? (\"true\") : (nil)) }), :data => ({ :turbo_frame => request.headers[\"Turbo-Frame\"].presence }))",
+      "code": "link_to(\"#{n} per page\", url_for((request.query_parameters or {}).merge(\"per\" => n, \"page\" => 1, :only_path => true)), :class => (\"menu__action #{\"menu__action--active\" if (n == per_page)}\"), :aria => ({ :current => ((n == per_page) ? (\"true\") : (nil)) }), :data => ({ :turbo_frame => request.headers[\"Turbo-Frame\"].presence, :action => \"menu#close\" }))",
       "render_path": null,
       "location": {
         "type": "template",
@@ -348,7 +348,7 @@
       "cwe_id": [
         79
       ],
-      "note": ""
+      "note": "False positive: url_for with a params hash and only_path builds a relative path, not a javascript: URL."
     },
     {
       "warning_type": "Cross-Site Scripting",


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes https://github.com/hackclub/hcb/issues/14896


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The menu gets cloned in and turbo never cleaned it up properly. Choosing a size now closes the menu, and when the old paginator is removed, the leftover popup is also deleted.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

