### PR TITLE
[Card grants] Add status filter to card grants table

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -17,6 +17,11 @@ class CardGrantsController < ApplicationController
   def card_index
     authorize @event, :card_grant_overview?
 
+    unless turbo_frame_request?
+      redirect_to event_card_grant_overview_path(@event, request.query_parameters)
+      return
+    end
+
     # The search query name was historically `search`. It has since been renamed
     # to `q`. This following line retains backwards compatibility.
     params[:q] ||= params[:search]
@@ -28,7 +33,7 @@ class CardGrantsController < ApplicationController
     @filter_options = [
       { key: "status", label: "Status", type: "select", options: status_options }
     ]
-    @has_filter = helpers.check_filters?(@filter_options, params)
+    @has_filter = CardGrant::FILTERABLE_STATES.key?(params[:status])
 
     @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger, :reimbursement_report).order(created_at: :desc)
     @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?

--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -24,8 +24,15 @@ class CardGrantsController < ApplicationController
     card_grants_page = (params[:page] || 1).to_i
     card_grants_per_page = safe_per(20)
 
+    status_options = CardGrant::FILTERABLE_STATES.map { |state, label| [label, state] }
+    @filter_options = [
+      { key: "status", label: "Status", type: "select", options: status_options }
+    ]
+    @has_filter = helpers.check_filters?(@filter_options, params)
+
     @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger, :reimbursement_report).order(created_at: :desc)
     @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?
+    @card_grants = @card_grants.filter_by_state(params[:status])
     @paginated_card_grants = @card_grants.page(card_grants_page).per(card_grants_per_page)
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -431,6 +431,18 @@ module EventsHelper
     end
   end
 
+  def filter_chip_label(filter, value)
+    options = filter[:options] || []
+
+    match = options.find do |option|
+      option.is_a?(Array) && option.last.to_s == value.to_s
+    end
+
+    return match.first if match
+
+    value.humanize
+  end
+
   def validate_filter_options(filter_options, params)
     filter_options.each do |opt|
       case opt[:type]

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -440,7 +440,7 @@ module EventsHelper
 
     return match.first if match
 
-    value.humanize
+    value.to_s.humanize
   end
 
   def validate_filter_options(filter_options, params)

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -111,7 +111,7 @@ class CardGrant < ApplicationRecord
   scope :activated, -> { active.where.not(stripe_card_id: nil) }
 
   scope :accepted, -> { active.joins(:stripe_card).merge(StripeCard.active) }
-  scope :frozen, -> { active.joins(:stripe_card).merge(StripeCard.frozen) }
+  scope :frozen, -> { active.joins(:stripe_card).merge(StripeCard.where(stripe_status: "inactive")) }
   scope :returned, -> { canceled.where.missing(:reimbursement_report) }
   scope :converted_to_reimbursement, -> { canceled.joins(:reimbursement_report) }
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -109,6 +109,29 @@ class CardGrant < ApplicationRecord
 
   scope :not_activated, -> { active.where(stripe_card_id: nil) }
   scope :activated, -> { active.where.not(stripe_card_id: nil) }
