### PR TITLE
[Card Grant] Defrost one time use card if refund processes

### DIFF
--- a/app/jobs/card_grant/defrost_one_time_use_job.rb
+++ b/app/jobs/card_grant/defrost_one_time_use_job.rb
@@ -9,6 +9,10 @@ class CardGrant
 
     DEFROSTABLE_STATUSES = %w[reversed released].freeze
 
+    # Stripe rejects activating a card that it considers permanently unusable
+    # (a canceled card, most often). Retrying can't fix that.
+    discard_on(Stripe::InvalidRequestError) { |_job, error| Rails.error.report(error) }
+
     def perform(ledger_item_id:)
       item = Ledger::Item.find_by(id: ledger_item_id)
       return unless item&.linked_object_type == "CardCharge"

--- a/app/jobs/card_grant/defrost_one_time_use_job.rb
+++ b/app/jobs/card_grant/defrost_one_time_use_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CardGrant
+  # One-time-use grant cards are frozen by the system after their first
+  # authorization. When that charge is fully refunded or released, the grant's
+  # balance is restored, so we defrost the card while keeping it one-time-use.
+  class DefrostOneTimeUseJob < ApplicationJob
+    queue_as :default
+
+    DEFROSTABLE_STATUSES = %w[reversed released].freeze
+
+    def perform(ledger_item_id:)
+      item = Ledger::Item.find_by(id: ledger_item_id)
+      return unless item&.linked_object_type == "CardCharge"
+      return unless item.status.in?(DEFROSTABLE_STATUSES)
+
+      card = item.linked_object&.stripe_card
+      grant = card&.card_grant
+      return unless grant&.one_time_use? && grant.active?
+      return unless card.frozen? && card.last_frozen_by == User.system_user
+      return if other_live_charges?(card, item)
+
+      PaperTrail.request(whodunnit: User.system_user.id) do
+        card.defrost!(keep_one_time_use: true)
+      end
+    end
+
+    private
+
+    def other_live_charges?(card, item)
+      Ledger::Item
+        .where(linked_object_type: "CardCharge", linked_object_id: card.card_charges.select(:id))
+        .where.not(id: item.id)
+        .where(status: %w[pending settled])
+        .exists?
+    end
+
+  end
+
+end

--- a/app/jobs/card_grant/defrost_one_time_use_job.rb
+++ b/app/jobs/card_grant/defrost_one_time_use_job.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class CardGrant
-  # One-time-use grant cards are frozen by the system after their first
-  # authorization. When that charge is fully refunded or released, the grant's
-  # balance is restored, so we defrost the card while keeping it one-time-use.
+  # One-time-use grant cards are frozen by the system after each purchase. When
+  # the purchase that froze the card is refunded or released, the freeze has no
+  # reason to stand, so we defrost while keeping the grant one-time-use.
   class DefrostOneTimeUseJob < ApplicationJob
     queue_as :default
 
@@ -23,9 +23,9 @@ class CardGrant
       return unless grant&.one_time_use? && grant.active?
       # Organizers can't defrost a card while the org is frozen, so neither should we.
       return if card.event.financially_frozen?
-      # Only undo the freeze HCB applied for the first purchase.
+      # Only undo a freeze HCB applied, never an organizer's.
       return unless card.frozen? && card.last_frozen_by == User.system_user
-      return if other_live_charges?(card, item)
+      return unless froze_the_card?(card, item)
 
       PaperTrail.request(whodunnit: User.system_user.id) do
         card.defrost!(keep_one_time_use: true)
@@ -34,12 +34,11 @@ class CardGrant
 
     private
 
-    def other_live_charges?(card, item)
-      Ledger::Item
-        .where(linked_object_type: "CardCharge", linked_object_id: card.card_charges.select(:id))
-        .where.not(id: item.id)
-        .where(status: %w[pending settled])
-        .exists?
+    # The card is frozen because of its latest charge, so only that charge
+    # reversing lifts the freeze. Earlier charges were spent under freezes an
+    # organizer has since lifted.
+    def froze_the_card?(card, item)
+      card.card_charges.order(created_at: :desc, id: :desc).first&.id == item.linked_object_id
     end
 
   end

