### PR TITLE
[Exports] Remove unimplemented RESTful routes for `ExportsController`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -596,7 +596,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :exports do
+  resources :exports, only: [] do
     collection do
       get "collect_email", to: "exports#collect_email", as: "collect_email"
       get ":event", to: "exports#transactions", as: "transactions"


### PR DESCRIPTION
## Summary of the problem

`GET /exports` throws an error report rather than 404ing:

```
AbstractController::ActionNotFound: The action 'index' could not be found for ExportsController
ExportsController#index — GET /exports
```

`resources :exports` was generating the full RESTful route set — `index`, `create`, `new`, `edit`, `show`, `update`, `destroy` — but `ExportsController` only implements `transactions`, `reimbursements`, and `collect_email`. So a request to `/exports` (a crawler, a truncated link, someone trimming a URL in the address bar) matched a real route and then blew up *inside* the controller, which reports as a server error instead of an ordinary routing 404.

## Describe your changes

Restricted the resource to `only: []`, which keeps the three collection routes in the block and drops the seven that pointed at actions that don't exist.

Confirmed with `bin/rails routes` that only the real routes remain:

```
collect_email_exports   GET   /exports/collect_email(.:format)          exports#collect_email
 transactions_exports   GET   /exports/:event(.:format)                 exports#transactions
reimbursements_exports  GET   /exports/reimbursements/:event(.:format)  exports#reimbursements
```

Also grepped `app`, `lib`, `config`, and `spec` for export path helpers — the only ones in use are `transactions_exports_path`, `reimbursements_exports_path`, and `collect_email_exports_path`, all of which are unaffected.

One incidental behavior change: `/exports/new` previously raised `ActionNotFound` and now falls through to `exports#transactions` with `event: "new"`, which ends in `SetEvent`'s `RecordNotFound` rescue and redirects to root with "We couldn't find that organization!" — a graceful outcome either way.