### PR TITLE
[v4 API] Idempotency keys on disbursements

### DIFF
--- a/app/controllers/api/v4/application_controller.rb
+++ b/app/controllers/api/v4/application_controller.rb
@@ -9,6 +9,7 @@ module Api
       include ErrorHandling
       include AdminScopeCheckable
       include Pagination
+      include IdempotencyKeyable
 
       attr_reader :current_user
 

--- a/app/controllers/api/v4/disbursements_controller.rb
+++ b/app/controllers/api/v4/disbursements_controller.rb
@@ -14,15 +14,18 @@ module Api
 
         authorize @disbursement
 
-        @disbursement = DisbursementService::Create.new(
+        service = DisbursementService::Create.new(
           source_event_id: @source_event.id,
           destination_event_id: @destination_event.id,
           name: params[:name],
           amount: Money.from_cents(params[:amount_cents]),
           requested_by_id: current_user.id,
-          fronted: @source_event.plan.front_disbursements_enabled?
-        ).run
+          fronted: @source_event.plan.front_disbursements_enabled?,
+          idempotency_key:
+        )
+        @disbursement = service.run
 
+        idempotent_replay! if service.replayed?
         render :show, status: :created, location: api_v4_transaction_path(@disbursement)
       end
 

--- a/app/controllers/concerns/api/v4/idempotency_keyable.rb
+++ b/app/controllers/concerns/api/v4/idempotency_keyable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V4
+    # `Idempotency-Key` request header handling, per draft-ietf-httpapi-idempotency-key-header.
+    module IdempotencyKeyable
+      extend ActiveSupport::Concern
+
+      HEADER = "Idempotency-Key"
+      REPLAYED_HEADER = "Idempotent-Replayed"
+
+      included do
+        rescue_from Errors::IdempotencyKeyMismatch do |e|
+          render json: { error: "idempotency_key_mismatch", messages: [e.message] }, status: :unprocessable_content
+        end
+      end
+
+      private
+
+      def idempotency_key
+        return @idempotency_key if defined?(@idempotency_key)
+
+        key = request.headers[HEADER]&.dup&.force_encoding(Encoding::UTF_8)
+        raise ArgumentError, "#{HEADER} must be valid UTF-8" if key && !key.valid_encoding?
+
+        @idempotency_key = key&.strip.presence
+      end
+
+      def idempotent_replay!
+        response.set_header(REPLAYED_HEADER, "true")
+      end
+
+    end
+  end
+end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -19,4 +19,7 @@ module Errors
   class TwilioAbuseError < StandardError
   end
 
+  class IdempotencyKeyMismatch < StandardError
+  end
+
 end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -9,6 +9,7 @@
 #  amount                              :integer
 #  deposited_at                        :datetime
 #  errored_at                          :datetime
+#  idempotency_key                     :string
 #  in_transit_at                       :datetime
 #  name                                :string
 #  pending_at                          :datetime
@@ -34,6 +35,7 @@
 #  index_disbursements_on_fulfilled_by_id                      (fulfilled_by_id)
 #  index_disbursements_on_requested_by_id                      (requested_by_id)
 #  index_disbursements_on_source_event_id                      (source_event_id)
+#  index_disbursements_on_source_event_id_and_idempotency_key  (source_event_id,idempotency_key) UNIQUE WHERE (idempotency_key IS NOT NULL)
 #  index_disbursements_on_source_subledger_id                  (source_subledger_id)
 #  index_disbursements_on_source_transaction_category_id       (source_transaction_category_id)
 #
@@ -128,6 +130,7 @@ class Disbursement < ApplicationRecord
                         :name
 
   validates :amount, numericality: { greater_than: 0 }
+  validates :idempotency_key, length: { maximum: 255 }, allow_nil: true
   validate :events_are_different
   validate :events_are_not_demos, on: :create
   validate :scheduled_on_must_be_in_the_future, on: :create

--- a/app/models/disbursement/base.rb
+++ b/app/models/disbursement/base.rb
@@ -9,6 +9,7 @@
 #  amount                              :integer
 #  deposited_at                        :datetime
 #  errored_at                          :datetime
+#  idempotency_key                     :string
 #  in_transit_at                       :datetime
 #  name                                :string
 #  pending_at                          :datetime
