### PR TITLE
[Grants] Allow CSV to specify `pre_authorization_required`

### DIFF
--- a/app/controllers/card_grants_controller.rb
+++ b/app/controllers/card_grants_controller.rb
@@ -132,8 +132,8 @@ class CardGrantsController < ApplicationController
     authorize @event, :bulk_upload_card_grants?
 
     csv_content = CSV.generate do |csv|
-      csv << %w[email amount_cents purpose instructions one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories]
-      csv << ["recipient@example.com", "1000", "Pizza for club meeting", "Please only purchase pizza for the meeting.", "false", "Thanks for your help!", "", "", "", "", ""]
+      csv << %w[email amount_cents purpose instructions one_time_use pre_authorization_required invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories]
+      csv << ["recipient@example.com", "1000", "Pizza for club meeting", "Please only purchase pizza for the meeting.", "false", "false", "Thanks for your help!", "", "", "", "", ""]
     end
 
     send_data csv_content,

--- a/app/services/card_grant_service/bulk_create.rb
+++ b/app/services/card_grant_service/bulk_create.rb
@@ -21,7 +21,7 @@ module CardGrantService
     end
 
     REQUIRED_HEADERS = %w[email amount_cents].freeze
-    OPTIONAL_HEADERS = %w[purpose instructions one_time_use invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories].freeze
+    OPTIONAL_HEADERS = %w[purpose instructions one_time_use pre_authorization_required invite_message merchant_lock category_lock keyword_lock banned_merchants banned_categories].freeze
     ALL_HEADERS = REQUIRED_HEADERS + OPTIONAL_HEADERS
     MAX_ERRORS_TO_DISPLAY = 10
     MAX_FILE_SIZE_BYTES = 1.megabyte
@@ -185,6 +185,7 @@ module CardGrantService
         purpose: get_field(row, header_mapping, "purpose")&.strip.presence,
         instructions: get_field(row, header_mapping, "instructions")&.strip.presence,
         one_time_use: parse_boolean(get_field(row, header_mapping, "one_time_use")),
+        pre_authorization_required: parse_boolean(get_field(row, header_mapping, "pre_authorization_required")),
         invite_message: get_field(row, header_mapping, "invite_message")&.strip.presence,
         merchant_lock: parse_comma_separated(get_field(row, header_mapping, "merchant_lock")),
         category_lock: parse_comma_separated(get_field(row, header_mapping, "category_lock")),

--- a/app/views/card_grants/bulk_upload_form.html.erb
+++ b/app/views/card_grants/bulk_upload_form.html.erb
@@ -50,6 +50,11 @@
           <td>Set to <code>true</code> to freeze card after first charge</td>
         </tr>
         <tr>
+          <td><code>pre_authorization_required</code></td>
+          <td><span class="badge bg-muted ml0">Optional</span></td>
+          <td>Set to <code>true</code> to require the recipient to submit purchase documentation before activation</td>
+        </tr>
+        <tr>
           <td><code>invite_message</code></td>
           <td><span class="badge bg-muted ml0">Optional</span></td>
           <td>Custom message included in the invitation email</td>

--- a/spec/services/card_grant_service/bulk_create_spec.rb
+++ b/spec/services/card_grant_service/bulk_create_spec.rb
@@ -100,6 +100,31 @@ RSpec.describe CardGrantService::BulkCreate do
         expect(bob_grant.instructions).to be_nil
       end
 
+      it "creates card grants with pre_authorization_required" do
+        csv_content = <<~CSV
+          email,amount_cents,pre_authorization_required
+          alice@example.com,1000,true
+          bob@example.com,2000,false
+        CSV
+
+        result = described_class.new(
+          event:,
+          csv_file: csv_file_from_content(csv_content),
+          sent_by:
+        ).run
+
+        expect(result.success?).to be true
+        expect(result.card_grants.count).to eq(2)
+
+        alice_grant = result.card_grants.find { |g| g.email == "alice@example.com" }
+        expect(alice_grant.pre_authorization_required).to be true
+        expect(alice_grant.pre_authorization).to be_present
+
+        bob_grant = result.card_grants.find { |g| g.email == "bob@example.com" }
+        expect(bob_grant.pre_authorization_required).to be false
+        expect(bob_grant.pre_authorization).to be_nil
+      end
+
       it "sends emails after successful creation" do
         csv_content = <<~CSV
           email,amount_cents


### PR DESCRIPTION
## Summary of the problem

>wish i had thought about it earlier but i noticed there also isn't any way to set pre-auth

now this is no longer a problem!


## Describe your changes

This adds a new optional header, `pre_authorization_required`, that you can use as part of CSV uploads
