### PR TITLE
[Reimbursements] add "Approve report" button and modal

### DIFF
--- a/app/assets/javascripts/ui.js
+++ b/app/assets/javascripts/ui.js
@@ -759,6 +759,8 @@ document.addEventListener('turbo:before-stream-render', event => {
       })
     } else if (streamElement.action == 'close_modal') {
       $.modal.close().remove()
+    } else if (streamElement.action == 'open_modal') {
+      BK.s('modal', '#' + streamElement.target).modal({ closeExisting: false })
     } else {
       fallbackToDefaultActions(streamElement)
     }

--- a/app/controllers/reimbursement/expenses_controller.rb
+++ b/app/controllers/reimbursement/expenses_controller.rb
@@ -72,7 +72,7 @@ module Reimbursement
       @expense.mark_approved!(current_user) if @expense.may_mark_approved?
 
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: on_update_streams }
+        format.turbo_stream { render turbo_stream: on_update_streams + approval_prompt_streams }
         format.html { redirect_to @expense.report }
       end
     end
@@ -145,6 +145,16 @@ module Reimbursement
 
     def on_update_streams
       [total_turbo_stream, actions_turbo_stream, replace_expense_turbo_stream]
+    end
+
+    def approval_prompt_streams
+      report = @expense.report
+      return [] unless report.submitted?
+      return [] unless report.expenses.pending.none?
+      return [] unless report.may_mark_reimbursement_requested?
+      return [] unless policy(report).request_reimbursement?
+
+      [turbo_stream.open_modal("all_expenses_approved_modal")]
     end
 
     def on_delete_streams

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -348,23 +348,6 @@ module Reimbursement
       redirect_to @report
     end
 
-    def approve_all_expenses
-      authorize @report
-
-      begin
-        @report.expenses.each do |expense|
-          expense.mark_approved!
-        end
-        flash[:success] = "All expenses have been approved; the report creator will be notified."
-      rescue => e
-        flash[:error] = e.message
-      end
-
-      # Reimbursement::NightlyJob.perform_later
-
-      redirect_to @report
-    end
-
     def approve
       authorize @report
 

--- a/app/controllers/reimbursement/reports_controller.rb
+++ b/app/controllers/reimbursement/reports_controller.rb
@@ -365,6 +365,24 @@ module Reimbursement
       redirect_to @report
     end
 
+    def approve
+      authorize @report
+
+      begin
+        @report.expenses.pending.each do |expense|
+          expense.mark_approved!(current_user)
+        end
+        @report.mark_reimbursement_requested!
+        flash[:success] = "All expenses have been approved and the reimbursement has been requested; the HCB team will review the request promptly."
+      rescue AASM::InvalidTransition
+        flash[:error] = @report.reload.reimbursement_requested? ? "This report was already sent for reimbursement." : "This report could not be sent for reimbursement."
+      rescue => e
+        flash[:error] = e.message
+      end
+
+      redirect_to @report
+    end
+
     def reject
 
       authorize @report

--- a/app/helpers/turbo_stream_actions_helper.rb
+++ b/app/helpers/turbo_stream_actions_helper.rb
@@ -12,6 +12,10 @@ module TurboStreamActionsHelper
   def close_modal
     turbo_stream_action_tag :close_modal
   end
+
+  def open_modal(target)
+    turbo_stream_action_tag :open_modal, target: target
+  end
 end
 
 Turbo::Streams::TagBuilder.prepend(TurboStreamActionsHelper)

--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -77,6 +77,10 @@ module Reimbursement
       (admin || (manager && !creator)) && open
     end
 
+    def approve?
+      (admin || (manager && !creator)) && open
+    end
+
     def reject?
       (admin || manager) && open
     end

--- a/app/policies/reimbursement/report_policy.rb
+++ b/app/policies/reimbursement/report_policy.rb
@@ -73,10 +73,6 @@ module Reimbursement
       (admin || manager) && open
     end
 
-    def approve_all_expenses?
-      (admin || (manager && !creator)) && open
-    end
-
     def approve?
       (admin || (manager && !creator)) && open
     end