--- a/app/jobs/card_grant/defrost_one_time_use_job.rb
+++ b/app/jobs/card_grant/defrost_one_time_use_job.rb
@@ -17,6 +17,9 @@ class CardGrant
       card = item.linked_object&.stripe_card
       grant = card&.card_grant
       return unless grant&.one_time_use? && grant.active?
+      # Organizers can't defrost a card while the org is frozen, so neither should we.
+      return if card.event.financially_frozen?
+      # Only undo the freeze HCB applied for the first purchase.
       return unless card.frozen? && card.last_frozen_by == User.system_user
       return if other_live_charges?(card, item)
 

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -99,6 +99,11 @@ class Ledger
     after_create :map!
     after_touch :map!
 
+    # A refunded or voided charge on a one-time-use grant card should defrost it.
+    after_update_commit if: -> { linked_object_type == "CardCharge" && status_previously_changed? && status.in?(%w[reversed released]) } do
+      CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id: id)
+    end
+
     scope :missing_receipt, -> { where(receipt_required: true, marked_no_or_lost_receipt_at: nil, receipt_count: 0) }
 
     def status_text

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -101,7 +101,7 @@ class Ledger
 
     # A refunded or voided charge on a one-time-use grant card should defrost it.
     after_update_commit if: -> { linked_object_type == "CardCharge" && status_previously_changed? && status.in?(%w[reversed released]) } do
-      CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id: id)
+      CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id: id) if linked_object&.stripe_card&.card_grant
     end
 
     scope :missing_receipt, -> { where(receipt_required: true, marked_no_or_lost_receipt_at: nil, receipt_count: 0) }

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -101,12 +101,10 @@ class Ledger
 
     # Defrost one-time-use grant cards after a full refund or release.
     # Capture the status change before another refresh clears it, and enqueue after commit.
-    after_update if: -> { linked_object_type == "CardCharge" && saved_change_to_status? && status.in?(CardGrant::DefrostOneTimeUseJob::DEFROSTABLE_STATUSES) } do
-      if linked_object&.stripe_card&.card_grant
-        ledger_item_id = id
-        self.class.current_transaction.after_commit do
-          CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id:)
-        end
+    after_update if: -> { linked_object_type == "CardCharge" && linked_object&.stripe_card&.card_grant && saved_change_to_status? && status.in?(CardGrant::DefrostOneTimeUseJob::DEFROSTABLE_STATUSES) } do
+      ledger_item_id = id
+      self.class.current_transaction.after_commit do
+        CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id:)
       end
     end
 

--- a/app/models/ledger/item.rb
+++ b/app/models/ledger/item.rb
@@ -99,9 +99,15 @@ class Ledger
     after_create :map!
     after_touch :map!
 
-    # A refunded or voided charge on a one-time-use grant card should defrost it.
-    after_update_commit if: -> { linked_object_type == "CardCharge" && status_previously_changed? && status.in?(%w[reversed released]) } do
-      CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id: id) if linked_object&.stripe_card&.card_grant
+    # Defrost one-time-use grant cards after a full refund or release.
+    # Capture the status change before another refresh clears it, and enqueue after commit.
+    after_update if: -> { linked_object_type == "CardCharge" && saved_change_to_status? && status.in?(CardGrant::DefrostOneTimeUseJob::DEFROSTABLE_STATUSES) } do
+      if linked_object&.stripe_card&.card_grant
+        ledger_item_id = id
+        self.class.current_transaction.after_commit do
+          CardGrant::DefrostOneTimeUseJob.perform_later(ledger_item_id:)
+        end
+      end
     end
 
     scope :missing_receipt, -> { where(receipt_required: true, marked_no_or_lost_receipt_at: nil, receipt_count: 0) }

--- a/app/models/stripe_card.rb
+++ b/app/models/stripe_card.rb
@@ -214,11 +214,11 @@ class StripeCard < ApplicationRecord
     save!
   end
 
-  def defrost!
+  def defrost!(keep_one_time_use: false)
     StripeService::Issuing::Card.update(self.stripe_id, status: :active)
     sync_from_stripe!
     save!
-    card_grant.update(one_time_use: false) if card_grant&.one_time_use
+    card_grant.update(one_time_use: false) if card_grant&.one_time_use && !keep_one_time_use
   end
 
   def cancel!

