### PR TITLE
[Stripe] Set authorization metadata via the webhook response

### DIFF
--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -44,7 +44,8 @@ class StripeController < ActionController::Base
     response.set_header "Stripe-Version", "2022-08-01"
 
     render json: {
-      approved:
+      approved:,
+      metadata: service.metadata
     }
   end
 

--- a/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
+++ b/app/services/stripe_authorization_service/webhook/handle_issuing_authorization_request.rb
@@ -17,14 +17,24 @@ module StripeAuthorizationService
         @card ||= StripeCard.includes(:card_grant).find_by(stripe_id: stripe_card_id)
       end
 
+      # Metadata to set on the authorization. This is returned as part of our
+      # webhook response (rather than being set with a separate
+      # `Stripe::Issuing::Authorization.update` API call) so that we don't eat
+      # into Stripe's 2 second window for responding to authorization requests.
+      #
+      # Stripe casts all metadata values to strings, so we do it ourselves to
+      # keep the response body valid.
+      def metadata
+        {
+          current_balance_available: card_balance_available,
+          declined_reason:
+        }.compact.transform_values(&:to_s)
+      end
+
       private
 
       def auth
         @stripe_event[:data][:object]
-      end
-
-      def auth_id
-        auth[:id]
       end
 
       def amount_cents
@@ -45,7 +55,6 @@ module StripeAuthorizationService
 
       def decline_with_reason!(reason)
         @declined_reason = reason
-        set_metadata!(declined_reason: reason)
 
         false
       end
@@ -82,22 +91,7 @@ module StripeAuthorizationService
 
         return decline_with_reason!("user_cards_locked") if card.user.cards_locked? && event.plan.card_lockable?
 
-        set_metadata!
-
         true
-      end
-
-      def set_metadata!(additional = {})
-        return if Rails.env.test?
-
-        default_metadata = {
-          current_balance_available: card_balance_available,
-        }
-
-        StripeService::Issuing::Authorization.update(
-          auth_id,
-          { metadata: default_metadata.deep_merge(additional) }
-        )
       end
 
       def merchant_category

--- a/spec/factories/stripe_authorization_factory.rb
+++ b/spec/factories/stripe_authorization_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     skip_create
     initialize_with { Stripe::Issuing::Authorization.construct_from(attributes) }
 
+    sequence(:id) { |n| "iauth_#{n}" }
     amount { 0 }
     approved { true }
     merchant_data do

--- a/spec/requests/stripe_webhook_spec.rb
+++ b/spec/requests/stripe_webhook_spec.rb
@@ -50,6 +50,51 @@ RSpec.describe "Stripe Webhook", type: :request do
       end
     end
 
+    context "with an issuing_authorization.request event" do
+      let(:event) { create(:event) }
+      let(:stripe_card) { create(:stripe_card, :with_stripe_id, event:) }
+      let(:authorization) { build(:stripe_authorization, card: { id: stripe_card.stripe_id }) }
+      let(:payload) do
+        {
+          id: "evt_test",
+          object: "event",
+          type: "issuing_authorization.request",
+          data: { object: authorization }
+        }.to_json
+      end
+
+      def post_webhook
+        post "/stripe/webhook",
+             params: payload,
+             headers: { "Stripe-Signature" => stripe_signature(payload), "Content-Type" => "application/json" }
+      end
+
+      it "responds with the metadata to set on a declined authorization" do
+        post_webhook
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(
+          "approved" => false,
+          "metadata" => {
+            "current_balance_available" => "0",
+            "declined_reason"           => "inadequate_balance"
+          }
+        )
+      end
+
+      it "responds with the metadata to set on an approved authorization" do
+        create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+
+        post_webhook
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq(
+          "approved" => true,
+          "metadata" => { "current_balance_available" => "1000" }
+        )
+      end
+    end
+
     context "with no Stripe signature" do
       it "returns 400 and does not process the webhook" do
         expect(StripeController.private_method_defined?(:handle_charge_updated)).to be(true)

--- a/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
+++ b/spec/services/stripe_authorization_service/webhook/handle_issuing_authorization_request_spec.rb
@@ -19,6 +19,25 @@ RSpec.describe StripeAuthorizationService::Webhook::HandleIssuingAuthorizationRe
     expect(service.declined_reason).to eq("inadequate_balance")
   end
 
+  describe "#metadata" do
+    it "includes the available balance and the reason when declining" do
+      expect(service.run).to be(false)
+
+      expect(service.metadata).to eq(
+        current_balance_available: "0",
+        declined_reason: "inadequate_balance"
+      )
+    end
+
+    it "includes the available balance when approving" do
+      create(:canonical_pending_transaction, amount_cents: 1000, event:, fronted: true)
+
+      expect(service.run).to be(true)
+
+      expect(service.metadata).to eq(current_balance_available: "1000")
+    end
+  end
+
   it "declines when insufficient funds" do
     create(:canonical_pending_transaction, amount_cents: 999, event:, fronted: true)
     expect(service.run).to be(false)


### PR DESCRIPTION
Closes #14874

## What

We attach `current_balance_available` (plus `declined_reason`, when we're the ones declining) as metadata on every card authorization. Until now that was a separate `Stripe::Issuing::Authorization.update` API call made *while* we were still handling the `issuing_authorization.request` webhook — i.e. inside [Stripe's 2 second window](https://docs.stripe.com/issuing/controls/real-time-authorizations) for responding, which is exactly @garyhtou's concern on the issue.

Stripe's direct webhook response accepts an optional `metadata` object in the body alongside `approved`, so we now return it from the controller instead:

```json
{ "approved": false, "metadata": { "current_balance_available": "0", "declined_reason": "inadequate_balance" } }
```

This is better than moving the API call into a job (the other option floated on the issue):

- **No API call at all** during the webhook, rather than one we've deferred.
- **No race.** `StripeAuthorization::CreateFromWebhookJob` (fired by `issuing_authorization.created`) retrieves the authorization from Stripe and reads `metadata.declined_reason` for the decline SMS/email. A `perform_later`'d metadata update could land *after* that retrieve, silently downgrading e.g. a `merchant_not_allowed` decline notification to the generic "insufficient funds" wording. With the metadata in the response, it's set at creation time.

Stripe casts metadata values to strings, so `metadata` does that itself to keep the response body valid.

## Also

- `spec/factories/stripe_authorization_factory.rb` now generates an `id`, which the factory was missing.
- The `Rails.env.test?` early-return is gone: there's no API call left to guard, so the specs now assert the real metadata instead of skipping it.

## Testing

New coverage in both the service spec and `spec/requests/stripe_webhook_spec.rb` (end-to-end through the controller, asserting the full response body) for approve + decline.

```
bundle exec rspec spec/requests/stripe_webhook_spec.rb spec/services/stripe_authorization_service/
# 40 examples, 0 failures
```

## Note for the reviewer

This is a live-money path, and per Stripe's docs an invalid response body shows up as `request_history.reason: webhook_error` and falls back to Autopilot/timeout settings. The `metadata` field isn't version-qualified in Stripe's response-body docs and we already respond directly with `Stripe-Version: 2022-08-01`, so this is a small delta on a body that already works — but worth a `stripe trigger issuing_authorization.request` in a sandbox before shipping to confirm `2022-08-01` accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)