### PR TITLE
[CPSM / CPDM] Remove double refresh from `after_commit`

### DIFF
--- a/app/models/canonical_pending_declined_mapping.rb
+++ b/app/models/canonical_pending_declined_mapping.rb
@@ -22,7 +22,6 @@ class CanonicalPendingDeclinedMapping < ApplicationRecord
 
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
     canonical_pending_transaction.ledger_item.map!
-    canonical_pending_transaction.ledger_item.refresh!
   end
 
 end

--- a/app/models/canonical_pending_settled_mapping.rb
+++ b/app/models/canonical_pending_settled_mapping.rb
@@ -42,7 +42,6 @@ class CanonicalPendingSettledMapping < ApplicationRecord
 
   after_commit if: -> { canonical_pending_transaction.ledger_item.present? } do
     canonical_pending_transaction.ledger_item.map!
-    canonical_pending_transaction.ledger_item.refresh!
   end
 
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link
any related issues to provide more details. -->
`map!` already calls `refresh!`.

#14741 removed this duplicate `refresh!` from `CanonicalTransaction` and `CanonicalPendingTransaction`, but the identical pattern was left in place in `CanonicalPendingSettledMapping` and `CanonicalPendingDeclinedMapping`.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick
summary of the changes. -->
Remove the extra `refresh!` call from both mappings' `after_commit`, exactly as #14741 did.

`Ledger::Item#map!` is `Ledger::Mapper.new(ledger_item: self).run` followed by `refresh!`, so the call on the next line is always a second full refresh of state that was just recomputed. `refresh!` re-reads every association (it deliberately `reset`s `primary_mapping` / `primary_ledger` first, so nothing is cached between calls) and ends in `save!` — measured at 14–35 SQL statements per call.

Measured on the same scenarios before and after, instrumenting `Ledger::Item` with a prepended module:

| Path | `map!` | `refresh!` before | `refresh!` after |
|---|---|---|---|
| `CanonicalPendingSettledMapping.create!` | 4 | 6 | **5** |
| `cpt.decline!` (`CanonicalPendingDeclinedMapping`) | 1 | 2 | **1** |

`map!` counts are unchanged, and the remaining `refresh!` is the one `map!` performs itself.

## Testing
197 examples across the ledger and settle/unsettle specs, 0 failures:

```
spec/services/canonical_pending_transaction_service/settle_spec.rb
spec/services/canonical_pending_transaction_service/unsettle_spec.rb
spec/services/pending_event_mapping_engine/anomaly_detection/bad_settled_mapping_spec.rb
spec/models/ledger/item_spec.rb
spec/models/ledger/mapping_spec.rb
spec/models/ledger/query_spec.rb
spec/services/ledger/mapper_spec.rb
spec/models/canonical_pending_transaction_spec.rb
spec/models/canonical_transaction_spec.rb
spec/models/ledger_spec.rb
```

(One pre-existing `skip` in `bad_settled_mapping_spec.rb` is unrelated and unchanged by this PR.)

## Notes
This is the smallest slice of a wider write-path amplification problem. Creating one CPT on a realistic path currently fires `map!` 5 times and `refresh!` 8 times on a single ledger item; the largest remaining contributor is `Ledger::Mapping.map_primary!` re-`save!`ing an unchanged mapping row, whose `after_commit` then fires a full `refresh!` on each no-op save. That is a separate, less mechanical change and is not attempted here.

Two unrelated bugs surfaced during the same investigation and are filed separately: #14967 and #14968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
