### PR TITLE
[Cards] Show card names in the org card overview grid

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -479,7 +479,7 @@ class EventsController < ApplicationController
 
     @has_filter = @status.present? || @type.present? || @user.present?
 
-    all_stripe_cards = @event.stripe_cards.where.missing(:card_grant).joins(:stripe_cardholder, :user)
+    all_stripe_cards = @event.stripe_cards.where.missing(:card_grant).joins(:stripe_cardholder, :user).includes(:card_grant)
                              .order("stripe_status asc, created_at desc")
 
     all_stripe_cards = all_stripe_cards.where(user: { id: @user.id }) if @user

--- a/app/views/events/card_overview.html.erb
+++ b/app/views/events/card_overview.html.erb
@@ -51,7 +51,7 @@
       <%= render "event_cards_table", stripe_cards: @paginated_stripe_cards, status: @status %>
     <% else %>
       <article class="mixed-grid grid--spacious">
-        <%= render partial: "stripe_cards/stripe_card", collection: @paginated_stripe_cards %>
+        <%= render partial: "stripe_cards/stripe_card", collection: @paginated_stripe_cards, locals: { show_purpose: true } %>
       </article>
 
       <% if @paginated_stripe_cards.blank? %>


### PR DESCRIPTION
## Summary of the problem

In the grid view of an organization's card overview, cards render with no label underneath, so there's no way to tell them apart at a glance — you have to click into each one. The `stripe_cards/stripe_card` partial already supports a `show_purpose` local for exactly this, and both My Cards and the dashboard pass it; the org card overview just didn't.

## Describe your changes

- Pass `show_purpose: true` to the collection render in `events/card_overview`, so each card in the grid gets its name underneath.
- Preload `card_grant` in the controller. The partial branches on `stripe_card.card_grant.present?`, and `where.missing(:card_grant)` uses a left join that doesn't populate the association, so without the preload each of the 18 cards on a page would fire its own query.

Worth flagging: this scope is `where.missing(:card_grant)`, so cards on this page never have a grant and every card renders `stripe_card.name` — the purpose branch of the partial is unreachable here. If the intent was to surface card grant purposes on this page too, that'd mean changing the controller scope to stop excluding grant-backed cards, which felt out of scope for this change.

Only affects the grid view; the list view already shows names via `event_cards_table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)