### PR TITLE
[Event::Application] Fix 500 on the agreement page when no contract exists

### DIFF
--- a/app/controllers/event/applications_controller.rb
+++ b/app/controllers/event/applications_controller.rb
@@ -166,13 +166,20 @@ class Event
     def agreement
       authorize @application
 
+      @contract = @application.contract
+      @party = @contract&.party(:signee)
+
+      # There's nothing to sign until the contract has been sent (teenagers get
+      # it on submission, adults on approval) and it's gone once it's voided.
+      if @party.nil?
+        redirect_to application_path(@application)
+        return
+      end
+
       unless @application.videos_watched
         redirect_to videos_application_path(@application)
         return
       end
-
-      @contract = @application.contract
-      @party = @contract.party :signee
     end
 
     def mark_videos_watched


### PR DESCRIPTION
## Summary of the problem

`GET /applications/:id/agreement` throws `NoMethodError: undefined method 'party' for nil` (`app/controllers/event/applications_controller.rb:175`).

`Event::ApplicationsController#agreement` assigned `@contract = @application.contract` and immediately called `@contract.party(:signee)`. The `contract` association is `has_one ->{ where.not(aasm_state: :voided) }`, and a contract only exists once `send_contract` has run — on submission for teen-led applications, on approval for adults. So the page 500s whenever it's opened while no live contract exists:

- a still-draft application (or one an admin moved back to draft) where `videos_watched` is already `true`, so the videos redirect doesn't fire
- an adult applicant who has submitted but isn't approved yet
- a rejected application — `mark_rejected` voids the contract, so the association goes `nil` and a bookmarked or back-button hit on the URL crashes
- an auditor viewing someone else's application (`agreement?` aliases `show?`, which permits auditors)

The application page only links here when `contract.present?`, which is why this only surfaces through direct navigation.

## Describe your changes

Resolve the contract and signee party before anything else, and redirect to the application page when there's nothing to sign; the `videos_watched` check now runs after. Guarding on the party rather than the contract also covers `contract/parties/_docuseal_embed`, which dereferences `party.docuseal_signature_url` unconditionally.

No spec added — there's no existing request spec for this controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)