### PR TITLE
[Settings] Editing phone number causes weird bugs

### DIFF
--- a/app/assets/javascripts/phone_input.js
+++ b/app/assets/javascripts/phone_input.js
@@ -1,16 +1,34 @@
 ;(() => {
   const phoneInputField = document.querySelector('#phone_raw')
+  const phoneNumberField = document.querySelector('#phone_number')
+  
   const phoneInput = window.intlTelInput(phoneInputField, {
     initialCountry: 'us',
     preferredCountries: ['us', 'in', 'ca', 'sg', 'au', 'gb'],
     utilsScript:
       'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
   })
-  const callback = () => {
-    document.getElementById('phone_number').value = phoneInput.getNumber()
-    return true
+
+  const persistedPhoneNumber = phoneInputField.dataset.persistedPhoneNumber || ''
+
+  const updatePhoneNumber = () => {
+    phoneNumberField.value = phoneInput.getNumber()
+
+    const phoneNumberChanged = phoneNumberField.value !== persistedPhoneNumber
+    
+    const unverifiedMessage = document.querySelector('#unverified-phone-message')
+    const changedMessage = document.querySelector('#unsaved-phone-message')
+
+    if (unverifiedMessage) {
+      unverifiedMessage.style.display = phoneNumberChanged ? 'none' : ''
+    }
+
+    if (changedMessage) {
+      changedMessage.style.display = phoneNumberChanged ? '' : 'none'
+    }
   }
 
-  window.onsubmit = callback
-  phoneInputField.onblur = callback
+  window.onsubmit = updatePhoneNumber
+  phoneInputField.addEventListener('input', updatePhoneNumber)
+  phoneInputField.addEventListener('blur', updatePhoneNumber)
 })()

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -434,7 +434,7 @@ legend {
 
 .btn--form-option,
 .field--options label,
-form:not(.no-error-styling) .field_with_errors > label {
+form:not(.no-error-styling) .field--options .field_with_errors > label {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -158,9 +158,13 @@
             </p>
           <% end %>
           <%= form.hidden_field :phone_number, required: true, placeholder: "555-555-5555", id: "phone_number" %>
-          <input type="tel" id="phone_raw" value="<%= @user.phone_number.presence %>" required="required" <%= "disabled" if disabled %>>
+          <input type="tel" id="phone_raw" value="<%= @user.phone_number.presence %>" required="required" data-persisted-phone-number="<%= @user.phone_number.presence %>" <%= "disabled" if disabled %>>
+          <p id="unsaved-phone-message" style="display: none;" class="h5 mt1 m0 warning flex items-center">
+            <%= inline_icon "important-fill", class: "warning mr1", size: 20 %>
+            <span>Please save to update the phone number.</span>
+          </p>
           <% if @user.phone_number_in_database.present? && !@user.phone_number_verified? %>
-            <p class="h5 mt1 m0 warning flex items-center">
+            <p id="unverified-phone-message" class="h5 mt1 m0 warning flex items-center">
               <%= inline_icon "important-fill", class: "warning mr1", size: 20 %>
               <span>Your phone number is unverified. <%= link_to "Click here to verify it.", "#", class: "info", data: { behavior: "modal_trigger", modal: "verify_phone" } if current_user == @user %></span>
             </p>


### PR DESCRIPTION
## Summary of the problem
closes #14839 
> Video summary: https://clips.garytou.com/s/1v1qe8thbzgjefm 
>
> Bugs in order of priority:
> 1. Editing your phone number may cause you to verify your old phone number; instead of your new one
> 2. The "phone number" field label is rendered weirdly when the form has a validation error
> 3. Editing your phone number requires clicking save before you discover that you need to verify it.

Overall just confusing UX.

## Describe your changes
For 1st and 3rd: added a data-attribute to the input to get the persisted (saved) phone number; the javascript just compares this against the value of the input field and if it differs, hides the verification message (if present) and prompts the user to click save to update the phone number. Even if the number is already verified, the user is still prompted to save, which should slightly improve the user experience.

For 2nd: just made the CSS selector more specific.

<img width="593" alt="image" src="https://github.com/user-attachments/assets/0dc2ee9f-580b-47c1-b520-1f8b1419c1a5" />


