### PR TITLE
[Reimbursement] Fix "must be pending payout holding only" when sending a Wise transfer

### DIFF
--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -303,14 +303,22 @@ module Reimbursement
       clearinghouse = Event.find_by(id: EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING)
       payout_holding = @report.payout_holding
       payout_holding.with_lock do
-        unless payout_holding.settled?
-          payout_holding.expense_payouts.pending.each do |expense_payout|
-            Reimbursement::ExpensePayoutService::ProcessSingle.new(expense_payout_id: expense_payout.id).run
-          end
+        # `with_lock` reloads, so this sees a concurrent or repeated submission
+        # (two admins, two tabs, a resubmitted form) that already sent a
+        # transfer for this holding. Carrying on would pay the recipient twice.
+        raise ArgumentError, "A Wise transfer has already been sent for this report." if payout_holding.wise_transfer.present? || payout_holding.sent?
+
+        payout_holding.expense_payouts.pending.each do |expense_payout|
+          Reimbursement::ExpensePayoutService::ProcessSingle.new(expense_payout_id: expense_payout.id).run
+        end
+        # An earlier attempt may have already moved the holding along, so only
+        # run the steps that are still outstanding; `ProcessSingle` accepts
+        # pending holdings only, and `mark_settled!` in transit & failed ones.
+        if payout_holding.pending?
           Reimbursement::PayoutHoldingService::ProcessSingle.new(payout_holding_id: payout_holding.id).run
           payout_holding.reload
-          payout_holding.mark_settled!
         end
