### PR TITLE
[Stripe Card Holder] Remove Stripe international phone numbers

### DIFF
--- a/app/models/stripe_cardholder.rb
+++ b/app/models/stripe_cardholder.rb
@@ -64,6 +64,7 @@ class StripeCardholder < ApplicationRecord
   after_validation :update_cardholder_in_stripe, on: :update, if: -> { errors.none? }
 
   before_validation :set_default_billing_address
+  before_validation :clear_unsupported_phone_number
 
   def state
     return :success if remote_status == "active"
@@ -105,6 +106,12 @@ class StripeCardholder < ApplicationRecord
     postal_code: "90069",
     country: "US"
   }.freeze
+
+  SMS_SUPPORTED = %w[US GB].freeze
+
+  def self.phone_number_supported?(phone_number)
+    SMS_SUPPORTED.include?(Phonelib.parse(phone_number).country)
+  end
 
   def default_billing_address?
     DEFAULT_BILLING_ADDRESS.all? do |key, value|
@@ -150,6 +157,13 @@ class StripeCardholder < ApplicationRecord
       method = :"address_#{key}"
       self.public_send(:"#{method}=", value) if self.public_send(method).blank?
     end
+  end
+
+  def clear_unsupported_phone_number
+    return if stripe_phone_number.blank?
+    return if StripeCardholder.phone_number_supported?(stripe_phone_number)
+
+    self.stripe_phone_number = nil
   end
 
   def update_cardholder_in_stripe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -436,6 +436,13 @@ class User < ApplicationRecord
     phone_number_verified? || phone_number_verification_bypassed?
   end
 
+  def phone_number_for_stripe
+    return nil unless phone_number_verified?
+    return nil unless StripeCardholder.phone_number_supported?(phone_number)
+
+    phone_number
+  end
+
   def locked?
     locked_at.present?
   end
@@ -745,7 +752,7 @@ class User < ApplicationRecord
 
     cardholder.update!(
       stripe_email: email,
-      stripe_phone_number: phone_number_verified? ? phone_number : nil,
+      stripe_phone_number: phone_number_for_stripe,
     )
   end
 

--- a/app/services/stripe_cardholder_service/create.rb
+++ b/app/services/stripe_cardholder_service/create.rb
@@ -62,7 +62,7 @@ module StripeCardholderService
     end
 
     def phone_number
-      @current_user.phone_number if @current_user.phone_number_verified?
+      @current_user.phone_number_for_stripe
     end
 
     def name

--- a/spec/models/stripe_cardholder_spec.rb
+++ b/spec/models/stripe_cardholder_spec.rb
@@ -60,4 +60,50 @@ RSpec.describe StripeCardholder, type: :model do
 
     stripe_cardholder.update!(stripe_email: "updated@example.com")
   end
+
+  it "drops a non-US/GB phone number before saving" do
+    stripe_cardholder = create(:stripe_cardholder, stripe_phone_number: "919876543210")
+
+    expect(stripe_cardholder.stripe_phone_number).to be_nil
+  end
+
+  it "clears a non-US/GB phone number on Stripe when it reaches an existing cardholder" do
+    stripe_cardholder = create(:stripe_cardholder, stripe_phone_number: "18556254225")
+
+    expect(StripeService::Issuing::Cardholder).to(
+      receive(:update)
+        .with(
+          stripe_cardholder.stripe_id,
+          hash_including(phone_number: "")
+        )
+    )
+
+    stripe_cardholder.update!(stripe_phone_number: "919876543210")
+
+    expect(stripe_cardholder.reload.stripe_phone_number).to be_nil
+  end
+
+  describe ".phone_number_supported?" do
+    it "works for US numbers" do
+      expect(StripeCardholder.phone_number_supported?("+18556254225")).to eq(true)
+    end
+
+    it "works for GB numbers" do
+      expect(StripeCardholder.phone_number_supported?("+447700900123")).to eq(true)
+    end
+
+    it "does not work for numbers outside US/GB" do
+      expect(StripeCardholder.phone_number_supported?("+919876543210")).to eq(false)
+      expect(StripeCardholder.phone_number_supported?("+61412345678")).to eq(false)
+    end
+
+    it "does not work for Canadian numbers even though they share +1" do
+      expect(StripeCardholder.phone_number_supported?("+12045551234")).to eq(false)
+    end
+
+    it "handles numbers stored without a plus sign" do
+      expect(StripeCardholder.phone_number_supported?("18556254225")).to eq(true)
+      expect(StripeCardholder.phone_number_supported?("919876543210")).to eq(false)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -455,6 +455,59 @@ RSpec.describe User, type: :model do
 
       expect(cardholder.stripe_phone_number).to eq("18556254225")
     end
