### PR TITLE
Protect against appending drag_and_drop to upload method twice

### DIFF
--- a/app/javascript/controllers/file_drop_controller.js
+++ b/app/javascript/controllers/file_drop_controller.js
@@ -98,7 +98,11 @@ export default class extends Controller {
     this.fileInputTarget.dispatchEvent(new Event('change'))
     if (!this.fileInputTarget.files.length) return
 
-    if (this.hasUploadMethodTarget && !this.submitting) {
+    if (
+      this.hasUploadMethodTarget &&
+      !this.submitting &&
+      !this.uploadMethodTarget.value.endsWith('_drag_and_drop')
+    ) {
       // Append `_drag_and_drop` to the upload method
       this.uploadMethodTarget.value += '_drag_and_drop'
     }


### PR DESCRIPTION
## Summary of the problem
<!-- Why are these changes being made? What problem does it solve? Link any related issues to provide more details. -->
https://appsignal.com/hack-club/sites/6596247683eb67648f30f807/exceptions/incidents/3071/traces/8b754345ed7c2fc0d4aa7a5216ac8805

It seems this code was running twice sometimes, which meant we ended up with an upload method like receipt_center_drag_and_drop_drag_and_drop

## Describe your changes
<!-- Explain your thought process to the solution and provide a quick summary of the changes. -->
Add a check to not append drag_and_drop if it already ends with it

<!-- If there are any visual changes, please attach images, videos, or gifs. -->