@@ -34,6 +35,7 @@
 #  index_disbursements_on_fulfilled_by_id                      (fulfilled_by_id)
 #  index_disbursements_on_requested_by_id                      (requested_by_id)
 #  index_disbursements_on_source_event_id                      (source_event_id)
+#  index_disbursements_on_source_event_id_and_idempotency_key  (source_event_id,idempotency_key) UNIQUE WHERE (idempotency_key IS NOT NULL)
 #  index_disbursements_on_source_subledger_id                  (source_subledger_id)
 #  index_disbursements_on_source_transaction_category_id       (source_transaction_category_id)
 #

--- a/app/models/disbursement/incoming.rb
+++ b/app/models/disbursement/incoming.rb
@@ -9,6 +9,7 @@
 #  amount                              :integer
 #  deposited_at                        :datetime
 #  errored_at                          :datetime
+#  idempotency_key                     :string
 #  in_transit_at                       :datetime
 #  name                                :string
 #  pending_at                          :datetime
@@ -34,6 +35,7 @@
 #  index_disbursements_on_fulfilled_by_id                      (fulfilled_by_id)
 #  index_disbursements_on_requested_by_id                      (requested_by_id)
 #  index_disbursements_on_source_event_id                      (source_event_id)
+#  index_disbursements_on_source_event_id_and_idempotency_key  (source_event_id,idempotency_key) UNIQUE WHERE (idempotency_key IS NOT NULL)
 #  index_disbursements_on_source_subledger_id                  (source_subledger_id)
 #  index_disbursements_on_source_transaction_category_id       (source_transaction_category_id)
 #

--- a/app/models/disbursement/outgoing.rb
+++ b/app/models/disbursement/outgoing.rb
@@ -9,6 +9,7 @@
 #  amount                              :integer
 #  deposited_at                        :datetime
 #  errored_at                          :datetime
+#  idempotency_key                     :string
 #  in_transit_at                       :datetime
 #  name                                :string
 #  pending_at                          :datetime
@@ -34,6 +35,7 @@
 #  index_disbursements_on_fulfilled_by_id                      (fulfilled_by_id)
 #  index_disbursements_on_requested_by_id                      (requested_by_id)
 #  index_disbursements_on_source_event_id                      (source_event_id)
+#  index_disbursements_on_source_event_id_and_idempotency_key  (source_event_id,idempotency_key) UNIQUE WHERE (idempotency_key IS NOT NULL)
 #  index_disbursements_on_source_subledger_id                  (source_subledger_id)
 #  index_disbursements_on_source_transaction_category_id       (source_transaction_category_id)
 #

--- a/app/services/disbursement_service/create.rb
+++ b/app/services/disbursement_service/create.rb
@@ -24,7 +24,8 @@ module DisbursementService
       fronted: false,
       source_transaction_category_slug: nil,
       destination_transaction_category_slug: nil,
-      category_assignment_strategy: "manual"
+      category_assignment_strategy: "manual",
+      idempotency_key: nil
     )
       @source_event_id = source_event_id
       @source_event = Event.find(@source_event_id)
@@ -43,13 +44,24 @@ module DisbursementService
       @source_transaction_category_slug = source_transaction_category_slug
       @destination_transaction_category_slug = destination_transaction_category_slug
       @category_assignment_strategy = category_assignment_strategy
+      @idempotency_key = idempotency_key
+      @replayed = false
     end
+
+    # True if `run` returned an existing disbursement matching the idempotency key
+    # instead of creating one.
+    def replayed? = @replayed
 
     def run
       raise ArgumentError, "amount is required" unless @amount
       raise ArgumentError, "amount_cents must be greater than 0" unless amount_cents > 0
 
       @source_event.with_lock do
+        if (existing = idempotent_replay)
+          @replayed = true
+          next existing
+        end
+
         if @source_subledger_id.present?
           raise UserError, "You don't have enough money to make this disbursement." unless Subledger.find(@source_subledger_id).balance_cents >= amount_cents || requested_by_admin?
         else
