### PR TITLE
Return 404 for unknown format extensions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,14 @@ class ApplicationController < ActionController::Base
     Current.session = find_current_session
   end
 
+  # Rails falls back to every registered template format when the requested
+  # extension is unknown, so `/feed.atom~` (or `/anything.html~`) renders the
+  # real page with a 200 and scanners report it as a leftover backup file.
+  # Treat an unrecognised extension as a missing page. Limited to GET/HEAD:
+  # a few non-GET routes (e.g. donation tier deletes) abuse the format slot
+  # for an ID.
+  before_action :reject_unknown_format, if: -> { request.get? || request.head? }
+
   include Pundit::Authorization
   include SessionsHelper
   include ToursHelper
@@ -126,6 +134,10 @@ class ApplicationController < ActionController::Base
 
   def not_found
     raise ActionController::RoutingError.new("Not Found")
+  end
+
+  def reject_unknown_format
+    not_found if params[:format].present? && Mime[params[:format]].nil?
   end
 
   def set_streaming_headers

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Rails otherwise falls back to any registered template format when the
+# requested extension is unknown, so a backup-file probe like `/feed.atom~`
+# rendered the real feed with a 200 and the PCI scan flagged it.
+RSpec.describe "Unknown format extensions", type: :request do
+  let(:event) { create(:event, is_public: true) }
+
+  it "returns 404 instead of rendering the page" do
+    get "/#{event.slug}/feed.atom~"
+    expect(response).to have_http_status(:not_found)
+
+    get "/#{event.slug}.html~"
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "still serves known formats and extension-less routes" do
+    get "/#{event.slug}/feed.atom"
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("application/atom+xml")
+
+    get "/#{event.slug}/feed"
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("application/atom+xml")
+  end
+end


### PR DESCRIPTION
## Summary of the problem
When the requested extension isn't a registered MIME type, `request.formats` ends up empty and Rails falls back to every template format it knows. So `/slug/feed.atom~`, `/slug/feed.foo`, `/slug.html~` and `/users/auth.html~` all render the real page with a 200 instead of a 404.

## Describe your changes
Adds a `reject_unknown_format` before_action to `ApplicationController` that 404s when `params[:format]` is present but `Mime[params[:format]]` is nil. `/slug/feed` and `/slug/feed.atom` still work.

It only runs for GET/HEAD. The donation tier delete link encodes the tier id in the format slot (`/slug/donation/tiers.123`), which would otherwise be blocked. That route is worth fixing separately.

Request spec covers an unknown extension returning 404 and the known-format/extension-less paths still returning the Atom feed.
