### PR TITLE
[Reimbursement] Prefill email on public page when signed in  

### DIFF
--- a/app/views/reimbursement/reports/start.html.erb
+++ b/app/views/reimbursement/reports/start.html.erb
@@ -39,7 +39,7 @@
 
   <div class="field mb2">
     <%= form.label :email, "Your email" %>
-    <%= form.email_field :email, placeholder: "fionah@gmail.com", required: true %>
+    <%= form.email_field :email, placeholder: "fionah@gmail.com", required: true, value: current_user&.email %>
   </div>
 
   <%= invisible_captcha :subtitle %>

--- a/spec/controllers/reimbursement/reports_controller_spec.rb
+++ b/spec/controllers/reimbursement/reports_controller_spec.rb
@@ -5,6 +5,34 @@ require "rails_helper"
 RSpec.describe Reimbursement::ReportsController do
   include SessionSupport
 
+  describe "#start" do
+    render_views
+
+    def email_field_value(body)
+      Nokogiri::HTML5(body).at_css('input[name="reimbursement_report[email]"]')&.[]("value")
+    end
+
+    it "prefills the email field when signed in" do
+      event = create(:event, public_reimbursement_page_enabled: true)
+      user = create(:user, email: "fiona@example.com")
+      create_session(user, verified: true)
+
+      get(:start, params: { event_name: event.slug })
+
+      expect(response).to have_http_status(:ok)
+      expect(email_field_value(response.body)).to eq("fiona@example.com")
+    end
+
+    it "does not prefill the email field when signed out" do
+      event = create(:event, public_reimbursement_page_enabled: true)
+
+      get(:start, params: { event_name: event.slug })
+
+      expect(response).to have_http_status(:ok)
+      expect(email_field_value(response.body)).to be_blank
+    end
+  end
+
   describe "#edit" do
     render_views
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14922 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
When logged in, the email field on the public reimbursement page is now prefilled.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