--- a/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
+++ b/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
@@ -133,6 +133,17 @@ RSpec.describe CardGrant::DefrostOneTimeUseJob do
     expect(card.reload).to be_frozen
   end
 
+  it "leaves the card frozen when the organization is financially frozen" do
+    freeze_by(system_user)
+    card.event.update!(financially_frozen: true)
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
   it "does nothing when the item is no longer reversed or released" do
     freeze_by(system_user)
     item = ledger_item_for(card_charge_for(card), status: "settled")

--- a/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
+++ b/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CardGrant::DefrostOneTimeUseJob do
+  let(:system_user) { create(:user, email: User::SYSTEM_USER_EMAIL) }
+  let(:card_grant) { create(:card_grant, event: create(:event, :with_positive_balance), one_time_use: true) }
+  let(:card) { card_grant.stripe_card }
+
+  before do
+    allow(User).to receive(:system_user).and_return(system_user)
+    allow(Stripe::Issuing::Card).to receive(:update)
+    allow(Stripe::Issuing::Card).to receive(:retrieve).and_return(
+      Stripe::Issuing::Card.construct_from(
+        id: card.stripe_id,
+        status: "active",
+        type: "virtual",
+        brand: "Visa",
+        exp_month: 2,
+        exp_year: 2030,
+        last4: "9876",
+        spending_controls: { spending_limits: [] }
+      )
+    )
+  end
+
+  def freeze_by(user)
+    card.update!(stripe_status: "inactive", initially_activated: true, last_frozen_by: user)
+  end
+
+  def card_charge_for(stripe_card)
+    create(
+      :raw_pending_stripe_transaction,
+      stripe_transaction: {
+        "id"                   => "iauth_#{SecureRandom.hex(6)}",
+        "card"                 => { "id" => stripe_card.stripe_id },
+        "authorization_method" => "online",
+        "merchant_data"        => { "name" => "merchant", "category" => "bakeries" }
+      }
+    ).card_charge
+  end
+
+  def ledger_item_for(card_charge, status:)
+    item = Ledger::Item.new(amount_cents: 0, memo: "Test", datetime: Time.current, linked_object: card_charge)
+    item.save(validate: false)
+    item.update_columns(status:)
+    item
+  end
+
+  def perform(item)
+    described_class.perform_now(ledger_item_id: item.id)
+  end
+
+  it "defrosts the card when a one-time-use charge is fully refunded, keeping the grant one-time-use" do
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    expect(Stripe::Issuing::Card).to receive(:update).with(card.stripe_id, status: :active)
+
+    perform(item)
+
+    expect(card.reload).to be_active
+    expect(card_grant.reload.one_time_use).to eq(true)
+  end
+
+  it "defrosts the card when the authorization was released without capture" do
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "released")
+
+    perform(item)
+
+    expect(card.reload).to be_active
+  end
+
+  it "ignores other charges on the card that are themselves reversed or released" do
+    freeze_by(system_user)
+    ledger_item_for(card_charge_for(card), status: "released")
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(card.reload).to be_active
+  end
+
+  it "does nothing when another charge on the card is still pending" do
+    freeze_by(system_user)
+    ledger_item_for(card_charge_for(card), status: "pending")
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
+  it "does nothing when another charge on the card has settled" do
+    freeze_by(system_user)
+    ledger_item_for(card_charge_for(card), status: "settled")
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
+  it "does nothing when the grant is not one-time-use" do
+    card_grant.update!(one_time_use: false)
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
+  it "does nothing when the card is not frozen" do
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+  end
+
+  it "does not undo a freeze made by a person" do
+    freeze_by(create(:user))
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
+  it "does nothing when the item is no longer reversed or released" do
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "settled")
+
+    perform(item)
+
+    expect(Stripe::Issuing::Card).not_to have_received(:update)
+    expect(card.reload).to be_frozen
+  end
+
+  it "does not raise for a missing ledger item id" do
+    expect { described_class.perform_now(ledger_item_id: -1) }.not_to raise_error
+  end
+end

--- a/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
+++ b/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
@@ -157,4 +157,39 @@ RSpec.describe CardGrant::DefrostOneTimeUseJob do
   it "does not raise for a missing ledger item id" do
     expect { described_class.perform_now(ledger_item_id: -1) }.not_to raise_error
   end
