### PR TITLE
[Reimbursement] Fix `NoMethodError` on nil when inviting to an eventless report

### DIFF
--- a/app/jobs/discord/handle_interaction_job.rb
+++ b/app/jobs/discord/handle_interaction_job.rb
@@ -151,7 +151,7 @@ module Discord
     def reimburse_component
       return require_linked_user unless @user
 
-      report = @user.reimbursement_reports.create!(name: "Reimbursement report from Discord")
+      report = @user.reimbursement_reports.create!(name: "Reimbursement report from Discord", inviter: @user)
 
       respond content: "Your new reimbursement report has been created!", embeds: [
         {

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -109,7 +109,9 @@ module Reimbursement
     before_create :set_payout_method
 
     after_create_commit do
-      ReimbursementMailer.with(report: self).invitation.deliver_later if inviter != user
+      # Eventless draft reports (created via Discord, SMS, or email) have nobody
+      # to invite on behalf of; the invitation email is entirely event-scoped.
+      ReimbursementMailer.with(report: self).invitation.deliver_later if inviter != user && event.present?
       Reimbursement::OneDayReminderJob.set(wait: 1.day).perform_later(self)
       Reimbursement::SevenDaysReminderJob.set(wait: 7.days).perform_later(self)
     end

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -97,4 +97,31 @@ RSpec.describe Reimbursement::Report, type: :model do
       end
     end
   end
+
+  describe "the invitation email" do
+    it "is sent when somebody else invited the user" do
+      inviter = create(:user)
+
+      expect {
+        create(:reimbursement_report, user: create(:user), inviter:)
+      }.to have_enqueued_mail(ReimbursementMailer, :invitation)
+    end
+
+    it "is not sent when the user created the report themselves" do
+      user = create(:user)
+
+      expect {
+        create(:reimbursement_report, user:, inviter: user)
+      }.not_to have_enqueued_mail(ReimbursementMailer, :invitation)
+    end
+
+    # Eventless draft reports come in from Discord, SMS, and email, and the
+    # invitation email is event-scoped from its subject line down. Enqueuing it
+    # for one raised NoMethodError on nil in the mail delivery job.
+    it "is not sent for an eventless draft report" do
+      expect {
+        create(:reimbursement_report, user: create(:user), event: nil, inviter: nil)
+      }.not_to have_enqueued_mail(ReimbursementMailer, :invitation)
+    end
+  end
 end


### PR DESCRIPTION
## The error

```
NoMethodError: undefined method 'name' for nil
app/mailers/reimbursement_mailer.rb:7 in ReimbursementMailer#invitation
```

## Root cause

`Reimbursement::Report#event` is `optional: true` — draft reports can legitimately have no event. But the `after_create_commit` hook only guarded the invitation email on the inviter:

```ruby
ReimbursementMailer.with(report: self).invitation.deliver_later if inviter != user
```

Three code paths create eventless reports off `user.reimbursement_reports`. Two pass `inviter: @user`, so `inviter != user` is false and no mail is sent:

- `app/mailboxes/reimbursement_mailbox.rb:19` — email-in
- `app/jobs/twilio/process_webhook_job.rb:25` — SMS

The third set no inviter at all:

- `app/jobs/discord/handle_interaction_job.rb:154` — Discord `/reimburse`

With `inviter` nil, `nil != user` is true, so the invitation email was enqueued for a report with no event. `@report.event.name` in the subject line then raised on nil. (`hcb_email_with_name_of` uses `try(:name)`, so it was the subject interpolation, not the `from:`.)

## The fix

Two layers, because either alone leaves a hole:

1. **Discord** now passes `inviter: @user`, matching the two sibling self-service paths. A user creating their own report has nobody to be invited by.

2. **The enqueue is guarded on `event.present?`.** `invitation.html.erb` references `@report.event` seven times, so an eventless report can never render a valid invitation — the mail should never be enqueued regardless of who created it. This also covers a second route to the same crash: `Event` is `acts_as_paranoid`, so a soft-deleted event makes `report.event` return nil even for an already-event-backed report.

## Testing

Three specs in `spec/models/reimbursement/report_spec.rb` cover mail sent / not sent / eventless. The eventless one genuinely reproduces the bug — reverting the guard makes it fail with `expected not to enqueue ReimbursementMailer.invitation ... but enqueued 1`.

With both fixes in place, 20 examples across `spec/models/reimbursement`, `spec/mailers/reimbursement_mailer_spec.rb`, and `spec/mailboxes` pass, and RuboCop is clean on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
