### PR TITLE
[Contractors] Improve UX

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -227,6 +227,10 @@ tr.clickable {
   }
 }
 
+tr.contractor-row--review {
+  background-color: rgba(map-get($palette, warning), 0.125);
+}
+
 thead {
   table-layout: fixed;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -227,8 +227,20 @@ tr.clickable {
   }
 }
 
-tr.contractor-row--review {
-  background-color: rgba(map-get($palette, warning), 0.125);
+.contractor-review-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background-color: map-get($palette, primary);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: bold;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 thead {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -903,6 +903,14 @@ class EventsController < ApplicationController
     render :reimbursements_pending_review_icon, layout: false
   end
 
+  def contractors_pending_review_icon
+    authorize @event
+    # Only reviewers see a count; the badge is hidden (count 0) for everyone else.
+    @contractors_pending_review_count = Payroll::PositionPolicy.new(current_user, @event).review? ? @event.payroll_invoices.where(aasm_state: "submitted").count : 0
+
+    render :contractors_pending_review_icon, layout: false
+  end
+
   def employees
     authorize @event
     @employees = @event.employees.order(

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -920,6 +920,10 @@ class EventsController < ApplicationController
 
     @contractors = @event.payroll_positions.includes(:event, payee: :payments).order(created_at: :desc)
 
+    can_review = Payroll::PositionPolicy.new(current_user, @event).review?
+    @pending_invoice_counts = can_review ? @event.payroll_invoices.where(aasm_state: "submitted").group(:payroll_position_id).count : {}
+    @pending_invoices_count = @pending_invoice_counts.values.sum
+
     counts_by_status = @contractors.to_a.group_by(&:status).transform_values(&:count)
     @stats = {
       active: counts_by_status[:active] || 0,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -930,7 +930,6 @@ class EventsController < ApplicationController
 
     can_review = Payroll::PositionPolicy.new(current_user, @event).review?
     @pending_invoice_counts = can_review ? @event.payroll_invoices.where(aasm_state: "submitted").group(:payroll_position_id).count : {}
-    @pending_invoices_count = @pending_invoice_counts.values.sum
 
     counts_by_status = @contractors.to_a.group_by(&:status).transform_values(&:count)
     @stats = {

--- a/app/controllers/payroll/positions_controller.rb
+++ b/app/controllers/payroll/positions_controller.rb
@@ -14,7 +14,7 @@ module Payroll
       authorize @position
       @frame = params[:frame].present?
       @can_review = Payroll::PositionPolicy.new(current_user, @event).review?
-      @invoices = @position.invoices.order(created_at: :desc)
+      @invoices = @position.invoices.includes(:reviewed_by).order(created_at: :desc)
       @payments = @position.payee.payments.order(created_at: :desc)
 
       @position.contract&.party(:organizer)&.sync_with_docuseal

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -154,6 +154,7 @@ module EventsHelper
     {
       name: "Contractors",
       path_proc: ->(event_id) { event_contractors_path(event_id:) },
+      async_badge_proc: ->(event) { event_contractors_pending_review_icon_path(event) },
       tooltip: "Manage payroll",
       icon: "person-badge",
       symbol: :contractors,

--- a/app/javascript/controllers/turbo_frame_modal_controller.js
+++ b/app/javascript/controllers/turbo_frame_modal_controller.js
@@ -8,8 +8,7 @@ export default class extends Controller {
   submitEnd(event) {
     if (event.detail.success) {
       $.modal.close()
-      if (this.reloadOnSuccessValue)
-        window.Turbo.visit(window.location.href, { action: 'replace' })
+      if (this.reloadOnSuccessValue) window.Turbo.visit(window.location.href, { action: 'replace' })
     }
   }
 }

--- a/app/javascript/controllers/turbo_frame_modal_controller.js
+++ b/app/javascript/controllers/turbo_frame_modal_controller.js
@@ -2,10 +2,13 @@ import { Controller } from '@hotwired/stimulus'
 import $ from 'jquery'
 
 export default class extends Controller {
+  static values = { reloadOnSuccess: Boolean }
+
   // https://turbo.hotwired.dev/reference/events#turbo%3Asubmit-end
   submitEnd(event) {
     if (event.detail.success) {
       $.modal.close()
+      if (this.reloadOnSuccessValue) window.Turbo.visit(window.location.href, { action: 'replace' })
     }
   }
 }

--- a/app/javascript/controllers/turbo_frame_modal_controller.js
+++ b/app/javascript/controllers/turbo_frame_modal_controller.js
@@ -8,7 +8,8 @@ export default class extends Controller {
   submitEnd(event) {
     if (event.detail.success) {
       $.modal.close()
-      if (this.reloadOnSuccessValue) window.Turbo.visit(window.location.href, { action: 'replace' })
+      if (this.reloadOnSuccessValue)
+        window.Turbo.visit(window.location.href, { action: 'replace' })
     }
   }
 }

--- a/app/models/contract/payroll_position.rb
+++ b/app/models/contract/payroll_position.rb
@@ -36,7 +36,7 @@
 
 class Contract
   class PayrollPosition < Contract
-    DOCUSEAL_TEMPLATE_ID = 4983902
+    DOCUSEAL_TEMPLATE_ID = 5023480
 
     after_update_commit :create_document!, if: -> { event.present? && sent_with_docuseal? && aasm_state_previously_changed?(to: "signed") }
 

--- a/app/models/contract/payroll_position.rb
+++ b/app/models/contract/payroll_position.rb
@@ -36,7 +36,7 @@
 
 class Contract
   class PayrollPosition < Contract
-    DOCUSEAL_TEMPLATE_ID = 5023480
+    DOCUSEAL_TEMPLATE_ID = 4983902
 
     after_update_commit :create_document!, if: -> { event.present? && sent_with_docuseal? && aasm_state_previously_changed?(to: "signed") }
 

--- a/app/models/payroll/invoice.rb
+++ b/app/models/payroll/invoice.rb
@@ -71,6 +71,14 @@ module Payroll
       end
     end
 
+    def state_color
+      case aasm_state.to_sym
+      when :approved then "success"
+      when :rejected then "muted"
+      else "warning"
+      end
+    end
+
     def receipt_required?
       true
     end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -213,6 +213,10 @@ class EventPolicy < ApplicationPolicy
     show?
   end
 
+  def contractors_pending_review_icon?
+    show?
+  end
+
   def reimbursements?
     auditor_or_reader? && record.plan.reimbursements_enabled?
   end

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -48,6 +48,13 @@
     <% end %>
   </h1>
 
+  <% if @pending_invoices_count.positive? %>
+    <%= render "application/callout", type: "warning", icon: "important",
+          title: "#{pluralize(@pending_invoices_count, "invoice")} awaiting your review" do %>
+      Open a contractor marked <span class="badge bg-warning">Review</span> below to approve or reject their invoices.
+    <% end %>
+  <% end %>
+
   <div class="statset mb-4">
     <div class="stat stat--plain">
       <span class="stat__label">Active</span>
@@ -87,8 +94,12 @@
         <tbody>
           <% @contractors.each do |contractor| %>
             <tr class="<%= "clickable" if show_details %>">
+              <% pending = @pending_invoice_counts[contractor.id] || 0 %>
               <td>
                 <span class="badge ml-0 bg-<%= contractor.status_color %>"><%= contractor.status_text %></span>
+                <% if pending.positive? %>
+                  <span class="badge ml-0 mt-1 bg-warning nowrap" title="<%= pluralize(pending, "invoice") %> to review">Review</span>
+                <% end %>
               </td>
               <td>
                 <strong><%= contractor.payee.display_name %></strong>

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -87,8 +87,7 @@
         <tbody>
           <% @contractors.each do |contractor| %>
             <% pending = @pending_invoice_counts[contractor.id] || 0 %>
-            <tr class="<%= "clickable" if show_details %>"
-                <% if pending.positive? %> title="<%= pluralize(pending, "invoice") %> awaiting review"<% end %>>
+            <tr class="<%= "clickable" if show_details %>">
               <td>
                 <span class="badge ml-0 bg-<%= contractor.status_color %>"><%= contractor.status_text %></span>
               </td>
@@ -96,7 +95,7 @@
                 <span class="flex items-center gap-1">
                   <strong><%= contractor.payee.display_name %></strong>
                   <% if pending.positive? %>
-                    <span class="contractor-review-badge" title="<%= pluralize(pending, "invoice") %> to review"><%= pending %></span>
+                    <span class="contractor-review-badge"><%= pending %></span>
                   <% end %>
                 </span>
                 <% if show_details %>

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -51,7 +51,7 @@
   <% if @pending_invoices_count.positive? %>
     <%= render "application/callout", type: "warning", icon: "important",
           title: "#{pluralize(@pending_invoices_count, "invoice")} awaiting your review" do %>
-      Open a contractor marked <span class="badge bg-warning">Review</span> below to approve or reject their invoices.
+      Open a highlighted contractor below to approve or reject their invoices.
     <% end %>
   <% end %>
 
@@ -93,8 +93,9 @@
 
         <tbody>
           <% @contractors.each do |contractor| %>
-            <tr class="<%= "clickable" if show_details %>">
-              <% pending = @pending_invoice_counts[contractor.id] || 0 %>
+            <% pending = @pending_invoice_counts[contractor.id] || 0 %>
+            <tr class="<%= "clickable" if show_details %> <%= "contractor-row--review" if pending.positive? %>"
+                <% if pending.positive? %>title="<%= pluralize(pending, "invoice") %> awaiting review"<% end %>>
               <td>
                 <span class="badge ml-0 bg-<%= contractor.status_color %>"><%= contractor.status_text %></span>
                 <% if pending.positive? %>

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -88,7 +88,7 @@
           <% @contractors.each do |contractor| %>
             <% pending = @pending_invoice_counts[contractor.id] || 0 %>
             <tr class="<%= "clickable" if show_details %>"
-                <% if pending.positive? %>title="<%= pluralize(pending, "invoice") %> awaiting review"<% end %>>
+                <% if pending.positive? %> title="<%= pluralize(pending, "invoice") %> awaiting review"<% end %>>
               <td>
                 <span class="badge ml-0 bg-<%= contractor.status_color %>"><%= contractor.status_text %></span>
               </td>

--- a/app/views/events/contractors.html.erb
+++ b/app/views/events/contractors.html.erb
@@ -48,13 +48,6 @@
     <% end %>
   </h1>
 
-  <% if @pending_invoices_count.positive? %>
-    <%= render "application/callout", type: "warning", icon: "important",
-          title: "#{pluralize(@pending_invoices_count, "invoice")} awaiting your review" do %>
-      Open a highlighted contractor below to approve or reject their invoices.
-    <% end %>
-  <% end %>
-
   <div class="statset mb-4">
     <div class="stat stat--plain">
       <span class="stat__label">Active</span>
@@ -94,16 +87,18 @@
         <tbody>
           <% @contractors.each do |contractor| %>
             <% pending = @pending_invoice_counts[contractor.id] || 0 %>
-            <tr class="<%= "clickable" if show_details %> <%= "contractor-row--review" if pending.positive? %>"
+            <tr class="<%= "clickable" if show_details %>"
                 <% if pending.positive? %>title="<%= pluralize(pending, "invoice") %> awaiting review"<% end %>>
               <td>
                 <span class="badge ml-0 bg-<%= contractor.status_color %>"><%= contractor.status_text %></span>
-                <% if pending.positive? %>
-                  <span class="badge ml-0 mt-1 bg-warning nowrap" title="<%= pluralize(pending, "invoice") %> to review">Review</span>
-                <% end %>
               </td>
               <td>
-                <strong><%= contractor.payee.display_name %></strong>
+                <span class="flex items-center gap-1">
+                  <strong><%= contractor.payee.display_name %></strong>
+                  <% if pending.positive? %>
+                    <span class="contractor-review-badge" title="<%= pluralize(pending, "invoice") %> to review"><%= pending %></span>
+                  <% end %>
+                </span>
                 <% if show_details %>
                   <span class="muted block"><%= contractor.payee.email %></span>
                 <% end %>

--- a/app/views/events/contractors_pending_review_icon.html.erb
+++ b/app/views/events/contractors_pending_review_icon.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag event_contractors_pending_review_icon_path(@event) do %>
+  <% if @contractors_pending_review_count != 0 %>
+    <div class="dock__item--badge">
+      <%= @contractors_pending_review_count %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/my/pay.html.erb
+++ b/app/views/my/pay.html.erb
@@ -116,6 +116,7 @@
             <section class="modal modal--scroll bg-snow" data-behavior="modal" role="dialog"
               id="<%= dom_id(position, :submit_invoice) %>"
               data-controller="turbo-frame-modal"
+              data-turbo-frame-modal-reload-on-success-value="true"
               data-action="turbo:submit-end->turbo-frame-modal#submitEnd">
               <%= modal_header "Submit an invoice" %>
               <%= turbo_frame_tag dom_id(position, :invoice_form), src: new_payroll_position_invoice_path(position), loading: :lazy do %>
@@ -174,9 +175,8 @@
         </thead>
         <tbody>
           <% @invoices.each do |invoice| %>
-            <% state_color = invoice.approved? ? "success" : (invoice.rejected? ? "muted" : "warning") %>
             <tr>
-              <td><span class="badge ml-0 bg-<%= state_color %>"><%= invoice.aasm_state.humanize %></span></td>
+              <td><span class="badge ml-0 bg-<%= invoice.state_color %>"><%= invoice.aasm_state.humanize %></span></td>
               <td><%= format_date invoice.created_at %></td>
               <td><strong><%= invoice.event.name %></strong></td>
               <td style="max-width: 25ch;" class="overflow-hidden truncate" title="<%= invoice.name %>">
@@ -218,10 +218,9 @@
       <tbody>
         <% @payments.each do |payment| %>
           <% payout = payment.latest_payout %>
-          <% state_color = { "pending_legal_entity" => "muted", "under_review" => "info", "sent" => "info", "successful" => "success", "rejected" => "error" }[payment.aasm_state] %>
           <tr class="clickable">
             <td>
-              <span class="ml0 badge bg-<%= state_color %>">
+              <span class="ml0 badge bg-<%= payment.state_color %>">
                 <%= payment.aasm_state.humanize %>
               </span>
             </td>

--- a/app/views/payments/_payee_picker.html.erb
+++ b/app/views/payments/_payee_picker.html.erb
@@ -44,8 +44,11 @@
       <% end %>
 
       <div class="flex flex-col gap-3">
-        <div class="flex justify-between flex-col sm:flex-row items-center gap-2">
-          <%= label_tag :name, "Name" %>
+        <div class="flex justify-between flex-col sm:flex-row sm:items-center gap-2">
+          <div>
+            <%= label_tag :name, "Name" %>
+            <span class="muted block text-sm">Shown publicly in transparency mode; needn't be their legal name</span>
+          </div>
           <%= text_field_tag :name, params[:payee_name], placeholder: "Orpheus", required: true, form: "new-payee-form", data: { "manual-payee-target": "nameInput", "payee-picker-target": "nameInput" } %>
         </div>
         <div class="flex justify-between flex-col sm:flex-row items-center gap-2">

--- a/app/views/payments/_payee_picker.html.erb
+++ b/app/views/payments/_payee_picker.html.erb
@@ -47,7 +47,12 @@
         <div class="flex justify-between flex-col sm:flex-row sm:items-center gap-2">
           <div>
             <%= label_tag :name, "Name" %>
-            <span class="muted block text-sm">Shown publicly in transparency mode; needn't be their legal name</span>
+            <span class="muted block text-sm mr-2">
+              <% if event.is_public? %>
+                Visible in transparency mode.
+              <% end %>
+              This does not have to match the recipient's legal name.
+            </span>
           </div>
           <%= text_field_tag :name, params[:payee_name], placeholder: "Orpheus", required: true, form: "new-payee-form", data: { "manual-payee-target": "nameInput", "payee-picker-target": "nameInput" } %>
         </div>

--- a/app/views/payroll/positions/show.html.erb
+++ b/app/views/payroll/positions/show.html.erb
@@ -57,9 +57,15 @@
         <strong>Total paid</strong>
         <%= render_money @position.payee.total_paid_cents %>
       </p>
+      <% if @position.contract&.document.present? %>
+        <p>
+          <strong>Signed contract</strong>
+          <%= link_to "View signed contract", @position.contract.document, data: { turbo_frame: "_top" } %>
+        </p>
+      <% end %>
       <% if @position.file.attached? %>
         <p>
-          <strong>Agreement</strong>
+          <strong>Extra attachment</strong>
           <%= link_to "View attachment", url_for(@position.file), data: { turbo_frame: "_top" } %>
         </p>
       <% end %>
@@ -101,9 +107,13 @@
         </thead>
         <tbody>
           <% @invoices.each do |invoice| %>
-            <% state_color = invoice.approved? ? "success" : (invoice.rejected? ? "muted" : "warning") %>
             <tr>
-              <td><span class="badge bg-<%= state_color %>"><%= invoice.aasm_state.humanize %></span></td>
+              <td>
+                <span class="badge bg-<%= invoice.state_color %>"><%= invoice.aasm_state.humanize %></span>
+                <% if invoice.reviewed_by.present? %>
+                  <span class="muted block text-xs mt-1"><%= invoice.approved? ? "Approved" : "Rejected" %> by <%= invoice.reviewed_by.name %></span>
+                <% end %>
+              </td>
               <td style="max-width: 25ch;" class="overflow-hidden truncate" title="<%= invoice.name %>">
                 <%= invoice.name %>
               </td>

--- a/app/views/payroll/positions/show.html.erb
+++ b/app/views/payroll/positions/show.html.erb
@@ -65,7 +65,7 @@
       <% end %>
       <% if @position.file.attached? %>
         <p>
-          <strong>Extra attachment</strong>
+          <strong>Agreement</strong>
           <%= link_to "View attachment", url_for(@position.file), data: { turbo_frame: "_top" } %>
         </p>
       <% end %>

--- a/app/views/payroll/positions/show.html.erb
+++ b/app/views/payroll/positions/show.html.erb
@@ -109,9 +109,9 @@
           <% @invoices.each do |invoice| %>
             <tr>
               <td>
-                <span class="badge bg-<%= invoice.state_color %>"><%= invoice.aasm_state.humanize %></span>
+                <span class="badge ml-0 bg-<%= invoice.state_color %>"><%= invoice.aasm_state.humanize %></span>
                 <% if invoice.reviewed_by.present? %>
-                  <span class="muted block text-xs mt-1"><%= invoice.approved? ? "Approved" : "Rejected" %> by <%= invoice.reviewed_by.name %></span>
+                  <span class="muted block text-xs mt-1 ml-2.5">by <%= invoice.reviewed_by.name %></span>
                 <% end %>
               </td>
               <td style="max-width: 25ch;" class="overflow-hidden truncate" title="<%= invoice.name %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1064,6 +1064,7 @@ Rails.application.routes.draw do
     get "async_sub_organization_balances"
     get "async_sub_organization_rows"
     get "reimbursements_pending_review_icon"
+    get "contractors_pending_review_icon"
 
     get "documentation", to: redirect("/%{event_id}/documents", status: 302)
     get "transfers"


### PR DESCRIPTION
- cmdk links
- standardize status colors
- redirect to pay tab after adding payout method on LE show page
- make clear that name you enter for payee is displayed in transparency mode and does not need to be legal name
- add specific dates of work performed to payroll::invoice
- add link from contractor payroll position page to the signed contract - not just the extra attachment the organizer added
- refresh user pay page after submiting invoice
- show who approved an invoice
- add clear message/alert/badge on contractors page when there are pending invoices to review