### PR TITLE
[Payments] Add attempts list to show page

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -4,7 +4,7 @@ class PaymentsController < ApplicationController
   include SetEvent
 
   before_action :set_event, only: [:new, :create]
-  before_action :set_payment, only: [:show, :cancel]
+  before_action :set_payment, only: [:show, :cancel, :retry]
 
   def show
     authorize @payment
@@ -71,6 +71,18 @@ class PaymentsController < ApplicationController
 
     flash[:success] = "Payment canceled"
     redirect_back_or_to payment_path(@payment)
+  end
+
+  def retry
+    authorize @payment
+
+    begin
+      @payment.retry!
+    rescue ArgumentError => e
+      flash[:error] = e.message
+    end
+
+    redirect_to @payment
   end
 
   private

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -206,6 +206,7 @@ class Payment < ApplicationRecord
   def create_payment_attempt!
     self.with_lock do
       raise ArgumentError, "this payment was rejected" if rejected?
+      raise ArgumentError, "this payment was canceled" if canceled?
       raise ArgumentError, "all attempts must be failed, rejected, or canceled" if attempts.any?(&:active?)
       raise ArgumentError, "there is no default payout method" if legal_entity.default_payout_method.nil?
 

--- a/app/models/payment/attempt.rb
+++ b/app/models/payment/attempt.rb
@@ -112,6 +112,20 @@ class Payment
 
     after_create :create_transfer!
 
+    def state_color
+      return "info" if pending? || under_review? || sent?
+      return "success" if successful?
+      return "error" if rejected? || failed?
+
+      "muted" # canceled
+    end
+
+    def state_text
+      return "Processing" if pending? || under_review?
+
+      return aasm_state.humanize
+    end
+
     private
 
     def create_transfer!

--- a/app/policies/payment_policy.rb
+++ b/app/policies/payment_policy.rb
@@ -20,4 +20,8 @@ class PaymentPolicy < ApplicationPolicy
     EventPolicy.new(user, record.event).create_payment?
   end
 
+  def retry?
+    EventPolicy.new(user, record.event).create_payment?
+  end
+
 end

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -92,15 +92,17 @@
   <% end %>
 
   <% if @payment.attempts.any? %>
-    <% @payment.attempts.each_with_index do |attempt, index| %>
-      <div class="card flex items-center w-full">
-        <p class="my-0"><%= link_to "Attempt ##{index + 1}", attempt.payout.local_hcb_code %></p>
-        <p class="my-0"><span class="badge h4 bg-<%= attempt.state_color %> nowrap order-1"><%= attempt.state_text %></span></p>
+    <div class="flex flex-col gap-1">
+      <% @payment.attempts.reorder(created_at: :asc).each_with_index do |attempt, index| %>
+        <div class="card flex items-center w-full">
+          <p class="my-0"><%= link_to "Attempt ##{index + 1}", attempt.payout.local_hcb_code %></p>
+          <p class="my-0"><span class="badge h4 bg-<%= attempt.state_color %> nowrap order-1"><%= attempt.state_text %></span></p>
 
-        <div class="flex-grow"></div>
-        <p class="my-0"><%= attempt.aasm_state.humanize %> on <%= format_date attempt.created_at %></p>
-      </div>
-    <% end %>
+          <div class="flex-grow"></div>
+          <p class="my-0"><%= attempt.aasm_state.humanize %> on <%= format_date attempt.created_at %></p>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 
   <% unless @payment.attempts.any?(&:active?) %>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -91,6 +91,18 @@
     <% end %>
   <% end %>
 
+  <% if @payment.attempts.any? %>
+    <% @payment.attempts.each_with_index do |attempt, index| %>
+      <div class="card flex items-center w-full">
+        <p class="my-0"><%= link_to "Attempt ##{index + 1}", attempt.payout.local_hcb_code %></p>
+        <p class="my-0"><span class="badge h4 bg-<%= attempt.state_color %> nowrap order-1"><%= attempt.state_text %></span></p>
+
+        <div class="flex-grow"></div>
+        <p class="my-0"><%= attempt.aasm_state.humanize %> on <%= format_date attempt.created_at %></p>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @payment.receipts.any? %>
     <ul class="grid grid--medium-narrow text-left w-100 mt-4 receipts_list">
       <%= render partial: "receipts/receipt", collection: @payment.receipts.with_attached_file.includes(:user).order(created_at: :asc), as: :receipt, locals: { show_delete_button: true, link_to_file: true } %>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -103,6 +103,10 @@
     <% end %>
   <% end %>
 
+  <% unless @payment.attempts.any?(&:active?) %>
+    <%= button_to "Retry payment", retry_payment_path(@payment), class: "btn mt-2" %>
+  <% end %>
+
   <% if @payment.receipts.any? %>
     <ul class="grid grid--medium-narrow text-left w-100 mt-4 receipts_list">
       <%= render partial: "receipts/receipt", collection: @payment.receipts.with_attached_file.includes(:user).order(created_at: :asc), as: :receipt, locals: { show_delete_button: true, link_to_file: true } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -665,6 +665,7 @@ Rails.application.routes.draw do
   resources :payments, only: [:show], concerns: :commentable do
     member do
       post "cancel"
+      post "retry"
     end
   end
 


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
There's currently not a way to see the attempts made for a payment or get to the underlying transfer pages.

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a list of attempts to the payment show page, which link to their underlying payouts.
Also adds a manual retry button. This is used when attempts fail, and we want to retry sending it with the current information. A future PR will automatically trigger retries when the default payout method is updated.
<img width="1087" height="777" alt="image" src="https://github.com/user-attachments/assets/90db0acf-1ed5-4dba-8f7a-37f8fa7bc3d9" />


<!-- If there are any visual changes, please attach images, videos, or gifs. -->

