### PR TITLE
[v4] Standardize / create outgoing transfers API endpoints

### DIFF
--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -7,6 +7,14 @@ module Api
 
       before_action :set_api_event, only: [:create]
 
+      def show
+        @ach_transfer = authorize find_for_api!(AchTransfer, params[:id]), :show_in_v4?
+
+        render :show, status: :ok
+      end
+
+      require_oauth2_scope "transfers:read", :show
+
       def create
         permitted_params = [
           :routing_number,

--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -8,8 +8,9 @@ module Api
       before_action :set_api_event, only: [:create]
 
       def show
-        @ach_transfer = authorize find_for_api!(AchTransfer, params[:id]), :show_in_v4?
+        @ach_transfer = authorize AchTransfer.find_by_public_id!(params[:id]), :show_in_v4?
 
+        render :show, status: :ok
       end
 
       require_oauth2_scope "transactions:read", :show

--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -12,7 +12,7 @@ module Api
 
       end
 
-      require_oauth2_scope "transfers:read", :show
+      require_oauth2_scope "transactions:read", :show
 
       def create
         permitted_params = [

--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -10,7 +10,6 @@ module Api
       def show
         @ach_transfer = authorize find_for_api!(AchTransfer, params[:id]), :show_in_v4?
 
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/ach_transfers_controller.rb
+++ b/app/controllers/api/v4/ach_transfers_controller.rb
@@ -10,7 +10,6 @@ module Api
       def show
         @ach_transfer = authorize AchTransfer.find_by_public_id!(params[:id]), :show_in_v4?
 
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transactions:read", :show

--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -46,6 +46,16 @@ module Api
         @current_user = current_token&.user
       end
 
+      # Looks up a record by its public ID. Admins with read
+      # access can additionally look records up by their internal (numeric) ID.
+      def find_for_api!(klass, id)
+        if can_admin?(:read)
+          klass.find_by_public_id(id) || klass.find(id)
+        else
+          klass.find_by_public_id!(id)
+        end
+      end
+
       def require_admin_scope!(level)
         unless can_admin?(level)
           skip_authorization

--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -46,6 +46,13 @@ module Api
         @current_user = current_token&.user
       end
 
+      def require_admin_scope!(level)
+        unless can_admin?(level)
+          skip_authorization
+          render json: { error: "not_authorized" }, status: :forbidden
+        end
+      end
+
       def require_trusted_oauth_app!
         unless current_token&.application&.trusted?
           render json: { error: "not_authorized" }, status: :forbidden

--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -46,23 +46,6 @@ module Api
         @current_user = current_token&.user
       end
 
-      # Looks up a record by its public ID. Admins with read
-      # access can additionally look records up by their internal (numeric) ID.
-      def find_for_api!(klass, id)
-        if can_admin?(:read)
-          klass.find_by_public_id(id) || klass.find(id)
-        else
-          klass.find_by_public_id!(id)
-        end
-      end
-
-      def require_admin_scope!(level)
-        unless can_admin?(level)
-          skip_authorization
-          render json: { error: "not_authorized" }, status: :forbidden
-        end
-      end
-
       def require_trusted_oauth_app!
         unless current_token&.application&.trusted?
           render json: { error: "not_authorized" }, status: :forbidden

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -13,8 +13,12 @@ module Api
       end
 
       def show
-        @check = authorize IncreaseCheck.find_by_public_id!(params[:id])
+        @check = authorize find_for_api!(IncreaseCheck, params[:id]), :show_in_v4?
+
+        render :show, status: :ok
       end
+
+      require_oauth2_scope "transfers:read", :show
 
       def create
         check_params = params.require(:check).permit(

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -18,7 +18,7 @@ module Api
         render :show, status: :ok
       end
 
-      require_oauth2_scope "transfers:read", :show
+      require_oauth2_scope "transactions:read", :show
 
       def create
         check_params = params.require(:check).permit(

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -14,8 +14,6 @@ module Api
 
       def show
         @check = authorize IncreaseCheck.find_by_public_id!(params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transactions:read", :show

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -13,7 +13,9 @@ module Api
       end
 
       def show
-        @check = authorize find_for_api!(IncreaseCheck, params[:id]), :show_in_v4?
+        @check = authorize IncreaseCheck.find_by_public_id!(params[:id]), :show_in_v4?
+
+        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/checks_controller.rb
+++ b/app/controllers/api/v4/checks_controller.rb
@@ -14,8 +14,6 @@ module Api
 
       def show
         @check = authorize find_for_api!(IncreaseCheck, params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -7,6 +7,14 @@ module Api
 
       before_action :set_api_event, only: [:create]
 
+      def show
+        @disbursement = authorize find_for_api!(Disbursement, params[:id]), :show_in_v4?
+
+        render :show, status: :ok
+      end
+
+      require_oauth2_scope "transfers:read", :show
+
       def create
         @source_event = @event
         @destination_event = Event.find_by_public_id(params[:to_organization_id]) || Event.friendly.find(params[:to_organization_id])

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -9,8 +9,6 @@ module Api
 
       def show
         @disbursement = authorize Disbursement.find_by_public_id!(params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transactions:read", :show

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -13,7 +13,7 @@ module Api
         render :show, status: :ok
       end
 
-      require_oauth2_scope "transfers:read", :show
+      require_oauth2_scope "transactions:read", :show
 
       def create
         @source_event = @event

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -9,8 +9,6 @@ module Api
 
       def show
         @disbursement = authorize find_for_api!(Disbursement, params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -8,7 +8,9 @@ module Api
       before_action :set_api_event, only: [:create]
 
       def show
-        @disbursement = authorize find_for_api!(Disbursement, params[:id]), :show_in_v4?
+        @disbursement = authorize Disbursement.find_by_public_id!(params[:id]), :show_in_v4?
+
+        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/wires_controller.rb
+++ b/app/controllers/api/v4/wires_controller.rb
@@ -13,10 +13,12 @@ module Api
       end
 
       def show
-        @wire = authorize Wire.find_by_public_id!(params[:id])
+        @wire = authorize find_for_api!(Wire, params[:id]), :show_in_v4?
 
         render :show, status: :ok
       end
+
+      require_oauth2_scope "transfers:read", :show
 
       def create
         @wire = @event.wires.build(wire_params.merge(user: current_user))

--- a/app/controllers/api/v4/wires_controller.rb
+++ b/app/controllers/api/v4/wires_controller.rb
@@ -14,8 +14,6 @@ module Api
 
       def show
         @wire = authorize Wire.find_by_public_id!(params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transactions:read", :show

--- a/app/controllers/api/v4/wires_controller.rb
+++ b/app/controllers/api/v4/wires_controller.rb
@@ -18,7 +18,7 @@ module Api
         render :show, status: :ok
       end
 
-      require_oauth2_scope "transfers:read", :show
+      require_oauth2_scope "transactions:read", :show
 
       def create
         @wire = @event.wires.build(wire_params.merge(user: current_user))

--- a/app/controllers/api/v4/wires_controller.rb
+++ b/app/controllers/api/v4/wires_controller.rb
@@ -14,8 +14,6 @@ module Api
 
       def show
         @wire = authorize find_for_api!(Wire, params[:id]), :show_in_v4?
-
-        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/controllers/api/v4/wires_controller.rb
+++ b/app/controllers/api/v4/wires_controller.rb
@@ -13,7 +13,9 @@ module Api
       end
 
       def show
-        @wire = authorize find_for_api!(Wire, params[:id]), :show_in_v4?
+        @wire = authorize Wire.find_by_public_id!(params[:id]), :show_in_v4?
+
+        render :show, status: :ok
       end
 
       require_oauth2_scope "transfers:read", :show

--- a/app/policies/ach_transfer_policy.rb
+++ b/app/policies/ach_transfer_policy.rb
@@ -18,6 +18,10 @@ class AchTransferPolicy < ApplicationPolicy
     is_public? || user_who_can_transfer?
   end
 
+  def show_in_v4?
+    auditor_or_user?
+  end
+
   def view_account_routing_numbers?
     admin_or_manager?
   end

--- a/app/policies/disbursement_policy.rb
+++ b/app/policies/disbursement_policy.rb
@@ -5,6 +5,13 @@ class DisbursementPolicy < ApplicationPolicy
     user.auditor?
   end
 
+  # Readable by anyone with read access to either side of the transfer.
+  def show_in_v4?
+    user&.auditor? ||
+      OrganizerPosition.role_at_least?(user, record.source_event, :reader) ||
+      OrganizerPosition.role_at_least?(user, record.destination_event, :reader)
+  end
+
   def can_send?(role: :manager)
     return true if user&.admin?
     return true if record.source_event.nil?

--- a/app/policies/increase_check_policy.rb
+++ b/app/policies/increase_check_policy.rb
@@ -9,6 +9,10 @@ class IncreaseCheckPolicy < ApplicationPolicy
     user_who_can_transfer?
   end
 
+  def show_in_v4?
+    auditor_or_user?
+  end
+
   def approve?
     user&.admin?
   end

--- a/app/policies/wire_policy.rb
+++ b/app/policies/wire_policy.rb
@@ -9,6 +9,10 @@ class WirePolicy < ApplicationPolicy
     auditor_or_user?
   end
 
+  def show_in_v4?
+    auditor_or_user?
+  end
+
   def create?
     user_who_can_transfer?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -820,7 +820,8 @@ Rails.application.routes.draw do
         resources :sponsors, only: [:index, :show, :create]
         resources :check_deposits, only: [:index, :show, :create]
         resources :wires, only: [:index, :show, :create]
-        resources :ach_transfers, only: [:create]
+        resources :ach_transfers, only: [:show, :create]
+        resources :disbursements, only: [:show]
 
         resources :comments, only: [:index, :create]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -821,7 +821,7 @@ Rails.application.routes.draw do
         resources :check_deposits, only: [:index, :show, :create]
         resources :wires, only: [:index, :show, :create]
         resources :ach_transfers, only: [:show, :create]
-        resources :disbursements, only: [:show]
+        resources :disbursements, path: "transfers", only: [:show]
 
         resources :comments, only: [:index, :create]
 

--- a/dev-docs/v4-api/scopes.md
+++ b/dev-docs/v4-api/scopes.md
@@ -145,7 +145,7 @@ To gate an action behind a new scope:
    def create
      # ...
    end
-   require_oauth2_scope "ach_transfers:write", :create
+   require_oauth2_scope "transfers:write", :create
    ```
 2. **Pick a name** following the [naming conventions](#scope-naming-conventions) — usually `<resource>:read` or `<resource>:write`.
 5. **Test with a `restricted` token** — remember the scope only takes effect for tokens carrying `restricted`. A non-restricted token will bypass the check entirely.

--- a/spec/controllers/api/v4/ach_transfers_controller_spec.rb
+++ b/spec/controllers/api/v4/ach_transfers_controller_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::AchTransfersController do
+  render_views
+
+  describe "#show" do
+    let(:event) do
+      event = create(:event)
+      create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+      event
+    end
+    let(:ach_transfer) { create(:ach_transfer, event:) }
+
+    def authenticate(user, scopes: nil)
+      token = create(:api_token, user:, scopes:)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+    end
+
+    it "returns the transfer by public ID" do
+      user = create(:user)
+      create(:organizer_position, user:, event:)
+      authenticate(user)
+
+      get :show, params: { id: ach_transfer.public_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("id" => ach_transfer.public_id, "object" => "ach_transfer")
+    end
+
+    it "doesn't return the transfer to an unrelated user" do
+      authenticate(create(:user))
+
+      get :show, params: { id: ach_transfer.public_id }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "doesn't allow lookups by internal ID for non-admins" do
+      user = create(:user)
+      create(:organizer_position, user:, event:)
+      authenticate(user)
+
+      get :show, params: { id: ach_transfer.id }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "allows lookups by internal ID for admins" do
+      authenticate(create(:user, :make_admin), scopes: "admin:read")
+
+      get :show, params: { id: ach_transfer.id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("id" => ach_transfer.public_id)
+    end
+
+    it "404s on an unknown ID for admins" do
+      authenticate(create(:user, :make_admin), scopes: "admin:read")
+
+      get :show, params: { id: "ach_nonexistent" }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/controllers/api/v4/ach_transfers_controller_spec.rb
+++ b/spec/controllers/api/v4/ach_transfers_controller_spec.rb
@@ -36,32 +36,5 @@ RSpec.describe Api::V4::AchTransfersController do
 
       expect(response).to have_http_status(:forbidden)
     end
-
-    it "doesn't allow lookups by internal ID for non-admins" do
-      user = create(:user)
-      create(:organizer_position, user:, event:)
-      authenticate(user)
-
-      get :show, params: { id: ach_transfer.id }, as: :json
-
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "allows lookups by internal ID for admins" do
-      authenticate(create(:user, :make_admin), scopes: "admin:read")
-
-      get :show, params: { id: ach_transfer.id }, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id" => ach_transfer.public_id)
-    end
-
-    it "404s on an unknown ID for admins" do
-      authenticate(create(:user, :make_admin), scopes: "admin:read")
-
-      get :show, params: { id: "ach_nonexistent" }, as: :json
-
-      expect(response).to have_http_status(:not_found)
-    end
   end
 end

--- a/spec/controllers/api/v4/disbursements_controller_spec.rb
+++ b/spec/controllers/api/v4/disbursements_controller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::DisbursementsController do
+  render_views
+
+  describe "#show" do
+    let(:source_event) { create(:event) }
+    let(:destination_event) { create(:event) }
+    let(:disbursement) { create(:disbursement, source_event:, event: destination_event) }
+
+    def authenticate(user, scopes: nil)
+      token = create(:api_token, user:, scopes:)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+    end
+
+    it "returns the transfer to a member of the sending organization" do
+      user = create(:user)
+      create(:organizer_position, user:, event: source_event)
+      authenticate(user)
+
+      get :show, params: { id: disbursement.public_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("id" => disbursement.public_id, "object" => "disbursement")
+    end
+
+    it "returns the transfer to a member of the receiving organization" do
+      user = create(:user)
+      create(:organizer_position, user:, event: destination_event)
+      authenticate(user)
+
+      get :show, params: { id: disbursement.public_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "doesn't return the transfer to an unrelated user" do
+      authenticate(create(:user))
+
+      get :show, params: { id: disbursement.public_id }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "doesn't allow lookups by internal ID for non-admins" do
+      user = create(:user)
+      create(:organizer_position, user:, event: source_event)
+      authenticate(user)
+
+      get :show, params: { id: disbursement.id }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "allows lookups by internal ID for admins" do
+      authenticate(create(:user, :make_admin), scopes: "admin:read")
+
+      get :show, params: { id: disbursement.id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("id" => disbursement.public_id)
+    end
+  end
+end

--- a/spec/controllers/api/v4/disbursements_controller_spec.rb
+++ b/spec/controllers/api/v4/disbursements_controller_spec.rb
@@ -43,24 +43,5 @@ RSpec.describe Api::V4::DisbursementsController do
 
       expect(response).to have_http_status(:forbidden)
     end
-
-    it "doesn't allow lookups by internal ID for non-admins" do
-      user = create(:user)
-      create(:organizer_position, user:, event: source_event)
-      authenticate(user)
-
-      get :show, params: { id: disbursement.id }, as: :json
-
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "allows lookups by internal ID for admins" do
-      authenticate(create(:user, :make_admin), scopes: "admin:read")
-
-      get :show, params: { id: disbursement.id }, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id" => disbursement.public_id)
-    end
   end
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->

Previously only `GET /api/v4/wires/:id` and GET /api/v4/checks/:id` existed (get by public ID). Given that we were also adding web endpoints for getting outgoing transfers via internal ID, Mohamad allowed me to implement finding by internal ID for API as well (partially for Steelyard).

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

- Added `show` endpoints for `AchTransfers`, `Disbursements`
- Edited the endpoints for `Checks` and `Wires`.
- Added `transfers:read` scope for all endpoints

Note endpoints do not yet exist for `WiseTransfers`, and I have not changed anything for incoming transfer types, e.g. `CheckDeposits`.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