+
+    it "does not send a non-US/GB phone number to stripe even when verified" do
+      user = create(:user, phone_number: "+919876543210", phone_number_verified: false, email: "test@example.com")
+      cardholder = create(:stripe_cardholder, user:, stripe_email: "test@example.com")
+
+      expect(StripeService::Issuing::Cardholder).to receive(:update)
+
+      user.update!(phone_number_verified: true)
+      cardholder.reload
+
+      expect(cardholder.stripe_phone_number).to be_nil
+    end
+
+    it "clears a synced US number once the verified number is no longer US/GB" do
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: false, email: "test@example.com")
+      cardholder = create(:stripe_cardholder, user:, stripe_phone_number: "18556254225", stripe_email: "test@example.com")
+      user.update_column(:phone_number, "+919876543210")
+
+      expect(StripeService::Issuing::Cardholder).to receive(:update).with(cardholder.stripe_id, hash_including(phone_number: ""))
+
+      user.update!(phone_number_verified: true)
+      cardholder.reload
+
+      expect(cardholder.stripe_phone_number).to be_nil
+    end
+  end
+
+  describe "#phone_number_for_stripe" do
+    it "returns the phone number when it is verified and in a supported country" do
+      user = create(:user, phone_number: "+18556254225")
+      user.update_column(:phone_number_verified, true)
+
+      expect(user.phone_number_for_stripe).to eq("18556254225")
+    end
+
+    it "returns nil when the phone number is not verified" do
+      user = create(:user, phone_number: "+18556254225", phone_number_verified: false)
+
+      expect(user.phone_number_for_stripe).to be_nil
+    end
+
+    it "returns nil when the phone number is outside the US and GB" do
+      user = create(:user, phone_number: "+919876543210")
+      user.update_column(:phone_number_verified, true)
+
+      expect(user.phone_number_for_stripe).to be_nil
+    end
+
+    it "returns nil when there is no phone number" do
+      user = create(:user, phone_number: nil, phone_number_verified: true)
+
+      expect(user.phone_number_for_stripe).to be_nil
+    end
   end
 
   describe "#on_phone_number_update" do

--- a/spec/services/stripe_cardholder_service/create_spec.rb
+++ b/spec/services/stripe_cardholder_service/create_spec.rb
@@ -14,5 +14,47 @@ RSpec.describe StripeCardholderService::Create do
 
       expect { service.run }.to raise_error(ArgumentError, /phone number must be verified/)
     end
+
+    it "sends a verified US phone number to Stripe" do
+      user = create(:user, phone_number: "+18556254225")
+      user.update_column(:phone_number_verified, true)
+      allow(StripeService::Issuing::Cardholder).to receive(:update)
+
+      expect(StripeService::Issuing::Cardholder).to receive(:create)
+        .with(hash_including(phone_number: "18556254225"))
+        .and_return(double(id: "ich_123"))
+
+      cardholder = described_class.new(current_user: user, ip_address:, event_id: event.id).run
+
+      expect(cardholder.stripe_phone_number).to eq("18556254225")
+    end
+
+    it "sends a verified GB phone number to Stripe" do
+      user = create(:user, phone_number: "+442079460000")
+      user.update_column(:phone_number_verified, true)
+      allow(StripeService::Issuing::Cardholder).to receive(:update)
+
+      expect(StripeService::Issuing::Cardholder).to receive(:create)
+        .with(hash_including(phone_number: "442079460000"))
+        .and_return(double(id: "ich_123"))
+
+      cardholder = described_class.new(current_user: user, ip_address:, event_id: event.id).run
+
+      expect(cardholder.stripe_phone_number).to eq("442079460000")
+    end
+
+    it "does not send a non-US/GB phone number to Stripe" do
+      user = create(:user, phone_number: "+919876543210")
+      user.update_column(:phone_number_verified, true)
+      allow(StripeService::Issuing::Cardholder).to receive(:update)
+
+      expect(StripeService::Issuing::Cardholder).to receive(:create)
+        .with(hash_including(phone_number: nil))
+        .and_return(double(id: "ich_123"))
+
+      cardholder = described_class.new(current_user: user, ip_address:, event_id: event.id).run
+
+      expect(cardholder.stripe_phone_number).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
fixes #13022
Stripe only sends 3DS verification codes to numbers with US and GB country codes, so Cardholders without those codes don't get a verification code at all. Stripe confirmed this issue but as of writing has not addressed it themselves.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->

This PR makes it so that phone numbers are only sent to Stripe if it is both verified and starts with a country code of +1 or +44. The allowed country codes are modifiable in `stripe_cardholder.rb:SMS_SUPPORTED`. If a number's country code is not in that list, the number that is sent to Stripe is nil so that the verification code becomes an email. This does _not_ remove it on HCB's end, just Stripe's end.

There is also a new maintenance task added, which clears numbers outside +1/+44 that are already on existing Stripe cardholders, making it so that this fix applies to existing users in addition to new ones.

<!-- If there are any visual changes, please attach images, videos, or gifs. -->
No visual changes, but heres a demo that I ran in `bin/rails console` that shows only GB/US numbers being sent to Stripe.

https://github.com/user-attachments/assets/26ec9fc4-d2e5-455e-82fa-c63e26da8449