--- a/app/views/reimbursement/reports/_actions.html.erb
+++ b/app/views/reimbursement/reports/_actions.html.erb
@@ -68,7 +68,7 @@
               <%= inline_icon "reply" %>
               Return to <%= report.user.first_name %>
               <% button_hint = capture do %>
-                <span class="bold">Your next step:</span> approve individual expenses and reimburse the report. Or, return the report to <%= report.user.first_name %>.
+                <span class="bold">Your next step:</span> review the expenses, then approve the report. Or, return the report to <%= report.user.first_name %>.
               <% end %>
             </button>
           <% end %>
@@ -228,10 +228,10 @@
               Reimburse <%= report.amount_to_reimburse.format %>
             </div>
           </div>
-        <% elsif report.submitted? && policy(report).approve_all_expenses? && report.expenses.approved.none? %>
-          <%= link_to reimbursement_report_approve_all_expenses_path(report), class: "btn bg-success", data: { turbo_method: :post } do %>
+        <% elsif report.submitted? && policy(report).approve? && report.expenses.approved.none? %>
+          <%= link_to reimbursement_report_approve_path(report), class: "btn bg-success", data: { turbo_method: :post } do %>
             <%= inline_icon "thumbsup" %>
-            Approve all expenses
+            Approve report
           <% end %>
         <% elsif report.reimbursement_requested? && !admin_signed_in? %>
           <div class="btn bg-info disabled" style="opacity: 0.75" disabled>

--- a/app/views/reimbursement/reports/show.html.erb
+++ b/app/views/reimbursement/reports/show.html.erb
@@ -105,6 +105,20 @@
   <% end %>
 </section>
 
+<% if @report.submitted? %>
+  <section data-behavior="modal" role="dialog" id="all_expenses_approved_modal" class="modal modal--scroll bg-snow">
+    <%= modal_header "All expenses approved" %>
+    <p>You just approved the last expense; do you want to reimburse the entire report?</p>
+    <div class="flex gap-2">
+      <%= link_to "Not now", "#", class: "btn bg-muted", rel: "modal:close" %>
+      <%= link_to reimbursement_report_approve_path(@report), class: "btn bg-info", data: { turbo_method: :post } do %>
+        <%= inline_icon "payment-transfer" %>
+        Reimburse report
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
 <% if @report.event&.public_reimbursement_page_message&.present? && policy(@event).reimbursements? %>
   <article class="card mt2 pt0">
     <%= MarkdownService.instance.render(@report.event.public_reimbursement_page_message) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -614,6 +614,7 @@ Rails.application.routes.draw do
       post "admin_send_wise_transfer"
       post "reverse"
       post "approve_all_expenses"
+      post "approve"
       post "request_changes"
       post "reject"
       post "submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -613,7 +613,6 @@ Rails.application.routes.draw do
       post "admin_approve"
       post "admin_send_wise_transfer"
       post "reverse"
-      post "approve_all_expenses"
       post "approve"
       post "request_changes"
       post "reject"

--- a/spec/controllers/reimbursement/expenses_controller_spec.rb
+++ b/spec/controllers/reimbursement/expenses_controller_spec.rb
@@ -101,4 +101,44 @@ RSpec.describe Reimbursement::ExpensesController do
     end
 
   end
+
+  describe "#approve" do
+    render_views
+
+    def submitted_eur_report(expense_count:)
+      report = create(:reimbursement_report, aasm_state: "submitted", currency: "EUR")
+      expense_count.times { create(:reimbursement_expense, report:) }
+      report
+    end
+
+    it "emits an open_modal stream prompting reimbursement when the last pending expense is approved" do
+      admin = create(:user, :make_admin)
+      report = submitted_eur_report(expense_count: 1)
+      expense = report.expenses.first
+
+      allow_any_instance_of(Reimbursement::Report).to receive(:wise_transfer_may_exceed_balance?).and_return(false)
+      create_session(admin, verified: true)
+
+      post(:approve, params: { expense_id: expense.id }, format: :turbo_stream)
+
+      expect(expense.reload).to be_approved
+      expect(response.body).to include('action="open_modal"')
+      expect(response.body).to include("all_expenses_approved_modal")
+    end
+
+    it "omits the open_modal stream while other expenses remain pending" do
+      admin = create(:user, :make_admin)
+      report = submitted_eur_report(expense_count: 2)
+      expense = report.expenses.first
+
+      allow_any_instance_of(Reimbursement::Report).to receive(:wise_transfer_may_exceed_balance?).and_return(false)
+      create_session(admin, verified: true)
+
+      post(:approve, params: { expense_id: expense.id }, format: :turbo_stream)
+
+      expect(expense.reload).to be_approved
+      expect(response.body).not_to include("open_modal")
+    end
+
+  end
 end

