### PR TITLE
[CT / CPT] Remove redundant `map!` from `assign_ledger_item`

### DIFF
--- a/app/models/canonical_pending_transaction.rb
+++ b/app/models/canonical_pending_transaction.rb
@@ -484,7 +484,6 @@ class CanonicalPendingTransaction < ApplicationRecord
       ActiveRecord::Base.transaction do
         li = local_hcb_code.ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime:, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
         update!(ledger_item: li)
-        li.map!
       end
     end
   end

--- a/app/models/canonical_transaction.rb
+++ b/app/models/canonical_transaction.rb
@@ -502,7 +502,6 @@ class CanonicalTransaction < ApplicationRecord
 
         li = calculated_ledger_item || create_ledger_item!(memo:, amount_cents: 0, datetime:, short_code: local_hcb_code.short_code, hcb_code: local_hcb_code)
         update!(ledger_item: li)
-        li.map!
       end
     end
   end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link
any related issues to provide more details. -->
Both models already carry `after_commit if: -> { ledger_item.present? } { ledger_item.map! }`, which maps the ledger item as soon as it has been assigned. The explicit `li.map!` inside `assign_ledger_item` runs the same mapping a second time.

It was added by #14259 to fix ledger items "not properly mapping". The next day, #14282 found the actual cause — `Ledger::Mapper` was evaluating a stale `@ledger_item` whose CT/CPT associations had not been loaded, "resulting in the ledger item going unmapped" — and fixed it by reloading in the mapper. Once the mapper reloads, the `after_commit` maps correctly on its own, and the earlier workaround is redundant.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick
summary of the changes. -->
Drop the `li.map!` line from `CanonicalPendingTransaction#assign_ledger_item` and `CanonicalTransaction#assign_ledger_item`.

Measured on a **fresh** ledger item with `use_transactional_tests = false`, so the commit ordering matches production rather than the nested test transaction:

| | `map!` | `refresh!` |
|---|---|---|
| before | 5 | 8 |
| after | **4** | **7** |

The resulting ledger item is identical on every field — mapped to the same event ledger, same `amount_cents`, `status`, `linked_object_type`, memo and CT/CPT counts. An A/B run on the already-existing-ledger-item path shows the same: 4 → 3 `map!`, identical state.

## Testing
274 examples, 0 failures:

```
spec/models/ledger/  spec/services/ledger/  spec/models/ledger_spec.rb
spec/models/canonical_pending_transaction_spec.rb  spec/models/canonical_transaction_spec.rb
spec/services/canonical_pending_transaction_service/
spec/services/pending_event_mapping_engine/  spec/services/event_mapping_engine/
spec/models/hcb_code_spec.rb  spec/models/ach_transfer_spec.rb
spec/controllers/ledgers_controller_spec.rb  spec/controllers/ledger/
spec/jobs/event/refresh_ledgers_job_spec.rb
```

(One pre-existing `skip` in `bad_settled_mapping_spec.rb` is unrelated and unchanged.)

## Notes
Independent of #14969 — different files, no conflict, either can merge first.

This does not address the remaining double-fire of `after_commit { ledger_item.map! }`, which still runs twice per create because `assign_ledger_item` opens a nested `ActiveRecord::Base.transaction` from inside an `after_create_commit`, re-running the record's commit-callback chain. That restructuring belongs with #14967, where the same nested write causes the more serious problem of silently skipping later `after_create_commit` callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
