### PR TITLE
[Suborgs] Sum the sub-organization balance stat from the ledger

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -545,10 +545,13 @@ class EventsController < ApplicationController
     render :async_balance, layout: false
   end
 
+  # Summed from the ledger, the same engine the balances in the table read
+  # from, so the total agrees with the rows beneath it.
   def async_sub_organization_balance
     authorize @event
 
-    @sub_organizations = filtered_sub_organizations
+    sub_organizations = filtered_sub_organizations.except(:includes, :order).includes(:ledger)
+    @sub_organization_balance_cents = sub_organizations.sum { |event| event.ledger.available_balance_cents }
 
     render :async_sub_organization_balance, layout: false
   end

--- a/app/views/events/async_sub_organization_balance.html.erb
+++ b/app/views/events/async_sub_organization_balance.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "sub_event_balance_#{@event.public_id}" do %>
-  <%= render_money_amount(@sub_organizations.to_a.sum(&:balance_available_v2_cents)) %>
+  <%= render_money_amount(@sub_organization_balance_cents) %>
 <% end %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -669,20 +669,19 @@ RSpec.describe EventsController do
     end
   end
 
+  # Distinct amounts, so a sum that leaves one out reads as a different number.
   describe "#async_sub_organization_balance" do
     render_views
 
     let(:parent) { create(:event, is_public: true) }
-    let!(:transparent_sub) { create(:event, :with_positive_balance, parent:, is_public: true) }
-    let!(:private_sub) { create(:event, :with_positive_balance, parent:, is_public: false) }
+    let!(:transparent_sub) { create(:event, :with_ledger_balance, ledger_balance_cents: 10_000, parent:, is_public: true) }
+    let!(:private_sub) { create(:event, :with_ledger_balance, ledger_balance_cents: 20_000, parent:, is_public: false) }
 
     it "sums only transparent sub-organizations for a signed out visitor", :aggregate_failures do
       get(:async_sub_organization_balance, params: { event_id: parent.slug })
 
-      expect(response.body).to include(money(transparent_sub.balance_available_v2_cents))
-      expect(response.body).not_to include(
-        money(transparent_sub.balance_available_v2_cents + private_sub.balance_available_v2_cents)
-      )
+      expect(response.body).to include(money(10_000))
+      expect(response.body).not_to include(money(30_000))
     end
 
     it "sums every sub-organization for an organizer of the parent" do
@@ -690,27 +689,25 @@ RSpec.describe EventsController do
 
       get(:async_sub_organization_balance, params: { event_id: parent.slug })
 
-      expect(response.body).to include(
-        money(transparent_sub.balance_available_v2_cents + private_sub.balance_available_v2_cents)
-      )
+      expect(response.body).to include(money(30_000))
     end
   end
 
   describe "#async_sub_organization_balances" do
     let(:parent) { create(:event, is_public: true) }
-    let!(:transparent_sub) { create(:event, :with_positive_balance, parent:, is_public: true) }
-    let!(:private_sub) { create(:event, :with_positive_balance, parent:, is_public: false) }
+    let!(:transparent_sub) { create(:event, :with_ledger_balance, ledger_balance_cents: 10_000, parent:, is_public: true) }
+    let!(:private_sub) { create(:event, :with_ledger_balance, ledger_balance_cents: 20_000, parent:, is_public: false) }
 
     it "returns a balance for each requested descendant" do
-      grandchild = create(:event, :with_positive_balance, parent: transparent_sub, is_public: true)
+      grandchild = create(:event, :with_ledger_balance, ledger_balance_cents: 40_000, parent: transparent_sub, is_public: true)
 
       get(:async_sub_organization_balances,
           params: { event_id: parent.slug, ids: [transparent_sub.public_id, grandchild.public_id] },
           format: :json)
 
       expect(response.parsed_body).to eq(
-        transparent_sub.public_id => money(transparent_sub.ledger.available_balance_cents),
-        grandchild.public_id      => money(grandchild.ledger.available_balance_cents)
+        transparent_sub.public_id => money(10_000),
+        grandchild.public_id      => money(40_000)
       )
     end
 

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -50,5 +50,21 @@ FactoryBot.define do
         create(:canonical_event_mapping, canonical_transaction:, event:)
       end
     end
+
+    # Ledger#available_balance_cents sums the items mapped onto the event's
+    # primary ledger, which the canonical transaction above does not create.
+    # Ledger::Item#refresh! recomputes the amount from the (absent) canonical
+    # transactions on create, so the amount is written after mapping.
+    trait :with_ledger_balance do
+      transient do
+        ledger_balance_cents { 100_000 }
+      end
+
+      after :create do |event, context|
+        item = create(:ledger_item, memo: "🏦 Test Donation")
+        Ledger::Mapping.create!(ledger: event.ledger, ledger_item: item, on_primary_ledger: true)
+        item.update_columns(amount_cents: context.ledger_balance_cents, status: "settled")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary of the problem

On the sub-organizations page, the table rows read `event.ledger.available_balance_cents` (per the review on #14762), while the "Sub-organization balance" stat above them summed `balance_available_v2_cents`. Two engines on one page means the stat can disagree with the rows it sits above, and the roll-up work stacked on this PR would have made that visible.

Separately, the specs for both surfaces were asserting against `ledger.available_balance_cents` on events built with `:with_positive_balance`. That trait funds canonical transactions but never the ledger, so every ledger balance in those specs was `$0.00` and the assertions passed trivially.

## Describe your changes

- `async_sub_organization_balance` now sums `ledger.available_balance_cents`, the same engine as the rows.
- New `:with_ledger_balance` factory trait with a `ledger_balance_cents` transient. It writes the amount with `update_columns` after mapping, since `Ledger::Item#refresh!` runs on create and recomputes the amount from the (absent) canonical transactions.
- Both sub-organization balance describe blocks use the trait with distinct amounts per event, so a sum that leaves one out reads as a different number.

No visual change. The next PR in the stack, which rolls balances up through the whole tree, is based on this branch.
