### PR TITLE
[Donation] Prefill email on public page when signed in

### DIFF
--- a/app/controllers/concerns/donation_page_setup.rb
+++ b/app/controllers/concerns/donation_page_setup.rb
@@ -23,13 +23,9 @@ module DonationPageSetup
     @tiers = event.donation_tiers.where(published: true)
     @show_tiers = event.donation_tiers_enabled? && @tiers.any?
 
-    # params override signed-in identity, skip for organizers
-    donor_name = params[:name].presence || (organizer_signed_in? ? nil : current_user&.name)
-    donor_email = params[:email].presence || (organizer_signed_in? ? nil : current_user&.email)
-
     @donation = Donation.new(
-      name: donor_name,
-      email: donor_email,
+      name: params[:name],
+      email: params[:email],
       amount: params[:amount],
       message: params[:message],
       fee_covered: params[:fee_covered],
@@ -50,8 +46,8 @@ module DonationPageSetup
 
     if @monthly
       @recurring_donation = event.recurring_donations.build(
-        name: donor_name,
-        email: donor_email,
+        name: params[:name],
+        email: params[:email],
         amount: params[:amount],
         message: params[:message],
         fee_covered: params[:fee_covered],

--- a/app/controllers/concerns/donation_page_setup.rb
+++ b/app/controllers/concerns/donation_page_setup.rb
@@ -23,9 +23,13 @@ module DonationPageSetup
     @tiers = event.donation_tiers.where(published: true)
     @show_tiers = event.donation_tiers_enabled? && @tiers.any?
 
+    # params override signed-in identity, skip for organizers
+    donor_name = params[:name].presence || (organizer_signed_in? ? nil : current_user&.name)
+    donor_email = params[:email].presence || (organizer_signed_in? ? nil : current_user&.email)
+
     @donation = Donation.new(
-      name: params[:name] || (organizer_signed_in? ? nil : current_user&.name),
-      email: params[:email] || (organizer_signed_in? ? nil : current_user&.email),
+      name: donor_name,
+      email: donor_email,
       amount: params[:amount],
       message: params[:message],
       fee_covered: params[:fee_covered],
@@ -46,8 +50,8 @@ module DonationPageSetup
 
     if @monthly
       @recurring_donation = event.recurring_donations.build(
-        name: params[:name],
-        email: params[:email],
+        name: donor_name,
+        email: donor_email,
         amount: params[:amount],
         message: params[:message],
         fee_covered: params[:fee_covered],

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -18,19 +18,21 @@
   <%= form_with(model: @monthly ? [@event, @recurring_donation] : donation, local: true, url: (make_donation_donations_path unless @monthly),
                 class: "card mx-auto max-w-96 mb3", data: form_data, html: { autocomplete: "off" }) do |form| %>
     <% donation = @recurring_donation if @monthly %>
+    <% prefill_name = donation.name.presence || params[:name] || (organizer_signed_in? ? nil : current_user&.name) %>
+    <% prefill_email = donation.email.presence || params[:email] || (organizer_signed_in? ? nil : current_user&.email) %>
 
     <%= form.invisible_captcha :subtitle %>
     <%= form_errors(donation, nil, "We couldn't start this") %>
 
     <div class="field mb2">
       <%= form.label :name, "Your name" %>
-      <%= form.text_field :name, placeholder: "John Smith", required: true, autofocus: !@tier, autocomplete: "off" %>
+      <%= form.text_field :name, placeholder: "John Smith", required: true, autofocus: !@tier, autocomplete: "off", value: prefill_name %>
     </div>
 
     <div class="field mb2">
       <%= form.label :email, "Your email" %>
       <span class="muted block h5"><%= @event.name %> will send <%= @monthly ? "receipts" : "a receipt" %> here for your tax records, and may use it to communicate with you.</span>
-      <%= form.email_field :email, placeholder: "jsmith@gmail.com", required: true, autocomplete: "off" %>
+      <%= form.email_field :email, placeholder: "jsmith@gmail.com", required: true, autocomplete: "off", value: prefill_email %>
       <% donation.errors.messages_for(:email).each do |message| %>
         <div class="primary"><%= message %></div>
       <% end %>

--- a/spec/requests/donations_prefill_spec.rb
+++ b/spec/requests/donations_prefill_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Signed-in donors shouldn't have to retype an email we already know. The
+# public donation page is skipped by `signed_in_user`, so this is the only
+# place that identity gets applied.
+RSpec.describe "Donation form prefill", type: :request do
+  let(:event) { create(:event) }
+  let(:user) { create(:user, full_name: "Jane Smith", email: "jane@example.com") }
+
+  before do
+    allow(TurnstileService).to receive_messages(site_key: "0x0000site", secret_key: "0x0000secret")
+  end
+
+  def email_field(body, model: "donation")
+    Nokogiri::HTML5(body).at_css(%(input[name="#{model}[email]"]))
+  end
+
+  def name_field(body, model: "donation")
+    Nokogiri::HTML5(body).at_css(%(input[name="#{model}[name]"]))
+  end
+
+  def sign_in_user(user)
+    user_session = create(:user_session, user:, verified: true)
+    allow_any_instance_of(SessionsHelper)
+      .to receive(:find_current_session)
+      .and_return(user_session)
+  end
+
+  it "leaves the form blank for signed-out visitors" do
+    get start_donation_donations_path(event.slug)
+
+    expect(response).to have_http_status(:ok)
+    expect(email_field(response.body)[:value]).to be_blank
+    expect(name_field(response.body)[:value]).to be_blank
+  end
+
+  it "prefills name and email when signed in" do
+    sign_in_user(user)
+
+    get start_donation_donations_path(event.slug)
+
+    expect(response).to have_http_status(:ok)
+    expect(email_field(response.body)[:value]).to eq(user.email)
+    expect(name_field(response.body)[:value]).to eq(user.name)
+  end
+
+  it "does not prefill for organizers" do
+    create(:organizer_position, event:, user:)
+    sign_in_user(user)
+
+    get start_donation_donations_path(event.slug)
+
+    expect(email_field(response.body)[:value]).to be_blank
+    expect(name_field(response.body)[:value]).to be_blank
+  end
+
+  it "prefills the monthly donation form" do
+    sign_in_user(user)
+
+    get start_donation_donations_path(event.slug, monthly: true)
+
+    expect(response).to have_http_status(:ok)
+    expect(email_field(response.body, model: "recurring_donation")[:value]).to eq(user.email)
+    expect(name_field(response.body, model: "recurring_donation")[:value]).to eq(user.name)
+  end
+
+  it "lets query params override the signed-in account" do
+    sign_in_user(user)
+
+    get start_donation_donations_path(event.slug, name: "Pat Donor", email: "pat@example.com")
+
+    expect(email_field(response.body)[:value]).to eq("pat@example.com")
+    expect(name_field(response.body)[:value]).to eq("Pat Donor")
+  end
+end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14923


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
When opening the monthly donation page the name and email fields are now prefilled with the user’s information (organizers remain excluded). Also adds related tests.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

