### PR TITLE
[CPT Mailer] Don't ask for already uploaded receipt in notified_settled email

### DIFF
--- a/app/views/canonical_pending_transaction_mailer/_receipt_uploaded.html.erb
+++ b/app/views/canonical_pending_transaction_mailer/_receipt_uploaded.html.erb
@@ -1,0 +1,7 @@
+<%= link_to hcb_code_url(hcb_code) do %>
+  <img height="43" style="display: block; margin-top: 10px; height: 43px;" src="<%= receipt_status_hcb_codes_url(format: :png, s: hcb_code.signed_id(purpose: :receipt_status)) %>" alt="Receipt uploaded">
+<% end %>
+<p>
+  A receipt has already been uploaded for this transaction.
+  If you'd like to manage this receipt or transaction, <%= link_to "click here", hcb_code_url(hcb_code) %>.
+</p>

--- a/app/views/canonical_pending_transaction_mailer/notify_settled.html.erb
+++ b/app/views/canonical_pending_transaction_mailer/notify_settled.html.erb
@@ -1,3 +1,7 @@
 <%= link_to @cpt.memo, hcb_code_url(@cpt.local_hcb_code) %> has settled at <%= render_money @ct.amount_cents %>; this was a charge on your card ending in <%= @cpt.stripe_card.last4 %> that previously was <%= render_money @cpt.amount_cents %>.
 
-<%= render partial: "canonical_pending_transaction_mailer/attach_receipt", locals: { hcb_code: @cpt.local_hcb_code, upload_url: @upload_url } if @cpt.local_hcb_code.missing_receipt? %>
+<% if @cpt.local_hcb_code.missing_receipt? %>
+  <%= render partial: "canonical_pending_transaction_mailer/attach_receipt", locals: { hcb_code: @cpt.local_hcb_code, upload_url: @upload_url } %>
+<% elsif @cpt.local_hcb_code.receipts.any? %>
+  <%= render partial: "canonical_pending_transaction_mailer/receipt_uploaded", locals: { hcb_code: @cpt.local_hcb_code } %>
+<% end %>


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
Fixes #14960 


## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
The `notified_settled` email used to ask for a receipt even if it was already uploaded, now it makes it clear that the receipt has been already uploaded.


<!-- If there are any visual changes, please attach images, videos, or gifs. -->
<img width="591" height="342" alt="Screenshot 2026-09-10 at 20 05 46" src="https://github.com/user-attachments/assets/e5c6a7ea-86de-4286-b10d-997e49e04643" />