### PR TITLE
Mark Ahoy cookies HttpOnly

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -12,3 +12,7 @@ Ahoy.api = true
 Ahoy.geocode = false
 
 Ahoy.exclude_method = ->(controller, request) { true }
+
+# Nothing in the browser needs to read these (the analytics Stimulus
+# controller only posts events), so keep them out of reach of scripts.
+Ahoy.cookie_options = { httponly: true }

--- a/spec/requests/ahoy_cookies_spec.rb
+++ b/spec/requests/ahoy_cookies_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Ahoy cookies", type: :request do
+  # Flagged by the PCI scan: nothing in the browser needs to read these.
+  it "are HttpOnly" do
+    get auth_users_path
+
+    set_cookie = Array(response.headers["set-cookie"]).join("\n")
+    %w[ahoy_visitor ahoy_visit].each do |name|
+      expect(set_cookie).to match(/^#{name}=[^\n]*;\s*httponly/i), "#{name} is missing HttpOnly"
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the problem
`ahoy_visitor` and `ahoy_visit` are set with `Secure` and `SameSite` from Rails, but Ahoy sets its own cookies and doesn't add `HttpOnly` by default, so they're readable from JavaScript.

## Describe your changes
Sets `Ahoy.cookie_options = { httponly: true }` in the Ahoy initializer.

Nothing in the browser needs to read these cookies. The only client-side use is the analytics Stimulus controller, which posts events, and server-side tracking has been fully excluded since #12803, so no analytics data is affected.

Request spec asserts both cookies carry `HttpOnly` on the sign-in page. Existing visitors keep their old `ahoy_visitor` cookie until it expires; new ones and every `ahoy_visit` refresh get the flag.