--- a/spec/controllers/reimbursement/reports_controller_spec.rb
+++ b/spec/controllers/reimbursement/reports_controller_spec.rb
@@ -335,6 +335,64 @@ RSpec.describe Reimbursement::ReportsController do
     end
   end
 
+  describe "#approve" do
+    it "approves all pending expenses and requests reimbursement" do
+      creator = create(:user)
+      event = create(:event)
+      approver = create(:user)
+      create(:organizer_position, user: approver, event:)
+      report = create(:reimbursement_report, user: creator, event:, aasm_state: :submitted, currency: "EUR")
+      expense_one = create(:reimbursement_expense, report:, value: 10.00)
+      expense_two = create(:reimbursement_expense, report:, value: 20.00)
+
+      expect(report.team_review_required?).to be(true)
+      expect(OrganizerPosition.where(user: creator, event:).exists?).to be(false)
+
+      create_session(approver, verified: true)
+
+      post(:approve, params: { report_id: report.id })
+
+      expect(response).to redirect_to(reimbursement_report_path(report))
+      expect(expense_one.reload.approved?).to be(true)
+      expect(expense_one.approved_by_id).to eq(approver.id)
+      expect(expense_two.reload.approved?).to be(true)
+      expect(expense_two.approved_by_id).to eq(approver.id)
+      expect(report.reload.aasm_state).to eq("reimbursement_requested")
+      expect(flash[:success]).to eq("All expenses have been approved and the reimbursement has been requested; the HCB team will review the request promptly.")
+    end
+
+    it "rejects the report creator" do
+      creator = create(:user)
+      event = create(:event)
+      report = create(:reimbursement_report, user: creator, event:, aasm_state: :submitted, currency: "EUR")
+      create(:reimbursement_expense, report:, value: 10.00)
+
+      create_session(creator, verified: true)
+
+      post(:approve, params: { report_id: report.id })
+
+      expect(flash[:error]).to match(/not authorized/i)
+      expect(report.reload.aasm_state).to eq("submitted")
+    end
+
+    it "keeps approved expenses when the reimbursement guard fails" do
+      creator = create(:user)
+      event = create(:event)
+      approver = create(:user)
+      create(:organizer_position, user: approver, event:)
+      report = create(:reimbursement_report, user: creator, event:, aasm_state: :submitted, currency: "USD")
+      expense = create(:reimbursement_expense, report:, value: 10.00)
+
+      create_session(approver, verified: true)
+
+      post(:approve, params: { report_id: report.id })
+
+      expect(expense.reload.approved?).to be(true)
+      expect(report.reload.aasm_state).to eq("submitted")
+      expect(flash[:error]).to be_present
+    end
+  end
+
   describe "#destroy" do
     it "lets an external contributor delete their own draft report" do
       user = create(:user)


### PR DESCRIPTION
## Summary of the problem

Solves #14727


## Describe your changes

Changes "approve all expenses" button to instead approve the entire report:
<img width="196" height="64" alt="image" src="https://github.com/user-attachments/assets/5b6ae89a-e618-4c13-bdbc-0aba6d33d6ec" />


As well as a modal when the last expense is individually approved, to approve the report itself:
<img width="597" height="225" alt="image" src="https://github.com/user-attachments/assets/5beb31b5-542a-4d02-9122-6d51c9fd470c" />