+
+  %w[canceled expired].each do |status|
+    it "does not defrost a #{status} grant" do
+      freeze_by(system_user)
+      card_grant.update!(status:)
+      item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+      perform(item)
+
+      expect(Stripe::Issuing::Card).not_to have_received(:update)
+      expect(card.reload).to be_frozen
+    end
+  end
+
+  it "does not activate the card again when the job is repeated" do
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+
+    2.times { perform(item) }
+
+    expect(Stripe::Issuing::Card).to have_received(:update).once
+    expect(card_grant.reload).to be_one_time_use
+  end
+
+  it "reports a permanent Stripe rejection without retrying" do
+    freeze_by(system_user)
+    item = ledger_item_for(card_charge_for(card), status: "reversed")
+    error = Stripe::InvalidRequestError.new("Card is canceled", "status")
+    allow(Stripe::Issuing::Card).to receive(:update).and_raise(error)
+    expect(Rails.error).to receive(:report).with(error)
+
+    expect { perform(item) }.not_to raise_error
+
+    expect(card.reload).to be_frozen
+  end
 end

--- a/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
+++ b/spec/jobs/card_grant/defrost_one_time_use_job_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe CardGrant::DefrostOneTimeUseJob do
     expect(card.reload).to be_active
   end
 
-  it "ignores other charges on the card that are themselves reversed or released" do
+  it "ignores an earlier charge that already settled" do
     freeze_by(system_user)
-    ledger_item_for(card_charge_for(card), status: "released")
+    ledger_item_for(card_charge_for(card), status: "settled")
     item = ledger_item_for(card_charge_for(card), status: "reversed")
 
     perform(item)
@@ -82,10 +82,10 @@ RSpec.describe CardGrant::DefrostOneTimeUseJob do
     expect(card.reload).to be_active
   end
 
-  it "does nothing when another charge on the card is still pending" do
+  it "does nothing when a newer charge on the card is still pending" do
     freeze_by(system_user)
-    ledger_item_for(card_charge_for(card), status: "pending")
     item = ledger_item_for(card_charge_for(card), status: "reversed")
+    ledger_item_for(card_charge_for(card), status: "pending")
 
     perform(item)
 
@@ -93,10 +93,10 @@ RSpec.describe CardGrant::DefrostOneTimeUseJob do
     expect(card.reload).to be_frozen
   end
 
-  it "does nothing when another charge on the card has settled" do
+  it "does nothing when a newer charge on the card has settled" do
     freeze_by(system_user)
-    ledger_item_for(card_charge_for(card), status: "settled")
     item = ledger_item_for(card_charge_for(card), status: "reversed")
+    ledger_item_for(card_charge_for(card), status: "settled")
 
     perform(item)
 

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -483,6 +483,51 @@ RSpec.describe Ledger::Item, type: :model do
         .to have_enqueued_job(CardGrant::DefrostOneTimeUseJob).with(ledger_item_id: item.id)
     end
 
+    it "enqueues when a full refund refreshes the item through transaction callbacks" do
+      item = card_charge_item(linked_object: card_charge)
+      create(:canonical_transaction, ledger_item: item, amount_cents: -1000)
+      expect(item.reload).to be_settled
+
+      expect { create(:canonical_transaction, ledger_item: item, amount_cents: 1000) }
+        .to have_enqueued_job(CardGrant::DefrostOneTimeUseJob).with(ledger_item_id: item.id)
+
+      expect(item.reload).to be_reversed
+    end
+
+    it "waits until commit even when the item is saved again" do
+      item = card_charge_item(linked_object: card_charge)
+
+      expect do
+        Ledger::Item.transaction do
+          item.update!(status: :released)
+          item.reload.update!(custom_memo: "Released authorization")
+          expect(enqueued_jobs.pluck(:job)).not_to include(CardGrant::DefrostOneTimeUseJob)
+        end
+      end.to have_enqueued_job(CardGrant::DefrostOneTimeUseJob).with(ledger_item_id: item.id)
+    end
+
+    it "does not enqueue for a partial refund" do
+      item = card_charge_item(linked_object: card_charge)
+      create(:canonical_transaction, ledger_item: item, amount_cents: -1000)
+
+      expect { create(:canonical_transaction, ledger_item: item, amount_cents: 500) }
+        .not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+
+      expect(item.reload).to be_settled
+    end
+
+    it "does not enqueue when the status change is rolled back" do
+      item = card_charge_item(linked_object: card_charge)
+
+      expect do
+        Ledger::Item.transaction(requires_new: true) do
+          item.update!(status: :released)
+          raise ActiveRecord::Rollback
+        end
+        item.reload.update!(custom_memo: "Still pending")
+      end.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+    end
+
     it "does not enqueue for other status transitions" do
       item = card_charge_item(linked_object: card_charge)
 

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -445,6 +445,52 @@ RSpec.describe Ledger::Item, type: :model do
     end
   end
 
