### PR TITLE
[CardGrant] Reset hidden card-only options when the virtual card is disabled

### DIFF
--- a/app/javascript/controllers/card_grant_form_controller.js
+++ b/app/javascript/controllers/card_grant_form_controller.js
@@ -12,6 +12,10 @@ export default class extends Controller {
     const enabled = this.stripeCardTarget.checked
     this.cardOptionTargets.forEach(el => {
       el.hidden = !enabled
+      // Clear hidden card-only options so a reimbursement-only grant can't submit them.
+      if (!enabled) {
+        el.querySelectorAll('input[type="checkbox"]').forEach(checkbox => { checkbox.checked = false })
+      }
     })
   }
 }


### PR DESCRIPTION
## Summary of the problem

Follow-up to #13687 (accept card grant invites as reimbursements). The new `card_grant_form_controller` only sets `el.hidden = true` on the "one-time use" / "require pre-authorization" fields when the virtual card method is unchecked, but hidden `check_box` inputs still POST their values. So an organizer who configures a card with pre-authorization and then switches the grant to reimbursement-only creates a grant that silently carries `pre_authorization_required: true`. That builds a draft `pre_authorization`, and since `accept_as_reimbursement?` requires `authorized_to_activate?`, the recipient can neither activate a card (disabled) nor accept the reimbursement until an organizer intervenes.

The grant-level `allow_stripe_card` flag is only settable through this create form, so the form controller is the right place to fix it.

## Describe your changes

Uncheck the hidden card-only checkboxes when the virtual card method is disabled, so a reimbursement-only grant submits only the options that apply to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYR5Q4GJ1yZUcmKo65ZCCh