### PR TITLE
[Search] Scope card grant overview search to the viewer, add email to reimbursement search

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -25,7 +25,13 @@ class CardGrantsController < ApplicationController
     card_grants_per_page = safe_per(20)
 
     @card_grants = @event.card_grants.includes(:disbursement, :user, :stripe_card, :pre_authorization, :subledger, :reimbursement_report).order(created_at: :desc)
-    @card_grants = @card_grants.search_for(params[:q]) if params[:q].present?
+    if params[:q].present?
+      @card_grants = if organizer_signed_in?
+                       @card_grants.search(params[:q])
+                     else
+                       @card_grants.public_search(params[:q])
+                     end
+    end
     @paginated_card_grants = @card_grants.page(card_grants_page).per(card_grants_per_page)
   end
 

--- a/app/models/card_grant.rb
+++ b/app/models/card_grant.rb
@@ -109,7 +109,8 @@ class CardGrant < ApplicationRecord
 
   scope :not_activated, -> { active.where(stripe_card_id: nil) }
   scope :activated, -> { active.where.not(stripe_card_id: nil) }
-  scope :search_for, ->(q) { joins(:user).where("users.full_name ILIKE :query OR card_grants.email ILIKE :query OR card_grants.purpose ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
+  scope :search, ->(q) { joins(:user).where("users.full_name ILIKE :query OR card_grants.email ILIKE :query OR card_grants.purpose ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
+  scope :public_search, ->(q) { joins(:user).where("users.preferred_name ILIKE :query OR card_grants.purpose ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
   scope :expired_before, ->(date) { where("card_grants.expiration_at < ?", date) }
   scope :expires_on, ->(date) { where("card_grants.expiration_at = DATE(?)", date) }
 

--- a/app/models/reimbursement/report.rb
+++ b/app/models/reimbursement/report.rb
@@ -88,7 +88,7 @@ module Reimbursement
 
     attribute :name, :string, default: -> { "Expenses from #{Time.now.strftime("%B %e, %Y")}" }
 
-    scope :search, ->(q) { joins("LEFT JOIN users AS u2 on u2.id = reimbursement_reports.user_id").where("u2.full_name ILIKE :query OR reimbursement_reports.name ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
+    scope :search, ->(q) { joins("LEFT JOIN users AS u2 on u2.id = reimbursement_reports.user_id").where("u2.full_name ILIKE :query OR u2.email ILIKE :query OR reimbursement_reports.name ILIKE :query", query: "%#{User.sanitize_sql_like(q)}%") }
     scope :pending, -> { where(aasm_state: ["draft", "submitted", "reimbursement_requested"]) }
     scope :to_calculate_total, -> { where.not(aasm_state: ["rejected"]) }
     scope :visible, -> { joins(:user).where.not(user: { full_name: nil }, invited_by_id: nil) }

--- a/spec/controllers/card_grants_controller_spec.rb
+++ b/spec/controllers/card_grants_controller_spec.rb
@@ -63,6 +63,41 @@ RSpec.describe CardGrantsController do
     end
   end
 
+  describe "#card_index" do
+    def create_grant(event:, full_name:, email:)
+      user = create(:user, full_name:, email:)
+      create(:card_grant, event:, user:, email:, purpose: "Pizza")
+    end
+
+    def search(event, query)
+      get(:card_index, params: { event_id: event.friendly_id, q: query })
+      expect(response).to have_http_status(:ok)
+      response.parsed_body.css("a[href*='/spending']").map { |a| a["href"] }
+    end
+
+    it "lets organizers search by email and full name" do
+      organizer = create(:user)
+      event = create(:event, :with_positive_balance, plan_type: Event::Plan::HackClubAffiliate)
+      create(:organizer_position, user: organizer, event:, role: :member)
+      card_grant = create_grant(event:, full_name: "Orpheus Dinosaur", email: "orpheus@hackclub.com")
+      create_session(organizer, verified: true)
+
+      expect(search(event, "orpheus@hackclub.com")).to eq([spending_card_grant_path(card_grant)])
+      expect(search(event, "Dinosaur")).to eq([spending_card_grant_path(card_grant)])
+    end
+
+    it "doesn't let non-organizers search by email or full name" do
+      event = create(:event, :with_positive_balance, plan_type: Event::Plan::HackClubAffiliate)
+      card_grant = create_grant(event:, full_name: "Orpheus Dinosaur", email: "orpheus@hackclub.com")
+
+      expect(search(event, "orpheus@hackclub.com")).to be_empty
+      expect(search(event, "Dinosaur")).to be_empty
+
+      # ...but they can still search over what the page shows them.
+      expect(search(event, "Pizza")).to eq([spending_card_grant_path(card_grant)])
+    end
+  end
+
   describe "#create" do
     def card_grant_params
       {

--- a/spec/models/reimbursement/report_spec.rb
+++ b/spec/models/reimbursement/report_spec.rb
@@ -56,6 +56,30 @@ RSpec.describe Reimbursement::Report, type: :model do
     end
   end
 
+  describe ".search" do
+    let!(:report) do
+      user = create(:user, full_name: "Orpheus Dinosaur", email: "orpheus@hackclub.com")
+      create(:reimbursement_report, user:, name: "Sticker printing")
+    end
+
+    it "matches on the reimbursee's email" do
+      expect(described_class.search("orpheus@hackclub.com")).to eq([report])
+      expect(described_class.search("@hackclub.com")).to eq([report])
+    end
+
+    it "matches on the reimbursee's full name" do
+      expect(described_class.search("dinosaur")).to eq([report])
+    end
+
+    it "matches on the report name" do
+      expect(described_class.search("sticker")).to eq([report])
+    end
+
+    it "returns nothing when there's no match" do
+      expect(described_class.search("nobody@example.com")).to be_empty
+    end
+  end
+
   describe "payout method association" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary of the problem

Two search scopes had drifted from what the pages around them actually show:

- The **card grant overview** (`/:event/card_grants`) is readable by anyone on a transparent organization, but its search matched `card_grants.email` and `users.full_name`. Neither is rendered in that table — it shows `user_mention`, i.e. `initial_name`, which abbreviates the surname to a single letter.
- The **reimbursement reports** page shows each reimbursee's email and includes it in the CSV export, but you couldn't search by it — only by full name and report name.

## Describe your changes

**Card grants.** `CardGrant.search_for` is split into two scopes:

- `search` — unchanged fields (full name, email, purpose), used for organizers (reader and above) and auditors.
- `public_search` — `users.preferred_name` and `card_grants.purpose`, i.e. what the page renders, used for everyone else.

`CardGrantsController#card_index` picks between them on `organizer_signed_in?`, which matches the `auditor_or_reader?` half of the `card_grant_overview?` policy. This follows the same pattern as the team directory search in `EventsController#team`, which already narrows fields for non-organizers.

**Reimbursements.** `Reimbursement::Report.search` now also matches `u2.email`, reusing the join that's already there. Its three callers are all appropriately scoped: the events page is organizer-gated, `MyController#reimbursements` covers your own reports plus ones you manage or are assigned, and the global search bar filters every result through `Reimbursement::ReportPolicy#show?` in `SearchService::Authorizer`.

Specs cover both: `CardGrantsController#card_index` for the organizer and non-organizer search paths, and `Reimbursement::Report.search` for email, full name, report name, and no-match. Both new specs fail against the previous scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
