### PR TITLE
[GSuiteAccount] Add `unmanage!` button for admins with feature flag

### DIFF
--- a/app/controllers/g_suite_accounts_controller.rb
+++ b/app/controllers/g_suite_accounts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GSuiteAccountsController < ApplicationController
-  before_action :set_g_suite_account, only: [:edit, :update, :reset_password, :toggle_suspension]
+  before_action :set_g_suite_account, only: [:edit, :update, :reset_password, :toggle_suspension, :unmanage]
 
   def index
     authorize GSuiteAccount
@@ -99,6 +99,27 @@ class GSuiteAccountsController < ApplicationController
       flash[:error] = "Something went wrong while trying to #{@g_suite_account.suspended? ? 'suspended' : 're-activate'} #{@g_suite_account.address}."
       redirect_to event_g_suite_overview_path(event_id: @event.slug)
     end
+  end
+
+  # Removes the account from HCB management, leaving the Google Workspace user
+  # (and its aliases) intact. See `GSuiteAccount#unmanage!`.
+  def unmanage
+    authorize @g_suite_account
+
+    @event = @g_suite_account.g_suite.event
+    address = @g_suite_account.address
+
+    begin
+      @g_suite_account.unmanage!(confirm: params[:confirm])
+
+      flash[:success] = "#{address} is no longer managed by HCB. The Google Workspace account still exists."
+    rescue => e
+      Rails.error.report(e)
+
+      flash[:error] = "Something went wrong while trying to unmanage #{address}."
+    end
+
+    redirect_to event_g_suite_overview_path(event_id: @event.slug)
   end
 
   private

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -111,9 +111,6 @@ class GSuiteAccount < ApplicationRecord
   # (and its aliases) intact. Intended for when a user's account is being
   # transferred to the unmanaged hackclub.com domain from an HCB managed domain
   # (e.g., events.hackclub.com).
-  #
-  # Available in the Rails console, and to admins with the
-  # `unmanage_gsuite_account` feature flag via the Google Workspace overview.
   def unmanage!(confirm:)
     raise ArgumentError, "confirm must match address" unless confirm == address
 

--- a/app/models/g_suite_account.rb
+++ b/app/models/g_suite_account.rb
@@ -107,11 +107,13 @@ class GSuiteAccount < ApplicationRecord
     self.save
   end
 
-  # Engineer-only via Rails console. Removes this account from HCB
-  # management, leaving the Google Workspace user (and its aliases) intact.
-  # Intended for use in the Rails console when a user's account is being
+  # Removes this account from HCB management, leaving the Google Workspace user
+  # (and its aliases) intact. Intended for when a user's account is being
   # transferred to the unmanaged hackclub.com domain from an HCB managed domain
   # (e.g., events.hackclub.com).
+  #
+  # Available in the Rails console, and to admins with the
+  # `unmanage_gsuite_account` feature flag via the Google Workspace overview.
   def unmanage!(confirm:)
     raise ArgumentError, "confirm must match address" unless confirm == address
 

--- a/app/policies/g_suite_account_policy.rb
+++ b/app/policies/g_suite_account_policy.rb
@@ -37,6 +37,10 @@ class GSuiteAccountPolicy < ApplicationPolicy
     admin_or_manager?
   end
 
+  def unmanage?
+    user&.admin? && Flipper.enabled?(:unmanage_gsuite_account, user)
+  end
+
   private
 
   def admin_or_manager?

--- a/app/views/g_suite_accounts/_panel.html.erb
+++ b/app/views/g_suite_accounts/_panel.html.erb
@@ -47,6 +47,9 @@
                 <%= link_to "Delete",
                   account,
                   data: { turbo_method: :delete, turbo_confirm: "Deleting #{account.address} is *permanent, irreversible, and does not back up any data*. Are you sure you want to continue?", turbo_confirm_danger: true } if policy(account).destroy? %>
+                <%= link_to "Unmanage",
+                  g_suite_account_unmanage_path(account.id, confirm: account.address),
+                  data: { turbo_method: :put, turbo_confirm: "Unmanaging #{account.address} removes it and its aliases from HCB, but leaves the Google Workspace account and its aliases intact. This can’t be undone. Are you sure you want to continue?", turbo_confirm_danger: true } if policy(account).unmanage? %>
               </div>
             </action>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,7 @@ Rails.application.routes.draw do
   resources :g_suite_accounts, only: [:index, :create, :update, :edit, :destroy], path: "g_suite_accounts" do
     put "reset_password"
     put "toggle_suspension"
+    put "unmanage"
     resources :g_suite_aliases, only: [:create, :destroy], shallow: true
   end
 

--- a/spec/controllers/g_suite_accounts_controller_spec.rb
+++ b/spec/controllers/g_suite_accounts_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GSuiteAccountsController do
+  include SessionSupport
+
+  describe "#unmanage" do
+    let(:g_suite) { create(:g_suite) }
+    let(:g_suite_account) { create(:g_suite_account, g_suite:) }
+
+    def unmanage!(confirm: g_suite_account.address)
+      put(:unmanage, params: { g_suite_account_id: g_suite_account.id, confirm: })
+    end
+
+    context "as a non-admin manager" do
+      it "is not authorized" do
+        user = g_suite.event.users.first
+        create_session(user, verified: true)
+
+        unmanage!
+
+        expect(flash[:error]).to eq("You are not authorized to perform this action.")
+        expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
+      end
+    end
+
+    context "as an admin without the feature flag" do
+      it "is not authorized" do
+        create_session(create(:user, :make_admin), verified: true)
+
+        unmanage!
+
+        expect(flash[:error]).to eq("You are not authorized to perform this action.")
+        expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
+      end
+    end
+
+    context "as an admin with the feature flag" do
+      before do
+        admin = create(:user, :make_admin)
+        Flipper.enable(:unmanage_gsuite_account, admin)
+        create_session(admin, verified: true)
+      end
+
+      it "unmanages the account" do
+        unmanage!
+
+        expect(flash[:success]).to include(g_suite_account.address)
+        expect(GSuiteAccount.exists?(g_suite_account.id)).to be false
+      end
+
+      it "does nothing when the confirmation doesn't match the address" do
+        unmanage!(confirm: "wrong@example.com")
+
+        expect(flash[:error]).to include(g_suite_account.address)
+        expect(GSuiteAccount.exists?(g_suite_account.id)).to be true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #14945

`GSuiteAccount#unmanage!` could previously only be run from the production Rails console. This adds an **Unmanage** item to the account menu on an organization's Google Workspace overview.

### Visibility

The button shows only if you're an admin **and** you have the `unmanage_gsuite_account` Flipper flag:

```ruby
def unmanage?
  user&.admin? && Flipper.enabled?(:unmanage_gsuite_account, user)
end
```

The flag doesn't exist yet — it'll need to be created in the Flipper UI before anyone sees the button.

### Notes

- New route: `PUT /g_suite_accounts/:g_suite_account_id/unmanage`, alongside the existing `reset_password` / `toggle_suspension`.
- The link passes the account's address as the `confirm` param, so the model's existing `confirm must match address` guard still applies — it safely aborts if the address changed between page render and click.
- Clicking it pops a danger-mode confirm explaining that HCB drops the account and its aliases while the Google Workspace user stays intact.
- Added `spec/controllers/g_suite_accounts_controller_spec.rb` covering: non-admin manager (denied), admin without the flag (denied), admin with the flag (unmanaged), and a mismatched `confirm` (no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)