@@ -95,17 +107,46 @@ module DisbursementService
     def attrs
       {
         source_event_id: source_event.id,
+        requested_by:,
+        source_transaction_category:,
+        destination_transaction_category:,
+        idempotency_key: @idempotency_key,
+        **idempotent_attrs
+      }
+    end
+
+    # The request-shaped attributes a replay is compared against. Kept to cheap
+    # values so the replay path does no lookups or writes inside the lock.
+    def idempotent_attrs
+      {
         event_id: destination_event.id,
         destination_subledger_id: @destination_subledger_id,
         source_subledger_id: @source_subledger_id,
         scheduled_on: @scheduled_on,
         name: @name,
         amount: amount_cents,
-        requested_by:,
-        should_charge_fee: @should_charge_fee,
-        source_transaction_category:,
-        destination_transaction_category:
+        should_charge_fee: @should_charge_fee
       }
+    end
+
+    MISMATCH_LABELS = { event_id: "destination" }.freeze
+
+    # Must run before the balance check: a replay must succeed even if the
+    # source event can no longer afford the original transfer.
+    def idempotent_replay
+      return if @idempotency_key.blank?
+
+      existing = Disbursement.find_by(source_event_id: source_event.id, idempotency_key: @idempotency_key)
+      return unless existing
+
+      requested = Disbursement.new(idempotent_attrs)
+      mismatched = idempotent_attrs.keys.reject { |attr| existing[attr] == requested[attr] }
+      if mismatched.any?
+        labels = mismatched.map { |attr| MISMATCH_LABELS.fetch(attr, attr) }
+        raise Errors::IdempotencyKeyMismatch, "Idempotency-Key was already used with different parameters (#{labels.join(', ')})"
+      end
+
+      existing
     end
 
     def requested_by

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -28,7 +28,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "/api/*",
              headers: :any,
              methods: %i[get post put patch delete options head],
-             expose: ["X-Next-Page", "X-Offset", "X-Page", "X-Per-Page", "X-Prev-Page", "X-Request-Id", "X-Runtime", "X-Total", "X-Total-Pages"]
+             expose: ["Idempotent-Replayed", "X-Next-Page", "X-Offset", "X-Page", "X-Per-Page", "X-Prev-Page", "X-Request-Id", "X-Runtime", "X-Total", "X-Total-Pages"]
 
     resource "*",
              headers: :any,

--- a/db/migrate/20260909120000_add_idempotency_key_to_disbursements.rb
+++ b/db/migrate/20260909120000_add_idempotency_key_to_disbursements.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIdempotencyKeyToDisbursements < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :disbursements, :idempotency_key, :string
+    add_index :disbursements, [:source_event_id, :idempotency_key], unique: true, where: "idempotency_key IS NOT NULL", algorithm: :concurrently
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_08_162456) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -715,6 +715,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_162456) do
     t.datetime "errored_at", precision: nil
     t.bigint "event_id"
     t.bigint "fulfilled_by_id"
+    t.string "idempotency_key"
     t.datetime "in_transit_at", precision: nil
     t.string "name"
     t.datetime "pending_at", precision: nil
@@ -731,6 +732,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_162456) do
     t.index ["event_id"], name: "index_disbursements_on_event_id"
     t.index ["fulfilled_by_id"], name: "index_disbursements_on_fulfilled_by_id"
     t.index ["requested_by_id"], name: "index_disbursements_on_requested_by_id"
+    t.index ["source_event_id", "idempotency_key"], name: "index_disbursements_on_source_event_id_and_idempotency_key", unique: true, where: "(idempotency_key IS NOT NULL)"
     t.index ["source_event_id"], name: "index_disbursements_on_source_event_id"
     t.index ["source_subledger_id"], name: "index_disbursements_on_source_subledger_id"
     t.index ["source_transaction_category_id"], name: "index_disbursements_on_source_transaction_category_id"

