### PR TITLE
[Card Grant] Add `instructions` to bulk CSV upload

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -132,8 +132,8 @@ class CardGrantsController < ApplicationController
     authorize @event, :bulk_upload_card_grants?
 
     csv_content = CSV.generate do |csv|
-      csv << %w[email amount_cents purpose one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories]
-      csv << ["recipient@example.com", "1000", "Pizza for club meeting", "false", "Thanks for your help!", "", "", "", "", ""]
+      csv << %w[email amount_cents purpose instructions one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories]
+      csv << ["recipient@example.com", "1000", "Pizza for club meeting", "Please only purchase pizza for the meeting.", "false", "Thanks for your help!", "", "", "", "", ""]
     end
 
     send_data csv_content,

--- a/app/services/card_grant_service/bulk_create.rb
+++ b/app/services/card_grant_service/bulk_create.rb
@@ -21,7 +21,7 @@ module CardGrantService
     end
 
     REQUIRED_HEADERS = %w[email amount_cents].freeze
-    OPTIONAL_HEADERS = %w[purpose one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories].freeze
+    OPTIONAL_HEADERS = %w[purpose instructions one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories].freeze
     ALL_HEADERS = REQUIRED_HEADERS + OPTIONAL_HEADERS
     MAX_ERRORS_TO_DISPLAY = 10
     MAX_FILE_SIZE_BYTES = 1.megabyte
@@ -183,6 +183,7 @@ module CardGrantService
         email: get_field(row, header_mapping, "email")&.strip,
         amount_cents: parse_amount(get_field(row, header_mapping, "amount_cents")),
         purpose: get_field(row, header_mapping, "purpose")&.strip.presence,
+        instructions: get_field(row, header_mapping, "instructions")&.strip.presence,
         one_time_use: parse_boolean(get_field(row, header_mapping, "one_time_use")),
         invite_message: get_field(row, header_mapping, "invite_message")&.strip.presence,
         merchant_lock: parse_comma_separated(get_field(row, header_mapping, "merchant_lock")),

--- a/app/views/card_grants/bulk_upload_form.html.erb
+++ b/app/views/card_grants/bulk_upload_form.html.erb
@@ -40,6 +40,11 @@
           <td>Purpose shown to recipient (max <%= CardGrant::MAXIMUM_PURPOSE_LENGTH %> characters)</td>
         </tr>
         <tr>
+          <td><code>instructions</code></td>
+          <td><span class="badge bg-muted ml0">Optional</span></td>
+          <td>Instructions shown to the recipient when they claim the grant</td>
+        </tr>
+        <tr>
           <td><code>one_time_use</code></td>
           <td><span class="badge bg-muted ml0">Optional</span></td>
           <td>Set to <code>true</code> to freeze card after first charge</td>

--- a/spec/services/card_grant_service/bulk_create_spec.rb
+++ b/spec/services/card_grant_service/bulk_create_spec.rb
@@ -77,6 +77,29 @@ RSpec.describe CardGrantService::BulkCreate do
         expect(bob_grant.banned_categories).to eq([])
       end
 
+      it "creates card grants with instructions" do
+        csv_content = <<~CSV
+          email,amount_cents,instructions
+          alice@example.com,1000,"Please only purchase a soldering iron"
+          bob@example.com,2000,
+        CSV
+
+        result = described_class.new(
+          event:,
+          csv_file: csv_file_from_content(csv_content),
+          sent_by:
+        ).run
+
+        expect(result.success?).to be true
+        expect(result.card_grants.count).to eq(2)
+
+        alice_grant = result.card_grants.find { |g| g.email == "alice@example.com" }
+        expect(alice_grant.instructions).to eq("Please only purchase a soldering iron")
+
+        bob_grant = result.card_grants.find { |g| g.email == "bob@example.com" }
+        expect(bob_grant.instructions).to be_nil
+      end
+
       it "sends emails after successful creation" do
         csv_content = <<~CSV
           email,amount_cents


### PR DESCRIPTION
Closes #14944

`instructions` can be set when creating a card grant through the form and the API, but not through the bulk CSV upload. This adds it as an optional column there.

- `CardGrantService::BulkCreate::OPTIONAL_HEADERS` gains `instructions`, and it's passed through in `build_card_grant` (blank cells stay `nil`, matching `purpose`).
- The downloadable CSV template includes the column with an example value.
- The column table on the bulk upload form documents it.

Note: the issue title says `instruction`, but the model attribute and DB column are `instructions`, so the header matches that — every other header in the CSV is named after its attribute.

There's no length validation on `instructions` on the model, so none was added for the CSV either.

## Testing
`spec/services/card_grant_service/bulk_create_spec.rb` gets a case covering a populated and an empty `instructions` cell. Full file passes (20 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)