### PR TITLE
[Admin] [Ledger] Navigate to transaction position in organization ledger

### DIFF
--- a/app/assets/stylesheets/components/_transactions.scss
+++ b/app/assets/stylesheets/components/_transactions.scss
@@ -254,8 +254,26 @@ details.receipt-card {
   max-width: 125px;
 }
 
+[class^='transaction--']:target,
+.transaction:target {
+  scroll-margin-block: 6rem;
+}
+
 [class^='transaction--']:target {
   animation: highlight 2s;
+}
+
+.transaction:target {
+  outline: 2px solid map-get($palette, warning);
+  outline-offset: -2px;
+  animation: highlight-row 2s;
+}
+
+[class^='transaction--']:target,
+.transaction:target {
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 .transaction__icon {
@@ -287,7 +305,7 @@ details.receipt-card {
     background-color: map-get($palette, warning);
   }
   to {
-    background-color: none;
+    background-color: transparent;
   }
 }
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,7 @@
 class EventsController < ApplicationController
   TRANSACTIONS_PER_PAGE = 75
   DONATIONS_PER_PAGE = 25
+  LEDGER_LOCATION_PARAMS = (SetLedgerFilters::FILTER_PARAMS + %i[q per]).freeze
 
   TREE_GUIDES = /\A[01]{0,#{Event::MAX_PARENT_DEPTH}}\z/
 
@@ -1331,6 +1332,8 @@ class EventsController < ApplicationController
       @items = @items.where(linked_object_type: "CardCharge", linked_object_id: CardCharge.where(merchant_network_id: @merchant).select(:id))
     end
 
+    return locate_ledger_item if params[:locate].present? && auditor_signed_in?
+
     @items = @items.page(params[:page]).per(@per).preload(:tags, hcb_code: { event: :tags })
   rescue Pundit::NotAuthorizedError
     return head :not_found
@@ -1349,6 +1352,17 @@ class EventsController < ApplicationController
   end
 
   private
+
+  def locate_ledger_item
+    destination = params.permit(*LEDGER_LOCATION_PARAMS).to_h.symbolize_keys.compact_blank
+    item = @items.find_by_hashid(params[:locate])
+    position = Ledger::Query.position_of(item, relation: @items)
+    unless position
+      return redirect_to event_ledger_path(@event, **destination), flash: { error: "That transaction isn't visible in this ledger. It may have been moved, removed, or excluded by filters." }
+    end
+
+    redirect_to event_ledger_path(@event, **destination, page: (position - 1) / @per + 1, anchor: helpers.dom_id(item))
+  end
 
   def process_hidden_param!(params_hash)
     if params_hash[:hidden] == "1" && !@event.hidden_at.present?

--- a/app/models/ledger/query.rb
+++ b/app/models/ledger/query.rb
@@ -69,6 +69,22 @@ class Ledger
              .preload(:hcb_code, :author, :linked_object)
     end
 
+    # Returns the item's 1-based position in the filtered, ordered relation.
+    # Filter by ID after ranking so the position isn't always 1.
+    def self.position_of(item, relation:)
+      return if item.nil?
+
+      window = Arel::Nodes::Window.new.order(*relation.arel.orders)
+      position = Arel::Nodes::NamedFunction.new("ROW_NUMBER", []).over(window).as("position")
+      ranked_items = relation.except(:preload).reselect(Ledger::Item.arel_table[:id], position).reorder(nil)
+
+      Ledger::Item.unscoped
+                  .from(ranked_items, :ledger_positions)
+                  .where(ledger_positions: { id: item.id })
+                  .pick(Arel.sql("ledger_positions.position"))
+                  &.to_i
+    end
+
     def self.sanitize_query(query_hash)
       # TODO: Implement query sanitization logic
       validate_complexity!(query_hash)

--- a/app/views/admin/transaction.html.erb
+++ b/app/views/admin/transaction.html.erb
@@ -36,6 +36,12 @@
       <th>HCB Code</th>
       <td><%= link_to @canonical_transaction.hcb_code, hcb_code_path(@canonical_transaction.local_hcb_code) %></td>
     </tr>
+    <% if @canonical_transaction.ledger_item&.primary_ledger&.event.present? %>
+      <tr>
+        <th>Ledger</th>
+        <td><%= render "ledger/items/locate", item: @canonical_transaction.ledger_item %></td>
+      </tr>
+    <% end %>
     <tr>
       <th>MappedBy</th>
       <td><%= @canonical_transaction.canonical_event_mapping.try(:user).try(:email) %></td>

--- a/app/views/hcb_codes/show.html.erb
+++ b/app/views/hcb_codes/show.html.erb
@@ -67,6 +67,7 @@
   <% admin_tool("p-2 my-3") do %>
     <h3 class="my-2">Quickly go to</h3>
     <% if @hcb_code.ledger_item.present? %>
+      <%= render "ledger/items/locate", item: @hcb_code.ledger_item %>
       <%= link_to "Ledger::Item #{@hcb_code.ledger_item.hashid}", ledger_item_path(@hcb_code.ledger_item), class: "btn btn--secondary" %>
     <% end %>
     <% @hcb_code.canonical_transactions.each do |tx| %>

--- a/app/views/ledger/_item.html.erb
+++ b/app/views/ledger/_item.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (item:, show_author: true) %>
 
-<tr class="transaction transaction--<%= item.sign %> <%= item.special_appearance&.css_class %>">
+<tr id="<%= dom_id(item) %>" class="transaction transaction--<%= item.sign %> <%= item.special_appearance&.css_class %>">
   <td class="transaction__icon">
     <div class="tooltipped tooltipped--e" aria-label="<%= item.humanized_type %>">
       <%= render "ledger/items/icon", ledger_item: item %>

--- a/app/views/ledger/items/_locate.html.erb
+++ b/app/views/ledger/items/_locate.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (item:) %>
+
+<% if auditor_signed_in? && (event = item&.primary_ledger&.event).present? %>
+  <%= link_to "Navigate to transaction position", event_ledger_path(event, locate: item.hashid), class: "btn btn--secondary", data: { turbo: false } %>
+<% end %>

--- a/app/views/ledger/items/show.html.erb
+++ b/app/views/ledger/items/show.html.erb
@@ -179,6 +179,7 @@
 
 <% admin_tool("p-2 my-3") do %>
   <h3 class="my-2">Quickly go to</h3>
+  <%= render "ledger/items/locate", item: @item %>
   <% if @item.hcb_code.present? %>
     <%= link_to @item.hcb_code.hcb_code, hcb_code_path(@item.hcb_code), class: "btn btn--secondary" %>
   <% end %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -200,6 +200,23 @@ RSpec.describe EventsController do
         expect(response.body).to include("Declined but moved money")
         expect(response.body).not_to include("Declined with no amount")
       end
+
+      it "redirects locate to the correct page and transaction fragment" do
+        older = create(:ledger_item, custom_memo: "Older funding", datetime: 2.days.ago)
+        Ledger::Mapping.create!(ledger: event.ledger, ledger_item: older, on_primary_ledger: true)
+        older.update_columns(status: "settled", amount_cents: 1000, ct_count: 1)
+
+        newer = create(:ledger_item, custom_memo: "Newer funding", datetime: 1.day.ago)
+        Ledger::Mapping.create!(ledger: event.ledger, ledger_item: newer, on_primary_ledger: true)
+        newer.update_columns(status: "settled", amount_cents: 1000, ct_count: 1)
+
+        get(:ledger, params: { event_id: event.slug, locate: older.hashid, per: 1 })
+
+        expect(response).to redirect_to(event_ledger_path(event, page: 2, per: 1, anchor: "ledger_item_#{older.id}"))
+        expect(response.location).to end_with("#ledger_item_#{older.id}")
+        expect(response.location).not_to include("anchor=")
+      end
+
     end
   end
 

--- a/spec/models/ledger/query_spec.rb
+++ b/spec/models/ledger/query_spec.rb
@@ -553,6 +553,25 @@ RSpec.describe Ledger::Query, type: :model do
     end
   end
 
+  describe ".position_of" do
+    it "ranks pending items first and breaks datetime ties by creation time and ID" do
+      timestamp = Time.zone.local(2024, 4, 1)
+      item_a.update_columns(status: "pending", datetime: timestamp - 1.day)
+      item_b.update_columns(status: "settled", datetime: timestamp + 1.day)
+      item_c.update_columns(status: "settled", datetime: timestamp, created_at: timestamp)
+      item_d.update_columns(status: "settled", datetime: timestamp, created_at: timestamp)
+      item_e.update_columns(status: "settled", datetime: timestamp, created_at: timestamp - 1.day)
+
+      relation = described_class.new({}).execute(ledgers: [test_ledger.id])
+                               .where(id: ids_of(item_a, item_b, item_c, item_d, item_e))
+
+      positions = [item_a, item_b, item_d, item_c, item_e].map do |item|
+        described_class.position_of(item, relation:)
+      end
+      expect(positions).to eq([1, 2, 3, 4, 5])
+    end
+  end
+
   describe "empty items" do
     it "excludes items with no CTs and no CPTs" do
       empty_item = create_mapped_item(amount_cents: 100, memo: "empty item", datetime: Date.new(2024, 1, 4))

--- a/spec/models/ledger/query_spec.rb
+++ b/spec/models/ledger/query_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Ledger::Query, type: :model do
       item_e.update_columns(status: "settled", datetime: timestamp, created_at: timestamp - 1.day)
 
       relation = described_class.new({}).execute(ledgers: [test_ledger.id])
-                               .where(id: ids_of(item_a, item_b, item_c, item_d, item_e))
+                                .where(id: ids_of(item_a, item_b, item_c, item_d, item_e))
 
       positions = [item_a, item_b, item_d, item_c, item_e].map do |item|
         described_class.position_of(item, relation:)


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14911


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Adds buttons for admins to navigate to a specific transaction on the ledger.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
Ledger item`/transaction/:hashid`
<img width="903" height="115" alt="Screenshot 2026-09-09 at 15 23 29" src="https://github.com/user-attachments/assets/6681684f-1511-4a31-876e-5cb9edbf958f" />
HCB code `/hcb/:id`
<img width="903" height="115" alt="Screenshot 2026-09-09 at 15 23 32" src="https://github.com/user-attachments/assets/072f0e92-88da-40c5-9d63-9fbd060eebec" />
Admin transaction `/admin/:id/transaction`
<img width="903" height="122" alt="Screenshot 2026-09-09 at 15 23 44" src="https://github.com/user-attachments/assets/a9b08d1e-cedd-44c3-99c0-a0d535f01694" />
Navigated transaction
<img width="890" height="49" alt="Screenshot 2026-09-09 at 16 04 51" src="https://github.com/user-attachments/assets/6b57da0d-bde6-4cd6-8dce-8aeb309a93a4" />