### PR TITLE
Send Cache-Control: no-transform on HTML responses

### DIFF
--- a/app/middleware/no_transform_html.rb
+++ b/app/middleware/no_transform_html.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# The reverse proxy in front of the app (Caddy) gzips every response. Compressing
+# HTML that reflects both user input and per-request secrets is what makes the
+# BREACH attack (CVE-2013-3587) possible, and it is flagged on every PCI scan.
+# `Cache-Control: no-transform` tells the proxy to pass these responses through
+# uncompressed; assets and API responses keep their compression.
+class NoTransformHtml
+  HTML_TYPES = ["text/html", "text/vnd.turbo-stream.html"].freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+
+    if html?(headers[Rack::CONTENT_TYPE])
+      directives = headers[Rack::CACHE_CONTROL].to_s.split(",").map(&:strip).reject(&:empty?)
+      directives << "no-transform" unless directives.include?("no-transform")
+      headers[Rack::CACHE_CONTROL] = directives.join(", ")
+    end
+
+    [status, headers, body]
+  end
+
+  private
+
+  def html?(content_type)
+    content_type.to_s.start_with?(*HTML_TYPES)
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require "rails/all"
 require_relative "../app/lib/credentials"
 require_relative "../lib/active_storage/previewer/document_previewer"
 require_relative "../app/middleware/set_current_request_ip"
+require_relative "../app/middleware/no_transform_html"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -64,6 +65,13 @@ module Bank
 
     # Track request IP for all requests
     config.middleware.insert_after ActionDispatch::RemoteIp, SetCurrentRequestIp
+
+    # Outermost so it sees the final Cache-Control value. Registered just before
+    # the stack is built so it lands outside Rack::MiniProfiler, which gem
+    # railties insert at position 0 after this file is evaluated.
+    initializer "hcb.no_transform_html", before: :build_middleware_stack do |app|
+      app.middleware.insert_before 0, NoTransformHtml
+    end
 
     config.active_storage.variant_processor = :mini_magick
 

--- a/spec/requests/no_transform_html_spec.rb
+++ b/spec/requests/no_transform_html_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cache-Control: no-transform", type: :request do
+  let(:event) { create(:event, is_public: true) }
+
+  it "is set on HTML so the reverse proxy does not gzip it (BREACH)" do
+    get auth_users_path
+
+    expect(response.media_type).to eq("text/html")
+    expect(response.headers["cache-control"]).to include("no-transform")
+  end
+
+  it "is not set on non-HTML responses" do
+    get "/#{event.slug}/feed.atom"
+
+    expect(response.headers["cache-control"]).not_to include("no-transform")
+  end
+end


### PR DESCRIPTION
## Summary of the problem
HTML pages are served with `content-encoding: gzip`. The compression comes from the Caddy that Hatchbox puts in front of Puma, not from Rails (`Rack::Deflater` isn't in our stack), and that config isn't in this repo. We want HTML passed through uncompressed while assets and API responses stay gzipped.

## Describe your changes
Adds a small `NoTransformHtml` Rack middleware that appends `no-transform` to `Cache-Control` on `text/html` and turbo-stream responses. Caddy's `encode` handler skips any response whose `Cache-Control` contains `no-transform`, so only HTML is affected.

It's registered via an `initializer ... before: :build_middleware_stack` rather than `config.middleware.insert_before 0` so it lands outside `Rack::MiniProfiler`, which is inserted at position 0 later and rewrites `Cache-Control` on profiled requests (auditors in prod).

Request spec checks the directive is present on an HTML page and absent on the Atom feed.

If Hatchbox lets us edit the Caddyfile, restricting `encode` to non-HTML content types there is the more direct fix and this header becomes belt-and-braces.
