### PR TITLE
[Receipts] Auto rotate when detected as sideways

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
       - uses: ./.github/actions/setup-ruby
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-db
+      # ubuntu-24.04 runners no longer ship ImageMagick, which MiniMagick
+      # shells out to for the receipt image specs. Production gets it from
+      # the ruby base image. setup-ruby already ran `apt-get update`.
+      - name: Install ImageMagick
+        run: sudo apt-get install -y --fix-missing imagemagick
       - name: Build Assets
         run: yarn build && yarn build:css
       - name: Run RSpec

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -259,12 +259,39 @@ class Receipt < ApplicationRecord
 
   def tesseract_ocr_text
     file.blob.open do |tempfile|
-      words = ::RTesseract.new(ImageProcessing::MiniMagick.source(tempfile.path).convert!("png").path).to_box
+      png = ImageProcessing::MiniMagick.source(tempfile.path).convert!("png")
+
+      # People often photograph receipts sideways or upside down. Tesseract
+      # reads rotated text fine, but the image is then shown sideways to
+      # everyone reviewing it. Since we already have the image open here, fix
+      # the stored file and OCR the corrected version.
+      if (rotation = ::ReceiptService::DetectRotation.new(path: png.path).run)
+        rotate_file!(tempfile.path, rotation)
+        png = ImageProcessing::MiniMagick.source(png.path).rotate(rotation).call
+      end
+
+      words = ::RTesseract.new(png.path).to_box
       words = words.select { |w| w[:confidence] > 85 }
       words = words.map { |w| w[:word] }
       text = words.join(" ")
       text.length > 50 ? text : nil
     end
+  end
+
+  # Replaces the attached file with a copy rotated clockwise by `degrees`.
+  # PNGs and JPEGs keep their format; anything else (HEIC, WebP, TIFF, ...)
+  # is written out as a JPEG since ImageMagick can't reliably encode them all.
+  def rotate_file!(source_path, degrees)
+    keep_format = file.content_type.in?(%w[image/png image/jpeg])
+
+    pipeline = ImageProcessing::MiniMagick.source(source_path).rotate(degrees)
+    pipeline = pipeline.convert("jpg") unless keep_format
+
+    file.attach(
+      io: pipeline.call,
+      filename: keep_format ? file.filename.to_s : "#{file.filename.base}.jpg",
+      content_type: keep_format ? file.content_type : "image/jpeg"
+    )
   end
 
   def has_owner

--- a/app/services/receipt_service/detect_rotation.rb
+++ b/app/services/receipt_service/detect_rotation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module ReceiptService
+  # Works out whether a receipt image was uploaded sideways or upside down.
+  #
+  # Uses Tesseract's orientation and script detection mode (`--psm 0`), which
+  # ships with the `tesseract-ocr` package we already install for OCR. Returns
+  # the clockwise rotation in degrees (90, 180 or 270) that would make the text
+  # upright, or nil when the image is already upright or Tesseract can't tell.
+  class DetectRotation
+    # Tesseract's "orientation confidence" is the margin between the best and
+    # second best orientation. Clean scans score around 8, blurry or skewed
+    # phone photos around 3-5, and guesses on images with too little text
+    # fall below 1. Rotating an upright receipt is worse than leaving a
+    # sideways one alone, so anything under this is treated as unknown.
+    MIN_CONFIDENCE = 2.0
+
+    def initialize(path:)
+      @path = path
+    end
+
+    def run
+      output, status = Open3.capture2e(RTesseract.config.command, @path.to_s, "stdout", "--psm", "0")
+      # Tesseract exits non-zero (e.g. "Too few characters") when it can't
+      # detect an orientation.
+      return nil unless status.success?
+
+      rotate = output[/^Rotate: (\d+)/, 1]&.to_i
+      confidence = output[/^Orientation confidence: ([\d.]+)/, 1]&.to_f
+      return nil if rotate.nil? || confidence.nil?
+      return nil if rotate.zero? || confidence < MIN_CONFIDENCE
+
+      rotate
+    end
+
+  end
+end