+  describe "one-time-use card grant defrost hook" do
+    include ActiveJob::TestHelper
+
+    def card_charge_item(linked_object:)
+      item = Ledger::Item.new(amount_cents: -1000, memo: "Test", datetime: Time.current, linked_object:)
+      item.save(validate: false)
+      item.reload
+    end
+
+    let(:card_charge) { create(:raw_pending_stripe_transaction).card_charge }
+
+    it "enqueues the defrost job when a card charge becomes reversed" do
+      item = card_charge_item(linked_object: card_charge)
+
+      expect { item.update!(status: :reversed) }
+        .to have_enqueued_job(CardGrant::DefrostOneTimeUseJob).with(ledger_item_id: item.id)
+    end
+
+    it "enqueues the defrost job when a card charge becomes released" do
+      item = card_charge_item(linked_object: card_charge)
+
+      expect { item.update!(status: :released) }
+        .to have_enqueued_job(CardGrant::DefrostOneTimeUseJob).with(ledger_item_id: item.id)
+    end
+
+    it "does not enqueue for other status transitions" do
+      item = card_charge_item(linked_object: card_charge)
+
+      expect { item.update!(status: :settled) }.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+    end
+
+    it "does not enqueue when the status is unchanged" do
+      item = card_charge_item(linked_object: card_charge)
+      item.update_columns(status: "reversed")
+
+      expect { item.update!(custom_memo: "Refund") }.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+    end
+
+    it "does not enqueue for items that are not card charges" do
+      stub_donation_payment_intent_creation
+      item = card_charge_item(linked_object: create(:donation))
+
+      expect { item.update!(status: :reversed) }.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+    end
+  end
+
   describe "#author" do
     it "is nobody for an in-person donation, which the donor paid rather than the organizer who collected it" do
       stub_donation_payment_intent_creation

--- a/spec/models/ledger/item_spec.rb
+++ b/spec/models/ledger/item_spec.rb
@@ -454,7 +454,20 @@ RSpec.describe Ledger::Item, type: :model do
       item.reload
     end
 
-    let(:card_charge) { create(:raw_pending_stripe_transaction).card_charge }
+    def charge_on(stripe_card)
+      create(
+        :raw_pending_stripe_transaction,
+        stripe_transaction: {
+          "id"                   => "iauth_#{SecureRandom.hex(6)}",
+          "card"                 => { "id" => stripe_card.stripe_id },
+          "authorization_method" => "online",
+          "merchant_data"        => { "name" => "merchant", "category" => "bakeries" }
+        }
+      ).card_charge
+    end
+
+    let(:card_grant) { create(:card_grant, event: create(:event, :with_positive_balance)) }
+    let(:card_charge) { charge_on(card_grant.stripe_card) }
 
     it "enqueues the defrost job when a card charge becomes reversed" do
       item = card_charge_item(linked_object: card_charge)
@@ -486,6 +499,12 @@ RSpec.describe Ledger::Item, type: :model do
     it "does not enqueue for items that are not card charges" do
       stub_donation_payment_intent_creation
       item = card_charge_item(linked_object: create(:donation))
+
+      expect { item.update!(status: :reversed) }.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
+    end
+
+    it "does not enqueue for a card that isn't a grant card" do
+      item = card_charge_item(linked_object: charge_on(create(:stripe_card, :with_stripe_id)))
 
       expect { item.update!(status: :reversed) }.not_to have_enqueued_job(CardGrant::DefrostOneTimeUseJob)
     end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14843 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
When a one time use card's last charge gets refunded (becomes reversed or released), the card is now defrosted automatically while remaining one time use.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

