### PR TITLE
[Stripe Card Personalization Designs] Add not-null constraint to color column, remove fallback

### DIFF
--- a/app/models/stripe_card/personalization_design.rb
+++ b/app/models/stripe_card/personalization_design.rb
@@ -5,7 +5,7 @@
 # Table name: stripe_card_personalization_designs
 #
 #  id                        :bigint           not null, primary key
-#  color                     :string
+#  color                     :string           not null
 #  common                    :boolean          default(FALSE), not null
 #  stale                     :boolean          default(FALSE), not null
 #  stripe_card_logo          :string
@@ -48,11 +48,6 @@ class StripeCard
     validate :common_designs_must_not_belong_to_an_event
 
     enum :color, { black: "black", white: "white" }
-
-    # TODO: remove after backfill populates the color column for all designs
-    def color
-      read_attribute(:color) || StripeService.physical_bundle_ids.invert[stripe_physical_bundle_id]&.to_s
-    end
 
     scope :active, -> { where(stripe_status: "active") }
     scope :inactive, -> { where(stripe_status: "inactive") }

--- a/db/migrate/20260908162254_add_not_null_to_stripe_card_personalization_design_color.rb
+++ b/db/migrate/20260908162254_add_not_null_to_stripe_card_personalization_design_color.rb
@@ -1,0 +1,5 @@
+class AddNotNullToStripeCardPersonalizationDesignColor < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :stripe_card_personalization_designs, "color IS NOT NULL", name: "stripe_card_personalization_designs_color_null", validate: false
+  end
+end

--- a/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
+++ b/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
@@ -1,0 +1,7 @@
+class ValidateNotNullOnStripeCardPersonalizationDesignColor < ActiveRecord::Migration[8.1]
+  def change
+    validate_check_constraint :stripe_card_personalization_designs, name: "stripe_card_personalization_designs_color_null"
+    change_column_null :stripe_card_personalization_designs, :color, false
+    remove_check_constraint :stripe_card_personalization_designs, name: "stripe_card_personalization_designs_color_null"
+  end
+end

--- a/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
+++ b/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
@@ -7,5 +7,6 @@ class ValidateNotNullOnStripeCardPersonalizationDesignColor < ActiveRecord::Migr
 
   def down
     change_column_null :stripe_card_personalization_designs, :color, true
+    add_check_constraint :stripe_card_personalization_designs, "color IS NOT NULL", name: "stripe_card_personalization_designs_color_null", validate: false
   end
 end

--- a/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
+++ b/db/migrate/20260908162456_validate_not_null_on_stripe_card_personalization_design_color.rb
@@ -1,7 +1,11 @@
 class ValidateNotNullOnStripeCardPersonalizationDesignColor < ActiveRecord::Migration[8.1]
-  def change
+  def up
     validate_check_constraint :stripe_card_personalization_designs, name: "stripe_card_personalization_designs_color_null"
     change_column_null :stripe_card_personalization_designs, :color, false
     remove_check_constraint :stripe_card_personalization_designs, name: "stripe_card_personalization_designs_color_null"
+  end
+
+  def down
+    change_column_null :stripe_card_personalization_designs, :color, true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_150254) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_162456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -2501,7 +2501,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_150254) do
   end
 
   create_table "stripe_card_personalization_designs", force: :cascade do |t|
-    t.string "color"
+    t.string "color", null: false
     t.boolean "common", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "event_id"


### PR DESCRIPTION
backfill is done! color column is populated for all 10k+ designs. remove the read_attribute fallback and enforce not-null at the DB level.