### PR TITLE
[Hashid] Remove spec asserting unordered `where_hashid` result order

### DIFF
--- a/spec/initializers/hashid_spec.rb
+++ b/spec/initializers/hashid_spec.rb
@@ -53,11 +53,6 @@ RSpec.describe HashidQueryable do
       expect(User.where_hashid([users.first.hashid] * 3)).to contain_exactly(users.first)
     end
 
-    it "does not preserve the order of the given hashids" do
-      # This is a set lookup; callers needing input order must re-sort themselves.
-      expect(User.where_hashid(hashids.reverse).map(&:id)).to eq(users.map(&:id).sort)
-    end
-
     describe "input this model cannot decode" do
       it "skips a hashid built from characters outside the alphabet" do
         expect(User.where_hashid([users.first.hashid, "not-a-real-hashid"])).to contain_exactly(users.first)


### PR DESCRIPTION
## Summary of the problem

`spec/initializers/hashid_spec.rb` had a test named "does not preserve the order of the given hashids" that asserted `User.where_hashid(hashids.reverse).map(&:id)` equals `users.map(&:id).sort`.

`where_hashid` builds a plain `where(id: ...)` relation with no `ORDER BY`, so Postgres is free to return the rows in any order. The ascending-id result the test asserted was incidental to the plan chosen for three freshly inserted rows, not a guarantee — a different plan (or a table with a different physical layout) could return them in another order and fail the spec.

## Describe your changes

Removed the test. The documented behaviour it was trying to pin down — that callers must not rely on input order — isn't something a result-order assertion can express, and the remaining specs already cover the actual contract (`match_array` on the returned set, dedupe on repeated hashids, undecodable input handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)