--- a/spec/controllers/api/v4/disbursements_controller_spec.rb
+++ b/spec/controllers/api/v4/disbursements_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::DisbursementsController do
+  render_views
+
+  describe "#create" do
+    let(:user) { create(:user) }
+    let(:source_event) { create(:event, :with_positive_balance) }
+    let(:destination_event) { create(:event) }
+
+    before do
+      create(:organizer_position, user:, event: source_event)
+      create(:organizer_position, user:, event: destination_event)
+
+      token = create(:api_token, user:)
+      request.headers["Authorization"] = "Bearer #{token.token}"
+    end
+
+    def post_create(key: "order-1234", **overrides)
+      request.headers["Idempotency-Key"] = key
+      post(:create, params: { event_id: source_event.friendly_id, to_organization_id: destination_event.public_id, name: "Boba Drops", amount_cents: 600_00, **overrides }, as: :json)
+    end
+
+    it "creates a disbursement" do
+      post_create
+
+      expect(response).to have_http_status(:created)
+      expect(response.headers["Idempotent-Replayed"]).to be_nil
+      disbursement = Disbursement.where(source_event:).sole
+      expect(disbursement.idempotency_key).to eq("order-1234")
+      expect(response.parsed_body["id"]).to eq(disbursement.public_id)
+      expect(response.parsed_body["amount_cents"]).to eq(600_00)
+    end
+
+    it "replays the existing disbursement with a 201 and Idempotent-Replayed" do
+      post_create
+      disbursement = Disbursement.where(source_event:).sole
+
+      post_create
+
+      expect(response).to have_http_status(:created)
+      expect(response.headers["Idempotent-Replayed"]).to eq("true")
+      expect(response.parsed_body["id"]).to eq(disbursement.public_id)
+      expect(Disbursement.where(source_event:).count).to eq(1)
+    end
+
+    it "returns 422 when the key is reused with a different payload" do
+      post_create
+      post_create(amount_cents: 1_00)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body).to eq("error" => "idempotency_key_mismatch", "messages" => ["Idempotency-Key was already used with different parameters (amount)"])
+      expect(Disbursement.where(source_event:).count).to eq(1)
+    end
+
+    it "rejects keys longer than 255 characters" do
+      post_create(key: "k" * 256)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq("error" => "invalid_record", "messages" => ["Idempotency key is too long (maximum is 255 characters)"])
+      expect(Disbursement.where(source_event:)).to be_empty
+    end
+
+    it "creates separate disbursements without a key" do
+      post_create(key: nil, amount_cents: 1_00)
+      post_create(key: nil, amount_cents: 1_00)
+
+      expect(Disbursement.where(source_event:).count).to eq(2)
+    end
+  end
+end

--- a/spec/controllers/api/v4/idempotency_keyable_spec.rb
+++ b/spec/controllers/api/v4/idempotency_keyable_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V4::IdempotencyKeyable do
+  controller(Api::V4::ApplicationController) do
+    def create
+      skip_authorization
+
+      raise Errors::IdempotencyKeyMismatch, "Idempotency-Key was already used with different parameters" if params[:mismatch]
+
+      idempotent_replay! if params[:replay]
+
+      render json: { key: idempotency_key }, status: :created
+    end
+  end
+
+  before do
+    token = create(:api_token, user: create(:user))
+    request.headers["Authorization"] = "Bearer #{token.token}"
+  end
+
+  it "exposes the Idempotency-Key header to the action" do
+    request.headers["Idempotency-Key"] = "order-1234"
+    post(:create, as: :json)
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body).to eq("key" => "order-1234")
+    expect(response.headers["Idempotent-Replayed"]).to be_nil
+  end
+
+  it "treats a missing or blank header as no key" do
+    request.headers["Idempotency-Key"] = "   "
+    post(:create, as: :json)
+
+    expect(response.parsed_body).to eq("key" => nil)
+  end
+
+  it "strips surrounding whitespace" do
+    request.headers["Idempotency-Key"] = " order-1234 "
+    post(:create, as: :json)
+
+    expect(response.parsed_body).to eq("key" => "order-1234")
+  end
+
+  it "rejects invalid UTF-8 with a 400" do
+    request.headers["Idempotency-Key"] = "caf\xE9".b
+    post(:create, as: :json)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(response.parsed_body).to eq("error" => "invalid_operation", "messages" => ["Idempotency-Key must be valid UTF-8"])
+  end
+
+  it "marks replayed responses with the Idempotent-Replayed header and keeps the original status" do
+    request.headers["Idempotency-Key"] = "order-1234"
+    post(:create, params: { replay: true }, as: :json)
+
+    expect(response).to have_http_status(:created)
+    expect(response.headers["Idempotent-Replayed"]).to eq("true")
+  end
+
+  it "renders a key/payload mismatch as a 422" do
+    request.headers["Idempotency-Key"] = "order-1234"
+    post(:create, params: { mismatch: true }, as: :json)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body).to eq("error" => "idempotency_key_mismatch", "messages" => ["Idempotency-Key was already used with different parameters"])
+  end
+end

--- a/spec/services/disbursement_service/create_spec.rb
+++ b/spec/services/disbursement_service/create_spec.rb
@@ -451,4 +451,79 @@ RSpec.describe DisbursementService::Create do
     end
   end
 