+        payout_holding.mark_settled! if payout_holding.may_mark_settled?
         wise_payout_method = @report.payout_method&.details
         wise_payout_method.update(wise_recipient_id: params[:wise_recipient_id])
         wise_transfer = clearinghouse.wise_transfers.create!(
@@ -343,7 +351,7 @@ module Reimbursement
       end
 
       redirect_to @report
-    rescue ActiveRecord::RecordInvalid => e
+    rescue ActiveRecord::RecordInvalid, ArgumentError, AASM::InvalidTransition => e
       flash[:error] = e.message
       redirect_to @report
     end

--- a/spec/controllers/reimbursement/reports_controller_spec.rb
+++ b/spec/controllers/reimbursement/reports_controller_spec.rb
@@ -373,4 +373,88 @@ RSpec.describe Reimbursement::ReportsController do
       expect(report.reload).to be_present
     end
   end
+  describe "#admin_send_wise_transfer" do
+    # A payout holding lives in the reimbursement clearinghouse, so the action
+    # needs that event to exist under its hardcoded ID.
+    def clearinghouse
+      Event.find_by(id: EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING) ||
+        create(:event, id: EventMappingEngine::EventIds::REIMBURSEMENT_CLEARING)
+    end
+
+    def wise_report
+      user = create(:user)
+      user.personal_legal_entity.payout_methods.create!(
+        default: true,
+        details: LegalEntity::PayoutMethod::WiseTransfer.new(
+          address_line1: "1 Main St", address_city: "London", address_state: "England",
+          address_postal_code: "SW1A 1AA", recipient_country: 1, currency: "GBP"
+        )
+      )
+      report = create(:reimbursement_report, user:, event: create(:event), aasm_state: :reimbursement_approved, currency: "GBP")
+      create(:reimbursement_expense, report:, value: 10.00, aasm_state: :approved)
+      report
+    end
+
+    def send_params(report)
+      {
+        report_id: report.id,
+        wise_id: "12345678",
+        wise_recipient_id: "00000000-0000-0000-0000-000000000001"
+      }
+    end
+
+    before do
+      clearinghouse
+      allow(User).to receive(:system_user).and_return(create(:user, email: User::SYSTEM_USER_EMAIL))
+      allow(ColumnService).to receive(:post)
+      allow(ColumnService::Accounts).to receive(:id_of).and_return("bacc_test")
+    end
+
+    it "sends the transfer for a pending payout holding" do
+      report = wise_report
+      holding = Reimbursement::PayoutHolding.create!(report:, amount_cents: 10_00)
+
+      create_session(create(:user, :make_admin), verified: true)
+
+      post(:admin_send_wise_transfer, params: send_params(report))
+
+      expect(flash[:error]).to be_nil
+      expect(holding.reload).to be_sent
+      expect(holding.wise_transfer).to be_present
+    end
+
+    # Regression: the action used to run `PayoutHoldingService::ProcessSingle`
+    # for anything that wasn't settled, and that service accepts pending
+    # holdings only — so an interrupted first attempt left the report stuck
+    # behind a "must be pending payout holding only" ArgumentError.
+    it "resumes an attempt that already moved the holding out of pending" do
+      report = wise_report
+      holding = Reimbursement::PayoutHolding.create!(report:, amount_cents: 10_00)
+      holding.mark_in_transit!
+
+      create_session(create(:user, :make_admin), verified: true)
+
+      post(:admin_send_wise_transfer, params: send_params(report))
+
+      expect(flash[:error]).to be_nil
+      expect(holding.reload).to be_sent
+      expect(holding.wise_transfer).to be_present
+    end
+
+    it "refuses to send a second transfer for a holding that already has one" do
+      report = wise_report
+      holding = Reimbursement::PayoutHolding.create!(report:, amount_cents: 10_00)
+
+      create_session(create(:user, :make_admin), verified: true)
+      post(:admin_send_wise_transfer, params: send_params(report))
+      expect(holding.reload).to be_sent
+      first_transfer = holding.wise_transfer
+
+      post(:admin_send_wise_transfer, params: send_params(report))
+
+      expect(flash[:error]).to match(/already been sent/i)
+      expect(holding.reload.wise_transfer).to eq(first_transfer)
+      expect(WiseTransfer.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## The error

```
ArgumentError: must be pending payout holding only
app/services/reimbursement/payout_holding_service/process_single.rb:11
app/controllers/reimbursement/reports_controller.rb:310 in Reimbursement::ReportsController#admin_send_wise_transfer
```

## Cause

`admin_send_wise_transfer` guarded its payout processing with `unless payout_holding.settled?`, but `Reimbursement::PayoutHolding` has six states. The guard only skipped one of them, so a holding sitting in `in_transit`, `sent`, or `failed` fell straight into `PayoutHoldingService::ProcessSingle`, which accepts `pending` holdings only.

The realistic trigger is a repeated submission. The action holds a row lock while it calls Column and creates records, so a second POST (two admins working the queue, two tabs, a resubmitted form) blocks on `with_lock`, then reloads to find the holding already `sent` — not `settled` — and re-enters the block.

The guard came in with #12554, which fixed the settled case but left the rest.

## The double-payment path behind it

That crash was also the only thing preventing a duplicate transfer. If a holding ever reached `settled` *with* a `wise_transfer` already attached, the old guard would skip processing and go straight on to create a second `WiseTransfer`, approve it, and mark it sent — paying the recipient twice.

## Changes

- An explicit guard raises if the holding already has a `wise_transfer` or is `sent`. `with_lock` reloads, so it is evaluated after any concurrent submission has committed; the duplicate-payment path is now closed deliberately rather than by accident.
- Processing is driven by what is actually outstanding: `ProcessSingle` runs only when the holding is `pending`, and `mark_settled!` only when `may_mark_settled?` (in transit or failed). An interrupted attempt resumes instead of dead-ending.
- The rescue also catches `ArgumentError` and `AASM::InvalidTransition`, so an unexpected state gives the admin a flash rather than a 500.

## Testing

Three specs in `spec/controllers/reimbursement/reports_controller_spec.rb` cover the pending happy path, resuming a holding already out of `pending`, and refusing a second transfer. Reverting the controller makes two of them fail with the exact production error; with the fix all 23 examples in the file pass, and RuboCop is clean.

Note: this fixes the endpoint, not the holding that hit it in production — that one is likely still mid-state, though it can now be retried through the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)