--- a/spec/models/receipt_spec.rb
+++ b/spec/models/receipt_spec.rb
@@ -13,6 +13,41 @@ RSpec.describe Receipt, type: :model do
     end
   end
 
+  describe "#extract_textual_content!" do
+    let(:receipt) { build_receipt(receiptable: create(:hcb_code), user: create(:user)).tap(&:save!) }
+    let(:words) { ("word " * 30).split.map { |w| { word: w, confidence: 99 } } }
+
+    before do
+      allow(RTesseract).to receive(:new).and_return(instance_double(RTesseract, to_box: words))
+    end
+
+    def dimensions(receipt)
+      image = MiniMagick::Image.read(receipt.file.download)
+      [image.width, image.height]
+    end
+
+    it "rotates the stored image when it was uploaded sideways" do
+      allow(ReceiptService::DetectRotation).to receive(:new).and_return(instance_double(ReceiptService::DetectRotation, run: 270))
+      expect(dimensions(receipt)).to eq([454, 678])
+
+      expect { receipt.extract_textual_content! }.to(change { receipt.reload.file.blob })
+
+      expect(dimensions(receipt)).to eq([678, 454])
+      expect(receipt.file.content_type).to eq("image/png")
+      expect(receipt.file.filename.to_s).to eq("receipt.png")
+      expect(receipt.textual_content).to be_present
+      expect(receipt).to be_tesseract_ocr_text
+    end
+
+    it "leaves the stored image alone when it is upright" do
+      allow(ReceiptService::DetectRotation).to receive(:new).and_return(instance_double(ReceiptService::DetectRotation, run: nil))
+
+      expect { receipt.extract_textual_content! }.not_to(change { receipt.reload.file.blob })
+      expect(dimensions(receipt)).to eq([454, 678])
+      expect(receipt.textual_content).to be_present
+    end
+  end
+
   describe "card locking" do
     include_context "card locking charges"
 

--- a/spec/services/receipt_service/detect_rotation_spec.rb
+++ b/spec/services/receipt_service/detect_rotation_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReceiptService::DetectRotation do
+  subject(:rotation) { described_class.new(path: "/tmp/receipt.png").run }
+
+  def stub_tesseract(output, success: true)
+    status = instance_double(Process::Status, success?: success)
+    allow(Open3).to receive(:capture2e)
+      .with("tesseract", "/tmp/receipt.png", "stdout", "--psm", "0")
+      .and_return([output, status])
+  end
+
+  def osd_output(rotate:, confidence:)
+    <<~OUTPUT
+      Page number: 0
+      Orientation in degrees: #{(360 - rotate) % 360}
+      Rotate: #{rotate}
+      Orientation confidence: #{confidence}
+      Script: Latin
+      Script confidence: 2.13
+    OUTPUT
+  end
+
+  it "returns the clockwise rotation needed to make the text upright" do
+    stub_tesseract(osd_output(rotate: 270, confidence: 8.35))
+    expect(rotation).to eq(270)
+  end
+
+  it "returns nil when the image is already upright" do
+    stub_tesseract(osd_output(rotate: 0, confidence: 8.04))
+    expect(rotation).to be_nil
+  end
+
+  it "returns nil when tesseract isn't confident" do
+    stub_tesseract(osd_output(rotate: 270, confidence: 0.63))
+    expect(rotation).to be_nil
+  end
+
+  it "returns nil when tesseract can't detect an orientation" do
+    stub_tesseract("Too few characters. Skipping this page\nError during processing.\n", success: false)
+    expect(rotation).to be_nil
+  end
+
+  it "returns nil when the output is missing the fields we need" do
+    stub_tesseract("Page number: 0\n")
+    expect(rotation).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary of the problem
#14417 
> I wish I could rotate pictures people submit for receipts. Sometimes they inexplicably decide to submit them sideways. Or upsidedown!




## Describe your changes
Turns out we have a DetectRotation feature built into our image library that we should use.