+
+  scope :accepted, -> { active.joins(:stripe_card).merge(StripeCard.active) }
+  scope :frozen, -> { active.joins(:stripe_card).merge(StripeCard.frozen) }
+  scope :returned, -> { canceled.where.missing(:reimbursement_report) }
+  scope :converted_to_reimbursement, -> { canceled.joins(:reimbursement_report) }
+
+  # statuses shown in the status filter that each map to their scope
+  FILTERABLE_STATES = {
+    "not_activated"              => "Invited",
+    "accepted"                   => "Accepted",
+    "frozen"                     => "Frozen",
+    "expired"                    => "Expired",
+    "returned"                   => "Returned",
+    "converted_to_reimbursement" => "Converted to reimbursement report"
+  }.freeze
+
+  scope :filter_by_state, ->(state) {
+    if FILTERABLE_STATES.key?(state)
+      public_send(state)
+    else
+      all
+    end
+  }
   scope :search_for, ->(q) { joins(:user).where("users.full_name ILIKE :query OR card_grants.email ILIKE :query OR card_grants.purpose ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
   scope :expired_before, ->(date) { where("card_grants.expiration_at < ?", date) }
   scope :expires_on, ->(date) { where("card_grants.expiration_at = DATE(?)", date) }

--- a/app/views/card_grants/card_index.html.erb
+++ b/app/views/card_grants/card_index.html.erb
@@ -2,6 +2,9 @@
   <div class="flex items-center gap-4 flex-col-reverse sm:flex-row mb-2">
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
       <%= render "events/filters/search", form: %>
+      <% if @has_filter %>
+        <%= form.hidden_field :status, value: params[:status] %>
+      <% end %>
     <% end %>
 
     <%= render "events/filters/menu", filters: @filter_options, append_to: "turbo-frame#card_grant_card_overview", toggle_label: "Add status filters" unless @has_filter %>

--- a/app/views/card_grants/card_index.html.erb
+++ b/app/views/card_grants/card_index.html.erb
@@ -3,7 +3,11 @@
     <%= form_with(model: false, local: true, method: :get, class: "flex-1 w-full sm:w-auto") do |form| %>
       <%= render "events/filters/search", form: %>
     <% end %>
+
+    <%= render "events/filters/menu", filters: @filter_options, append_to: "turbo-frame#card_grant_card_overview", toggle_label: "Add status filters" unless @has_filter %>
   </div>
+
+  <%= render "events/filters/bar", filters: @filter_options, append_to: "turbo-frame#card_grant_card_overview", toggle_label: "Add status filters", clear_label: "Clear status filters" if @has_filter %>
 
   <% if @card_grants.any? %>
     <div class="table-container">

--- a/app/views/card_grants/index.html.erb
+++ b/app/views/card_grants/index.html.erb
@@ -12,7 +12,7 @@
     <%= render "card_grants/buttons" %>
   </h1>
 
-  <%= turbo_frame_tag :card_grant_card_overview, src: event_card_grant_card_overview_path(@event), loading: :eager do %>
+  <%= turbo_frame_tag :card_grant_card_overview, src: event_card_grant_card_overview_path(@event, request.query_parameters), loading: :eager do %>
     <%= render "application/loading_container", klass: "mt-8" %>
   <% end %>
 

--- a/app/views/card_grants/index.html.erb
+++ b/app/views/card_grants/index.html.erb
@@ -12,7 +12,7 @@
     <%= render "card_grants/buttons" %>
   </h1>
 
-  <%= turbo_frame_tag :card_grant_card_overview, src: event_card_grant_card_overview_path(@event, request.query_parameters), loading: :eager do %>
+  <%= turbo_frame_tag :card_grant_card_overview, src: event_card_grant_card_overview_path(@event, request.query_parameters), loading: :eager, data: { turbo_action: "advance" } do %>
     <%= render "application/loading_container", klass: "mt-8" %>
   <% end %>
 

--- a/app/views/events/_card_grant_actions.html.erb
+++ b/app/views/events/_card_grant_actions.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="menu" data-menu-placement-value="bottom-end">
-  <button class="pop menu__toggle tooltipped tooltipped--w" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle" aria-label="Actions">
+  <button class="pop menu__toggle menu__toggle--arrowless tooltipped tooltipped--w" data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown" data-menu-target="toggle" aria-label="Actions">
     <%= inline_icon "more" %>
   </button>
 

--- a/app/views/events/filters/_bar.html.erb
+++ b/app/views/events/filters/_bar.html.erb
@@ -1,8 +1,10 @@
+<%# locals: (filters:, append_to: "turbo-frame#ledger", toggle_label: "Add filters...", clear_label: "Clear filters") %>
+
 <div class="flex items-center filter-menu -mt-2 mb-1">
-  <%= render "events/filters/menu", filters: %>
+  <%= render "events/filters/menu", filters:, append_to:, toggle_label: %>
   <%= link_to nil,
               class: "-ml-2 pop muted tooltipped tooltipped--s",
-              aria: { label: "Clear filters" },
+              aria: { label: clear_label },
               data: { turbo_prefetch: "false" } do %>
     <%= inline_icon "view-close", size: 28 %>
   <% end %>
@@ -11,7 +13,7 @@
     <% filters.each do |filter| %>
       <% if params[filter[:key]] %>
         <div class="badge badge-large bg-muted">
-          <%= params[filter[:key]].humanize %>
+          <%= filter_chip_label(filter, params[filter[:key]]) %>
           <%= link_to upsert_query_params(filter[:key] => nil),
                       class: "flex items-center",
                       data: { turbo_prefetch: "false" } do %>

--- a/app/views/events/filters/_menu.html.erb
+++ b/app/views/events/filters/_menu.html.erb
@@ -1,13 +1,15 @@
+<%# locals: (filters:, append_to: "turbo-frame#ledger", toggle_label: "Add filters...") %>
+
 <div
   data-controller="menu"
   class="inline-flex items-center"
-  data-menu-append-to-value="turbo-frame#ledger"
+  data-menu-append-to-value="<%= append_to %>"
   data-menu-placement-value="bottom-start">
 
   <button
     type="button"
     class="pop my-2 cursor-pointer tooltipped tooltipped--s"
-    aria-label="Add filters..."
+    aria-label="<%= toggle_label %>"
     data-menu-target="toggle"
     data-action="menu#toggle click@document->menu#close keydown@document->menu#keydown">
     <%= inline_icon "filter", size: 28 %>

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe CardGrantsController do
     before do
       create(:organizer_position, user:, event:)
       create_session(user, verified: true)
+      request.headers["Turbo-Frame"] = "card_grant_card_overview"
     end
 
     it "filters grants by state" do
@@ -57,12 +58,13 @@ RSpec.describe CardGrantsController do
     it "renders the status filter menu + chips" do
       get(:card_index, params: { event_id: event.friendly_id })
       expect(response.body).to include("Add status filters")
-
       expect(response.body).to include("Invited")
-      expect(response.body).not_to include("Not activated")
 
       get(:card_index, params: { event_id: event.friendly_id, status: "not_activated" })
       expect(response.body).to include("Clear status filters")
+
+      expect(response.body).to include("Invited")
+      expect(response.body).not_to include("Not activated")
     end
 
     it "shows all grants when the status paramater is invalid" do
@@ -71,6 +73,51 @@ RSpec.describe CardGrantsController do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(not_activated.purpose)
       expect(response.body).to include(accepted.purpose)
+
+      expect(response.body).not_to include("Clear status filters")
+    end
+
+    it "shows all grants when the status is not a string" do
+      get(:card_index, params: { event_id: event.friendly_id, status: ["not_activated"] })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(not_activated.purpose)
+      expect(response.body).to include(accepted.purpose)
+      expect(response.body).not_to include("Clear status filters")
+    end
+
+    it "keeps status filter when searching" do
+      get(:card_index, params: { event_id: event.friendly_id, status: "not_activated" })
+
+      hidden_status = response.parsed_body.at_css("form input[type='hidden'][name='status']")
+      expect(hidden_status["value"]).to eq("not_activated")
+    end
+
+    it "redirects direct visits to grants page with filters" do
+      request.headers["Turbo-Frame"] = nil
+
+      get(:card_index, params: { event_id: event.friendly_id, status: "not_activated", q: "travel" })
+
+      expect(response).to redirect_to(event_card_grant_overview_path(event, status: "not_activated", q: "travel"))
+    end
+  end
+
+  describe "#index" do
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+    end
+
+    it "allows filter changes to update the page url" do
+      user = create(:user)
+      event = create(:event, plan_type: Event::Plan::HackClubAffiliate)
+      create(:card_grant, event:)
+      create(:organizer_position, user:, event:)
+      create_session(user, verified: true)
+
+      get(:index, params: { event_id: event.friendly_id })
+
+      frame = response.parsed_body.at_css("turbo-frame#card_grant_card_overview")
+      expect(frame["data-turbo-action"]).to eq("advance")
     end
   end
 

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -31,6 +31,49 @@ RSpec.describe CardGrantsController do
     end
   end
 
+  describe "#card_index" do
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+    end
+
+    let(:user) { create(:user) }
+    let(:event) { create(:event, plan_type: Event::Plan::HackClubAffiliate) }
+    let!(:not_activated) { create(:card_grant, event:, stripe_card: nil, purpose: "conference travel") }
+    let!(:accepted) { create(:card_grant, event:, purpose: "lunch stipend") }
+
+    before do
+      create(:organizer_position, user:, event:)
+      create_session(user, verified: true)
+    end
+
+    it "filters grants by state" do
+      get(:card_index, params: { event_id: event.friendly_id, status: "not_activated" })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(not_activated.purpose)
+      expect(response.body).not_to include(accepted.purpose)
+    end
+
+    it "renders the status filter menu + chips" do
+      get(:card_index, params: { event_id: event.friendly_id })
+      expect(response.body).to include("Add status filters")
+
+      expect(response.body).to include("Invited")
+      expect(response.body).not_to include("Not activated")
+
+      get(:card_index, params: { event_id: event.friendly_id, status: "not_activated" })
+      expect(response.body).to include("Clear status filters")
+    end
+
+    it "shows all grants when the status paramater is invalid" do
+      get(:card_index, params: { event_id: event.friendly_id, status: "bogus" })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(not_activated.purpose)
+      expect(response.body).to include(accepted.purpose)
+    end
+  end
+
   describe "#new" do
     it "renders successfully" do
       user = create(:user)

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CardGrantsController do
       expect(response.body).not_to include("Not activated")
     end
 
-    it "shows all grants when the status paramater is invalid" do
+    it "shows all grants when the status parameter is invalid" do
       get(:card_index, params: { event_id: event.friendly_id, status: "bogus" })
 
       expect(response).to have_http_status(:ok)

--- a/spec/factories/card_grant_factory.rb
+++ b/spec/factories/card_grant_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     keyword_lock { nil }
 
     after(:create) do |card_grant|
-      card_grant.stripe_card.update(subledger: card_grant.subledger)
+      card_grant.stripe_card&.update(subledger: card_grant.subledger)
     end
   end
 end

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe CardGrant, type: :model do
       expect(event.card_grants.converted_to_reimbursement).to contain_exactly(converted)
     end
 
+    it "treats a card that went inactive before its first activation as frozen" do
+      inactive_card = create(:stripe_card, :with_stripe_id, event:, stripe_status: "inactive", initially_activated: false)
+      frozen_before_activation = create(:card_grant, event:, stripe_card: inactive_card)
+
+      expect(event.card_grants.frozen).to contain_exactly(frozen, frozen_before_activation)
+      expect(event.card_grants.accepted).to contain_exactly(accepted)
+    end
+
     describe ".filter_by_state" do
       it "filters to the state" do
         expect(event.card_grants.filter_by_state("not_activated")).to contain_exactly(not_activated)

--- a/spec/models/card_grant_spec.rb
+++ b/spec/models/card_grant_spec.rb
@@ -3,6 +3,45 @@
 require "rails_helper"
 
 RSpec.describe CardGrant, type: :model do
+  describe "state scopes" do
+    before do
+      allow_any_instance_of(CardGrant).to receive(:transfer_money)
+    end
+
+    let(:event) { create(:event) }
+    let!(:not_activated) { create(:card_grant, event:, stripe_card: nil) }
+    let!(:accepted) { create(:card_grant, event:) }
+    let!(:frozen) { create(:card_grant, event:, stripe_card: create(:stripe_card, :with_stripe_id, event:, stripe_status: "inactive", initially_activated: true)) }
+    let!(:expired) { create(:card_grant, event:).tap { |grant| grant.update!(status: :expired) } }
+    let!(:returned) { create(:card_grant, event:).tap { |grant| grant.update!(status: :canceled) } }
+    let!(:converted) do
+      create(:card_grant, event:).tap do |grant|
+        grant.update!(status: :canceled)
+        create(:reimbursement_report, event:, user: grant.user, card_grant: grant)
+      end
+    end
+
+    it "sorts each grant status into one state" do
+      expect(event.card_grants.not_activated).to contain_exactly(not_activated)
+      expect(event.card_grants.accepted).to contain_exactly(accepted)
+      expect(event.card_grants.frozen).to contain_exactly(frozen)
+      expect(event.card_grants.expired).to contain_exactly(expired)
+      expect(event.card_grants.returned).to contain_exactly(returned)
+      expect(event.card_grants.converted_to_reimbursement).to contain_exactly(converted)
+    end
+
+    describe ".filter_by_state" do
+      it "filters to the state" do
+        expect(event.card_grants.filter_by_state("not_activated")).to contain_exactly(not_activated)
+      end
+
+      it "ignores unknown states" do
+        expect(event.card_grants.filter_by_state("nonsense")).to contain_exactly(not_activated, accepted, frozen, expired, returned, converted)
+        expect(event.card_grants.filter_by_state(nil)).to contain_exactly(not_activated, accepted, frozen, expired, returned, converted)
+      end
+    end
+  end
+
   describe "ledger association" do
     # CardGrant has an after_create :transfer_money callback that triggers
     # DisbursementService::Create, which requires the source event to have


### PR DESCRIPTION
 ## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14043.

The card grants table on an event's card grants page only has a text search box. There's no way to narrow the list down to, say, just the ones that have been activated vs. not activated, which is not great for events with a _lot_ of grants.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

This PR creates a filter for the different status types that matches the existing filter UI (like the one on the ledger page). There are new `CardGrant` scopes for each state, and a `filter_by_state` scope that maps the `status` param to one of them, falling back to `all` on unknown values. Canceled grants are split into "Returned" and "Converted to reimbursement report" depending or not on whether a reimbursements report was created from them.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

Filter:
<img width="305" height="308" alt="image" src="https://github.com/user-attachments/assets/135f7d72-3185-4247-ac14-3b025259719f" />

Filter in action:
<img width="968" height="259" alt="image" src="https://github.com/user-attachments/assets/538ac407-7739-491a-b095-c92b1c4d7100" />