+
+  describe "idempotency keys" do
+    let(:requestor) { create(:user) }
+    let(:source_event) { create(:event, :with_positive_balance) }
+    let(:destination_event) { create(:event) }
+
+    before { create(:organizer_position, event: source_event, user: requestor) }
+
+    def run(**overrides)
+      service = described_class.new(
+        name: "Boba Drops",
+        amount: "600.00",
+        requested_by_id: requestor.id,
+        source_event_id: source_event.id,
+        destination_event_id: destination_event.id,
+        idempotency_key: "order-1234",
+        **overrides
+      )
+      [service.run, service]
+    end
+
+    it "stores the key on the disbursement" do
+      disbursement, service = run
+
+      expect(disbursement.idempotency_key).to eq("order-1234")
+      expect(service).not_to be_replayed
+    end
+
+    it "returns the existing disbursement on replay, even once the balance can no longer cover it" do
+      first, = run
+      expect(source_event.balance_available_v2_cents).to be < 600_00
+
+      second, service = run
+
+      expect(second).to eq(first)
+      expect(service).to be_replayed
+      expect(Disbursement.count).to eq(1)
+    end
+
+    it "raises when the key is reused with different parameters" do
+      run
+
+      expect { run(amount: "1.00") }.to raise_error(Errors::IdempotencyKeyMismatch, /amount/)
+      expect { run(name: "Not Boba") }.to raise_error(Errors::IdempotencyKeyMismatch, /name/)
+      expect { run(destination_event_id: create(:event).id) }.to raise_error(Errors::IdempotencyKeyMismatch, /destination/)
+      expect(Disbursement.count).to eq(1)
+    end
+
+    it "scopes keys to the source event" do
+      other_source = create(:event, :with_positive_balance)
+      create(:organizer_position, event: other_source, user: requestor)
+
+      first, = run
+      second, service = run(source_event_id: other_source.id)
+
+      expect(second).not_to eq(first)
+      expect(service).not_to be_replayed
+    end
+
+    it "does not claim a key when creation fails" do
+      expect { run(amount: "5000.00") }.to raise_error(DisbursementService::Create::UserError)
+      expect(Disbursement.count).to eq(0)
+
+      disbursement, service = run
+      expect(disbursement.idempotency_key).to eq("order-1234")
+      expect(service).not_to be_replayed
+    end
+
+    it "creates separate disbursements when no key is given" do
+      run(idempotency_key: nil, amount: "1.00")
+      run(idempotency_key: nil, amount: "1.00")
+
+      expect(Disbursement.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
as i'm building out more org-to-org payments use cases, i'm noticing a lot of edge cases where these would be super handy
previously if you POSTed a transfer and the connection died before you got the response, your options were "retry and maybe send the money twice" or "don't retry and maybe never send it." neither of these were great as an integration developer!

### What?

`POST /api/v4/organizations/:org_id/transfers` now honors the `Idempotency-Key` header, ~approximately following [draft-ietf-httpapi-idempotency-key-header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) (i.e. Stripe's design):

```
Idempotency-Key: internal-id-from-your-app-ideally-a-uuid-or-something
```

- same key again => the same transfer, still a `201` (the request did create it; this is a retry, not a new request), plus an `Idempotent-Replayed: true` header so clients can tell.
- same key with a different amount, destination, or name => `422 idempotency_key_mismatch`. silently returning the wrong transfer would hide a client bug...
- no header => nothing changes. the 6 other callers of `DisbursementService::Create` get a `NULL` in the insert and are otherwise untouched.

### How it works for Disbursements:

The lookup runs at the top of the `source_event.with_lock` block that already guards creation, before the balance check. That makes check-and-create race-free using the existing lock, and means a replay succeeds even if the org can no longer cover the original amount (the money already moved). A failed create claims no key, so "insufficient balance → top up → retry with the same key" works. An admin rejecting the transfer does keep the key: that request was answered, and trying again is a new request.

Keys are unique per source org (`[source_event_id, idempotency_key]`, partial index).

The header contract (parsing, the replay header, the 422 rendering) lives in `Api::V4::IdempotencyKeyable`, included in the v4 base controller. It's inert until an action reads `idempotency_key`, so adding it to ACH later is two method calls (and maybe a good idea?) 
